### PR TITLE
perf(appointments): no-issue: 2.54 hotfix: gate AppointmentDetailPopper additionalData fetch on open

### DIFF
--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailPopper.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailPopper.jsx
@@ -54,9 +54,10 @@ export const AppointmentDetailPopper = ({
   const dispatch = useDispatch();
   const patientId = appointment.patient.id;
 
-  const { data: additionalData } = usePatientAdditionalDataQuery(appointment.patient.id, {
-    enabled: open && Boolean(appointment.patient.id),
-  });
+  const { data: additionalData, isLoading: isLoadingAdditionalData } =
+    usePatientAdditionalDataQuery(appointment.patient.id, {
+      enabled: open && Boolean(appointment.patient.id),
+    });
   const navigate = useNavigate();
 
   const handlePatientDetailsClick = useCallback(async () => {
@@ -120,6 +121,7 @@ export const AppointmentDetailPopper = ({
           <StyledPaper elevation={0} data-testid="styledpaper-mvu3">
             <PatientDetailsDisplay
               additionalData={additionalData}
+              isLoadingAdditionalData={isLoadingAdditionalData}
               onClick={handlePatientDetailsClick}
               patient={appointment.patient}
               data-testid="patientdetailsdisplay-hxfv"

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailPopper.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailPopper.jsx
@@ -55,7 +55,7 @@ export const AppointmentDetailPopper = ({
   const patientId = appointment.patient.id;
 
   const { data: additionalData } = usePatientAdditionalDataQuery(appointment.patient.id, {
-    enabled: open,
+    enabled: open && Boolean(appointment.patient.id),
   });
   const navigate = useNavigate();
 

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailPopper.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailPopper.jsx
@@ -54,7 +54,9 @@ export const AppointmentDetailPopper = ({
   const dispatch = useDispatch();
   const patientId = appointment.patient.id;
 
-  const { data: additionalData } = usePatientAdditionalDataQuery(appointment.patient.id);
+  const { data: additionalData } = usePatientAdditionalDataQuery(appointment.patient.id, {
+    enabled: open,
+  });
   const navigate = useNavigate();
 
   const handlePatientDetailsClick = useCallback(async () => {

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/PatientDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/PatientDetailsDisplay.jsx
@@ -1,3 +1,4 @@
+import Skeleton from '@mui/material/Skeleton';
 import { styled } from '@mui/material/styles';
 import React from 'react';
 
@@ -50,7 +51,18 @@ const PatientId = styled('p')`
   margin-block: 0.25rem 0;
 `;
 
-export const PatientDetailsDisplay = ({ patient, onClick, additionalData }) => {
+const ContactSkeleton = styled(Skeleton).attrs({ variant: 'text' })`
+  display: inline-block;
+  width: 6rem;
+  vertical-align: middle;
+`;
+
+export const PatientDetailsDisplay = ({
+  patient,
+  onClick,
+  additionalData,
+  isLoadingAdditionalData = false,
+}) => {
   const { displayId, sex, dateOfBirth } = patient;
   return (
     <Header onClick={onClick} tabIndex={0} data-testid="header-p2x8">
@@ -87,7 +99,13 @@ export const PatientDetailsDisplay = ({ patient, onClick, additionalData }) => {
             data-testid="translatedtext-9cmr"
           />
         }
-        value={additionalData?.primaryContactNumber}
+        value={
+          isLoadingAdditionalData ? (
+            <ContactSkeleton data-testid="contactskeleton-yceg" />
+          ) : (
+            additionalData?.primaryContactNumber
+          )
+        }
         data-testid="inlinedetailsdisplay-yceg"
       />
       <PatientId data-testid="patientid-xol3">{displayId}</PatientId>

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/PatientDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/PatientDetailsDisplay.jsx
@@ -51,7 +51,7 @@ const PatientId = styled('p')`
   margin-block: 0.25rem 0;
 `;
 
-const ContactSkeleton = styled(Skeleton).attrs({ variant: 'text' })`
+const ContactSkeleton = styled(Skeleton)`
   display: inline-block;
   width: 6rem;
   vertical-align: middle;


### PR DESCRIPTION
### Changes

`AppointmentDetailPopper` calls `usePatientAdditionalDataQuery(patient.id)` in its component body, so every appointment tile rendered on the outpatient calendar, location bookings calendar, and clinician dashboard "Today's appointments" pane fires a per-patient `/api/patient/{id}/additionalData` request on mount — an N+1 burst proportional to the number of tiles. We've been seeing this hit Nauru hard (~25–50 parallel `additionalData` calls per calendar load, each 1.5–2s server-side).

Gate the query with `{ enabled: open }` so it only fires when the popper is actually opened. MUI `<Popper>` already unmounts its children (e.g. `CheckInButton`) when closed by default, so this single change covers all callers of `AppointmentTile`.

No behaviour change when opening the popper — `additionalData` is fetched on first open, then served from React Query cache.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->