### PR TITLE
db: no-issue: drop sync_lookup rebuilds from 2.54 migrations

### DIFF
--- a/packages/database/src/migrations/1768527768375-addSecondaryResultToLabTest.ts
+++ b/packages/database/src/migrations/1768527768375-addSecondaryResultToLabTest.ts
@@ -5,8 +5,6 @@ export async function up(query: QueryInterface): Promise<void> {
     type: DataTypes.TEXT,
     allowNull: true,
   });
-
-  await query.sequelize.query(`SELECT flag_lookup_model_to_rebuild('lab_tests');`);
 }
 
 export async function down(query: QueryInterface): Promise<void> {

--- a/packages/database/src/migrations/1770868233506-addBirthOrderColumnToPatientBirthData.ts
+++ b/packages/database/src/migrations/1770868233506-addBirthOrderColumnToPatientBirthData.ts
@@ -5,8 +5,6 @@ export async function up(query: QueryInterface): Promise<void> {
     type: DataTypes.INTEGER,
     allowNull: true,
   });
-
-  await query.sequelize.query(`SELECT flag_lookup_model_to_rebuild('patient_birth_data');`);
 }
 
 export async function down(query: QueryInterface): Promise<void> {

--- a/packages/database/src/migrations/1770952177082-addExtraDataFieldToPatientDeathData.ts
+++ b/packages/database/src/migrations/1770952177082-addExtraDataFieldToPatientDeathData.ts
@@ -5,10 +5,8 @@ export async function up(query: QueryInterface): Promise<void> {
     type: DataTypes.JSONB,
     allowNull: true,
   });
-  await query.sequelize.query(`SELECT flag_lookup_model_to_rebuild('patient_death_data');`);
 }
 
 export async function down(query: QueryInterface): Promise<void> {
   await query.removeColumn('patient_death_data', 'extra_data');
-  await query.sequelize.query(`SELECT flag_lookup_model_to_rebuild('patient_death_data');`);
 }


### PR DESCRIPTION
### Changes

🤖 Three migrations on `release/2.54` incorrectly flagged their tables for `sync_lookup` rebuild on apply. Removed the `flag_lookup_model_to_rebuild` calls from:

- `1768527768375-addSecondaryResultToLabTest`
- `1770868233506-addBirthOrderColumnToPatientBirthData`
- `1770952177082-addExtraDataFieldToPatientDeathData`

No new migrations; existing schema changes are preserved.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->