### PR TITLE
fix(web): no-issue: autocomplete crash when option label is nullish

### DIFF
--- a/packages/ui-components/src/components/Field/AutocompleteField.jsx
+++ b/packages/ui-components/src/components/Field/AutocompleteField.jsx
@@ -185,7 +185,7 @@ export class AutocompleteInput extends Component {
       if (currentOption) {
         this.setState({
           selectedOption: {
-            value: currentOption.label,
+            value: currentOption.label ?? '',
             tag: currentOption.tag,
           },
         });
@@ -270,6 +270,7 @@ export class AutocompleteInput extends Component {
       return false;
     }
     const autoSelectOption = suggestions[0];
+    if (!autoSelectOption.label) return false;
     this.setState({
       selectedOption: {
         value: autoSelectOption.label,
@@ -562,7 +563,7 @@ export class AutocompleteInput extends Component {
             placeholder,
             infoTooltip,
             size,
-            value: selectedOption?.value,
+            value: selectedOption?.value ?? '',
             tag: selectedOption?.tag,
             onKeyDown: this.onKeyDown,
             onChange: this.handleInputChange,


### PR DESCRIPTION
### Changes

Propagation of the autocomplete trim crash fix originally PRd against release/2.52 (#9879).

Coerces `inputProps.value` to a string at the boundary in `AutocompleteField`, and the two setState writes that propagate `option.label`, to prevent a crash from inside react-autosuggest's `defaultShouldRenderSuggestions(value)` (which does `value.trim()` with no null guard) when a suggester ends up producing a nullish label.

See #9879 for the diagnosis and bundle trace.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->