### PR TITLE
fix(auth): no-issue: 2.52 hotfix: keep central login access controls on fallback

### DIFF
--- a/packages/facility-server/__tests__/apiv1/User.test.js
+++ b/packages/facility-server/__tests__/apiv1/User.test.js
@@ -19,14 +19,14 @@ const createUser = overrides => ({
 });
 
 const enableCentralLoginForTest = () => {
-  const previous = process.env.IS_PLAYWRIGHT_TEST;
-  process.env.IS_PLAYWRIGHT_TEST = 'true';
+  const previous = process.env.ENABLE_CENTRAL_LOGIN_IN_TEST;
+  process.env.ENABLE_CENTRAL_LOGIN_IN_TEST = 'true';
 
   return () => {
     if (previous === undefined) {
-      delete process.env.IS_PLAYWRIGHT_TEST;
+      delete process.env.ENABLE_CENTRAL_LOGIN_IN_TEST;
     } else {
-      process.env.IS_PLAYWRIGHT_TEST = previous;
+      process.env.ENABLE_CENTRAL_LOGIN_IN_TEST = previous;
     }
   };
 };
@@ -264,6 +264,31 @@ describe('User', () => {
         expect(result.body.central).toBe(false);
         expect(result.body).toHaveProperty('token');
       });
+
+      it.each([[ERROR_TYPE.FORBIDDEN], [ERROR_TYPE.RATE_LIMITED]])(
+        'should not fall back to local login when central login fails with %s',
+        async errorType => {
+          centralServer.login.mockClear();
+          centralServer.login.mockRejectedValueOnce(
+            new Problem(errorType, 'Central login unavailable', 400, 'Central login unavailable'),
+          );
+
+          const restoreCentralLoginShortcut = enableCentralLoginForTest();
+          let result;
+          try {
+            result = await baseApp.post('/api/login').send({
+              email: authUser.email,
+              password: rawPassword,
+              deviceId: 'test-device-id',
+            });
+          } finally {
+            restoreCentralLoginShortcut();
+          }
+
+          expect(centralServer.login).toHaveBeenCalledTimes(1);
+          expect(result).toHaveRequestError();
+        },
+      );
 
       it('should include permissions in the data returned by a successful login', async () => {
         const result = await baseApp.post('/api/login').send({

--- a/packages/facility-server/app/middleware/auth.js
+++ b/packages/facility-server/app/middleware/auth.js
@@ -22,20 +22,35 @@ const { tokenDuration, secret } = config.auth;
 
 const jwtSecretKey = secret ?? crypto.randomBytes(32).toString('hex');
 
-const CENTRAL_LOGIN_LOCAL_FALLBACK_ERROR_TYPES = new Set([
+const CENTRAL_LOGIN_INCOMPATIBLE_ERROR_TYPES = new Set([
   ERROR_TYPE.CLIENT_INCOMPATIBLE,
   ERROR_TYPE.REMOTE_INCOMPATIBLE,
 ]);
 
+const CENTRAL_LOGIN_NON_FALLBACK_ERROR_TYPES = new Set([
+  ERROR_TYPE.FORBIDDEN,
+  ERROR_TYPE.RATE_LIMITED,
+]);
+
 function shouldThrowCentralLoginError(error) {
-  return error.type?.startsWith(ERROR_TYPE.AUTH);
+  return (
+    error.type?.startsWith(ERROR_TYPE.AUTH) || CENTRAL_LOGIN_NON_FALLBACK_ERROR_TYPES.has(error.type)
+  );
 }
 
 function getCentralLoginFallbackReason(error) {
-  if (CENTRAL_LOGIN_LOCAL_FALLBACK_ERROR_TYPES.has(error.type)) {
+  if (CENTRAL_LOGIN_INCOMPATIBLE_ERROR_TYPES.has(error.type)) {
     return 'central server is incompatible';
   }
   return 'central server login failed';
+}
+
+function shouldSkipCentralLoginForTest() {
+  return (
+    process.env.NODE_ENV === 'test' &&
+    !process.env.IS_PLAYWRIGHT_TEST &&
+    !process.env.ENABLE_CENTRAL_LOGIN_IN_TEST
+  );
 }
 
 export async function buildToken({
@@ -169,7 +184,7 @@ async function centralServerLoginWithLocalFallback({
   facilityDeviceId,
 }) {
   // always log in locally when testing
-  if (process.env.NODE_ENV === 'test' && !process.env.IS_PLAYWRIGHT_TEST) {
+  if (shouldSkipCentralLoginForTest()) {
     return await localLogin({ models, settings, email, password, deviceId });
   }
 


### PR DESCRIPTION
### Changes

Follows up the 2.52 local-login fallback hotfix by preserving central FORBIDDEN and RATE_LIMITED responses as non-fallback errors, so central access controls cannot be bypassed by successful local authentication. Also clarifies the incompatible-version fallback naming and uses a dedicated Jest override for exercising central login in unit tests.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

Ran `npx eslint packages/facility-server/app/middleware/auth.js packages/facility-server/__tests__/apiv1/User.test.js`.

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)