### PR TITLE
tweak(alerts): no-issue: silence benign sync restart errors, alert on sustained restarts

### DIFF
--- a/alerts/sync-errors-mobile.yml
+++ b/alerts/sync-errors-mobile.yml
@@ -1,0 +1,35 @@
+sql: |
+  SELECT
+    id,
+    errors::text,
+    jsonb_array_elements_text(parameters->'facilityIds') AS facility_id,
+    created_at::text AS created,
+    (completed_at - created_at)::text AS duration
+  FROM sync_sessions
+  WHERE
+    updated_at > now() - interval '1 minute' -- Lookback window
+    AND parameters->>'isMobile' = 'true'
+    AND errors IS NOT NULL
+    -- The prior session was marked complete because the device reconnected; benign.
+    AND errors <> ARRAY['Session marked as completed due to its device reconnecting']
+    -- Transient Postgres serialisation failure: the next cycle re-runs.
+    AND errors <> ARRAY['could not serialize access due to concurrent update']
+  ORDER BY created_at DESC
+
+send:
+  - target: external
+    id: default
+    subject: '[Tamanu Alert] Sync session error (mobile, {{ hostname }})'
+    template: |
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      **Report this immediately to support.**
+
+      Sync sessions with an error in the last minute:
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.id }}**: _{{ row.errors }}_ ({{ row.facility_id }},  duration {{ row.duration }}, start {{ row.created }})
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/sync-errors-server.yml
+++ b/alerts/sync-errors-server.yml
@@ -12,6 +12,13 @@ sql: |
     AND errors IS NOT NULL
     -- Transient Postgres serialisation failure: the next cycle re-runs.
     AND errors <> ARRAY['could not serialize access due to concurrent update']
+    -- "snapshot-for-pushing" errors are a deliberate restart of the sync cycle when a
+    -- pulled record was edited locally mid-session; the next cycle picks it up. Only
+    -- worth surfacing if it happens repeatedly — see sync-restart-loop.yml for that.
+    AND NOT (
+      cardinality(errors) = 1
+      AND errors[1] LIKE '%snapshot-for-pushing%'
+    )
   ORDER BY created_at DESC
 
 send:

--- a/alerts/sync-errors-server.yml
+++ b/alerts/sync-errors-server.yml
@@ -8,20 +8,16 @@ sql: |
   FROM sync_sessions
   WHERE
     updated_at > now() - interval '1 minute' -- Lookback window
-  AND errors IS NOT NULL
-  AND (
-    (
-      parameters->>'isMobile' <> 'true'
-      AND errors <> ARRAY['Session marked as completed due to its device reconnecting']
-    )
-    OR errors <> ARRAY['could not serialize access due to concurrent update']
-  )
+    AND parameters->>'isMobile' IS DISTINCT FROM 'true' -- non-mobile (NULL-safe)
+    AND errors IS NOT NULL
+    -- Transient Postgres serialisation failure: the next cycle re-runs.
+    AND errors <> ARRAY['could not serialize access due to concurrent update']
   ORDER BY created_at DESC
 
 send:
   - target: external
     id: default
-    subject: '[Tamanu Alert] Sync session error ({{ hostname }})'
+    subject: '[Tamanu Alert] Sync session error (server, {{ hostname }})'
     template: |
       - Server: {{ hostname }}
       - Alert: {{ filename }}

--- a/alerts/sync-restart-loop.yml
+++ b/alerts/sync-restart-loop.yml
@@ -1,0 +1,40 @@
+interval: 5 minutes
+
+sql: |
+  -- A single "snapshot-for-pushing" error is benign: it means a pulled record was edited
+  -- locally mid-session, so the facility deliberately aborts and restarts to push the edit.
+  -- The next cycle picks it up. But a sustained rate suggests the push -> pull window is
+  -- too wide for the facility's write velocity, and sync may struggle to converge.
+  SELECT
+    jsonb_array_elements_text(parameters->'facilityIds') AS facility_id,
+    COUNT(*) AS error_count
+  FROM sync_sessions
+  WHERE
+    created_at > now() - interval '1 hour'
+    AND errors IS NOT NULL
+    AND cardinality(errors) = 1
+    AND errors[1] LIKE '%snapshot-for-pushing%'
+  GROUP BY facility_id
+  HAVING COUNT(*) >= 10
+  ORDER BY error_count DESC
+
+send:
+  - target: external
+    id: default
+    subject: '[Tamanu Alert] Sync restart loop for at least one facility ({{ hostname }})'
+    template: |
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      One or more facilities have had repeated sync sessions abort with a
+      "snapshot-for-pushing" restart in the past hour. A single occurrence is
+      expected when a clinician edits a record mid-sync, but a sustained rate
+      suggests the push -> pull window is too wide for the facility's write
+      velocity. Consider tuning `sync.dynamicLimiter` to shorten sessions.
+
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.facility_id }}**: {{ row.error_count }} restart(s) in the last hour
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}


### PR DESCRIPTION
### Changes

Stacked on #9871.

The `snapshot-for-pushing` sync error is thrown deliberately by the facility when a pulled record was edited locally between push and pull — the cycle is restarted so the local edit can be pushed on the next session, and a single occurrence is self-healing. We've been seeing it page repeatedly on one busy deployment.

This PR stops it from triggering `sync-errors-server.yml` when it's the sole error on a session, and adds a companion `sync-restart-loop.yml` alert that fires when a single facility accumulates 10 or more such restarts within an hour — the pattern that suggests the push -> pull window is too wide for the facility's write velocity.

Threshold is a guess; tune once we have a feel for real volumes.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->