### PR TITLE
feat(web): no-issue: site-wide system banner with expiry

### DIFF
--- a/packages/constants/src/settings.ts
+++ b/packages/constants/src/settings.ts
@@ -32,6 +32,7 @@ export const SETTINGS_SCOPES = {
 export const SETTING_EDITORS = {
   MULTILINE: 'multiline',
   MARKDOWN: 'markdown',
+  DATETIME: 'datetime',
 } as const;
 
 export type SettingEditor = (typeof SETTING_EDITORS)[keyof typeof SETTING_EDITORS];

--- a/packages/e2e-tests/pages/AdminLoginPage.ts
+++ b/packages/e2e-tests/pages/AdminLoginPage.ts
@@ -1,0 +1,31 @@
+import { Locator, Page } from '@playwright/test';
+
+const adminFrontend = process.env.ADMIN_FRONTEND_URL ?? 'http://localhost:5174';
+
+/**
+ * Login page object for the admin frontend (central). The shared
+ * `tests/setup/auth.setup.ts` only authenticates against the facility
+ * frontend, so tests that need admin-side state do their own inline login
+ * via this page object.
+ */
+export class AdminLoginPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly loginButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.locator('input[name="email"]');
+    this.passwordInput = page.locator('input[name="password"]');
+    this.loginButton = page.getByTestId('loginbutton-gx21');
+  }
+
+  async login(email: string, password: string) {
+    await this.page.goto(adminFrontend);
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.loginButton.click();
+    await this.page.waitForLoadState('networkidle');
+  }
+}

--- a/packages/e2e-tests/pages/AdminSettingsPage.ts
+++ b/packages/e2e-tests/pages/AdminSettingsPage.ts
@@ -10,14 +10,12 @@ const adminFrontend = process.env.ADMIN_FRONTEND_URL ?? 'http://localhost:5174';
  * to drive both the new DATETIME setting editor and the banner setting itself.
  *
  * The admin frontend (port 5174 by default) talks to the central server and is
