### PR TITLE
fix(mobile): no-issue: fix crash on initial sync when mobileSync settings missing

### DIFF
--- a/packages/mobile/App/services/settings.ts
+++ b/packages/mobile/App/services/settings.ts
@@ -21,7 +21,10 @@ export class SettingsService extends LocalDataService {
   }
 
   async setSettings(settings: object): Promise<void> {
-    this.data = settings;
+    // Merge over existing data so that keys only present in the login response (e.g. mobileSync,
+    // which is a central-scope setting not returned by the setFacility endpoint) are preserved
+    // when facility-specific settings are applied on top.
+    this.data = { ...this.data, ...settings };
     await this._writeDataToConfig();
     this.onDataLoaded();
   }

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -104,7 +104,7 @@ export class MobileSyncManager {
   }
 
   get syncSettings(): MobileSyncSettings {
-    return this.settings.getSetting<MobileSyncSettings>('mobileSync');
+    return this.settings.getSetting<MobileSyncSettings>('mobileSync') ?? ({} as MobileSyncSettings);
   }
 
   setSyncStage(syncStage: number): void {

--- a/packages/mobile/App/services/sync/utils/pullRecordsInBatches.ts
+++ b/packages/mobile/App/services/sync/utils/pullRecordsInBatches.ts
@@ -20,7 +20,7 @@ export const pullRecordsInBatches = async (
     return { records, pullTime };
   };
 
-  const { dynamicLimiter: dynamicLimiterSettings } = syncSettings || {};
+  const { dynamicLimiter: dynamicLimiterSettings } = syncSettings ?? {};
   let limit = calculatePageLimit(dynamicLimiterSettings);
   let totalPulled = 0;
   let current = await fetchPage(limit);

--- a/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
@@ -20,7 +20,7 @@ export const pushOutgoingChanges = async (
   syncSettings: MobileSyncSettings,
   progressCallback: (total: number, progressCount: number) => void,
 ): Promise<void> => {
-  const { dynamicLimiter: dynamicLimiterSettings } = syncSettings || {};
+  const { dynamicLimiter: dynamicLimiterSettings } = syncSettings ?? {};
   let startOfPage = 0;
   let limit = calculatePageLimit(dynamicLimiterSettings);
   let pushedRecordsCount = 0;

--- a/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
@@ -90,6 +90,7 @@ export const saveChangesFromMemory = async (
   syncSettings: MobileSyncSettings,
   progressCallback: (recordsProcessed: number) => void,
 ): Promise<void> => {
+  const { maxRecordsPerInsertBatch = 2000 } = syncSettings;
   const modelChanges = prepareChangesForModels(records, sortedModels);
   for (const { model, records } of modelChanges) {
     if (model.name === 'User') {
@@ -98,7 +99,7 @@ export const saveChangesFromMemory = async (
       await executePreparedInsert(
         model.getTransactionalRepository(),
         buildFromSyncRecord(model, records),
-        syncSettings.maxRecordsPerInsertBatch,
+        maxRecordsPerInsertBatch,
         progressCallback,
       );
     }


### PR DESCRIPTION
On first install, the setFacility endpoint returns settings built from the facility schema context, which does not include mobileSync (a central-scope setting). Calling setSettings() with these facility settings was replacing all previously loaded data, discarding the mobileSync values that came from the central server login response.

Two fixes:
- SettingsService.setSettings now merges over existing data instead of replacing, preserving central-scope keys like mobileSync when facility settings are applied.
- syncSettings getter falls back to {} instead of returning undefined, preventing a crash on destructuring when mobileSync is genuinely absent (e.g. facility-only server deployments where login never returns mobileSync).

**Note:**
This is a short term fix, as currently initial sync is ignoring the mobile sync settings. I want to move the mobile settings out into a separate settings context, so that they're always available on mobile. But that feels like a bit of a big change for a hotfix.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
