### PR TITLE
feat(DHIS2): TAM-3990: Mark DHIS2 data sets as complete when posted

### DIFF
--- a/database/model/public/lab_tests.md
+++ b/database/model/public/lab_tests.md
@@ -45,11 +45,3 @@ Optional secondary result value for the test.
 
 Only applicable when the test type has `supports_secondary_results` enabled. Used to record an additional result value alongside the primary result, typically for tests that require multiple measurements or interpretations.
 {% enddocs %}
-
-{% docs lab_tests__reference_range_min %}
-Custom reference range for this individual lab test, minimum value.
-{% enddocs %}
-
-{% docs lab_tests__reference_range_max %}
-Custom reference range for this individual lab test, maximum value.
-{% enddocs %}

--- a/database/model/public/lab_tests.yml
+++ b/database/model/public/lab_tests.yml
@@ -121,12 +121,6 @@ sources:
             config:
               meta:
                 masking: text
-          - name: reference_range_min
-            data_type: double precision
-            description: "{{ doc('lab_tests__reference_range_min') }}"
-          - name: reference_range_max
-            data_type: double precision
-            description: "{{ doc('lab_tests__reference_range_max') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_tests."

--- a/database/model/public/program_registries.md
+++ b/database/model/public/program_registries.md
@@ -26,11 +26,3 @@ One of:
 {% docs program_registries__program_id %}
 Reference to a [program](#!/source/source.tamanu.tamanu.programs).
 {% enddocs %}
-
-{% docs program_registries__loss_to_follow_up_enabled %}
-A boolean flag indicating if the program registry should have the automatic loss to follow up flagger.
-{% enddocs %}
-
-{% docs program_registries__loss_to_follow_up_threshold_days %}
-The number of days the registry should be considered potentially loss to follow up.
-{% enddocs %}

--- a/database/model/public/program_registries.yml
+++ b/database/model/public/program_registries.yml
@@ -64,16 +64,6 @@ sources:
             description: "{{ doc('program_registries__program_id') }}"
             data_tests:
               - not_null
-          - name: loss_to_follow_up_enabled
-            data_type: boolean
-            description: "{{ doc('program_registries__loss_to_follow_up_enabled') }}"
-            data_tests:
-              - not_null
-          - name: loss_to_follow_up_threshold_days
-            data_type: integer
-            description: "{{ doc('program_registries__loss_to_follow_up_threshold_days') }}"
-            data_tests:
-              - not_null
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in program_registries."

--- a/database/model/public/report_definition_versions.md
+++ b/database/model/public/report_definition_versions.md
@@ -20,12 +20,17 @@ Free-form description or usage notes.
 Status of this version of the report.
 
 One of:
+
 - `draft`
 - `published`
 {% enddocs %}
 
 {% docs report_definition_versions__query %}
 The SQL query.
+{% enddocs %}
+
+{% docs report_definition_versions__report_definition_id %}
+The [report definition](#!/source/source.tamanu.tamanu.report_definitions).
 {% enddocs %}
 
 {% docs report_definition_versions__query_options %}
@@ -36,10 +41,16 @@ JSON config containing additional options for the query.
 - Context for executing query e.g. this facility or all facilities (facility or central server)
 {% enddocs %}
 
-{% docs report_definition_versions__report_definition_id %}
-The [report definition](#!/source/source.tamanu.tamanu.report_definitions).
-{% enddocs %}
-
 {% docs report_definition_versions__user_id %}
 Reference to the [user](#!/source/source.tamanu.tamanu.users) who saved this report version.
+{% enddocs %}
+
+{% docs report_definition_versions__advanced_config %}
+Optional JSONB metadata for the report version.
+
+Unlike `query_options`, this is not used when running the report query. It holds integration and
+other non-query settings, for example:
+
+- `dhis2DataSet`: DHIS2 data set ID used when pushing this report’s data to DHIS2 (see
+  DHIS2 integration processor).
 {% enddocs %}

--- a/database/model/public/report_definition_versions.yml
+++ b/database/model/public/report_definition_versions.yml
@@ -72,6 +72,9 @@ sources:
                   arguments:
                     to: source('tamanu', 'users')
                     field: id
+          - name: advanced_config
+            data_type: jsonb
+            description: "{{ doc('report_definition_versions__advanced_config') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in report_definition_versions."

--- a/package-lock.json
+++ b/package-lock.json
@@ -42167,6 +42167,7 @@
         "formik": "^2.2.9",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
+        "react-ace": "^10.1.0",
         "react-autosuggest": "^10.1.0",
         "react-dom": "^18.2.0",
         "react-router": "^7.13.1",

--- a/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
+++ b/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
@@ -56,6 +56,7 @@ describe('reportRoutes', () => {
     },
     status: 'draft',
     notes: 'test',
+    advancedConfig: null,
     userId: user.id,
   });
 
@@ -96,7 +97,7 @@ describe('reportRoutes', () => {
       const res = await adminApp.get(`/api/admin/reports/${testReport.id}/versions`);
       expect(res).toHaveSucceeded();
       expect(res.body).toHaveLength(2);
-      expect(res.body.map((x) => x.id)).toEqual(expect.arrayContaining([v1.id, v2.id]));
+      expect(res.body.map(x => x.id)).toEqual(expect.arrayContaining([v1.id, v2.id]));
     });
     it('shouldnt return unnecessary metadata', async () => {
       const { ReportDefinitionVersion } = models;
@@ -115,7 +116,7 @@ describe('reportRoutes', () => {
         'active',
         'createdBy',
       ];
-      const additionalKeys = Object.keys(res.body[0]).filter((k) => !allowedKeys.includes(k));
+      const additionalKeys = Object.keys(res.body[0]).filter(k => !allowedKeys.includes(k));
       expect(additionalKeys).toHaveLength(0);
     });
   });
@@ -235,6 +236,7 @@ describe('reportRoutes', () => {
         dbSchema: 'raw',
         updatedAt: v1.updatedAt.toISOString(),
         deletedAt: null,
+        advancedConfig: null,
       });
     });
     it('should export a report as sql', async () => {

--- a/packages/central-server/__tests__/tasks/DHIS2IntegrationProcessor.test.js
+++ b/packages/central-server/__tests__/tasks/DHIS2IntegrationProcessor.test.js
@@ -66,7 +66,8 @@ describe('DHIS2 integration processor', () => {
           parameters: [],
           defaultDateRange: 'allTime',
         }),
-        query: 'SELECT id, email from users;',
+        query:
+          "SELECT '202401' AS period, 'OU_TEST' AS orgunit, '' AS attributeoptioncombo, 'DE_TEST' AS dataelement, '' AS categoryoptioncombo, '10' AS value, '' AS comment;",
         status: REPORT_STATUSES.PUBLISHED,
       }),
     );