- * served by a separate Vite build from the facility frontend. It uses the same
- * LoginView so the credential prompts match.
+ * served by a separate Vite build from the facility frontend. Login is
+ * handled separately by AdminLoginPage — pass an already-authenticated page
+ * to this constructor.
  */
 export class AdminSettingsPage {
   readonly page: Page;
-  readonly emailInput: Locator;
-  readonly passwordInput: Locator;
-  readonly loginButton: Locator;
 
   readonly bannerEnabledSwitch: Locator;
   readonly bannerMessageInput: Locator;
@@ -27,9 +25,6 @@ export class AdminSettingsPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.emailInput = page.locator('input[name="email"]');
-    this.passwordInput = page.locator('input[name="password"]');
-    this.loginButton = page.getByTestId('loginbutton-gx21');
 
     // banner.* settings are emitted by Category.jsx with a deterministic data-testid
     // derived from the dotted setting path (dots replaced with dashes).
@@ -51,13 +46,7 @@ export class AdminSettingsPage {
     this.saveButton = page.getByRole('button', { name: /^Save$/ });
   }
 
-  async loginAndOpen(email: string, password: string) {
-    await this.page.goto(adminFrontend);
-    await this.emailInput.fill(email);
-    await this.passwordInput.fill(password);
-    await this.loginButton.click();
-    await this.page.waitForLoadState('networkidle');
-
+  async open() {
     await this.page.goto(`${adminFrontend}/#/admin/settings`);
     await expect(this.bannerEnabledSwitch).toBeVisible({ timeout: 30_000 });
   }

--- a/packages/e2e-tests/pages/AdminSettingsPage.ts
+++ b/packages/e2e-tests/pages/AdminSettingsPage.ts
@@ -1,0 +1,117 @@
+import { Locator, Page, expect } from '@playwright/test';
+import { format } from 'date-fns';
+
+import { fillMuiDateTimeField } from '../utils/dateTimeHelpers';
+
+const adminFrontend = process.env.ADMIN_FRONTEND_URL ?? 'http://localhost:5174';
+
+/**
+ * Page object for the admin settings editor. Used by the system banner tests
+ * to drive both the new DATETIME setting editor and the banner setting itself.
+ *
+ * The admin frontend (port 5174 by default) talks to the central server and is
+ * served by a separate Vite build from the facility frontend. It uses the same
+ * LoginView so the credential prompts match.
+ */
+export class AdminSettingsPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly loginButton: Locator;
+
+  readonly bannerEnabledSwitch: Locator;
+  readonly bannerMessageInput: Locator;
+  readonly bannerSeverityInput: Locator;
+  readonly bannerExpiresAtInput: Locator;
+  readonly saveButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.locator('input[name="email"]');
+    this.passwordInput = page.locator('input[name="password"]');
+    this.loginButton = page.getByTestId('loginbutton-gx21');
+
+    // banner.* settings are emitted by Category.jsx with a deterministic data-testid
+    // derived from the dotted setting path (dots replaced with dashes).
+    this.bannerEnabledSwitch = page
+      .getByTestId('settinginput-2wuw-banner-enabled')
+      .locator('input[type="checkbox"]');
+    this.bannerMessageInput = page
+      .getByTestId('settinginput-2wuw-banner-message')
+      .locator('input, textarea')
+      .first();
+    this.bannerSeverityInput = page
+      .getByTestId('settinginput-2wuw-banner-severity')
+      .locator('input')
+      .first();
+    this.bannerExpiresAtInput = page
+      .getByTestId('settinginput-2wuw-banner-expiresAt')
+      .locator('input')
+      .first();
+    this.saveButton = page.getByRole('button', { name: /^Save$/ });
+  }
+
+  async loginAndOpen(email: string, password: string) {
+    await this.page.goto(adminFrontend);
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.loginButton.click();
+    await this.page.waitForLoadState('networkidle');
+
+    await this.page.goto(`${adminFrontend}/#/admin/settings`);
+    await expect(this.bannerEnabledSwitch).toBeVisible({ timeout: 30_000 });
+  }
+
+  /**
+   * Fills the datetime picker with a local-time value via the shared MUI
+   * date-time helper. The picker is the new SETTING_EDITORS.DATETIME editor;
+   * it emits UTC ISO 8601 via `Date.prototype.toISOString()` regardless of the
+   * displayed format, so this exercise covers the round-trip.
+   */
+  async setExpiresAt(date: Date) {
+    await fillMuiDateTimeField(this.bannerExpiresAtInput, format(date, "yyyy-MM-dd'T'HH:mm"));
+  }
+
+  /**
+   * Saves and returns the request body that was sent to the central
+   * `/admin/settings` endpoint. Caller can assert on the persisted shape
+   * — particularly that expiresAt is a UTC ISO 8601 string.
+   */
+  async saveAndCaptureRequest(): Promise<{ settings: { banner?: Record<string, unknown> } }> {
+    const requestPromise = this.page.waitForRequest(
+      req => req.method() === 'PUT' && req.url().includes('/admin/settings'),
+    );
+    await this.saveButton.click();
+    const request = await requestPromise;
+    return request.postDataJSON();
+  }
+
+  async setBanner(opts: {
+    message: string;
+    severity?: 'info' | 'warning' | 'error';
+    expiresAt?: Date | null;
+  }) {
+    if (!(await this.bannerEnabledSwitch.isChecked())) {
+      await this.bannerEnabledSwitch.click();
+    }
+    await this.bannerMessageInput.fill(opts.message);
+    if (opts.severity) {
+      await this.bannerSeverityInput.fill(opts.severity);
+    }
+    if (opts.expiresAt) {
+      await this.setExpiresAt(opts.expiresAt);
+    }
+    await this.saveButton.click();
+    // Wait for the success toast to appear so we know the round-trip is done.
+    await expect(this.page.getByText('Settings saved')).toBeVisible({ timeout: 15_000 });
+  }
+
+  async clearBanner() {
+    if (await this.bannerEnabledSwitch.isChecked()) {
+      await this.bannerEnabledSwitch.click();
+    }
+    await this.bannerMessageInput.fill('');
+    await this.saveButton.click();
+    await expect(this.page.getByText('Settings saved')).toBeVisible({ timeout: 15_000 });
+  }
+}

