### PR TITLE
fix(mobile): TAM-6812: fix lab test types not loading when category selected (hotfix 2.54)

### DIFF
--- a/packages/mobile/App/models/LabTestType.ts
+++ b/packages/mobile/App/models/LabTestType.ts
@@ -1,7 +1,7 @@
-import { Column, Entity, ManyToMany, RelationId } from 'typeorm';
+import { Column, Entity, ManyToMany } from 'typeorm';
 
 import { ILabTestType, LabTestResultType } from '~/types';
-import { BaseModel } from './BaseModel';
+import { BaseModel, IdRelation } from './BaseModel';
 import { ReferenceData, ReferenceDataRelation } from './ReferenceData';
 import { VisibilityStatus } from '../visibilityStatuses';
 import { SYNC_DIRECTIONS } from './types';
@@ -44,10 +44,9 @@ export class LabTestType extends BaseModel implements ILabTestType {
   @ManyToMany(() => LabTestPanel, (labTestPanel) => labTestPanel.tests)
   labTestPanels: LabTestPanel[];
 
-  // TODO: What to do with relations with no "as"
   @ReferenceDataRelation()
   labTestCategory: ReferenceData;
-  @RelationId(({ labTestCategory }) => labTestCategory)
+  @IdRelation()
   labTestCategoryId: string;
 
   @Column({ nullable: false, default: false })

--- a/packages/mobile/App/ui/components/Forms/LabRequestForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/LabRequestForm/index.tsx
@@ -81,7 +81,7 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
 
   const handleLabRequestTypeSelected = useCallback(async (selectedValue) => {
     const where: any = {
-      labTestCategory: { id: selectedValue },
+      labTestCategoryId: selectedValue,
       visibilityStatus: VisibilityStatus.Current,
     };
     if (!canCreateSensitive) {
@@ -103,7 +103,7 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
       value: false,
     }));
     setLabTestTypes(labTestTypeOptions);
-  }, []);
+  }, [canCreateSensitive]);
 
   return (
     <FormScreenView paddingRight={20} paddingLeft={20} paddingTop={20}>


### PR DESCRIPTION
### Changes

Cherry-picks the TAM-6812 fix from release/2.56: fixes lab test types not loading when a category is selected on mobile. The root cause was `labTestCategoryId` using `@RelationId()` (a virtual property) instead of `@IdRelation()` (a real DB column), which broke `find()` where clause queries after the TypeORM 0.2.31 → 0.3.20 upgrade._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->