### PR TITLE
refactor(alerts): no-issue: split sync-errors into separate mobile and server alerts

### DIFF
--- a/alerts/sync-errors-mobile.yml
+++ b/alerts/sync-errors-mobile.yml
@@ -1,0 +1,35 @@
+sql: |
+  SELECT
+    id,
+    errors::text,
+    jsonb_array_elements_text(parameters->'facilityIds') AS facility_id,
+    created_at::text AS created,
+    (completed_at - created_at)::text AS duration
+  FROM sync_sessions
+  WHERE
+    updated_at > now() - interval '1 minute' -- Lookback window
+    AND parameters->>'isMobile' = 'true'
+    AND errors IS NOT NULL
+    -- The prior session was marked complete because the device reconnected; benign.
+    AND errors <> ARRAY['Session marked as completed due to its device reconnecting']
+    -- Transient Postgres serialisation failure: the next cycle re-runs.
+    AND errors <> ARRAY['could not serialize access due to concurrent update']
+  ORDER BY created_at DESC
+
+send:
+  - target: external
+    id: default
+    subject: '[Tamanu Alert] Sync session error (mobile, {{ hostname }})'
+    template: |
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      **Report this immediately to support.**
+
+      Sync sessions with an error in the last minute:
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.id }}**: _{{ row.errors }}_ ({{ row.facility_id }},  duration {{ row.duration }}, start {{ row.created }})
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/sync-errors-server.yml
+++ b/alerts/sync-errors-server.yml
@@ -8,20 +8,16 @@ sql: |
   FROM sync_sessions
   WHERE
     updated_at > now() - interval '1 minute' -- Lookback window
-  AND errors IS NOT NULL
-  AND (
-    (
-      parameters->>'isMobile' <> 'true'
-      AND errors <> ARRAY['Session marked as completed due to its device reconnecting']
-    )
-    OR errors <> ARRAY['could not serialize access due to concurrent update']
-  )
+    AND parameters->>'isMobile' IS DISTINCT FROM 'true' -- non-mobile (NULL-safe)
+    AND errors IS NOT NULL
+    -- Transient Postgres serialisation failure: the next cycle re-runs.
+    AND errors <> ARRAY['could not serialize access due to concurrent update']
   ORDER BY created_at DESC
 
 send:
   - target: external
     id: default
-    subject: '[Tamanu Alert] Sync session error ({{ hostname }})'
+    subject: '[Tamanu Alert] Sync session error (server, {{ hostname }})'
     template: |
       - Server: {{ hostname }}
       - Alert: {{ filename }}


### PR DESCRIPTION
### Changes

The previous `sync-errors.yml` combined mobile and server sync sessions under one alert with a compound boolean exclusion clause. That clause had two problems we ran into while trying to add another exclusion:

- The two existing exclusions were joined with `OR` instead of `AND`, so each disjunct could rescue rows the other was trying to drop. A mobile session whose only error was the reconnect noise would still alert, and a non-mobile session whose only error was the concurrent-update message would also alert.
- Adding more exclusions to that shape invited SQL three-valued-logic pitfalls — a naive `NOT (isMobile = 'true' AND ...)` form silently suppresses rows where the `isMobile` key is absent because `NULL` propagates through `NOT`.

Split into `sync-errors-mobile.yml` and `sync-errors-server.yml`, partitioned NULL-safely with `IS DISTINCT FROM 'true'`. Each query is now a flat list of `AND` exclusions specific to its audience, with no nested booleans. The two also route via distinct subject lines so on-call can tell mobile and server sync issues apart at a glance.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->