### PR TITLE
fix(appointments): no-issue: 2.52 hotfix: only send appointment email when checkbox ticked

### DIFF
--- a/packages/web/app/components/Appointments/EmailSection.jsx
+++ b/packages/web/app/components/Appointments/EmailSection.jsx
@@ -8,13 +8,20 @@ import { CheckField } from '../Field';
 
 export const EmailSection = ({ label }) => {
   const { setFieldValue, values } = useFormikContext();
-  const { data: patient } = usePatientDataQuery(values.patientId);
+  const { patientId, shouldEmailAppointment } = values;
+  const { data: patient } = usePatientDataQuery(patientId);
 
   // Keep form state up to date with relevant selected patient email
   useEffect(() => {
+    if (!shouldEmailAppointment) {
+      setFieldValue('email', '');
+      setFieldValue('confirmEmail', '');
+      return;
+    }
+
     setFieldValue('email', patient?.email ?? '');
     setFieldValue('confirmEmail', '');
-  }, [patient?.email, setFieldValue]);
+  }, [patient?.email, setFieldValue, shouldEmailAppointment]);
 
   const handleResetEmailFields = e => {
     if (e.target.checked) return;

--- a/packages/web/app/components/Appointments/EmailSection.jsx
+++ b/packages/web/app/components/Appointments/EmailSection.jsx
@@ -11,7 +11,6 @@ export const EmailSection = ({ label }) => {
   const { patientId, shouldEmailAppointment } = values;
   const { data: patient } = usePatientDataQuery(patientId);
 
-  // Keep form state up to date with relevant selected patient email
   useEffect(() => {
     if (!shouldEmailAppointment) {
       setFieldValue('email', '');
@@ -23,19 +22,12 @@ export const EmailSection = ({ label }) => {
     setFieldValue('confirmEmail', '');
   }, [patient?.email, setFieldValue, shouldEmailAppointment]);
 
-  const handleResetEmailFields = e => {
-    if (e.target.checked) return;
-    setFieldValue('email', '');
-    setFieldValue('confirmEmail', '');
-  };
-
   return (
     <>
       <Field
         name="shouldEmailAppointment"
         label={label}
         component={CheckField}
-        onChange={handleResetEmailFields}
         data-testid="field-160d"
       />
       {values.shouldEmailAppointment && (

--- a/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
@@ -298,6 +298,7 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
       additionalClinicianId,
       procedureTypeIds,
       linkEncounterId,
+      shouldEmailAppointment,
       email,
     },
     { resetForm },
@@ -314,7 +315,7 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
         additionalClinicianId,
         procedureTypeIds,
         linkEncounterId,
-        email,
+        ...(shouldEmailAppointment ? { email } : {}),
       },
       {
         onSuccess: () => {

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
@@ -506,8 +506,8 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {},
   });
 
   const handleSubmitForm = async (values, { resetForm }) => {
-    const { shouldEmailAppointment, email, ...appointmentValues } = values;
-    delete appointmentValues.confirmEmail;
+    const { shouldEmailAppointment, email } = values;
+    const appointmentValues = omit(values, ['shouldEmailAppointment', 'email', 'confirmEmail']);
     await handleSubmit({
       ...appointmentValues,
       ...(shouldEmailAppointment ? { email } : {}),

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
@@ -506,7 +506,13 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {},
   });
 
   const handleSubmitForm = async (values, { resetForm }) => {
-    await handleSubmit({ ...values, modifyMode });
+    const { shouldEmailAppointment, email, ...appointmentValues } = values;
+    delete appointmentValues.confirmEmail;
+    await handleSubmit({
+      ...appointmentValues,
+      ...(shouldEmailAppointment ? { email } : {}),
+      modifyMode,
+    });
     resetForm();
   };
 


### PR DESCRIPTION
### Changes

When creating an outpatient appointment or location booking, the patient was sent an appointment confirmation email even if the user did not tick the "Email appointment" checkbox.

The cause was twofold:

- `EmailSection` populated `values.email` from the selected patient's stored email via a `useEffect`, regardless of the checkbox state.
- The drawer submit handlers in both outpatient and location booking forms forwarded `email` straight through to the API. The backend's `POST /appointments` route gates email sending on `if (email)` only — it does not consult `shouldEmailAppointment` — so any patient with an email on file received a confirmation on every booking.

This PR fixes the frontend so:

- `EmailSection` only copies the patient's email into the form when `shouldEmailAppointment` is `true`; when unchecked, the email/confirmEmail fields are cleared.
- `OutpatientAppointmentDrawer` and `LocationBookingDrawer` only include `email` in the payload when `shouldEmailAppointment` is `true`. `confirmEmail` is also stripped from the outpatient payload.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
