### PR TITLE
fix(web): no-issue: 2.51 hotfix: prevent encounter summary PDF render failures

### DIFF
--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -277,18 +277,15 @@ const NoteFooter = ({ note }) => {
     </Text>
   );
 };
-const NotesMultipageCellPadding = () => {
-  let firstPageOccurrence = Number.MAX_SAFE_INTEGER;
+const NoteTypeHeading = ({ note }) => {
+  const { getTranslation } = useLanguageContext();
   return (
-    <View
-      fixed
-      render={({ pageNumber, subPageNumber }) => {
-        if (pageNumber < firstPageOccurrence && subPageNumber) {
-          firstPageOccurrence = pageNumber;
-        }
-        return pageNumber !== firstPageOccurrence && <View style={{ paddingBottom: 7 }} />;
-      }}
-    />
+    <Text bold style={textStyles.tableColumnHeader}>
+      {getTranslation(
+        getReferenceDataStringId(note.noteTypeId, REFERENCE_TYPES.NOTE_TYPE),
+        note.noteTypeReference?.name || note.noteTypeId,
+      )}
+    </Text>
   );
 };
 
@@ -301,43 +298,18 @@ const NotesSection = ({ notes }) => {
         <MultipageTableHeading title={getTranslation('general.notes.label', 'Notes')} />
         <Table>
           {notes.map(note => (
-            <>
+            <React.Fragment key={note.id}>
               <View minPresenceAhead={80} />
-              <View style={tableStyles.notesRow} key={note.id}>
-                <View
-                  style={{
-                    borderTop: borderStyle,
-                    position: 'absolute',
-                    top: -1,
-                    right: 0,
-                    left: 0,
-                  }}
-                  fixed
-                />
+              <View style={tableStyles.notesRow}>
                 <NotesCell>
-                  <NotesMultipageCellPadding />
-                  <MultipageTableHeading
-                    title={getTranslation(
-                      getReferenceDataStringId(note.noteTypeId, REFERENCE_TYPES.NOTE_TYPE),
-                      note.noteTypeReference?.name || note.noteTypeId,
-                    )}
-                    style={textStyles.tableColumnHeader}
-                  />
-                  <Text style={textStyles.tableCellContent}>{`${note.content}\n`}</Text>
+                  <NoteTypeHeading note={note} />
+                  <View style={{ width: '100%', marginBottom: 10 }}>
+                    <Text style={textStyles.tableCellContent}>{note.content}</Text>
+                  </View>
                   <NoteFooter note={note} />
-                  <View
-                    style={{
-                      borderBottom: borderStyle,
-                      position: 'absolute',
-                      bottom: -1,
-                      right: -1,
-                      left: -1,
-                    }}
-                    fixed
-                  />
                 </NotesCell>
               </View>
-            </>
+            </React.Fragment>
           ))}
         </Table>
       </View>

--- a/packages/shared/src/utils/patientCertificates/printComponents/EncounterDetailsExtended.jsx
+++ b/packages/shared/src/utils/patientCertificates/printComponents/EncounterDetailsExtended.jsx
@@ -23,7 +23,7 @@ export const EncounterDetailsExtended = ({ encounter, discharge }) => {
       <Col>
         <DataItem
           label={getTranslation('general.localisedField.facility.label', 'Facility')}
-          value={location.facility.name}
+          value={location?.facility?.name}
           key="facility"
         />
         <DataItem
@@ -32,7 +32,7 @@ export const EncounterDetailsExtended = ({ encounter, discharge }) => {
               clinician: clinicianText,
             },
           })}
-          value={examiner.displayName}
+          value={examiner?.displayName}
           key="supervisingClinician"
         />
         <DataItem
@@ -58,7 +58,7 @@ export const EncounterDetailsExtended = ({ encounter, discharge }) => {
       <Col>
         <DataItem
           label={getTranslation('general.department.label', 'Department')}
-          value={department.name}
+          value={department?.name}
           key="department"
         />
         <DataItem

--- a/packages/web/app/utils/useRenderPDF.js
+++ b/packages/web/app/utils/useRenderPDF.js
@@ -1,9 +1,20 @@
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { wrap } from 'comlink';
+import { releaseProxy, wrap } from 'comlink';
 import Worker from '../workers/pdf.worker?worker';
 
-export const pdfWorker = wrap(new Worker());
+const renderPDFInWorker = async props => {
+  const worker = new Worker();
+  const pdfWorker = wrap(worker);
+
+  try {
+    const pdf = await pdfWorker.renderPDFInWorker(props);
+    return URL.createObjectURL(pdf);
+  } finally {
+    pdfWorker[releaseProxy]?.();
+    worker.terminate();
+  }
+};
 
 export const useRenderPDF = (props) => {
   const {
@@ -12,7 +23,7 @@ export const useRenderPDF = (props) => {
     error,
   } = useQuery(
     ['renderPDF', props.id, ...(props.queryDeps || [])],
-    () => pdfWorker.renderPDFInWorker(props),
+    () => renderPDFInWorker(props),
     {
       enabled: !!props.id,
     },

--- a/packages/web/app/utils/useRenderPDF.js
+++ b/packages/web/app/utils/useRenderPDF.js
@@ -29,6 +29,13 @@ export const useRenderPDF = (props) => {
     },
   );
 
-  useEffect(() => (url ? () => URL.revokeObjectURL(url) : undefined), [url]);
+  useEffect(() => {
+    if (!url) {
+      return undefined;
+    }
+
+    return () => URL.revokeObjectURL(url);
+  }, [url]);
+
   return { url, isFetching, error };
 };

--- a/packages/web/app/workers/pdf.worker.js
+++ b/packages/web/app/workers/pdf.worker.js
@@ -3,8 +3,7 @@ import './workerShim';
 
 const renderPDFInWorker = async (props) => {
   const { renderPDF } = await import('../renderPDF');
-  const pdf = await renderPDF(props);
-  return URL.createObjectURL(pdf);
+  return renderPDF(props);
 };
 
 expose({ renderPDFInWorker });


### PR DESCRIPTION
### Changes

Fixes encounter summary PDFs failing with large note volumes and prevents one bad PDF render from breaking later PDF renders in the same browser session. Each PDF render now uses an isolated worker, encounter note rendering avoids per-note fixed react-pdf elements, and missing historical encounter facility/clinician/department data is tolerated.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)