--- a/packages/e2e-tests/pages/index.ts
+++ b/packages/e2e-tests/pages/index.ts
@@ -1,3 +1,4 @@
+export { AdminLoginPage } from './AdminLoginPage';
 export { AdminSettingsPage } from './AdminSettingsPage';
 export { DashboardPage } from './DashboardPage';
 export { LoginPage } from './LoginPage';

--- a/packages/e2e-tests/pages/index.ts
+++ b/packages/e2e-tests/pages/index.ts
@@ -1,3 +1,4 @@
+export { AdminSettingsPage } from './AdminSettingsPage';
 export { DashboardPage } from './DashboardPage';
 export { LoginPage } from './LoginPage';
 export { SidebarPage } from './SidebarPage';

--- a/packages/e2e-tests/tests/admin/BannerSettings.spec.ts
+++ b/packages/e2e-tests/tests/admin/BannerSettings.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { AdminSettingsPage } from '../../pages/AdminSettingsPage';
+
+/**
+ * Verifies the DATETIME setting editor used by the new banner.expiresAt
+ * setting. The picker displays in the operator's local timezone but must
+ * serialise to UTC ISO 8601 — otherwise operators in different timezones
+ * would disagree about when the banner expires.
+ *
+ * Runs against the admin frontend (port 5174) which connects to central.
+ */
+test.describe('Admin settings: banner DATETIME editor', () => {
+  // Login flow is exercised inline rather than via storageState because the
+  // shared auth setup logs into the facility frontend, which is a different
+  // origin from the admin frontend.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('[SB-0001] saves banner.expiresAt as a UTC ISO 8601 string', async ({ page }) => {
+    test.setTimeout(120_000);
+    const email = process.env.TEST_EMAIL;
+    const password = process.env.TEST_PASSWORD;
+    if (!email || !password) {
+      throw new Error('TEST_EMAIL and TEST_PASSWORD must be set');
+    }
+
+    const settingsPage = new AdminSettingsPage(page);
+    await settingsPage.loginAndOpen(email, password);
+
+    // Pick a deterministic time in the local browser timezone, well in the future.
+    const localExpiry = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    localExpiry.setSeconds(0, 0);
+
+    // Enable banner so the save isn't a no-op, fill required message field.
+    if (!(await settingsPage.bannerEnabledSwitch.isChecked())) {
+      await settingsPage.bannerEnabledSwitch.click();
+    }
+    await settingsPage.bannerMessageInput.fill('e2e expiresAt test');
+    await settingsPage.setExpiresAt(localExpiry);
+
+    const body = await settingsPage.saveAndCaptureRequest();
+    const expiresAt = body.settings?.banner?.expiresAt;
+
+    expect(typeof expiresAt).toBe('string');
+    // Must end with 'Z' (UTC) — the editor uses Date.prototype.toISOString().
+    expect(expiresAt as string).toMatch(/Z$/);
+    // The instant we sent must equal the instant we picked, regardless of TZ
+    // representation.
+    expect(new Date(expiresAt as string).getTime()).toBe(localExpiry.getTime());
+
+    // Cleanup
+    await settingsPage.clearBanner();
+  });
+});

