### PR TITLE
fix(web): no-issue: autocomplete crash when option label is nullish

### DIFF
--- a/packages/ui-components/src/components/Field/AutocompleteField.jsx
+++ b/packages/ui-components/src/components/Field/AutocompleteField.jsx
@@ -185,7 +185,7 @@ export class AutocompleteInput extends Component {
       if (currentOption) {
         this.setState({
           selectedOption: {
-            value: currentOption.label,
+            value: currentOption.label ?? '',
             tag: currentOption.tag,
           },
         });
@@ -270,6 +270,7 @@ export class AutocompleteInput extends Component {
       return false;
     }
     const autoSelectOption = suggestions[0];
+    if (!autoSelectOption.label) return false;
     this.setState({
       selectedOption: {
         value: autoSelectOption.label,
@@ -551,7 +552,7 @@ export class AutocompleteInput extends Component {
             placeholder,
             infoTooltip,
             size,
-            value: selectedOption?.value,
+            value: selectedOption?.value ?? '',
             tag: selectedOption?.tag,
             onKeyDown: this.onKeyDown,
             onChange: this.handleInputChange,


### PR DESCRIPTION
### Changes

Fixes a frontend crash where the page becomes unusable with `Cannot read properties of undefined (reading 'trim')` thrown from inside `react-autosuggest` when an autocomplete field ends up with a nullish `selectedOption.value`.

The bundle slice for `index-CZeLzjCQ.js:781` confirms the crash is in react-autosuggest's `defaultShouldRenderSuggestions(value)`, which does `value.trim().length > 0` with no null guard. If any state path in `AutocompleteField` produces a nullish `selectedOption.value` (e.g. a suggester `fetchCurrentOption` returning an option with a nullish `label`), the next time suggestions transition to non-empty the page crashes.

Coerces `inputProps.value` to a string at the boundary, and also coerces the two setState writes that propagate `option.label` from upstream formatter output, so a nullish label cannot make the input controlled-but-uncontrolled.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->