### PR TITLE
fix(web): no-issue: 2.56 hotfix: wait for PDF worker readiness

### DIFF
--- a/packages/web/app/utils/useRenderPDF.js
+++ b/packages/web/app/utils/useRenderPDF.js
@@ -1,9 +1,52 @@
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { wrap } from 'comlink';
+import { releaseProxy, wrap } from 'comlink';
 import Worker from '../workers/pdf.worker?worker';
 
-export const pdfWorker = wrap(new Worker());
+const waitForWorkerReady = worker =>
+  new Promise((resolve, reject) => {
+    const handleTimeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('PDF worker did not signal readiness within 5 minutes'));
+    }, 5 * 60 * 1000);
+
+    const handleMessage = event => {
+      if (event.data?.type !== 'pdf-render-ready') {
+        return;
+      }
+      cleanup();
+      resolve();
+    };
+
+    const handleError = error => {
+      cleanup();
+      reject(error);
+    };
+
+    const cleanup = () => {
+      clearTimeout(handleTimeout);
+      worker.removeEventListener('message', handleMessage);
+      worker.removeEventListener('error', handleError);
+    };
+
+    worker.addEventListener('message', handleMessage);
+    worker.addEventListener('error', handleError);
+  });
+
+const renderPDFInWorker = async props => {
+  const worker = new Worker();
+  const workerReady = waitForWorkerReady(worker);
+  const pdfWorker = wrap(worker);
+
+  try {
+    await workerReady;
+    const pdf = await pdfWorker.renderPDFInWorker(props);
+    return URL.createObjectURL(pdf);
+  } finally {
+    pdfWorker[releaseProxy]?.();
+    worker.terminate();
+  }
+};
 
 export const useRenderPDF = (props) => {
   const {
@@ -12,12 +55,19 @@ export const useRenderPDF = (props) => {
     error,
   } = useQuery(
     ['renderPDF', props.id, ...(props.queryDeps || [])],
-    () => pdfWorker.renderPDFInWorker(props),
+    () => renderPDFInWorker(props),
     {
       enabled: !!props.id,
     },
   );
 
-  useEffect(() => (url ? () => URL.revokeObjectURL(url) : undefined), [url]);
+  useEffect(() => {
+    if (!url) {
+      return undefined;
+    }
+
+    return () => URL.revokeObjectURL(url);
+  }, [url]);
+
   return { url, isFetching, error };
 };

--- a/packages/web/app/workers/pdf.worker.js
+++ b/packages/web/app/workers/pdf.worker.js
@@ -3,8 +3,10 @@ import './workerShim';
 
 const renderPDFInWorker = async (props) => {
   const { renderPDF } = await import('../renderPDF');
-  const pdf = await renderPDF(props);
-  return URL.createObjectURL(pdf);
+  return renderPDF(props);
 };
 
 expose({ renderPDFInWorker });
+Promise.resolve().then(() => {
+  self.postMessage({ type: 'pdf-render-ready' });
+});


### PR DESCRIPTION
### Changes

Cherry-picks #9839 (`869748d`) onto `release/2.56` to fix intermittent blank/failed PDF generation. Both touched files now match `main`.

Changes:

- **Per-call PDF worker** — `renderPDFInWorker` creates a worker per render and terminates/releases it in a `finally` block, instead of sharing a single module-level worker.
- **Readiness wait** — each render waits for the worker to signal `pdf-render-ready` before rendering.
- **Worker returns the Blob** — `pdf.worker.js` now returns the raw Blob and the main thread creates the object URL. On `release/2.56` the worker previously created the blob URL itself; left as-is, the new per-call wrapper would call `URL.createObjectURL` on that string and throw. Aligning the worker with `main` keeps it to a single `createObjectURL`.

`release/2.56` predated the per-call refactor, so all of the above are included here (the readiness fix depends on the per-call worker).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->