--- a/packages/e2e-tests/tests/admin/BannerSettings.spec.ts
+++ b/packages/e2e-tests/tests/admin/BannerSettings.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { AdminLoginPage } from '../../pages/AdminLoginPage';
 import { AdminSettingsPage } from '../../pages/AdminSettingsPage';
 
 /**
@@ -23,8 +24,9 @@ test.describe('Admin settings: banner DATETIME editor', () => {
       throw new Error('TEST_EMAIL and TEST_PASSWORD must be set');
     }
 
+    await new AdminLoginPage(page).login(email, password);
     const settingsPage = new AdminSettingsPage(page);
-    await settingsPage.loginAndOpen(email, password);
+    await settingsPage.open();
 
     // Pick a deterministic time in the local browser timezone, well in the future.
     const localExpiry = new Date(Date.now() + 24 * 60 * 60 * 1000);

--- a/packages/e2e-tests/tests/banner/SystemBanner.spec.ts
+++ b/packages/e2e-tests/tests/banner/SystemBanner.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { AdminLoginPage } from '../../pages/AdminLoginPage';
 import { AdminSettingsPage } from '../../pages/AdminSettingsPage';
 import { goToFacilityFrontend } from '../../utils/navigation';
 
@@ -33,8 +34,9 @@ test.describe('System banner', () => {
     // different origin from the one the facility auth setup populated.
     const adminContext = await browser.newContext();
     const adminPage = await adminContext.newPage();
+    await new AdminLoginPage(adminPage).login(email, password);
     const adminSettings = new AdminSettingsPage(adminPage);
-    await adminSettings.loginAndOpen(email, password);
+    await adminSettings.open();
 
     try {
       await adminSettings.setBanner({
@@ -86,8 +88,9 @@ test.describe('System banner', () => {
 
     const adminContext = await browser.newContext();
     const adminPage = await adminContext.newPage();
+    await new AdminLoginPage(adminPage).login(email, password);
     const adminSettings = new AdminSettingsPage(adminPage);
-    await adminSettings.loginAndOpen(email, password);
+    await adminSettings.open();
 
     try {
       // ExpiresAt in the past — banner must not appear even with enabled=true.

--- a/packages/e2e-tests/tests/banner/SystemBanner.spec.ts
+++ b/packages/e2e-tests/tests/banner/SystemBanner.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import { AdminSettingsPage } from '../../pages/AdminSettingsPage';
+import { goToFacilityFrontend } from '../../utils/navigation';
+
+const TEST_BANNER_MESSAGE = `e2e banner ${Date.now()}`;
+
+/**
+ * End-to-end coverage for the site-wide system banner. The banner is driven by
+ * the global `banner` setting, written from the admin frontend (central) and
+ * picked up live by the facility frontend through the existing settings cache
+ * invalidation pipeline.
+ *
+ * The two contexts:
+ *  - adminContext: a fresh login to the admin frontend so we can toggle the
+ *    banner setting.
+ *  - default `page`: facility frontend with storageState from auth.setup so we
+ *    can observe the banner as a logged-in clinician would.
+ */
+test.describe('System banner', () => {
+  test('[SB-0010] banner enabled on central displays on facility frontend and dismissal sticks', async ({
+    browser,
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    const email = process.env.TEST_EMAIL;
+    const password = process.env.TEST_PASSWORD;
+    if (!email || !password) {
+      throw new Error('TEST_EMAIL and TEST_PASSWORD must be set');
+    }
+
+    // Admin context: fresh, no shared storageState since admin frontend is a
+    // different origin from the one the facility auth setup populated.
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    const adminSettings = new AdminSettingsPage(adminPage);
+    await adminSettings.loginAndOpen(email, password);
+
+    try {
+      await adminSettings.setBanner({
+        message: TEST_BANNER_MESSAGE,
+        severity: 'warning',
+      });
+
+      // Facility context: use the storageState-authenticated page provided by
+      // the project fixture and reload so the just-updated settings are picked
+      // up. Settings push is debounced by ~1s in SettingsRefresher; reload is
+      // the simplest deterministic wait.
+      await goToFacilityFrontend(page);
+      await page.reload();
+
+      const banner = page.getByTestId('system-banner');
+      await expect(banner).toBeVisible({ timeout: 30_000 });
+      await expect(banner).toContainText(TEST_BANNER_MESSAGE);
+
+      // Dismissal — banner should disappear immediately and stay gone on
+      // reload because dismissal is persisted in localStorage.
+      await page.getByTestId('system-banner-dismiss').click();
+      await expect(banner).toBeHidden();
+      await page.reload();
+      await expect(page.getByTestId('system-banner')).toBeHidden();
+
+      // Editing the banner content must reset dismissals for everyone (the
+      // dismissal key is derived from message + expiresAt).
+      await adminSettings.setBanner({
+        message: `${TEST_BANNER_MESSAGE} v2`,
+        severity: 'warning',
+      });
+      await page.reload();
+      await expect(page.getByTestId('system-banner')).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId('system-banner')).toContainText(`${TEST_BANNER_MESSAGE} v2`);
+    } finally {
+      await adminSettings.clearBanner();
+      await adminContext.close();
+    }
+  });
+
+  test('[SB-0011] expired banner is not displayed', async ({ browser, page }) => {
+    test.setTimeout(180_000);
+
+    const email = process.env.TEST_EMAIL;
+    const password = process.env.TEST_PASSWORD;
+    if (!email || !password) {
+      throw new Error('TEST_EMAIL and TEST_PASSWORD must be set');
+    }
+
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    const adminSettings = new AdminSettingsPage(adminPage);
+    await adminSettings.loginAndOpen(email, password);
+
+    try {
+      // ExpiresAt in the past — banner must not appear even with enabled=true.
+      const pastExpiry = new Date(Date.now() - 60 * 60 * 1000);
+      await adminSettings.setBanner({
+        message: `${TEST_BANNER_MESSAGE} expired`,
+        severity: 'info',
+        expiresAt: pastExpiry,
+      });
+
+      await goToFacilityFrontend(page);
+      await page.reload();
+
+      // Give the SettingsRefresher debounce window to settle and the component
+      // to render; then assert the banner is not visible.
+      await page.waitForLoadState('networkidle');
+      await expect(page.getByTestId('system-banner')).toBeHidden();
+    } finally {
+      await adminSettings.clearBanner();
+      await adminContext.close();
+    }
+  });
+});

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -48,10 +48,62 @@ const generateFrequencyProperties = frequencies => {
   );
 };
 
