### PR TITLE
fix(mobile): TAM-6812: fix lab test types not loading when category selected (hotfix 2.56)

### DIFF
--- a/packages/mobile/App/models/LabTestType.ts
+++ b/packages/mobile/App/models/LabTestType.ts
@@ -1,7 +1,7 @@
-import { Column, Entity, ManyToMany, RelationId } from 'typeorm';
+import { Column, Entity, ManyToMany } from 'typeorm';
 
 import { ILabTestType, LabTestResultType } from '~/types';
-import { BaseModel } from './BaseModel';
+import { BaseModel, IdRelation } from './BaseModel';
 import { ReferenceData, ReferenceDataRelation } from './ReferenceData';
 import { VisibilityStatus } from '../visibilityStatuses';
 import { SYNC_DIRECTIONS } from './types';
@@ -44,10 +44,9 @@ export class LabTestType extends BaseModel implements ILabTestType {
   @ManyToMany(() => LabTestPanel, (labTestPanel) => labTestPanel.tests)
   labTestPanels: LabTestPanel[];
 
-  // TODO: What to do with relations with no "as"
   @ReferenceDataRelation()
   labTestCategory: ReferenceData;
-  @RelationId(({ labTestCategory }) => labTestCategory)
+  @IdRelation()
   labTestCategoryId: string;
 
   @Column({ nullable: false, default: false })

--- a/packages/mobile/App/ui/components/Forms/LabRequestForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/LabRequestForm/index.tsx
@@ -81,7 +81,7 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
 
   const handleLabRequestTypeSelected = useCallback(async (selectedValue) => {
     const where: any = {
-      labTestCategory: { id: selectedValue },
+      labTestCategoryId: selectedValue,
       visibilityStatus: VisibilityStatus.Current,
     };
     if (!canCreateSensitive) {
@@ -103,7 +103,7 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
       value: false,
     }));
     setLabTestTypes(labTestTypeOptions);
-  }, []);
+  }, [canCreateSensitive]);
 
   return (
     <FormScreenView paddingRight={20} paddingLeft={20} paddingTop={20}>


### PR DESCRIPTION
### Changes

The TypeORM 0.2 → 0.3 upgrade changed the LabRequestForm query from `{ labTestCategory: id 

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->` to `{ labTestCategory: { id } }`, but the nested object form does not work for `@ReferenceDataRelation` fields (eager `ManyToOne` with no inverse side). This caused no lab test types to load after selecting a category, so users could not submit a lab request.

Fix uses the foreign key column `labTestCategoryId` directly, which is the correct approach in TypeORM 0.3.x. Also fixes a stale closure: `canCreateSensitive` was missing from the `useCallback` dependency array.}