--- a/packages/central-server/__tests__/tasks/DHIS2IntegrationProcessor.test.js
+++ b/packages/central-server/__tests__/tasks/DHIS2IntegrationProcessor.test.js
@@ -157,9 +157,12 @@ describe('DHIS2 integration processor', () => {
     it("should log.error if we can't establish a connection to DHIS2", async () => {
       await dhis2IntegrationProcessor.run();
 
-      expect(logSpy.error).toHaveBeenLastCalledWith(ERROR_LOGS.ERROR_PROCESSING_REPORT, {
+      expect(logSpy.error).toHaveBeenLastCalledWith(ERROR_LOGS.ERROR_POSTING_DATA_VALUE_SET, {
         reportId: report.id,
-        error: expect.any(Error),
+        period: expect.any(String),
+        orgUnit: expect.any(String),
+        dataValueCount: expect.any(Number),
+        error: expect.any(String),
       });
     });
 
@@ -197,8 +200,11 @@ describe('DHIS2 integration processor', () => {
       expect(pushLogs).toHaveLength(1);
 
       expect(logSpy.warn).toHaveBeenCalledWith(
-        WARNING_LOGS.FAILED_TO_SEND_REPORT,
-        pick(pushLogs[0], LOG_FIELDS),
+        WARNING_LOGS.DATA_VALUE_SET_REJECTED,
+        expect.objectContaining({
+          ...pick(pushLogs[0], LOG_FIELDS),
+          httpStatusCode: mockWarningResponse.httpStatusCode,
+        }),
       );
       expect(logSpy.warn).toHaveBeenCalledWith('Data element not found: DE123');
       expect(logSpy.warn).toHaveBeenCalledWith('Organisation unit not found: OU456');
@@ -218,7 +224,7 @@ describe('DHIS2 integration processor', () => {
         ...importCount,
       });
       expect(logSpy.info).toHaveBeenLastCalledWith(
-        INFO_LOGS.SUCCESSFULLY_SENT_REPORT,
+        INFO_LOGS.SUCCESSFULLY_SENT_DATA_VALUE_SET,
         pick(pushLogs[0], LOG_FIELDS),
       );
     });
@@ -253,7 +259,7 @@ describe('DHIS2 integration processor', () => {
       });
     });
 
-    it('should create a success log when report is successfully sent to DHIS2', async () => {
+    it('should create a success log when dataValueSet is successfully sent to DHIS2', async () => {
       dhis2IntegrationProcessor.postToDHIS2 = jest.fn().mockResolvedValue(mockSuccessResponse);
       await dhis2IntegrationProcessor.run();
 

--- a/packages/central-server/app/tasks/DHIS2IntegrationProcessor.js
+++ b/packages/central-server/app/tasks/DHIS2IntegrationProcessor.js
@@ -1,11 +1,12 @@
 import config from 'config';
-import { pick } from 'lodash';
+import { pick, groupBy } from 'lodash';
 import { fetch } from 'undici';
 import { utils } from 'xlsx';
 
 import { ScheduledTask } from '@tamanu/shared/tasks';
 import { log } from '@tamanu/shared/services/logging';
 import { REPORT_STATUSES } from '@tamanu/constants';
+import { getCurrentDateString } from '@tamanu/utils/dateTime';
 import { fetchWithRetryBackoff } from '@tamanu/api-client/fetchWithRetryBackoff';
 import {
   getConfigSecret,
@@ -13,12 +14,62 @@ import {
   SecretNotConfiguredError,
 } from '@tamanu/shared/utils/crypto';
 
-const arrayOfArraysToCSV = reportData => utils.sheet_to_csv(utils.aoa_to_sheet(reportData));
+// DHIS2 dataValueSet object format:
+// {
+//   "dataSet": "dataSetID",
+//   "completeDate": "date",
+//   "period": "period",
+//   "orgUnit": "orgUnitID",
+//   "attributeOptionCombo": "aocID",
+//   "dataValues": [
+//     {
+//       "dataElement": "dataElementID",
+//       "categoryOptionCombo": "cocID",
+//       "value": "1",
+//       "comment": "comment1"
+//     },
+//     ...
+//   ]
+// }
+const convertToDHIS2DataValueSets = (reportData, dataSet) => {
+  // Convert 2D array report data to JSON format
+  const reportJSON = utils.sheet_to_json(utils.aoa_to_sheet(reportData));
+
+  // Group rows by their composite key (period + orgunit + attributeoptioncombo)
+  const createGroupingKey = ({ period = '', orgunit = '', attributeoptioncombo = '' }) =>
+    `${period}|${orgunit}|${attributeoptioncombo}`;
+
+  const groupedRows = Object.values(groupBy(reportJSON, createGroupingKey));
+
+  // Transform each group of rows into a DHIS2 data value set object
+  return groupedRows.map(rows => {
+    // Extract common metadata from the first row (all rows in a group share these values)
+    const { period, orgunit: orgUnit, attributeoptioncombo: attributeOptionCombo } = rows[0];
+
+    // Map each row from the group to a data value object containing the actual data element values
+    const dataValues = rows.map(row => ({
+      dataElement: row.dataelement,
+      categoryOptionCombo: row.categoryoptioncombo,
+      value: row.value,
+      comment: row.comment,
+    }));
+
+    // Construct the DHIS2 data value set object
+    return {
+      ...(dataSet && { dataSet, completeDate: getCurrentDateString() }),
+      period,
+      orgUnit,
+      attributeOptionCombo,
+      dataValues,
+    };
+  });
+};
 
 export const INFO_LOGS = {
   SENDING_REPORTS: 'DHIS2IntegrationProcessor: Sending reports to DHIS2',
   PROCESSING_REPORT: 'DHIS2IntegrationProcessor: Processing report',
-  SUCCESSFULLY_SENT_REPORT: 'DHIS2IntegrationProcessor: Report sent to DHIS2 successfully',
+  SUCCESSFULLY_SENT_DATA_VALUE_SET:
+    'DHIS2IntegrationProcessor: dataValueSet sent to DHIS2 successfully',
 };
 
 export const WARNING_LOGS = {
@@ -27,10 +78,12 @@ export const WARNING_LOGS = {
   REPORT_DOES_NOT_EXIST: "DHIS2IntegrationProcessor: Report doesn't exist, skipping",
   REPORT_HAS_NO_PUBLISHED_VERSION:
     'DHIS2IntegrationProcessor: Report has no published version, skipping',
-  FAILED_TO_SEND_REPORT: 'DHIS2IntegrationProcessor: Failed to send report to DHIS2',
+  REPORT_DATA_EMPTY: 'DHIS2IntegrationProcessor: Report returned no data rows, skipping push',
+  DATA_VALUE_SET_REJECTED: 'DHIS2IntegrationProcessor: dataValueSet rejected by DHIS2',
 };
 
 export const ERROR_LOGS = {
+  ERROR_POSTING_DATA_VALUE_SET: 'DHIS2IntegrationProcessor: Error posting dataValueSet to DHIS2',
   ERROR_PROCESSING_REPORT: 'DHIS2IntegrationProcessor: Error processing report',
 };
 
@@ -122,7 +175,7 @@ export class DHIS2IntegrationProcessor extends ScheduledTask {
     return config.integrations?.dhis2?.password ?? null;
   }
 
-  async postToDHIS2({ reportId, reportCSV }) {
+  async postToDHIS2(dataValueSet) {
     const { idSchemes, host, backoff } = await this.context.settings.get('integrations.dhis2');
     const { username, password } = await this.getDHIS2Credentials();
     if (!username || !password) {
@@ -134,31 +187,23 @@ export class DHIS2IntegrationProcessor extends ScheduledTask {
     const authHeader = Buffer.from(`${username}:${password}`).toString('base64');
 
     const params = new URLSearchParams({ ...idSchemes, importStrategy: 'CREATE_AND_UPDATE' });
-    try {
-      const response = await fetchWithRetryBackoff(
-        `${host}/api/dataValueSets?${params.toString()}`,
-        {
-          fetch,
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/csv',
-            Accept: 'application/json',
-            Authorization: `Basic ${authHeader}`,
-          },
-          body: reportCSV,
-        },
-        { ...backoff, log },
-      );
 
-      return await response.json();
-    } catch (error) {
-      await this.logDHIS2Push({
-        reportId,
-        status: AUDIT_STATUSES.FAILURE,
-        message: error.message,
-      });
-      throw error;
-    }
+    const response = await fetchWithRetryBackoff(
+      `${host}/api/dataValueSets?${params.toString()}`,
+      {
+        fetch,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: `Basic ${authHeader}`,
+        },
+        body: JSON.stringify(dataValueSet),
+      },
+      { ...backoff, log },
+    );
+
+    return await response.json();
   }
 
   async processReport(reportId) {
@@ -196,35 +241,60 @@ export class DHIS2IntegrationProcessor extends ScheduledTask {
     log.info(INFO_LOGS.PROCESSING_REPORT, { report: reportString });
 
     const latestVersion = report.versions[0];
+    const advancedConfig = latestVersion.getAdvancedConfig();
+
     const reportData = await latestVersion.dataGenerator({ ...this.context, sequelize }, {}); // We don't support parameters in this task
-    const reportCSV = arrayOfArraysToCSV(reportData);
+    const dhis2DataValueSets = convertToDHIS2DataValueSets(reportData, advancedConfig.dhis2DataSet);
 
-    const {
-      message,
-      httpStatusCode,
-      response: { importCount, conflicts = [] },
-    } = await this.postToDHIS2({ reportId, reportCSV });
+    if (dhis2DataValueSets.length === 0) {
+      log.warn(WARNING_LOGS.REPORT_DATA_EMPTY, { report: reportString });
+      return;
+    }
 
-    if (httpStatusCode === 200) {
-      const successLog = await this.logDHIS2Push({
-        reportId,
-        status: AUDIT_STATUSES.SUCCESS,
-        message,
-        importCount,
-      });
+    for (const dataValueSet of dhis2DataValueSets) {
+      try {
+        const dhis2Response = await this.postToDHIS2(dataValueSet);
+        const {
+          message,
+          httpStatusCode,
+          response: { importCount, conflicts = [] } = {},
+        } = dhis2Response;
 
-      log.info(INFO_LOGS.SUCCESSFULLY_SENT_REPORT, successLog);
-    } else {
-      const warningLog = await this.logDHIS2Push({
-        reportId,
-        status: AUDIT_STATUSES.WARNING,
-        message,
-        importCount,
-        conflicts: conflicts.map(conflict => conflict.value),
-      });
+        if (httpStatusCode === 200) {
+          const successLog = await this.logDHIS2Push({
+            reportId,
+            status: AUDIT_STATUSES.SUCCESS,
+            message,
+            importCount,
+          });
 
-      log.warn(WARNING_LOGS.FAILED_TO_SEND_REPORT, warningLog);
-      conflicts.forEach(conflict => log.warn(conflict.value));
+          log.info(INFO_LOGS.SUCCESSFULLY_SENT_DATA_VALUE_SET, successLog);
+        } else {
+          const warningLog = await this.logDHIS2Push({
+            reportId,
+            status: AUDIT_STATUSES.WARNING,
+            message,
+            importCount,
+            conflicts: conflicts.map(conflict => conflict.value),
+          });
+
+          log.warn(WARNING_LOGS.DATA_VALUE_SET_REJECTED, { ...warningLog, httpStatusCode });
+          conflicts.forEach(conflict => log.warn(conflict.value));
+        }
+      } catch (error) {
+        await this.logDHIS2Push({
+          reportId,
+          status: AUDIT_STATUSES.FAILURE,
+          message: error.message,
+        });
+        log.error(ERROR_LOGS.ERROR_POSTING_DATA_VALUE_SET, {
+          reportId,
+          period: dataValueSet.period,
+          orgUnit: dataValueSet.orgUnit,
+          dataValueCount: dataValueSet.dataValues?.length,
+          error: error.message,
+        });
+      }
     }
   }
 
@@ -252,10 +322,7 @@ export class DHIS2IntegrationProcessor extends ScheduledTask {
       try {
         await this.processReport(reportId);
       } catch (error) {
-        log.error(ERROR_LOGS.ERROR_PROCESSING_REPORT, {
-          reportId,
-          error,
-        });
+        log.error(ERROR_LOGS.ERROR_PROCESSING_REPORT, { reportId, error: error.message });
       }
     }
   }

--- a/packages/central-server/app/tasks/DHIS2IntegrationProcessor.js
+++ b/packages/central-server/app/tasks/DHIS2IntegrationProcessor.js
@@ -1,7 +1,6 @@
 import config from 'config';
 import { pick, groupBy } from 'lodash';
 import { fetch } from 'undici';
-import { utils } from 'xlsx';
 
 import { ScheduledTask } from '@tamanu/shared/tasks';
 import { log } from '@tamanu/shared/services/logging';
@@ -14,26 +13,10 @@ import {
   SecretNotConfiguredError,
 } from '@tamanu/shared/utils/crypto';
 
-// DHIS2 dataValueSet object format:
-// {
-//   "dataSet": "dataSetID",
-//   "completeDate": "date",
-//   "period": "period",
-//   "orgUnit": "orgUnitID",
-//   "attributeOptionCombo": "aocID",
-//   "dataValues": [
-//     {
-//       "dataElement": "dataElementID",
-//       "categoryOptionCombo": "cocID",
-//       "value": "1",
-//       "comment": "comment1"
-//     },
-//     ...
-//   ]
-// }
+// https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-239/data.html#webapi_sending_bulks_data_values
 const convertToDHIS2DataValueSets = (reportData, dataSet) => {
-  // Convert 2D array report data to JSON format
-  const reportJSON = utils.sheet_to_json(utils.aoa_to_sheet(reportData));
+  const [headers, ...rows] = reportData;
+  const reportJSON = rows.map(row => Object.fromEntries(headers.map((h, i) => [h, row[i]])));
 
   // Group rows by their composite key (period + orgunit + attributeoptioncombo)
   const createGroupingKey = ({ period = '', orgunit = '', attributeoptioncombo = '' }) =>

--- a/packages/central-server/app/tasks/DHIS2IntegrationProcessor.js
+++ b/packages/central-server/app/tasks/DHIS2IntegrationProcessor.js
@@ -5,7 +5,8 @@ import { fetch } from 'undici';
 import { ScheduledTask } from '@tamanu/shared/tasks';
 import { log } from '@tamanu/shared/services/logging';
 import { REPORT_STATUSES } from '@tamanu/constants';
-import { getCurrentDateString } from '@tamanu/utils/dateTime';
+import { getCurrentDateStringInTimezone } from '@tamanu/utils/dateTime';
+import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
 import { fetchWithRetryBackoff } from '@tamanu/api-client/fetchWithRetryBackoff';
 import {
   getConfigSecret,
@@ -15,6 +16,7 @@ import {
 
 // https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-239/data.html#webapi_sending_bulks_data_values
 const convertToDHIS2DataValueSets = (reportData, dataSet) => {
+  if (!Array.isArray(reportData) || reportData.length === 0) return [];
   const [headers, ...rows] = reportData;
   const reportJSON = rows.map(row => Object.fromEntries(headers.map((h, i) => [h, row[i]])));
 
@@ -25,12 +27,10 @@ const convertToDHIS2DataValueSets = (reportData, dataSet) => {
   const groupedRows = Object.values(groupBy(reportJSON, createGroupingKey));
 
   // Transform each group of rows into a DHIS2 data value set object
-  return groupedRows.map(rows => {
-    // Extract common metadata from the first row (all rows in a group share these values)
-    const { period, orgunit: orgUnit, attributeoptioncombo: attributeOptionCombo } = rows[0];
+  return groupedRows.map(group => {
+    const { period, orgunit: orgUnit, attributeoptioncombo: attributeOptionCombo } = group[0];
 
-    // Map each row from the group to a data value object containing the actual data element values
-    const dataValues = rows.map(row => ({
+    const dataValues = group.map(row => ({
       dataElement: row.dataelement,
       categoryOptionCombo: row.categoryoptioncombo,
       value: row.value,
@@ -39,7 +39,7 @@ const convertToDHIS2DataValueSets = (reportData, dataSet) => {
 
     // Construct the DHIS2 data value set object
     return {
-      ...(dataSet && { dataSet, completeDate: getCurrentDateString() }),
+      ...(dataSet && { dataSet, completeDate: getCurrentDateStringInTimezone(getPrimaryTimeZone(config)) }),
       period,
       orgUnit,
       attributeOptionCombo,
@@ -237,11 +237,8 @@ export class DHIS2IntegrationProcessor extends ScheduledTask {
     for (const dataValueSet of dhis2DataValueSets) {
       try {
         const dhis2Response = await this.postToDHIS2(dataValueSet);
-        const {
-          message,
-          httpStatusCode,
-          response: { importCount, conflicts = [] } = {},
-        } = dhis2Response;
+        const { message, httpStatusCode, response } = dhis2Response;
+        const { importCount, conflicts = [] } = response ?? {};
 
         if (httpStatusCode === 200) {
           const successLog = await this.logDHIS2Push({

--- a/packages/database/src/migrations/1770200000000-addAdvancedConfigToReportDefinitionVersions.ts
+++ b/packages/database/src/migrations/1770200000000-addAdvancedConfigToReportDefinitionVersions.ts
@@ -1,0 +1,12 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('report_definition_versions', 'advanced_config', {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeColumn('report_definition_versions', 'advanced_config');
+}

--- a/packages/database/src/models/ReportDefinitionVersion.ts
+++ b/packages/database/src/models/ReportDefinitionVersion.ts
@@ -39,6 +39,7 @@ export class ReportDefinitionVersion extends Model {
   declare status: string;
   declare query: string;
   declare queryOptions: Record<string, any>;
+  declare advancedConfig: Record<string, any> | null;
   declare reportDefinitionId?: string;
   declare userId?: string;
 
@@ -81,7 +82,7 @@ export class ReportDefinitionVersion extends Model {
            *       "suggesterEndpoint": "nursingZone"
            *     }
            *   ],
-           *   "dataSources": [],
+           *   "dataSources": []
            * }
            */
           type: DataTypes.JSON,
@@ -89,6 +90,17 @@ export class ReportDefinitionVersion extends Model {
           validate: {
             matchesSchema: (value: Record<string, any>) => optionsValidator.validate(value),
           },
+        },
+        advancedConfig: {
+          /**
+           * Arbitrary metadata for the report version, not used as query parameters.
+           * e.g.
+           * {
+           *   "dhis2DataSet": "optional-data-set-id-for-dhis2-integration"
+           * }
+           */
+          type: DataTypes.JSONB,
+          allowNull: true,
         },
       },
       {
@@ -118,6 +130,10 @@ export class ReportDefinitionVersion extends Model {
     return typeof this.queryOptions === 'string'
       ? JSON.parse(this.queryOptions)
       : this.queryOptions;
+  }
+
+  getAdvancedConfig() {
+    return this.advancedConfig ?? {};
   }
 
   getParameters() {

--- a/packages/e2e-tests/fixtures/baseFixture.ts
+++ b/packages/e2e-tests/fixtures/baseFixture.ts
@@ -2,6 +2,7 @@ import { test as base, APIRequestContext, Page } from '@playwright/test';
 
 import { createPatient, createApiContext, createHospitalAdmissionEncounterViaAPI, createClinicEncounterViaApi, createTriageEncounterViaApi } from '../utils/apiHelpers';
 import {
+  AdminLoginPage,
   DashboardPage,
   LoginPage,
   SidebarPage,
@@ -30,6 +31,7 @@ type BaseFixtures = {
   newPatientWithHospitalAdmission: Awaited<ReturnType<typeof createPatient>>;
   newPatientWithClinicAdmission: Awaited<ReturnType<typeof createPatient>>;
   newPatientWithTriageAdmission: Awaited<ReturnType<typeof createPatient>>;
+  adminLoginPage: AdminLoginPage;
   dashboardPage: DashboardPage;
   loginPage: LoginPage;
   sidebarPage: SidebarPage;
@@ -95,6 +97,10 @@ export const test = base.extend<BaseFixtures>({
 
   dashboardPage: async ({ page }, use) => {
     await use(new DashboardPage(page));
+  },
+
+  adminLoginPage: async ({ page }, use) => {
+    await use(new AdminLoginPage(page));
   },
 
   loginPage: async ({ page }, use) => {

--- a/packages/e2e-tests/pages/AdminLoginPage.ts
+++ b/packages/e2e-tests/pages/AdminLoginPage.ts
@@ -1,0 +1,28 @@
+import { Locator, Page } from '@playwright/test';
+
+import { BasePage } from './BasePage';
+import { constructAdminUrl } from '../utils/navigation';
+
+export class AdminLoginPage extends BasePage {
+  readonly loginButton: Locator;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.loginButton = page.getByTestId('loginbutton-gx21');
+    this.emailInput = page.locator('input[name="email"]');
+    this.passwordInput = page.locator('input[name="password"]');
+  }
+
+  async goto() {
+    await this.page.goto(constructAdminUrl('/'));
+  }
+
+  async login(email: string, password: string) {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.loginButton.click();
+    await this.page.waitForURL(/\/admin\//, { timeout: 30000 });
+  }
+}

--- a/packages/e2e-tests/pages/index.ts
+++ b/packages/e2e-tests/pages/index.ts
@@ -1,3 +1,4 @@
+export { AdminLoginPage } from './AdminLoginPage';
 export { DashboardPage } from './DashboardPage';
 export { LoginPage } from './LoginPage';
 export { SidebarPage } from './SidebarPage';

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -39,15 +39,28 @@ module.exports = defineConfig({
   projects: [
     {
       name: 'setup',
-      testMatch: /setup\.ts/,
+      testMatch: '**/setup/auth.setup.ts',
       // Auth setup hits a cold Vite + app bundle on CI; default 30s is often too tight.
+      timeout: 120 * 1000,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'admin-setup',
+      testMatch: '**/setup/adminAuth.setup.ts',
       timeout: 120 * 1000,
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'], storageState: resolve(__dirname, '.auth/user.json') },
+      testIgnore: '**/admin/**',
       dependencies: ['setup'],
+    },
+    {
+      name: 'chromium-admin',
+      use: { ...devices['Desktop Chrome'], storageState: resolve(__dirname, '.auth/admin.json') },
+      testMatch: '**/admin/**',
+      dependencies: ['admin-setup'],
     },
 
     // {

--- a/packages/e2e-tests/tests/admin/report.spec.ts
+++ b/packages/e2e-tests/tests/admin/report.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../../fixtures/baseFixture';
+
+import { selectFieldOption } from '@utils/fieldHelpers';
+
+const ADMIN_URL = process.env.ADMIN_FRONTEND_URL ?? 'http://localhost:5174';
+
+// Admin panel auth is included in the shared storageState via auth.setup.ts.
+test.beforeEach(async ({ page }) => {
+  await page.goto(`${ADMIN_URL}/admin/reports`);
+});
+
+test.setTimeout(90000);
+
+test.describe('Admin panel report editor', () => {
+  test('Create a report with a parameter and advanced config', async ({ page }) => {
+    await page.getByTestId('tab-create').click();
+
+    // Required fields
+    await page.getByTestId('styledfield-pb9c-input').fill('Test DHIS2 Report');
+
+    // SQL query editor (Ace) — select-all then type
+    // react-ace only passes id/style to the DOM div (not data-testid), so use the id from name="sqlEditor"
+    const sqlTextarea = page.locator('#sqlEditor .ace_text-input');
+    await sqlTextarea.focus({ force: true });
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type('SELECT 1');
+
+    // Add one parameter
+    await page.getByTestId('textbutton-4yah').click();
+    await page.getByTestId('field-4eel-input').fill('facilityId');
+    await page.getByTestId('field-vuew-input').fill('Facility');
+    await selectFieldOption(page, page.getByTestId('field-jfys-select'), {
+      optionToSelect: 'FacilityField',
+    });
+
+    // Expand Advanced Config and enter a value
+    const advancedConfigSummary = page.getByTestId('accordionsummary-advanced-config');
+    await advancedConfigSummary.scrollIntoViewIfNeeded();
+    await advancedConfigSummary.click();
+    const jsonTextarea = page
+      .getByTestId('accordiondetails-advanced-config')
+      .locator('.ace_text-input');
+    await jsonTextarea.focus({ force: true });
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type('{"dhis2DataSet": "some-dataset-id"}');
+
+    // Submit
+    await page.getByTestId('button-dbqt').click();
+
+    // After creation the app navigates to the edit view for the new version
+    await expect(page).toHaveURL(/\/admin\/reports\/.+\/versions\/.+\/edit/, { timeout: 15000 });
+  });
+});

--- a/packages/e2e-tests/tests/admin/report.spec.ts
+++ b/packages/e2e-tests/tests/admin/report.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '../../fixtures/baseFixture';
 
 import { selectFieldOption } from '@utils/fieldHelpers';
+import { constructAdminUrl } from '@utils/navigation';
 
-const ADMIN_URL = process.env.ADMIN_FRONTEND_URL ?? 'http://localhost:5174';
-
-// Admin panel auth is included in the shared storageState via auth.setup.ts.
+// Admin panel auth is included in the shared storageState via adminAuth.setup.ts.
 test.beforeEach(async ({ page }) => {
-  await page.goto(`${ADMIN_URL}/admin/reports`);
+  await page.goto(constructAdminUrl('/admin/reports'));
 });
 
 test.setTimeout(90000);

--- a/packages/e2e-tests/tests/setup/adminAuth.setup.ts
+++ b/packages/e2e-tests/tests/setup/adminAuth.setup.ts
@@ -12,9 +12,6 @@ setup('authenticate admin', async ({ adminLoginPage }) => {
   await adminLoginPage.goto();
   await adminLoginPage.login(email, password);
 
-  // Ensure state is persisted
-  await adminLoginPage.page.waitForTimeout(1000);
-
   const authStatePath = path.join(__dirname, '../../.auth/admin.json');
   await adminLoginPage.page.context().storageState({ path: authStatePath });
 });

--- a/packages/e2e-tests/tests/setup/adminAuth.setup.ts
+++ b/packages/e2e-tests/tests/setup/adminAuth.setup.ts
@@ -1,0 +1,20 @@
+import { test as setup } from '../../fixtures/baseFixture';
+import path from 'path';
+
+setup('authenticate admin', async ({ adminLoginPage }) => {
+  const email = process.env.TEST_EMAIL;
+  const password = process.env.TEST_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error('TEST_EMAIL and TEST_PASSWORD environment variables must be set');
+  }
+
+  await adminLoginPage.goto();
+  await adminLoginPage.login(email, password);
+
+  // Ensure state is persisted
+  await adminLoginPage.page.waitForTimeout(1000);
+
+  const authStatePath = path.join(__dirname, '../../.auth/admin.json');
+  await adminLoginPage.page.context().storageState({ path: authStatePath });
+});

--- a/packages/e2e-tests/utils/navigation.ts
+++ b/packages/e2e-tests/utils/navigation.ts
@@ -15,3 +15,7 @@ export const goToAdminFrontend = async (page: Page) => {
 export const constructFacilityUrl = (url: string) => {
   return `${facilityFrontend}${url}`;
 };
+
+export const constructAdminUrl = (url: string) => {
+  return `${adminFrontend}${url}`;
+};

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -29,6 +29,7 @@
     "react": "^18.2.0",
     "react-autosuggest": "^10.1.0",
     "react-dom": "^18.2.0",
+    "react-ace": "^10.1.0",
     "react-router": "^7.13.1",
     "react-toastify": "^8.2.0",
     "styled-components": "^5.3.3",

--- a/packages/ui-components/src/components/JSONEditor.jsx
+++ b/packages/ui-components/src/components/JSONEditor.jsx
@@ -5,7 +5,7 @@ import 'ace-builds/src-noconflict/mode-json';
 import 'ace-builds/src-noconflict/theme-eclipse';
 import 'ace-builds/src-noconflict/theme-dawn';
 
-import { Colors } from '../../../../constants';
+import { TAMANU_COLORS } from '../constants';
 
 const THEMES = {
   VIEW: 'dawn',
@@ -13,12 +13,12 @@ const THEMES = {
 };
 
 const StyledJSONEditor = styled(AceEditor)`
-  border: 1px solid ${(p) => (p.$hasError ? Colors.alert : Colors.outline)};
+  border: 1px solid ${(p) => (p.$hasError ? TAMANU_COLORS.alert : TAMANU_COLORS.outline)};
   border-radius: 4px;
   z-index: 0;
   .error-marker {
     position: absolute;
-    background-color: ${Colors.alert};
+    background-color: ${TAMANU_COLORS.alert};
   }
 `;
 
@@ -75,7 +75,7 @@ export const JSONEditor = React.memo(
       editor.commands.addCommand({
         name: 'undo',
         bindKey: { win: 'Ctrl-Z', mac: 'Command-Z' },
-        exec: () => {}, // does nothing
+        exec: () => { }, // does nothing
       });
     };
 

--- a/packages/ui-components/src/components/index.js
+++ b/packages/ui-components/src/components/index.js
@@ -6,6 +6,7 @@ export * from './DateDisplay';
 export * from './Dialog';
 export * from './Field';
 export * from './Form';
+export * from './JSONEditor';
 export * from './Modal';
 export * from './PatientNameDisplay';
 export * from './Suggester';

--- a/packages/web/app/views/administration/reports/CreateReportView.jsx
+++ b/packages/web/app/views/administration/reports/CreateReportView.jsx
@@ -24,10 +24,20 @@ export const CreateReportView = () => {
   const queryClient = useQueryClient();
   const { ability } = useAuth();
 
-  const onSubmit = async ({ name, query, status, dbSchema, notes, ...queryOptions }) => {
-    const { dataSources } = queryOptions;
-    const isRawReport = dbSchema === REPORT_DB_CONNECTIONS.RAW;
+  const onSubmit = async ({
+    name,
+    query,
+    status,
+    dbSchema,
+    notes,
+    parameters,
+    dateRangeLabel,
+    defaultDateRange,
+    dataSources,
+    advancedConfig = {},
+  }) => {
     try {
+      const isRawReport = dbSchema === REPORT_DB_CONNECTIONS.RAW;
       const { reportDefinitionId, id } = await api.post('admin/reports', {
         name,
         query,
@@ -35,9 +45,12 @@ export const CreateReportView = () => {
         dbSchema,
         notes,
         queryOptions: {
-          ...queryOptions,
+          parameters,
+          dateRangeLabel,
+          defaultDateRange,
           dataSources: isRawReport ? dataSources : [REPORT_DATA_SOURCES.ALL_FACILITIES],
         },
+        advancedConfig,
       });
       queryClient.invalidateQueries(['reportList']);
       navigate(`/admin/reports/${reportDefinitionId}/versions/${id}/edit`);
@@ -72,6 +85,9 @@ export const CreateReportView = () => {
           defaultDateRange: REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
           dbSchema: canEditSchema ? REPORT_DB_CONNECTIONS.RAW : null,
           parameters: [],
+          advancedConfig: {
+            dhis2DataSet: '',
+          },
         }}
         onSubmit={onSubmit}
         data-testid="reporteditor-kh3x"

--- a/packages/web/app/views/administration/reports/CreateReportView.jsx
+++ b/packages/web/app/views/administration/reports/CreateReportView.jsx
@@ -85,9 +85,7 @@ export const CreateReportView = () => {
           defaultDateRange: REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
           dbSchema: canEditSchema ? REPORT_DB_CONNECTIONS.RAW : null,
           parameters: [],
-          advancedConfig: {
-            dhis2DataSet: '',
-          },
+          advancedConfig: null,
         }}
         onSubmit={onSubmit}
         data-testid="reporteditor-kh3x"

--- a/packages/web/app/views/administration/reports/EditReportView.jsx
+++ b/packages/web/app/views/administration/reports/EditReportView.jsx
@@ -25,17 +25,20 @@ const StyledButton = styled(OutlinedButton)`
 `;
 
 const getInitialValues = (version, report) => {
-  const { query, status, queryOptions, notes } = version;
-  const { dataSources, ...options } = queryOptions;
+  const { query, status, queryOptions, advancedConfig, notes } = version;
+  const { dataSources, parameters, dateRangeLabel, defaultDateRange } = queryOptions;
   const { name, dbSchema } = report;
   return {
     name,
     query,
     status,
     dbSchema,
-    ...options,
+    parameters,
+    dateRangeLabel,
+    defaultDateRange,
     dataSources,
     notes,
+    advancedConfig: advancedConfig && Object.keys(advancedConfig).length > 0 ? advancedConfig : null,
   };
 };
 
@@ -57,20 +60,33 @@ export const EditReportView = () => {
     navigate('/admin/reports');
   };
 
-  const handleSave = async ({ query, status, dbSchema, notes, ...queryOptions }) => {
-    const { dataSources } = queryOptions;
-    const { reportDefinition } = version;
+  const handleSave = async ({
+    query,
+    status,
+    dbSchema,
+    notes,
+    parameters,
+    dateRangeLabel,
+    defaultDateRange,
+    dataSources,
+    advancedConfig = {},
+  }) => {
     const payload = {
       queryOptions: {
-        ...queryOptions,
+        parameters,
+        dateRangeLabel,
+        defaultDateRange,
         dataSources,
       },
+      advancedConfig,
       query,
       status,
       dbSchema,
       notes,
     };
+
     try {
+      const { reportDefinition } = version;
       const result = await api.post(`admin/reports/${reportDefinition.id}/versions`, payload);
       toast.success(
         <TranslatedText
@@ -118,6 +134,7 @@ export const EditReportView = () => {
             <VersionInfo version={version} data-testid="versioninfo-1dbs" />
           </Box>
           <ReportEditor
+            key={params.versionId}
             isEdit
             onSubmit={handleSave}
             initialValues={getInitialValues(version, version.reportDefinition)}

--- a/packages/web/app/views/administration/reports/ReportEditor.jsx
+++ b/packages/web/app/views/administration/reports/ReportEditor.jsx
@@ -68,8 +68,9 @@ const StyledAccordionSummary = styled(AccordionSummary)`
 
 const AdvancedConfigField = ({ field, form }) => {
   const { name, value } = field;
-  const { setFieldValue, setFieldError, errors } = form;
+  const { setFieldValue, errors, touched } = form;
   const [jsonString, setJsonString] = useState(value ? JSON.stringify(value, null, 2) : '');
+  const [jsonError, setJsonError] = useState(null);
   // Prevents the sync effect from reformatting the string after our own setFieldValue calls.
   const skipNextSync = useRef(false);
 
@@ -83,24 +84,28 @@ const AdvancedConfigField = ({ field, form }) => {
 
   const handleChange = (newValue) => {
     setJsonString(newValue);
+    // Always set — we call setFieldValue in every branch below.
+    skipNextSync.current = true;
 
     if (!newValue || newValue.trim() === '') {
-      skipNextSync.current = true;
       setFieldValue(name, null);
-      setFieldError(name, null);
+      setJsonError(null);
       return;
     }
 
     try {
       const parsed = JSON.parse(newValue);
-      skipNextSync.current = true;
       setFieldValue(name, parsed);
-      setFieldError(name, null);
+      setJsonError(null);
     } catch (err) {
-      // Don't update Formik value; set a field error to block submission.
-      setFieldError(name, err.message);
+      // Store the raw string so yup's .object() check fails and blocks submission.
+      setFieldValue(name, newValue);
+      setJsonError(err);
     }
   };
+
+  const fieldError = touched[name] && errors[name];
+  const displayError = jsonError || (fieldError ? new Error(fieldError) : null);
 
   return (
     <JSONEditorWrapper>
@@ -108,7 +113,7 @@ const AdvancedConfigField = ({ field, form }) => {
         value={jsonString}
         onChange={handleChange}
         editMode={true}
-        error={errors[name] ? new Error(errors[name]) : null}
+        error={displayError}
         placeholder="{}"
         height="200px"
         fontSize={14}

--- a/packages/web/app/views/administration/reports/ReportEditor.jsx
+++ b/packages/web/app/views/administration/reports/ReportEditor.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import * as yup from 'yup';
@@ -10,6 +10,7 @@ import {
   Form,
   ButtonRow,
   Button,
+  JSONEditor,
 } from '@tamanu/ui-components';
 import {
   REPORT_DATA_SOURCE_VALUES,
@@ -32,6 +33,7 @@ import { useAuth } from '../../../contexts/Auth';
 import { useApi } from '../../../api';
 import { TranslatedText } from '../../../components/Translation/TranslatedText';
 import { useTranslation } from '../../../contexts/Translation';
+import { Colors } from '../../../constants';
 
 const StyledField = styled(Field)`
   flex-grow: 1;
@@ -40,6 +42,71 @@ const StyledField = styled(Field)`
 const StatusField = styled(Field)`
   width: 130px;
 `;
+
+const JSONEditorWrapper = styled.div`
+  margin-top: 8px;
+  margin-bottom: 8px;
+`;
+
+const StyledAccordion = styled(Accordion)`
+  margin-top: 20px;
+  border-radius: 5px;
+  overflow: hidden;
+  box-shadow: none;
+  border: 1px solid ${Colors.outline};
+`;
+
+const StyledAccordionSummary = styled(AccordionSummary)`
+  .MuiAccordionSummary-content {
+    color: ${Colors.darkText};
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 16px;
+    letter-spacing: 0;
+  }
+`;
+
+const AdvancedConfigField = ({ field, form }) => {
+  const { name, value } = field;
+  const { setFieldValue, errors, touched } = form;
+  const [jsonString, setJsonString] = useState(value ? JSON.stringify(value, null, 2) : '');
+  const [jsonError, setJsonError] = useState(null);
+
+  const handleChange = (newValue) => {
+    setJsonString(newValue);
+    setJsonError(null);
+
+    if (!newValue || newValue.trim() === '') {
+      setFieldValue(name, null);
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(newValue);
+      setFieldValue(name, parsed);
+    } catch (err) {
+      // Invalid JSON — keep the string in the editor but don't update Formik
+      setJsonError(err);
+    }
+  };
+
+  const fieldError = touched[name] && errors[name];
+  const displayError = jsonError || (fieldError ? new Error(fieldError) : null);
+
+  return (
+    <JSONEditorWrapper>
+      <JSONEditor
+        value={jsonString}
+        onChange={handleChange}
+        editMode={true}
+        error={displayError}
+        placeholder="{}"
+        height="200px"
+        fontSize={14}
+      />
+    </JSONEditorWrapper>
+  );
+};
 
 const generateDefaultParameter = () => ({
   id: Math.random(),
@@ -146,8 +213,8 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit, setF
           />
         </Grid>
       </Grid>
-      <Accordion defaultExpanded data-testid="accordion-5sik">
-        <AccordionSummary data-testid="accordionsummary-peqh">
+      <StyledAccordion defaultExpanded data-testid="accordion-5sik">
+        <StyledAccordionSummary data-testid="accordionsummary-peqh">
           <Grid container spacing={1} data-testid="grid-t6ch">
             <Grid item xs={8} data-testid="grid-a375">
               <TranslatedText
@@ -164,7 +231,7 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit, setF
               />
             </Grid>
           </Grid>
-        </AccordionSummary>
+        </StyledAccordionSummary>
         <AccordionDetails data-testid="accordiondetails-uvr4">
           <Grid container spacing={2} data-testid="grid-z7ao">
             <Grid item xs={8} data-testid="grid-52vl">
@@ -194,7 +261,27 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit, setF
             </Grid>
           </Grid>
         </AccordionDetails>
-      </Accordion>
+      </StyledAccordion>
+      <StyledAccordion data-testid="accordion-advanced-config">
+        <StyledAccordionSummary data-testid="accordionsummary-advanced-config">
+          <TranslatedText
+            stringId="admin.report.advancedConfig.label"
+            fallback="Advanced Config"
+            data-testid="translatedtext-advanced-config"
+          />
+        </StyledAccordionSummary>
+        <AccordionDetails data-testid="accordiondetails-advanced-config">
+          <Grid container spacing={2} data-testid="grid-advanced-config">
+            <Grid item xs={12} data-testid="grid-advanced-config-field">
+              <Field
+                name="advancedConfig"
+                component={AdvancedConfigField}
+                data-testid="field-advanced-config"
+              />
+            </Grid>
+          </Grid>
+        </AccordionDetails>
+      </StyledAccordion>
       <ButtonRow data-testid="buttonrow-on12">
         <StatusField
           name="status"
@@ -350,6 +437,16 @@ export const ReportEditor = ({ initialValues, onSubmit, isEdit }) => {
               stringId="general.status.label"
               fallback="Status"
               data-testid="translatedtext-gj6l"
+            />,
+          ),
+        advancedConfig: yup
+          .object()
+          .nullable()
+          .translatedLabel(
+            <TranslatedText
+              stringId="admin.report.validation.rule.invalidJson"
+              fallback="Invalid JSON format"
+              data-testid="translatedtext-invalid-json"
             />,
           ),
       })}

--- a/packages/web/app/views/administration/reports/ReportEditor.jsx
+++ b/packages/web/app/views/administration/reports/ReportEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import * as yup from 'yup';
@@ -68,30 +68,39 @@ const StyledAccordionSummary = styled(AccordionSummary)`
 
 const AdvancedConfigField = ({ field, form }) => {
   const { name, value } = field;
-  const { setFieldValue, errors, touched } = form;
+  const { setFieldValue, setFieldError, errors } = form;
   const [jsonString, setJsonString] = useState(value ? JSON.stringify(value, null, 2) : '');
-  const [jsonError, setJsonError] = useState(null);
+  // Prevents the sync effect from reformatting the string after our own setFieldValue calls.
+  const skipNextSync = useRef(false);
+
+  useEffect(() => {
+    if (skipNextSync.current) {
+      skipNextSync.current = false;
+      return;
+    }
+    setJsonString(value ? JSON.stringify(value, null, 2) : '');
+  }, [value]);
 
   const handleChange = (newValue) => {
     setJsonString(newValue);
-    setJsonError(null);
 
     if (!newValue || newValue.trim() === '') {
+      skipNextSync.current = true;
       setFieldValue(name, null);
+      setFieldError(name, null);
       return;
     }
 
     try {
       const parsed = JSON.parse(newValue);
+      skipNextSync.current = true;
       setFieldValue(name, parsed);
+      setFieldError(name, null);
     } catch (err) {
-      // Invalid JSON — keep the string in the editor but don't update Formik
-      setJsonError(err);
+      // Don't update Formik value; set a field error to block submission.
+      setFieldError(name, err.message);
     }
   };
-
-  const fieldError = touched[name] && errors[name];
-  const displayError = jsonError || (fieldError ? new Error(fieldError) : null);
 
   return (
     <JSONEditorWrapper>
@@ -99,7 +108,7 @@ const AdvancedConfigField = ({ field, form }) => {
         value={jsonString}
         onChange={handleChange}
         editMode={true}
-        error={displayError}
+        error={errors[name] ? new Error(errors[name]) : null}
         placeholder="{}"
         height="200px"
         fontSize={14}

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -3,10 +3,9 @@ import styled from 'styled-components';
 import Settings from '@mui/icons-material/Settings';
 
 import { SETTINGS_SCOPES } from '@tamanu/constants';
-import { TextButton, ButtonRow, Button } from '@tamanu/ui-components';
+import { TextButton, ButtonRow, Button, JSONEditor } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
 
-import { JSONEditor } from './components/JSONEditor';
 import { DefaultSettingsModal } from './components/DefaultSettingsModal';
 import { notifyError } from '../../../utils';
 import { TranslatedText } from '../../../components/Translation';

--- a/packages/web/app/views/administration/settings/components/DefaultSettingsModal.jsx
+++ b/packages/web/app/views/administration/settings/components/DefaultSettingsModal.jsx
@@ -5,7 +5,7 @@ import { SETTINGS_SCOPES } from '@tamanu/constants';
 import { centralDefaults, globalDefaults, facilityDefaults } from '@tamanu/settings';
 
 import { Modal } from '../../../../components/Modal';
-import { JSONEditor } from './JSONEditor';
+import { JSONEditor } from '@tamanu/ui-components';
 
 const SCOPE_DEFAULT_SETTINGS = {
   [SETTINGS_SCOPES.CENTRAL]: centralDefaults,

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -18,7 +18,7 @@ import {
   TranslatedText,
 } from '../../../../components';
 import { Colors } from '../../../../constants/styles';
-import { JSONEditor } from './JSONEditor';
+import { JSONEditor } from '@tamanu/ui-components';
 import { MarkdownEditorModal } from './MarkdownEditorModal';
 import { ConditionalTooltip } from '../../../../components/Tooltip';
 import { MultiAutocompleteInput } from '../../../../components/Field/MultiAutocompleteField';


### PR DESCRIPTION
### Changes

Marks DHIS2 data sets as complete after they are pushed. Also moves the JSONEditor component into ui-components to make it reusable, and adds a new advanced config column to report definition versions to support per-report DHIS2 configuration. Includes unit tests and a Playwright E2E test for the report editor.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DHIS2 integration payload/format and error handling, plus adds a new persisted JSONB config field used by that integration; regressions could break scheduled DHIS2 pushes or report version CRUD if mismatched across layers.
> 
> **Overview**
> **DHIS2 pushes now send JSON `dataValueSets` (grouped by `period`/`orgUnit`/`attributeOptionCombo`) and optionally include `dataSet` + `completeDate`** (derived from server timezone) so posted data sets can be marked complete. The processor adds clearer logging/alerting for empty report results, per-dataValueSet failures, and DHIS2 rejection responses.
> 
> **Report versions gain a new nullable `advanced_config` JSONB field** (migration + model + docs) to store non-query metadata like `dhis2DataSet`; the admin report editor UI now supports editing/validating this JSON and includes it in create/save payloads.
> 
> **JSON editing is centralized and reused** by moving `JSONEditor` into `@tamanu/ui-components` (adding `react-ace` peer dep) and updating admin settings to import it from there. E2E coverage is extended with separate admin auth setup/project and a Playwright test that creates a report including advanced config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53f7f43f224bb1409a9bf61a926df1f0189630c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->