+// Validates that a value is an ISO 8601 datetime string carrying explicit
+// timezone information (either trailing 'Z' for UTC or a numeric offset like
+// '+10:00'). Operators in any timezone can then read the value without
+// ambiguity. Empty string / null is treated as "no expiry" — the validator
+// allows it through.
+const ISO_DATETIME_WITH_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})$/;
+const isoDatetimeWithTz = yup
+  .string()
+  .nullable()
+  .test(
+    'iso-datetime-with-tz',
+    'Must be an ISO 8601 datetime with timezone (e.g. 2026-05-28T11:00:00.000Z). Use the datetime picker to set it.',
+    value => {
+      if (value === '' || value == null) return true;
+      if (typeof value !== 'string') return false;
+      if (!ISO_DATETIME_WITH_TZ.test(value)) return false;
+      return !Number.isNaN(Date.parse(value));
+    },
+  );
+
 export const globalSettings = {
   title: 'Global settings',
   description: 'Settings that apply to all servers',
   properties: {
+    banner: {
+      name: 'System banner',
+      description:
+        'Site-wide banner shown to every logged-in web user. Typically used to ' +
+        'announce planned downtime. Picked up live — no restart or reload required.',
+      exposedToWeb: true,
+      properties: {
+        enabled: {
+          description: 'Show the banner',
+          type: yup.boolean(),
+          defaultValue: false,
+        },
+        message: {
+          description: 'Banner text shown to all users',
+          type: yup.string(),
+          defaultValue: '',
+        },
+        severity: {
+          description: "Banner styling: 'info', 'warning', or 'error'",
+          type: yup.string().oneOf(['info', 'warning', 'error']),
+          defaultValue: 'info',
+        },
+        expiresAt: {
+          description:
+            'Optional ISO 8601 datetime (with timezone) at which the banner ' +
+            'stops showing. Leave empty for no expiry.',
+          type: isoDatetimeWithTz,
+          editor: SETTING_EDITORS.DATETIME,
+          defaultValue: '',
+        },
+      },
+    },
     audit: {
       description: 'Audit settings',
       highRisk: true,

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -49,11 +49,13 @@ const generateFrequencyProperties = frequencies => {
 };
 
 // Validates that a value is an ISO 8601 datetime string carrying explicit
-// timezone information (either trailing 'Z' for UTC or a numeric offset like
-// '+10:00'). Operators in any timezone can then read the value without
-// ambiguity. Empty string / null is treated as "no expiry" — the validator
-// allows it through.
-const ISO_DATETIME_WITH_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})$/;
+// timezone information (either trailing 'Z' for UTC or a colon-separated
+// offset like '+10:00'). The colon in the offset is mandatory — the basic
+// form (e.g. '+1000') is technically ISO 8601 but is inconsistently parsed
+// across runtimes, so we don't accept it.
+// Operators in any timezone can then read the value without ambiguity. Empty
+// string / null is treated as "no expiry" — the validator allows it through.
+const ISO_DATETIME_WITH_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})$/;
 const isoDatetimeWithTz = yup
   .string()
   .nullable()

