### PR TITLE
fix(web): no-issue: 2.50 hotfix: wait for PDF worker readiness

### DIFF
--- a/packages/web/app/utils/useRenderPDF.js
+++ b/packages/web/app/utils/useRenderPDF.js
@@ -3,11 +3,43 @@ import { useQuery } from '@tanstack/react-query';
 import { releaseProxy, wrap } from 'comlink';
 import Worker from '../workers/pdf.worker?worker';
 
+const waitForWorkerReady = worker =>
+  new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error('PDF worker did not become ready after 10s'));
+    }, 10000);
+
+    const handleMessage = event => {
+      if (event.data?.type !== 'pdf-render-ready') {
+        return;
+      }
+      cleanup();
+      resolve();
+    };
+
+    const handleError = error => {
+      cleanup();
+      reject(error);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      worker.removeEventListener('message', handleMessage);
+      worker.removeEventListener('error', handleError);
+    };
+
+    worker.addEventListener('message', handleMessage);
+    worker.addEventListener('error', handleError);
+  });
+
 const renderPDFInWorker = async props => {
   const worker = new Worker();
+  const workerReady = waitForWorkerReady(worker);
   const pdfWorker = wrap(worker);
 
   try {
+    await workerReady;
     const pdf = await pdfWorker.renderPDFInWorker(props);
     return URL.createObjectURL(pdf);
   } finally {

--- a/packages/web/app/utils/useRenderPDF.js
+++ b/packages/web/app/utils/useRenderPDF.js
@@ -5,6 +5,11 @@ import Worker from '../workers/pdf.worker?worker';
 
 const waitForWorkerReady = worker =>
   new Promise((resolve, reject) => {
+    const handleTimeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('PDF worker did not signal readiness within 5 minutes'));
+    }, 5 * 60 * 1000);
+
     const handleMessage = event => {
       if (event.data?.type !== 'pdf-render-ready') {
         return;
@@ -19,6 +24,7 @@ const waitForWorkerReady = worker =>
     };
 
     const cleanup = () => {
+      clearTimeout(handleTimeout);
       worker.removeEventListener('message', handleMessage);
       worker.removeEventListener('error', handleError);
     };

--- a/packages/web/app/utils/useRenderPDF.js
+++ b/packages/web/app/utils/useRenderPDF.js
@@ -5,11 +5,6 @@ import Worker from '../workers/pdf.worker?worker';
 
 const waitForWorkerReady = worker =>
   new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      cleanup();
-      reject(new Error('PDF worker did not become ready after 10s'));
-    }, 10000);
-
     const handleMessage = event => {
       if (event.data?.type !== 'pdf-render-ready') {
         return;
@@ -24,7 +19,6 @@ const waitForWorkerReady = worker =>
     };
 
     const cleanup = () => {
-      clearTimeout(timeoutId);
       worker.removeEventListener('message', handleMessage);
       worker.removeEventListener('error', handleError);
     };

--- a/packages/web/app/workers/pdf.worker.js
+++ b/packages/web/app/workers/pdf.worker.js
@@ -7,3 +7,4 @@ const renderPDFInWorker = async (props) => {
 };
 
 expose({ renderPDFInWorker });
+self.postMessage({ type: 'pdf-render-ready' });

--- a/packages/web/app/workers/pdf.worker.js
+++ b/packages/web/app/workers/pdf.worker.js
@@ -7,4 +7,6 @@ const renderPDFInWorker = async (props) => {
 };
 
 expose({ renderPDFInWorker });
-self.postMessage({ type: 'pdf-render-ready' });
+Promise.resolve().then(() => {
+  self.postMessage({ type: 'pdf-render-ready' });
+});


### PR DESCRIPTION
### Changes

Adds an explicit ready handshake before the main thread sends the Comlink render request to a newly-created PDF worker. This prevents the first render call from racing worker startup, which caused encounter summary PDFs to hang even after the worker module had loaded.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->