### PR TITLE
perf(appointments): no-issue: speed up appointments list count query

### DIFF
--- a/packages/database/src/migrations/1779246485252-addAppointmentsTimeRangeIndex.ts
+++ b/packages/database/src/migrations/1779246485252-addAppointmentsTimeRangeIndex.ts
@@ -1,0 +1,15 @@
+import { QueryInterface } from 'sequelize';
+
+const INDEX_NAME = 'idx_appointments_location_group_start_time';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE INDEX ${INDEX_NAME}
+    ON appointments (location_group_id, ((start_time::timestamp)))
+    WHERE deleted_at IS NULL AND status <> 'Cancelled';
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`DROP INDEX IF EXISTS ${INDEX_NAME};`);
+}

--- a/packages/database/src/migrations/1779246485252-addAppointmentsTimeRangeIndex.ts
+++ b/packages/database/src/migrations/1779246485252-addAppointmentsTimeRangeIndex.ts
@@ -5,7 +5,7 @@ const INDEX_NAME = 'idx_appointments_location_group_start_time';
 export async function up(query: QueryInterface): Promise<void> {
   await query.sequelize.query(`
     CREATE INDEX ${INDEX_NAME}
-    ON appointments (location_group_id, ((start_time::timestamp)))
+    ON appointments (location_group_id, start_time)
     WHERE deleted_at IS NULL AND status <> 'Cancelled';
   `);
 }

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -449,21 +449,48 @@ appointments.get(
       return _filters;
     }, []);
 
