### PR TITLE
fix(migrations): no-issue: 2.51 hotfix: rebuild procedures sync lookup

### DIFF
--- a/packages/database/src/migrations/1778725000000-RebuildLookupTableForProceduresAfterAssistantClinicianMigration.ts
+++ b/packages/database/src/migrations/1778725000000-RebuildLookupTableForProceduresAfterAssistantClinicianMigration.ts
@@ -1,0 +1,9 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    SELECT flag_lookup_model_to_rebuild('procedures');
+  `);
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
### Changes

Adds a database migration to rebuild `procedures` entries in `sync_lookup` after procedure assistant clinicians were moved out of the `procedures.assistant_id` column. This regenerates stale lookup payloads that can still contain `assistantId: null`, which causes facility sync pulls to fail when saving `procedures` rows after the column has been removed.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)