### PR TITLE
fix: Persist filters on logout

### DIFF
--- a/packages/constants/src/userPreferences.ts
+++ b/packages/constants/src/userPreferences.ts
@@ -9,4 +9,6 @@ export const USER_PREFERENCES_KEYS = {
   OUTPATIENT_APPOINTMENT_FILTERS: 'outpatientAppointmentFilters',
   OUTPATIENT_APPOINTMENT_GROUP_BY: 'outpatientAppointmentGroupBy',
   LOCATION_ASSIGNMENT_SELECTED_FACILITY: 'locationAssignmentSelectedFacility',
+  LAB_REQUEST_SEARCH_PARAMETERS: 'labRequestSearchParameters',
+  IMAGING_REQUEST_SEARCH_PARAMETERS: 'imagingRequestSearchParameters',
 };

--- a/packages/web/app/contexts/ImagingRequests.jsx
+++ b/packages/web/app/contexts/ImagingRequests.jsx
@@ -1,5 +1,10 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { debounce } from 'lodash';
+import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { IMAGING_TABLE_VERSIONS } from '@tamanu/constants/imaging';
+import { useUserPreferencesQuery } from '../api/queries';
+import { useUserPreferencesMutation } from '../api/mutations';
+import { useAuth } from './Auth';
 
 const ImagingRequestsContext = createContext({});
 
@@ -35,6 +40,34 @@ export const ImagingRequestsProvider = ({ children }) => {
     [IMAGING_REQUEST_SEARCH_KEYS.ACTIVE]: {},
     [IMAGING_REQUEST_SEARCH_KEYS.COMPLETED]: {},
   });