--- a/packages/web/app/App.jsx
+++ b/packages/web/app/App.jsx
@@ -11,6 +11,7 @@ import { LoginView, FacilitySelectionView } from './views';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PromiseErrorBoundary } from './components/PromiseErrorBoundary';
 import { ForbiddenErrorModal } from './components/ForbiddenErrorModal';
+import { SystemBanner } from './components/SystemBanner';
 import {
   LoadingStatusPage,
   UnavailableStatusPage,
@@ -71,6 +72,7 @@ export function App({ sidebar, children }) {
       <PromiseErrorBoundary>
         <ErrorBoundary errorKey={location.pathname}>
           <AppContentsContainer>
+            <SystemBanner />
             {children}
             <ForbiddenErrorModal />
           </AppContentsContainer>

--- a/packages/web/app/App.jsx
+++ b/packages/web/app/App.jsx
@@ -69,15 +69,18 @@ export function App({ sidebar, children }) {
   return (
     <AppContainer>
       {sidebar}
-      <PromiseErrorBoundary>
-        <ErrorBoundary errorKey={location.pathname}>
-          <AppContentsContainer>
-            <SystemBanner />
+      <AppContentsContainer>
+        {/* The banner sits outside the route ErrorBoundary so that downtime
+            warnings (the most likely cause of an error) stay visible if the
+            route component throws. */}
+        <SystemBanner />
+        <PromiseErrorBoundary>
+          <ErrorBoundary errorKey={location.pathname}>
             {children}
             <ForbiddenErrorModal />
-          </AppContentsContainer>
-        </ErrorBoundary>
-      </PromiseErrorBoundary>
+          </ErrorBoundary>
+        </PromiseErrorBoundary>
+      </AppContentsContainer>
     </AppContainer>
   );
 }

--- a/packages/web/app/components/SystemBanner.jsx
+++ b/packages/web/app/components/SystemBanner.jsx
@@ -38,6 +38,10 @@ const DismissButton = styled(IconButton)`
   padding: 4px;
 `;
 
+// Cap the dismissed list so it doesn't grow unboundedly over months of use.
+// 10 is generous given there is one global banner at a time.
+const DISMISSED_HISTORY_LIMIT = 10;
+
 const readDismissed = () => {
   try {
     const raw = localStorage.getItem(LOCAL_STORAGE_KEYS.DISMISSED_BANNERS);
@@ -62,11 +66,16 @@ export const SystemBanner = () => {
   const { getTranslation } = useTranslation();
   const banner = getSetting('banner');
 
+  // Only tick the clock when there's an active banner with an expiry to
+  // check. The common case is no banner at all — running this interval for
+  // every logged-in user would burn re-renders for no reason.
+  const hasExpiry = Boolean(banner?.enabled && banner?.expiresAt);
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
+    if (!hasExpiry) return undefined;
     const interval = setInterval(() => setNow(Date.now()), 30_000);
     return () => clearInterval(interval);
-  }, []);
+  }, [hasExpiry]);
 
   const [dismissed, setDismissed] = useState(readDismissed);
 
@@ -87,9 +96,12 @@ export const SystemBanner = () => {
 
   const handleDismiss = () => {
     if (!key) return;
-    const next = [...dismissed, key];
-    setDismissed(next);
-    writeDismissed(next);
+    setDismissed(prev => {
+      if (prev.includes(key)) return prev;
+      const next = [...prev, key].slice(-DISMISSED_HISTORY_LIMIT);
+      writeDismissed(next);
+      return next;
+    });
   };
 
   return (

--- a/packages/web/app/components/SystemBanner.jsx
+++ b/packages/web/app/components/SystemBanner.jsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { IconButton } from '@material-ui/core';
+import CloseIcon from '@mui/icons-material/Close';
+
+import { useSettings } from '../contexts/Settings';
+import { useTranslation } from '../contexts/Translation';
+import { Colors } from '../constants';
+import { LOCAL_STORAGE_KEYS } from '../constants/misc';
+
+const SEVERITY_COLOURS = {
+  info: { background: Colors.primary10, text: Colors.darkestText },
+  warning: { background: Colors.secondary, text: Colors.darkestText },
+  error: { background: Colors.alert, text: Colors.white },
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  background: ${props => SEVERITY_COLOURS[props.$severity].background};
+  color: ${props => SEVERITY_COLOURS[props.$severity].text};
+  border-block-end: 1px solid ${Colors.softOutline};
+`;
+
+const Message = styled.p`
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  white-space: pre-wrap;
+`;
+
+const DismissButton = styled(IconButton)`
+  color: inherit;
+  padding: 4px;
+`;
+
+const readDismissed = () => {
+  try {
+    const raw = localStorage.getItem(LOCAL_STORAGE_KEYS.DISMISSED_BANNERS);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeDismissed = list => {
+  localStorage.setItem(LOCAL_STORAGE_KEYS.DISMISSED_BANNERS, JSON.stringify(list));
+};
+
+// Dismissal key is derived from the content so that editing the message or
+// expiry on the server resets dismissal state for every user automatically.
+const dismissalKey = (message, expiresAt) => `${message}|${expiresAt ?? ''}`;
+
+export const SystemBanner = () => {
+  const { getSetting } = useSettings();
+  const { getTranslation } = useTranslation();
+  const banner = getSetting('banner');
+
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const [dismissed, setDismissed] = useState(readDismissed);
+
+  const key = useMemo(
+    () => (banner?.message ? dismissalKey(banner.message, banner.expiresAt) : null),
+    [banner?.message, banner?.expiresAt],
+  );
+
+  if (!banner?.enabled) return null;
+  if (!banner.message) return null;
+  if (banner.expiresAt) {
+    const expiry = Date.parse(banner.expiresAt);
+    if (!Number.isNaN(expiry) && expiry <= now) return null;
+  }
+  if (key && dismissed.includes(key)) return null;
+
+  const severity = SEVERITY_COLOURS[banner.severity] ? banner.severity : 'info';
+
+  const handleDismiss = () => {
+    if (!key) return;
+    const next = [...dismissed, key];
+    setDismissed(next);
+    writeDismissed(next);
+  };
+
+  return (
+    <Container $severity={severity} role="status" data-testid="system-banner">
+      <Message>{banner.message}</Message>
+      <DismissButton
+        size="small"
+        onClick={handleDismiss}
+        aria-label={getTranslation('general.action.dismiss', 'Dismiss')}
+        data-testid="system-banner-dismiss"
+      >
+        <CloseIcon style={{ fontSize: 18 }} />
+      </DismissButton>
+    </Container>
+  );
+};

--- a/packages/web/app/constants/misc.js
+++ b/packages/web/app/constants/misc.js
@@ -10,6 +10,7 @@ export const LOCAL_STORAGE_KEYS = /** @type {const} */ ({
   ROLE: 'role',
   LANGUAGE: 'language',
   SETTINGS: 'settings',
+  DISMISSED_BANNERS: 'dismissedBanners',
 });
 
 export const ALPHABET_FOR_ID =

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { Switch, IconButton, InputAdornment } from '@material-ui/core';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { SECRET_PLACEHOLDER } from '@tamanu/settings';
 import EditIcon from '@mui/icons-material/Edit';
 import { useFormikContext } from 'formik';
@@ -108,8 +109,19 @@ const SETTING_TYPES = {
   NUMBER: 'number',
   MULTILINE: 'multiline',
   MARKDOWN: 'markdown',
+  DATETIME: 'datetime',
   OBJECT: 'object',
   ARRAY: 'array',
+};
+
+// Picker operates on Date objects in the browser's local timezone for display,
+// and emits UTC ISO 8601 strings (`.toISOString()`) for storage. That keeps the
+// stored value unambiguous so operators in any timezone agree on the same
+// instant. Empty value clears the setting.
+const parseUtcIsoToDate = value => {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? null : new Date(ms);
 };
 
 const normalize = val => (val === null || val === '' ? '' : val);
@@ -496,6 +508,34 @@ export const SettingInput = ({
           DefaultButton={DefaultButton}
           data-testid={dataTestId}
         />
+      );
+    }
+    case SETTING_TYPES.DATETIME: {
+      const dateValue = parseUtcIsoToDate(displayValue);
+      return (
+        <Flexbox data-testid="flexbox-datetime">
+          <DateTimePicker
+            value={dateValue}
+            onChange={date => {
+              if (!date || Number.isNaN(date.getTime())) {
+                handleChangeValue('');
+                return;
+              }
+              handleChangeValue(date.toISOString());
+            }}
+            disabled={disabled}
+            slotProps={{
+              textField: {
+                error: Boolean(error),
+                helperText: error?.message,
+                size: 'small',
+                style: { width: '253px' },
+              },
+              actionBar: { actions: ['clear', 'today', 'accept'] },
+            }}
+          />
+          <DefaultButton data-testid="defaultbutton-datetime" />
+        </Flexbox>
       );
     }
     case SETTING_TYPES.OBJECT:


### PR DESCRIPTION
### Changes

🤖 Adds a site-wide system banner driven by a new `banner` global setting (`enabled`, `message`, `severity`, `expiresAt`). Operators set it from the admin Settings UI; the existing PG NOTIFY → `dbNotifier` → Socket.IO pipeline pushes the change to every connected web client in ~1s via the existing `SettingsRefresher`, so no restart or reload is needed.

Dismissal is per-user (localStorage) and keyed by message+expiresAt, so editing the banner content automatically resets dismissals.

`expiresAt` uses a new `SETTING_EDITORS.DATETIME` editor (MUI `DateTimePicker` in the admin UI). The editor displays in the operator's browser-local timezone but emits UTC ISO 8601 via `.toISOString()` and the schema validates it tightly with a yup test requiring either `Z` or a numeric offset — so operators in different timezones agree on the same instant and don't have to do timezone maths.

Includes Playwright coverage for both the picker (round-trip → UTC ISO) and the banner (display / dismissal / content-change-resets-dismissal / expiry suppression).

<img width="1695" height="382" alt="image" src="https://github.com/user-attachments/assets/dba24ce8-f2b7-4e90-82b1-f56b2abd688a" />


### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->