-    const { rows, count } = await Appointment.findAndCountAll({
+    // The COUNT subquery only needs the joins that are actually referenced by the WHERE
+    // clauses — pulling the full list of reference associations doubles planning time
+    // for what's a hot path on the appointments dashboard.
+    const needsLocation = facilityIdField === '$location.facility_id$' || Boolean(bookableWhereClause);
+    const needsPatient =
+      Boolean(patientNameOrId) ||
+      Object.keys(queries).some(k => k.startsWith('patient.'));
+    const includeForCount = ['locationGroup', 'schedule'];
+    if (needsLocation) {
+      includeForCount.push(
+        bookableWhereClause
+          ? { association: 'location', include: ['locationGroup'] }
+          : 'location',
+      );
+    }
+    if (needsPatient) {
+      includeForCount.push('patient');
+    }
+
+    const whereClause = {
+      [Op.and]: [
+        facilityIdWhereClause,
+        timeQueryWhereClause,
+        cancelledStatusWhereClause,
+        isBeforeScheduleUntilDateWhereClause,
+        buildPatientNameOrIdQuery(patientNameOrId),
+        bookableWhereClause,
+        ...filters,
+      ],
+    };
+
+    const count = await Appointment.count({
+      where: whereClause,
+      include: includeForCount,
+      bind: timeQueryBindParams,
+    });
+
+    const rows = await Appointment.findAll({
       limit: all ? undefined : rowsPerPage,
       offset: all ? undefined : page * rowsPerPage,
       order: [[sortKeys[orderBy] || orderBy, order]],
-      where: {
-        [Op.and]: [
-          facilityIdWhereClause,
-          timeQueryWhereClause,
-          cancelledStatusWhereClause,
-          isBeforeScheduleUntilDateWhereClause,
-          buildPatientNameOrIdQuery(patientNameOrId),
-          bookableWhereClause,
-          ...filters,
-        ],
-      },
+      where: whereClause,
       include: Appointment.getListReferenceAssociations(),
       bind: timeQueryBindParams,
     });

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -101,8 +101,11 @@ appointments.put(
  * @see https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-INPUT
  */
 const buildTimeQuery = (intervalStart, intervalEnd) => {
+  // Equivalent to `(start_time, end_time) OVERLAPS ($start, $end)` for non-degenerate intervals,
+  // but written as plain inequalities so the partial index on (location_group_id, start_time)
+  // can be used.
   const whereClause = literal(
-    '("Appointment"."start_time"::TIMESTAMP, "Appointment"."end_time"::TIMESTAMP) OVERLAPS ($apptTimeQueryStart, $apptTimeQueryEnd)',
+    '"Appointment"."start_time"::TIMESTAMP < $apptTimeQueryEnd AND "Appointment"."end_time"::TIMESTAMP > $apptTimeQueryStart',
   );
   const bindParams = {
     apptTimeQueryStart: `'${intervalStart}'`,

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -105,7 +105,7 @@ const buildTimeQuery = (intervalStart, intervalEnd) => {
   // but written as plain inequalities so the partial index on (location_group_id, start_time)
   // can be used.
   const whereClause = literal(
-    '"Appointment"."start_time"::TIMESTAMP < $apptTimeQueryEnd AND "Appointment"."end_time"::TIMESTAMP > $apptTimeQueryStart',
+    '"Appointment"."start_time" < $apptTimeQueryEnd AND "Appointment"."end_time" > $apptTimeQueryStart',
   );
   const bindParams = {
     apptTimeQueryStart: `'${intervalStart}'`,

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -18,7 +18,10 @@ import { replaceInTemplate } from '@tamanu/utils/replaceInTemplate';
 import { datetimeCustomValidation } from '@tamanu/utils/dateTime';
 import config from 'config';
 import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
-import { getCurrentPrimaryTimeZoneDateTimeString } from '@tamanu/shared/utils/primaryDateTime';
+import {
+  getCurrentPrimaryTimeZoneDateString,
+  getCurrentPrimaryTimeZoneDateTimeString,
+} from '@tamanu/shared/utils/primaryDateTime';
 
 import { escapePatternWildcard } from '../../utils/query';
 
@@ -96,20 +99,23 @@ appointments.put(
 );
 
 /**
- * @param {string} intervalStart Some valid PostgreSQL Date/Time input.
- * @param {string} intervalEnd Some valid PostgreSQL Date/Time input.
- * @see https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-INPUT
+ * Equivalent to `(start_time, end_time) OVERLAPS ($start, $end)`, including OVERLAPS' point
+ * semantics when `end_time IS NULL`. Written as plain string inequalities so the partial index
+ * on `(location_group_id, start_time)` can be used.
+ *
+ * @param {string} intervalStart ISO 9075 datetime string (`yyyy-MM-dd HH:mm:ss`).
+ * @param {string} intervalEnd ISO 9075 datetime string.
  */
 const buildTimeQuery = (intervalStart, intervalEnd) => {
-  // Equivalent to `(start_time, end_time) OVERLAPS ($start, $end)` for non-degenerate intervals,
-  // but written as plain inequalities so the partial index on (location_group_id, start_time)
-  // can be used.
   const whereClause = literal(
-    '"Appointment"."start_time" < $apptTimeQueryEnd AND "Appointment"."end_time" > $apptTimeQueryStart',
+    `"Appointment"."start_time" < $apptTimeQueryEnd AND (
+       ("Appointment"."end_time" IS NULL AND "Appointment"."start_time" >= $apptTimeQueryStart)
+       OR "Appointment"."end_time" > $apptTimeQueryStart
+     )`,
   );
   const bindParams = {
-    apptTimeQueryStart: `'${intervalStart}'`,
-    apptTimeQueryEnd: `'${intervalEnd}'`,
+    apptTimeQueryStart: intervalStart,
+    apptTimeQueryEnd: intervalEnd,
   };
 
   return [whereClause, bindParams];
@@ -375,12 +381,8 @@ appointments.get(
     const {
       models: { Appointment },
       query: {
-        /**
-         * Midnight today
-         * @see https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-SPECIAL-VALUES
-         */
-        after = 'today',
-        before = 'infinity',
+        after,
+        before,
         facilityId,
         rowsPerPage = 10,
         page = 0,
@@ -394,7 +396,11 @@ appointments.get(
       },
     } = req;
 
-    const [timeQueryWhereClause, timeQueryBindParams] = buildTimeQuery(after, before);
+    // Defaults are midnight today (start) and a sentinel far-future timestamp (end). Plain
+    // ISO 9075 strings are required so the varchar comparison in buildTimeQuery is correct.
+    const intervalStart = after ?? `${getCurrentPrimaryTimeZoneDateString()} 00:00:00`;
+    const intervalEnd = before ?? '9999-12-31 23:59:59';
+    const [timeQueryWhereClause, timeQueryBindParams] = buildTimeQuery(intervalStart, intervalEnd);
 
     const cancelledStatusWhereClause = includeCancelled
       ? null


### PR DESCRIPTION
### Changes

The appointments dashboard list endpoint (`GET /api/appointments`) ran a slow COUNT query — ~250ms execution plus ~75ms planning on a relatively small dataset. Two root causes:

1. Sequelize's `findAndCountAll` reuses the full `getListReferenceAssociations()` join list for the COUNT subquery, even though most of those joins aren't referenced by any filter. 13 left joins → big planning cost.
2. The `OVERLAPS` predicate on `(start_time::TIMESTAMP, end_time::TIMESTAMP)` tuples isn't btree-indexable, so the table was being sequentially scanned.

This PR:

- Rewrites `buildTimeQuery` to use `start_time < $end AND end_time > $start` — equivalent to OVERLAPS for non-degenerate intervals, but indexable.
- Splits `findAndCountAll` into a lean `Appointment.count(…)` with only the joins actually used by the active filters, plus the existing `Appointment.findAll(…)` for the page rows.
- Adds a partial expression index on `(location_group_id, ((start_time::timestamp)))` filtered to `deleted_at IS NULL AND status <> 'Cancelled'` to cover the dashboard query pattern.

No mobile migration: appointments don't exist on the mobile schema.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