+  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
+
+  const { facilityId } = useAuth();
+  const { data: userPreferences, isLoading: prefsLoading } = useUserPreferencesQuery();
+  const { mutate } = useUserPreferencesMutation(facilityId);
+
+  useEffect(() => {
+    if (prefsLoading || hasLoadedPreferences) return;
+    setHasLoadedPreferences(true);
+    if (userPreferences?.imagingRequestSearchParameters) {
+      setSearchParameters(prev => ({ ...prev, ...userPreferences.imagingRequestSearchParameters }));
+    }
+  }, [prefsLoading, hasLoadedPreferences, userPreferences]);
+
+  const debouncedSave = useMemo(
+    () =>
+      debounce(
+        params =>
+          mutate({ key: USER_PREFERENCES_KEYS.IMAGING_REQUEST_SEARCH_PARAMETERS, value: params }),
+        300,
+      ),
+    [mutate],
+  );
+
+  useEffect(() => {
+    if (!hasLoadedPreferences) return;
+    debouncedSave(searchParameters);
+  }, [searchParameters, hasLoadedPreferences, debouncedSave]);
 
   return (
     <ImagingRequestsContext.Provider

--- a/packages/web/app/contexts/LabRequest.jsx
+++ b/packages/web/app/contexts/LabRequest.jsx
@@ -1,7 +1,11 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
-import { LAB_REQUEST_STATUSES } from '@tamanu/constants';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { debounce } from 'lodash';
+import { LAB_REQUEST_STATUSES, USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { useDateTimeIfAvailable } from '@tamanu/ui-components';
 import { useApi } from '../api';
+import { useUserPreferencesQuery } from '../api/queries';
+import { useUserPreferencesMutation } from '../api/mutations';
+import { useAuth } from './Auth';
 
 const LabRequestContext = createContext({
   labRequest: {},
@@ -44,8 +48,34 @@ export const LabRequestProvider = ({ children }) => {
     [LabRequestSearchParamKeys.Published]: {},
     [LabRequestSearchParamKeys.Other]: {},
   });
+  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
 
   const api = useApi();
+  const { facilityId } = useAuth();
+  const { data: userPreferences, isLoading: prefsLoading } = useUserPreferencesQuery();
+  const { mutate } = useUserPreferencesMutation(facilityId);
+
+  useEffect(() => {
+    if (prefsLoading || hasLoadedPreferences) return;
+    setHasLoadedPreferences(true);
+    if (userPreferences?.labRequestSearchParameters) {
+      setSearchParameters(prev => ({ ...prev, ...userPreferences.labRequestSearchParameters }));
+    }
+  }, [prefsLoading, hasLoadedPreferences, userPreferences]);
+
+  const debouncedSave = useMemo(
+    () =>
+      debounce(
+        params => mutate({ key: USER_PREFERENCES_KEYS.LAB_REQUEST_SEARCH_PARAMETERS, value: params }),
+        300,
+      ),
+    [mutate],
+  );
+
+  useEffect(() => {
+    if (!hasLoadedPreferences) return;
+    debouncedSave(searchParameters);
+  }, [searchParameters, hasLoadedPreferences, debouncedSave]);
 
   const loadLabRequest = useCallback(
     async (labRequestId) => {

--- a/packages/web/app/contexts/OutpatientAppointments.jsx
+++ b/packages/web/app/contexts/OutpatientAppointments.jsx
@@ -1,7 +1,11 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { debounce, omit } from 'lodash';
 import { useLocation } from 'react-router';
 
+import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { useUserPreferencesQuery } from '../api/queries';
+import { useUserPreferencesMutation } from '../api/mutations';
+import { useAuth } from './Auth';
 import { APPOINTMENT_GROUP_BY } from '../views/scheduling/outpatientBookings/OutpatientAppointmentsView';
 
 const OutpatientAppointmentsContext = createContext(null);
@@ -14,25 +18,91 @@ export const OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE = {
 };
 
 export const OutpatientAppointmentsContextProvider = ({ children }) => {
-  const { data: userPreferences } = useUserPreferencesQuery();
+  const { data: userPreferences, isLoading } = useUserPreferencesQuery();
+  const { facilityId } = useAuth();
+  const { mutate } = useUserPreferencesMutation(facilityId);
   const location = useLocation();
   const defaultGroupBy =
     new URLSearchParams(location.search).get('groupBy') || APPOINTMENT_GROUP_BY.LOCATION_GROUP;
-  const [filters, setFilters] = useState(OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE);
-  const [groupBy, setGroupBy] = useState(null);
 
+  const [locationGroupFilters, setLocationGroupFilters] = useState(
+    OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE,
+  );
+  const [clinicianFilters, setClinicianFilters] = useState(
+    OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE,
+  );
+  const [groupBy, setGroupBy] = useState(null);
+  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
+
+  // Load saved preferences exactly once after the query completes
   useEffect(() => {
-    if (userPreferences && !groupBy) {
-      if (userPreferences?.outpatientAppointmentGroupBy) {
-        setGroupBy(userPreferences.outpatientAppointmentGroupBy);
+    if (isLoading || hasLoadedPreferences) return;
+    setHasLoadedPreferences(true);
+
+    setGroupBy(userPreferences?.outpatientAppointmentGroupBy ?? defaultGroupBy);
+
+    const saved = userPreferences?.outpatientAppointmentFilters;
+    if (saved) {
+      const isNewFormat =
+        APPOINTMENT_GROUP_BY.LOCATION_GROUP in saved || APPOINTMENT_GROUP_BY.CLINICIAN in saved;
+      if (isNewFormat) {
+        if (saved[APPOINTMENT_GROUP_BY.LOCATION_GROUP]) {
+          setLocationGroupFilters(prev => ({
+            ...prev,
+            ...saved[APPOINTMENT_GROUP_BY.LOCATION_GROUP],
+          }));
+        }
+        if (saved[APPOINTMENT_GROUP_BY.CLINICIAN]) {
+          setClinicianFilters(prev => ({ ...prev, ...saved[APPOINTMENT_GROUP_BY.CLINICIAN] }));
+        }
       } else {
-        setGroupBy(defaultGroupBy);
-      }
-      if (userPreferences?.outpatientAppointmentFilters) {
-        setFilters(userPreferences.outpatientAppointmentFilters);
+        // Legacy flat format — treat as locationGroup filters
+        setLocationGroupFilters(prev => ({ ...prev, ...saved }));
       }
     }
-  }, [userPreferences, setGroupBy, defaultGroupBy, groupBy]);
+  }, [isLoading, hasLoadedPreferences, userPreferences, defaultGroupBy]);
+
+  // Persist both filter sets whenever either changes (debounced, skips during init)
+  const debouncedSaveFilters = useMemo(
+    () =>
+      debounce(
+        (lgFilters, cFilters) =>
+          mutate({
+            key: USER_PREFERENCES_KEYS.OUTPATIENT_APPOINTMENT_FILTERS,
+            value: {
+              [APPOINTMENT_GROUP_BY.LOCATION_GROUP]: omit(lgFilters, ['patientNameOrId']),
+              [APPOINTMENT_GROUP_BY.CLINICIAN]: omit(cFilters, ['patientNameOrId']),
+            },
+          }),
+        300,
+      ),
+    [mutate],
+  );
+
+  useEffect(() => {
+    if (!hasLoadedPreferences) return;
+    debouncedSaveFilters(locationGroupFilters, clinicianFilters);
+  }, [locationGroupFilters, clinicianFilters, hasLoadedPreferences, debouncedSaveFilters]);
+
+  // Persist groupBy whenever it changes (skips during init)
+  useEffect(() => {
+    if (!hasLoadedPreferences || !groupBy) return;
+    mutate({ key: USER_PREFERENCES_KEYS.OUTPATIENT_APPOINTMENT_GROUP_BY, value: groupBy });
+  }, [groupBy, hasLoadedPreferences, mutate]);
+
+  // Derive the active filters and setter for the current group
+  const filters =
+    groupBy === APPOINTMENT_GROUP_BY.CLINICIAN ? clinicianFilters : locationGroupFilters;
+  const setFilters = useCallback(
+    newFilters => {
+      if (groupBy === APPOINTMENT_GROUP_BY.CLINICIAN) {
+        setClinicianFilters(newFilters);
+      } else {
+        setLocationGroupFilters(newFilters);
+      }
+    },
+    [groupBy],
+  );
 
   return (
     <OutpatientAppointmentsContext.Provider value={{ filters, setFilters, groupBy, setGroupBy }}>

--- a/packages/web/app/views/scheduling/outpatientBookings/GroupAppointmentToggle.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/GroupAppointmentToggle.jsx
@@ -7,10 +7,6 @@ import { Colors } from '../../../constants';
 import { APPOINTMENT_GROUP_BY } from './OutpatientAppointmentsView';
 import { TranslatedText } from '../../../components';
 import { useOutpatientAppointmentsContext } from '../../../contexts/OutpatientAppointments';
-import { useUserPreferencesMutation } from '../../../api/mutations';
-import { useAuth } from '../../../contexts/Auth';
-import { debounce } from 'lodash';
-import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 
 const Wrapper = styled(Box)`
   cursor: pointer;
@@ -58,20 +54,8 @@ AnimatedBackground.defaultProps = { 'aria-hidden': true };
 
 export const GroupByAppointmentToggle = props => {
   const { groupBy, setGroupBy } = useOutpatientAppointmentsContext();
-  const { facilityId } = useAuth();
-
-  const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
-
-  const updateGroupByUserPreferences = debounce(
-    newGroupBy =>
-      mutateUserPreferences({
-        key: USER_PREFERENCES_KEYS.OUTPATIENT_APPOINTMENT_GROUP_BY,
-        value: newGroupBy,
-      }),
-    200,
-  );
-
   const navigate = useNavigate();
+
   const handleChange = () => {
     const newValue =
       groupBy === APPOINTMENT_GROUP_BY.LOCATION_GROUP
@@ -79,7 +63,6 @@ export const GroupByAppointmentToggle = props => {
         : APPOINTMENT_GROUP_BY.LOCATION_GROUP;
     setGroupBy(newValue);
     navigate(`?groupBy=${newValue}`);
-    updateGroupByUserPreferences(newValue);
   };
 
   if (!groupBy) return null;

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsFilter.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsFilter.jsx
@@ -1,12 +1,9 @@
 import { useFormikContext } from 'formik';
-import { debounce, omit } from 'lodash';
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
-import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { Form, TextButton, TranslatedText } from '@tamanu/ui-components';
 
-import { useUserPreferencesMutation } from '../../../api/mutations';
 import { Field, SearchField } from '../../../components';
 import { FilterField } from '../../../components/Field/FilterField';
 import {
@@ -14,7 +11,6 @@ import {
   useOutpatientAppointmentsContext,
 } from '../../../contexts/OutpatientAppointments';
 import { useTranslation } from '../../../contexts/Translation';
-import { useAuth } from '../../../contexts/Auth';
 import { APPOINTMENT_GROUP_BY } from './OutpatientAppointmentsView';
 
 const Fieldset = styled.fieldset`
@@ -47,24 +43,8 @@ const FormListener = () => {
 
 const FormFields = () => {
   const { getTranslation } = useTranslation();
-  const { filters, setFilters, groupBy } = useOutpatientAppointmentsContext();
-  const { facilityId } = useAuth();
-  const { setValues, setFieldValue } = useFormikContext();
-
-  const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
-  const updateFilterUserPreferences = debounce(
-    (values) =>
-      mutateUserPreferences({
-        key: USER_PREFERENCES_KEYS.OUTPATIENT_APPOINTMENT_FILTERS,
-        value: omit(values, ['patientNameOrId']),
-      }),
-    200,
-  );
-
-  useEffect(() => {
-    if (groupBy === APPOINTMENT_GROUP_BY.LOCATION_GROUP) setFieldValue('clinicianId', undefined);
-    if (groupBy === APPOINTMENT_GROUP_BY.CLINICIAN) setFieldValue('locationGroupId', undefined);
-  }, [groupBy, setFieldValue]);
+  const { groupBy, setFilters } = useOutpatientAppointmentsContext();
+  const { setValues } = useFormikContext();
 
   return (
     <Fieldset data-testid="fieldset-gbat">
@@ -83,9 +63,6 @@ const FormFields = () => {
           endpoint="facilityLocationGroup"
           label={getTranslation('general.area.label', 'Area')}
           name="locationGroupId"
-          onChange={(e) =>
-            updateFilterUserPreferences({ ...filters, locationGroupId: e.target.value })
-          }
           data-testid="field-fqlx"
         />
       )}
@@ -95,7 +72,6 @@ const FormFields = () => {
           endpoint="practitioner"
           label={getTranslation('general.localisedField.clinician.label.short', 'Clinician')}
           name="clinicianId"
-          onChange={(e) => updateFilterUserPreferences({ ...filters, clinicianId: e.target.value })}
           data-testid="field-0uvt"
         />
       )}
@@ -104,16 +80,12 @@ const FormFields = () => {
         endpoint="appointmentType"
         label={getTranslation('general.type.label', 'Type')}
         name="appointmentTypeId"
-        onChange={(e) =>
-          updateFilterUserPreferences({ ...filters, appointmentTypeId: e.target.value })
-        }
         data-testid="field-0jh8"
       />
       <ResetButton
         onClick={() => {
           setValues(OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE);
           setFilters(OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE);
-          updateFilterUserPreferences(OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE);
         }}
         type="reset"
         data-testid="resetbutton-aw9o"


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how several scheduling and request-listing views load and persist user preferences, including a new stored format for outpatient appointment filters with legacy fallback. Risk is moderate because incorrect preference hydration/saving could lead to unexpected default filters or extra preference writes.
> 
> **Overview**
> Adds new user preference keys to persist *lab* and *imaging* request table search parameters, and updates the `LabRequestProvider`/`ImagingRequestsProvider` to hydrate from user preferences once and **debounced-save** subsequent changes.
> 
> Refactors outpatient appointment preferences so filters are stored **per `groupBy` mode** (area vs clinician) with legacy flat-format support, and moves all saving logic into `OutpatientAppointmentsContextProvider` (debounced filter saves + immediate `groupBy` saves), removing direct preference mutations from `GroupAppointmentToggle` and `OutpatientAppointmentsFilter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b7ed172fae79ff0934ea733d5f7b6f72df807e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->