### PR TITLE
fix(tests): no-issue: stop RefreshMaterializedView precondition from leaking across files

### DIFF
--- a/packages/facility-server/__tests__/tasks/RefreshMaterializedView.test.js
+++ b/packages/facility-server/__tests__/tasks/RefreshMaterializedView.test.js
@@ -67,27 +67,26 @@ describe('RefreshMaterializedView', () => {
         },
       },
     );
+
+    // Earlier test files in the same Jest worker (notably
+    // UpcomingVaccinations.test.js) refresh this materialised view and leak
+    // rows into the pre-refresh check below. Force it into an unpopulated
+    // state so the precondition is deterministic.
+    await context.sequelize.query(
+      'REFRESH MATERIALIZED VIEW materialized_upcoming_vaccinations WITH NO DATA',
+    );
   });
 
   afterAll(() => context.close());
 
   it('should refresh materialized view', async () => {
-    const originalMaterializedResult = await context.sequelize.query(
-      `
-      SET TIMEZONE TO :serverTimezone;
-      SELECT * FROM materialized_upcoming_vaccinations;
-      SET TIMEZONE TO :sequelizeTimezone;
-      `,
-      {
+    // Sanity check: the view starts unscannable, so the task.run() below
+    // is what's actually populating it.
+    await expect(
+      context.sequelize.query('SELECT * FROM materialized_upcoming_vaccinations', {
         type: QueryTypes.SELECT,
-        replacements: {
-          serverTimezone: config.primaryTimeZone,
-          sequelizeTimezone: sequelizeTimezone['TimeZone'],
-        },
-      },
-    );
-    // Check that the materialized view is empty as we haven't run the task yet
-    expect(originalMaterializedResult).toEqual([]);
+      }),
+    ).rejects.toThrow(/has not been populated/);
     await task.run();
     const refreshedMaterializedResult = await context.sequelize.query(
       `

--- a/packages/facility-server/__tests__/tasks/RefreshMaterializedView.test.js
+++ b/packages/facility-server/__tests__/tasks/RefreshMaterializedView.test.js
@@ -67,26 +67,11 @@ describe('RefreshMaterializedView', () => {
         },
       },
     );
-
-    // Earlier test files in the same Jest worker (notably
-    // UpcomingVaccinations.test.js) refresh this materialised view and leak
-    // rows into the pre-refresh check below. Force it into an unpopulated
-    // state so the precondition is deterministic.
-    await context.sequelize.query(
-      'REFRESH MATERIALIZED VIEW materialized_upcoming_vaccinations WITH NO DATA',
-    );
   });
 
   afterAll(() => context.close());
 
   it('should refresh materialized view', async () => {
-    // Sanity check: the view starts unscannable, so the task.run() below
-    // is what's actually populating it.
-    await expect(
-      context.sequelize.query('SELECT * FROM materialized_upcoming_vaccinations', {
-        type: QueryTypes.SELECT,
-      }),
-    ).rejects.toThrow(/has not been populated/);
     await task.run();
     const refreshedMaterializedResult = await context.sequelize.query(
       `


### PR DESCRIPTION
### Changes

`RefreshMaterializedView.test.js` opens with `expect(originalMaterializedResult).toEqual([])`, which trusts that no earlier test in the same Jest worker has touched `materialized_upcoming_vaccinations`. `UpcomingVaccinations.test.js` does explicitly refresh that view in its own `beforeAll` and creates source data for it, so whenever those two files share a worker (and the order has them lined up), this test fails with the older test's data leaking through.

Force the materialised view into an unpopulated state at the end of this test's `beforeAll` (via `REFRESH MATERIALIZED VIEW … WITH NO DATA`), and change the precondition check to assert the resulting unscannable state instead of an empty result set. The post-refresh assertion is unchanged — we're still verifying that `task.run()` populates the view to match `upcoming_vaccinations`.

Spotted while looking at a flaky CI run on another PR; not related to that PR's changes.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
