### PR TITLE
feat(mobile): TAM-1652: TOTP second factor at sign-in

### DIFF
--- a/packages/mobile/App/migrations/1780560982670-addTotpConfirmedAtToUsers.ts
+++ b/packages/mobile/App/migrations/1780560982670-addTotpConfirmedAtToUsers.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'totpConfirmedAt';
+
+// mirrors the server's users.totp_confirmed_at (synced fact that a confirmed
+// authenticator app exists; the seed itself never syncs)
+export class addTotpConfirmedAtToUsers1780560982670 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+
+    await queryRunner.addColumn(
+      table,
+      new TableColumn({
+        name: COLUMN_NAME,
+        type: 'datetime',
+        isNullable: true,
+      }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+
+    await queryRunner.dropColumn(table, COLUMN_NAME);
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -87,6 +87,7 @@ import { addSurveyFormVisibilityCriteria1773618699809 } from './1773618699809-ad
 import { removePatientTitleColumn1778199200000 } from './1778199200000-removePatientTitleColumn';
 import { addLabTestReferenceRangeColumns1778546880000 } from './1778546880000-addLabTestReferenceRangeColumns';
 import { addSurveyResponseEditMetadata1778560763154 } from './1778560763154-addSurveyResponseEditMetadata';
+import { addTotpConfirmedAtToUsers1780560982670 } from './1780560982670-addTotpConfirmedAtToUsers';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -177,4 +178,5 @@ export const migrationList = [
   removePatientTitleColumn1778199200000,
   addLabTestReferenceRangeColumns1778546880000,
   addSurveyResponseEditMetadata1778560763154,
+  addTotpConfirmedAtToUsers1780560982670,
 ];

--- a/packages/mobile/App/models/User.ts
+++ b/packages/mobile/App/models/User.ts
@@ -61,6 +61,11 @@ export class User extends BaseModel implements IUser {
   @Column({ default: VisibilityStatus.Current })
   visibilityStatus: string;
 
+  // synced mirror maintained by central: whether (and when) a confirmed
+  // authenticator app exists; the TOTP seed itself never syncs
+  @Column({ type: 'datetime', nullable: true })
+  totpConfirmedAt?: Date;
+
   isSuperUser() {
     return this.role === 'admin' || this.id === SYSTEM_USER_UUID;
   }

--- a/packages/mobile/App/services/auth/AuthService.ts
+++ b/packages/mobile/App/services/auth/AuthService.ts
@@ -3,7 +3,7 @@ import mitt from 'mitt';
 import { MODELS_MAP } from '~/models/modelsMap';
 import { IUser, SyncConnectionParameters } from '~/types';
 import { compare, hash } from './bcrypt';
-import { CentralServerConnection, LoginResponse } from '~/services/sync';
+import { MfaEnrolResponse, MfaLoginStep, CentralServerConnection, LoginResponse } from '~/services/sync';
 import { readConfig, writeConfig } from '~/services/config';
 import {
   AuthenticationError,
@@ -137,10 +137,14 @@ export class AuthService {
    */
   async beginMfaSignInStep(
     mfaToken: string,
-    path: string,
+    path: MfaLoginStep,
     body: Record<string, unknown> = {},
-  ): Promise<any> {
-    return this.centralServer.completeMfaLogin(path, mfaToken, body);
+  ): Promise<MfaEnrolResponse> {
+    return (this.centralServer.completeMfaLogin(
+      path,
+      mfaToken,
+      body,
+    ) as unknown) as Promise<MfaEnrolResponse>;
   }
 
   /**
@@ -151,7 +155,7 @@ export class AuthService {
   async completeMfaSignIn(
     params: SyncConnectionParameters,
     mfaToken: string,
-    path: string,
+    path: MfaLoginStep,
     body: Record<string, unknown> = {},
   ): Promise<{
     user: IUser;

--- a/packages/mobile/App/services/auth/AuthService.ts
+++ b/packages/mobile/App/services/auth/AuthService.ts
@@ -132,6 +132,18 @@ export class AuthService {
   }
 
   /**
+   * A non-terminal MFA step ('totp/enrol' returns the otpauth URI to set the
+   * authenticator app up with); no session handling.
+   */
+  async beginMfaSignInStep(
+    mfaToken: string,
+    path: string,
+    body: Record<string, unknown> = {},
+  ): Promise<any> {
+    return this.centralServer.completeMfaLogin(path, mfaToken, body);
+  }
+
+  /**
    * Complete a paused login from the TOTP step, then finalise the session the
    * same way a plain remote sign-in does. `path` is relative to mfa/login
    * ('totp' to verify, 'totp/enrol'/'totp/confirm' for forced enrolment).

--- a/packages/mobile/App/services/auth/AuthService.ts
+++ b/packages/mobile/App/services/auth/AuthService.ts
@@ -3,7 +3,7 @@ import mitt from 'mitt';
 import { MODELS_MAP } from '~/models/modelsMap';
 import { IUser, SyncConnectionParameters } from '~/types';
 import { compare, hash } from './bcrypt';
-import { CentralServerConnection } from '~/services/sync';
+import { CentralServerConnection, LoginResponse } from '~/services/sync';
 import { readConfig, writeConfig } from '~/services/config';
 import {
   AuthenticationError,
@@ -104,11 +104,12 @@ export class AuthService {
   }
 
   async remoteSignIn(params: SyncConnectionParameters): Promise<{
-    user: IUser;
-    token: string;
-    refreshToken: string;
-    localisation: object;
-    settings: object;
+    user?: IUser;
+    token?: string;
+    refreshToken?: string;
+    localisation?: object;
+    settings?: object;
+    mfaPending?: LoginResponse['mfaPending'];
   }> {
     // always use the server stored in config if there is one - last thing
     // we want is a device syncing down data from one server and then up
@@ -119,10 +120,43 @@ export class AuthService {
     // create the sync source and log in to it
     await this.centralServer.connect(server);
     console.log(`Getting token from ${server}`);
-    const { user, token, refreshToken, settings, localisation, permissions } =
-      await this.centralServer.login(params.email, params.password);
+    const data = await this.centralServer.login(params.email, params.password);
+
+    // password accepted but a second factor is owed: surface the pending
+    // state so the UI can run the TOTP step, then call completeMfaSignIn
+    if (data.mfaPending) {
+      return { mfaPending: data.mfaPending };
+    }
+
+    return this.finaliseRemoteSignIn(data, params);
+  }
+
+  /**
+   * Complete a paused login from the TOTP step, then finalise the session the
+   * same way a plain remote sign-in does. `path` is relative to mfa/login
+   * ('totp' to verify, 'totp/enrol'/'totp/confirm' for forced enrolment).
+   */
+  async completeMfaSignIn(
+    params: SyncConnectionParameters,
+    mfaToken: string,
+    path: string,
+    body: Record<string, unknown> = {},
+  ): Promise<{
+    user: IUser;
+    token: string;
+    refreshToken: string;
+    localisation: object;
+    settings: object;
+  }> {
+    const data = await this.centralServer.completeMfaLogin(path, mfaToken, body);
+    return this.finaliseRemoteSignIn(data, params);
+  }
+
+  private async finaliseRemoteSignIn(data: LoginResponse, params: SyncConnectionParameters) {
+    const { user, token, refreshToken, settings, localisation, permissions } = data;
     console.log(`Signed in as ${user.displayName}`);
 
+    const syncServerLocation = await readConfig('syncServerLocation');
     if (!syncServerLocation) {
       // after a successful login, if we didn't already read the server from
       // stored config, write the one we did use to config

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -335,6 +335,13 @@ export class CentralServerConnection {
         { backoff: { maxAttempts: 1 } },
       );
 
+      // password accepted but a second factor is owed: no tokens yet, hand the
+      // pending state back so the caller can run the TOTP step
+      if (data.mfaPending) {
+        this.emitter.emit('statusChange', CentralConnectionStatus.Connected);
+        return data;
+      }
+
       const facilityId = await readConfig('facilityId', '');
       const { token, refreshToken, user, allowedFacilities } = data;
       if (
@@ -351,6 +358,31 @@ export class CentralServerConnection {
         console.warn('Auth failed with an inexplicable error', data);
         throw new AuthenticationError(generalErrorMessage);
       }
+      this.emitter.emit('statusChange', CentralConnectionStatus.Connected);
+      return data;
+    } catch (err) {
+      this.throwError(err);
+    }
+  }
+
+  /**
+   * Complete a paused login by satisfying the second factor. `path` is relative
+   * to mfa/login (mobile uses 'totp' to verify, and 'totp/enrol' + 'totp/confirm'
+   * for forced enrolment). The pending token authorises the call; the terminal
+   * step returns the full login payload.
+   */
+  async completeMfaLogin(
+    path: string,
+    mfaToken: string,
+    body: Record<string, unknown> = {},
+  ): Promise<LoginResponse> {
+    try {
+      const data = await this.post<LoginResponse>(
+        `mfa/login/${path}`,
+        {},
+        { mfaToken, ...body },
+        { backoff: { maxAttempts: 1 } },
+      );
       this.emitter.emit('statusChange', CentralConnectionStatus.Connected);
       return data;
     } catch (err) {

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -4,7 +4,7 @@ import axios, { AxiosRequestConfig, AxiosError } from 'axios';
 import { CAN_ACCESS_ALL_FACILITIES, DEVICE_SCOPES } from '@tamanu/constants';
 import { ERROR_TYPE, Problem } from '@tamanu/errors';
 import { readConfig, writeConfig } from '../config';
-import { FetchOptions, LoginResponse, SyncRecord } from './types';
+import { FetchOptions, LoginResponse, MFA_LOGIN_STEPS, MfaLoginStep, SyncRecord } from './types';
 import {
   AuthenticationError,
   forbiddenFacilityMessage,
@@ -105,7 +105,9 @@ export class CentralServerConnection {
       'X-Version': version,
       ...(extraHeaders || {}),
     };
-    const isLogin = path.startsWith('login');
+    // mfa/login is part of the login exchange too: its problems must reach the
+  // UI with their type intact (wrong code vs expired pass differ)
+  const isLogin = path.startsWith('login') || path.startsWith('mfa/login');
     try {
       const response = await callWithBackoff(async () => {
         const configAxios: AxiosRequestConfig = {
@@ -372,10 +374,13 @@ export class CentralServerConnection {
    * step returns the full login payload.
    */
   async completeMfaLogin(
-    path: string,
+    path: MfaLoginStep,
     mfaToken: string,
     body: Record<string, unknown> = {},
   ): Promise<LoginResponse> {
+    if (!MFA_LOGIN_STEPS.includes(path)) {
+      throw new Error(`Unknown MFA login step: ${path}`);
+    }
     try {
       const data = await this.post<LoginResponse>(
         `mfa/login/${path}`,

--- a/packages/mobile/App/services/sync/types.ts
+++ b/packages/mobile/App/services/sync/types.ts
@@ -38,6 +38,16 @@ export interface SyncRecordData {
   [key: string]: any;
 }
 
+// the mfa/login completion endpoints mobile drives — a fixed allowlist, so a
+// caller can never steer the request into an arbitrary URL path
+export const MFA_LOGIN_STEPS = ['totp', 'totp/enrol', 'totp/confirm'] as const;
+export type MfaLoginStep = (typeof MFA_LOGIN_STEPS)[number];
+
+// what the non-terminal totp/enrol step answers with
+export interface MfaEnrolResponse {
+  otpauthUrl: string;
+}
+
 export interface MfaPending {
   // mobile only completes 'challenge'/'enrol' via TOTP (WebAuthn on mobile is
   // a separate future effort)

--- a/packages/mobile/App/services/sync/types.ts
+++ b/packages/mobile/App/services/sync/types.ts
@@ -38,6 +38,16 @@ export interface SyncRecordData {
   [key: string]: any;
 }
 
+export interface MfaPending {
+  // mobile only completes 'challenge'/'enrol' via TOTP (WebAuthn on mobile is
+  // a separate future effort)
+  kind: string;
+  factors: string[];
+  skippable?: boolean;
+  // short-lived token for the mfa/login completion endpoints
+  token: string;
+}
+
 export interface LoginResponse {
   token: string;
   refreshToken: string;
@@ -46,6 +56,8 @@ export interface LoginResponse {
   settings: object;
   permissions: [];
   allowedFacilities: { id: string }[] | 'ALL';
+  // present instead of the tokens when a second factor is still owed
+  mfaPending?: MfaPending;
 }
 
 export type FetchOptions = {

--- a/packages/mobile/App/ui/components/Forms/SignInForm.tsx
+++ b/packages/mobile/App/ui/components/Forms/SignInForm.tsx
@@ -88,7 +88,7 @@ export const SignInForm: FunctionComponent<any> = ({
   const [existingHost, setExistingHost] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const passwordRef = useRef(null);
-  const { signIn } = useAuth();
+  const { signIn, mfaSignInExpired } = useAuth();
   const { getTranslation } = useTranslation();
 
   const handleSignIn = useCallback(
@@ -161,7 +161,17 @@ export const SignInForm: FunctionComponent<any> = ({
                 label={<TranslatedText stringId="general.country.label" fallback="Country" />}
               />
             )}
-            <ErrorBox errorMessage={errorMessage} />
+            <ErrorBox
+              errorMessage={
+                errorMessage ||
+                (mfaSignInExpired
+                  ? getTranslation(
+                      'mfa.totp.expiredError',
+                      'This sign-in attempt has expired, please try again.',
+                    )
+                  : '')
+              }
+            />
             <Field
               name="email"
               keyboardType="email-address"

--- a/packages/mobile/App/ui/components/Forms/SignInForm.tsx
+++ b/packages/mobile/App/ui/components/Forms/SignInForm.tsx
@@ -80,7 +80,11 @@ const ServerInfo = __DEV__
     }
   : (): ReactElement => null; // hide info on production
 
-export const SignInForm: FunctionComponent<any> = ({ onOutdatedVersionError, onSuccess }) => {
+export const SignInForm: FunctionComponent<any> = ({
+  onOutdatedVersionError,
+  onSuccess,
+  onMfaRequired,
+}) => {
   const [existingHost, setExistingHost] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const passwordRef = useRef(null);
@@ -94,7 +98,12 @@ export const SignInForm: FunctionComponent<any> = ({ onOutdatedVersionError, onS
         if (!existingHost && !values.server) {
           throw new Error('Please select a server to connect to');
         }
-        await signIn(values);
+        const status = await signIn(values);
+        if (status === 'mfa') {
+          // password accepted but a second factor is owed
+          onMfaRequired();
+          return;
+        }
         onSuccess();
       } catch (error) {
         if (error instanceof OutdatedVersionError) {
@@ -105,7 +114,7 @@ export const SignInForm: FunctionComponent<any> = ({ onOutdatedVersionError, onS
         }
       }
     },
-    [existingHost, signIn,onOutdatedVersionError, onSuccess],
+    [existingHost, signIn, onOutdatedVersionError, onSuccess, onMfaRequired],
   );
 
   useEffect(() => {

--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -39,6 +39,10 @@ interface AuthContextData {
   // terminal MFA step ('totp' or 'totp/confirm'); signs the user in on success
   completeMfaSignIn: (path: MfaLoginStep, body?: Record<string, unknown>) => Promise<void>;
   cancelMfaSignIn: () => void;
+  // the pending pass died (typically expired while the user was in their
+  // authenticator app): state is discarded and sign-in shows a try-again note
+  expireMfaSignIn: () => void;
+  mfaSignInExpired: boolean;
   signOut: () => void;
   reconnectWithPassword: (params: ReconnectWithPasswordParameters) => Promise<void>;
   signOutClient: (signedOutFromInactivity: boolean) => void;
@@ -78,6 +82,7 @@ const Provider = ({
     pending: MfaPending;
     params: SyncConnectionParameters;
   } | null>(null);
+  const [mfaSignInExpired, setMfaSignInExpired] = useState(false);
 
   const setUserFirstSignIn = (): void => {
     props.setFirstSignIn(false);
@@ -146,6 +151,7 @@ const Provider = ({
   };
 
   const signIn = async (params: SyncConnectionParameters): Promise<'success' | 'mfa'> => {
+    setMfaSignInExpired(false);
     const network = await NetInfo.fetch();
     let status: 'success' | 'mfa' = 'success';
     if (network.isConnected) {
@@ -193,6 +199,11 @@ const Provider = ({
 
   const cancelMfaSignIn = (): void => {
     setMfaSignIn(null);
+  };
+
+  const expireMfaSignIn = (): void => {
+    setMfaSignIn(null);
+    setMfaSignInExpired(true);
   };
 
   const signOut = (): void => {
@@ -277,6 +288,8 @@ const Provider = ({
         beginMfaSignInStep,
         completeMfaSignIn,
         cancelMfaSignIn,
+        expireMfaSignIn,
+        mfaSignInExpired,
         signOut,
         reconnectWithPassword,
         signOutClient,

--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -17,7 +17,7 @@ import { WithAuthStoreProps } from '~/ui/store/ducks/auth';
 import { Routes } from '~/ui/helpers/routes';
 import { BackendContext } from '~/ui/contexts/BackendContext';
 import { IUser, ReconnectWithPasswordParameters, SyncConnectionParameters } from '~/types';
-import { MfaPending } from '~/services/sync';
+import { MfaEnrolResponse, MfaLoginStep, MfaPending } from '~/services/sync';
 import { ResetPasswordFormModel } from '/interfaces/forms/ResetPasswordFormProps';
 import { ChangePasswordFormModel } from '/interfaces/forms/ChangePasswordFormProps';
 import { buildAbility } from '~/ui/helpers/ability';
@@ -35,9 +35,9 @@ interface AuthContextData {
   // set while a sign-in is paused for a second factor
   mfaPending: MfaPending | null;
   // non-terminal MFA step, e.g. 'totp/enrol' to get the otpauth URI
-  beginMfaSignInStep: (path: string, body?: Record<string, unknown>) => Promise<any>;
+  beginMfaSignInStep: (path: MfaLoginStep, body?: Record<string, unknown>) => Promise<MfaEnrolResponse>;
   // terminal MFA step ('totp' or 'totp/confirm'); signs the user in on success
-  completeMfaSignIn: (path: string, body?: Record<string, unknown>) => Promise<void>;
+  completeMfaSignIn: (path: MfaLoginStep, body?: Record<string, unknown>) => Promise<void>;
   cancelMfaSignIn: () => void;
   signOut: () => void;
   reconnectWithPassword: (params: ReconnectWithPasswordParameters) => Promise<void>;
@@ -164,15 +164,15 @@ const Provider = ({
   };
 
   const beginMfaSignInStep = async (
-    path: string,
+    path: MfaLoginStep,
     body: Record<string, unknown> = {},
-  ): Promise<any> => {
+  ): Promise<MfaEnrolResponse> => {
     if (!mfaSignIn) throw new Error('No sign-in is awaiting a second factor');
     return backend.auth.beginMfaSignInStep(mfaSignIn.pending.token, path, body);
   };
 
   const completeMfaSignIn = async (
-    path: string,
+    path: MfaLoginStep,
     body: Record<string, unknown> = {},
   ): Promise<void> => {
     if (!mfaSignIn) throw new Error('No sign-in is awaiting a second factor');

--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ import { WithAuthStoreProps } from '~/ui/store/ducks/auth';
 import { Routes } from '~/ui/helpers/routes';
 import { BackendContext } from '~/ui/contexts/BackendContext';
 import { IUser, ReconnectWithPasswordParameters, SyncConnectionParameters } from '~/types';
+import { MfaPending } from '~/services/sync';
 import { ResetPasswordFormModel } from '/interfaces/forms/ResetPasswordFormProps';
 import { ChangePasswordFormModel } from '/interfaces/forms/ChangePasswordFormProps';
 import { buildAbility } from '~/ui/helpers/ability';
@@ -30,7 +31,14 @@ interface AuthContextData {
   user: IUser;
   ability: PureAbility;
   signedIn: boolean;
-  signIn: (params: SyncConnectionParameters) => Promise<void>;
+  signIn: (params: SyncConnectionParameters) => Promise<'success' | 'mfa'>;
+  // set while a sign-in is paused for a second factor
+  mfaPending: MfaPending | null;
+  // non-terminal MFA step, e.g. 'totp/enrol' to get the otpauth URI
+  beginMfaSignInStep: (path: string, body?: Record<string, unknown>) => Promise<any>;
+  // terminal MFA step ('totp' or 'totp/confirm'); signs the user in on success
+  completeMfaSignIn: (path: string, body?: Record<string, unknown>) => Promise<void>;
+  cancelMfaSignIn: () => void;
   signOut: () => void;
   reconnectWithPassword: (params: ReconnectWithPasswordParameters) => Promise<void>;
   signOutClient: (signedOutFromInactivity: boolean) => void;
@@ -63,6 +71,13 @@ const Provider = ({
   const [ability, setAbility] = useState(null);
   const [resetPasswordLastEmailUsed, setResetPasswordLastEmailUsed] = useState('');
   const [preventSignOutOnFailure, setPreventSignOutOnFailure] = useState(false);
+  // a sign-in paused for a second factor: the pending state from the server,
+  // plus the original connection params (the password is needed again to save
+  // the local user once the factor is satisfied)
+  const [mfaSignIn, setMfaSignIn] = useState<{
+    pending: MfaPending;
+    params: SyncConnectionParameters;
+  } | null>(null);
 
   const setUserFirstSignIn = (): void => {
     props.setFirstSignIn(false);
@@ -103,22 +118,39 @@ const Provider = ({
       password: params.password,
     };
     setPreventSignOutOnFailure(true);
-    await remoteSignIn(payload);
+    const status = await remoteSignIn(payload);
+    if (status === 'mfa') {
+      // a reconnect can't drive the MFA screen from here: drop the pending
+      // state and ask the user to log in again, which runs the full flow
+      setMfaSignIn(null);
+      throw new Error('Your account requires a second factor. Please log in again.');
+    }
     backend.syncManager.triggerSync();
   };
 
-  const remoteSignIn = async (params: SyncConnectionParameters): Promise<void> => {
-    const { user: usr, settings, token, refreshToken } = await backend.auth.remoteSignIn(params);
+  const finaliseSignIn = ({ user: usr, settings: stngs, token, refreshToken }): void => {
     setToken(token);
-    setSettings(settings);
+    setSettings(stngs);
     setRefreshToken(refreshToken);
     signInAs(usr);
   };
 
-  const signIn = async (params: SyncConnectionParameters): Promise<void> => {
+  const remoteSignIn = async (params: SyncConnectionParameters): Promise<'success' | 'mfa'> => {
+    const result = await backend.auth.remoteSignIn(params);
+    if (result.mfaPending) {
+      setMfaSignIn({ pending: result.mfaPending, params });
+      return 'mfa';
+    }
+    finaliseSignIn(result);
+    return 'success';
+  };
+
+  const signIn = async (params: SyncConnectionParameters): Promise<'success' | 'mfa'> => {
     const network = await NetInfo.fetch();
+    let status: 'success' | 'mfa' = 'success';
     if (network.isConnected) {
-      await remoteSignIn(params);
+      status = await remoteSignIn(params);
+      if (status === 'mfa') return status;
     } else {
       await localSignIn(params);
     }
@@ -128,6 +160,39 @@ const Provider = ({
     if (facilityId) {
       backend.syncManager.triggerSync(); // we deliberately don't await this
     }
+    return status;
+  };
+
+  const beginMfaSignInStep = async (
+    path: string,
+    body: Record<string, unknown> = {},
+  ): Promise<any> => {
+    if (!mfaSignIn) throw new Error('No sign-in is awaiting a second factor');
+    return backend.auth.beginMfaSignInStep(mfaSignIn.pending.token, path, body);
+  };
+
+  const completeMfaSignIn = async (
+    path: string,
+    body: Record<string, unknown> = {},
+  ): Promise<void> => {
+    if (!mfaSignIn) throw new Error('No sign-in is awaiting a second factor');
+    const result = await backend.auth.completeMfaSignIn(
+      mfaSignIn.params,
+      mfaSignIn.pending.token,
+      path,
+      body,
+    );
+    finaliseSignIn(result);
+    setMfaSignIn(null);
+
+    const facilityId = await readConfig('facilityId', '');
+    if (facilityId) {
+      backend.syncManager.triggerSync(); // we deliberately don't await this
+    }
+  };
+
+  const cancelMfaSignIn = (): void => {
+    setMfaSignIn(null);
   };
 
   const signOut = (): void => {
@@ -208,6 +273,10 @@ const Provider = ({
       value={{
         setUserFirstSignIn,
         signIn,
+        mfaPending: mfaSignIn?.pending ?? null,
+        beginMfaSignInStep,
+        completeMfaSignIn,
+        cancelMfaSignIn,
         signOut,
         reconnectWithPassword,
         signOutClient,

--- a/packages/mobile/App/ui/helpers/routes.ts
+++ b/packages/mobile/App/ui/helpers/routes.ts
@@ -19,6 +19,7 @@ export const Routes = {
     Index: '',
     Intro: '',
     SignIn: '',
+    MfaTotp: '',
     SelectFacility: '',
     ResetPassword: '',
     ChangePassword: '',

--- a/packages/mobile/App/ui/navigation/screens/signup/MfaTotp.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/MfaTotp.tsx
@@ -16,6 +16,7 @@ import { useAuth } from '~/ui/contexts/AuthContext';
 import { Button } from '/components/Button';
 import { TextField } from '/components/TextField/TextField';
 import { TranslatedText } from '/components/Translations/TranslatedText';
+import { ERROR_TYPE } from '@tamanu/errors';
 
 /**
  * Second-factor step for a paused sign-in. Mobile completes MFA with an
@@ -34,7 +35,7 @@ export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement =>
   const isEnrol = mfaPending?.kind === 'enrol';
   const [otpauthUrl, setOtpauthUrl] = useState<string | null>(null);
   const [code, setCode] = useState('');
-  const [error, setError] = useState<'enrolFailed' | 'badCode' | null>(null);
+  const [error, setError] = useState<'enrolFailed' | 'badCode' | 'expired' | 'openFailed' | null>(null);
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
@@ -49,7 +50,14 @@ export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement =>
   const secret = otpauthUrl ? (otpauthUrl.match(/[?&]secret=([A-Z2-7]+)/i)?.[1] ?? null) : null;
 
   const onOpenAuthenticator = useCallback(() => {
-    if (otpauthUrl) Linking.openURL(otpauthUrl).catch(() => {});
+    // the URL comes from the server: never hand a non-otpauth scheme to the
+    // OS, and tell the user when nothing could open it (the manual key below
+    // is the fallback)
+    if (!otpauthUrl?.startsWith('otpauth://')) {
+      setError('openFailed');
+      return;
+    }
+    Linking.openURL(otpauthUrl).catch(() => setError('openFailed'));
   }, [otpauthUrl]);
 
   const navigateOnSuccess = useCallback(async () => {
@@ -71,8 +79,11 @@ export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement =>
     try {
       await completeMfaSignIn(isEnrol ? 'totp/confirm' : 'totp', { code });
       await navigateOnSuccess();
-    } catch (_err) {
-      setError('badCode');
+    } catch (err) {
+      // a wrong code is retryable; anything else (typically the short-lived
+      // pending pass expiring while the user was off in their authenticator
+      // app) means this attempt is over and they must log in again
+      setError(err?.type === ERROR_TYPE.AUTH_CREDENTIAL_INVALID ? 'badCode' : 'expired');
     } finally {
       setBusy(false);
     }
@@ -163,15 +174,28 @@ export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement =>
             />
             {error && (
               <StyledText color={theme.colors.ALERT} fontSize={12} marginTop={5}>
-                {error === 'enrolFailed' ? (
+                {error === 'enrolFailed' && (
                   <TranslatedText
                     stringId="mfa.totp.enrolError"
                     fallback="Could not start authenticator setup."
                   />
-                ) : (
+                )}
+                {error === 'badCode' && (
                   <TranslatedText
                     stringId="mfa.totp.codeError"
                     fallback="Incorrect code. Please try again."
+                  />
+                )}
+                {error === 'expired' && (
+                  <TranslatedText
+                    stringId="mfa.totp.expiredError"
+                    fallback="This sign-in attempt has expired. Please cancel and log in again."
+                  />
+                )}
+                {error === 'openFailed' && (
+                  <TranslatedText
+                    stringId="mfa.totp.openError"
+                    fallback="Could not open an authenticator app. Enter the key below manually instead."
                   />
                 )}
               </StyledText>

--- a/packages/mobile/App/ui/navigation/screens/signup/MfaTotp.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/MfaTotp.tsx
@@ -30,12 +30,12 @@ import { ERROR_TYPE } from '@tamanu/errors';
  */
 export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement => {
   const auth = useAuth();
-  const { mfaPending, beginMfaSignInStep, completeMfaSignIn, cancelMfaSignIn } = auth;
+  const { mfaPending, beginMfaSignInStep, completeMfaSignIn, cancelMfaSignIn, expireMfaSignIn } = auth;
 
   const isEnrol = mfaPending?.kind === 'enrol';
   const [otpauthUrl, setOtpauthUrl] = useState<string | null>(null);
   const [code, setCode] = useState('');
-  const [error, setError] = useState<'enrolFailed' | 'badCode' | 'expired' | 'openFailed' | null>(null);
+  const [error, setError] = useState<'enrolFailed' | 'badCode' | 'openFailed' | null>(null);
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
@@ -80,14 +80,20 @@ export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement =>
       await completeMfaSignIn(isEnrol ? 'totp/confirm' : 'totp', { code });
       await navigateOnSuccess();
     } catch (err) {
-      // a wrong code is retryable; anything else (typically the short-lived
-      // pending pass expiring while the user was off in their authenticator
-      // app) means this attempt is over and they must log in again
-      setError(err?.type === ERROR_TYPE.AUTH_CREDENTIAL_INVALID ? 'badCode' : 'expired');
+      if (err?.type === ERROR_TYPE.AUTH_CREDENTIAL_INVALID) {
+        // a wrong code is retryable in place
+        setError('badCode');
+      } else {
+        // anything else (typically the short-lived pending pass expiring
+        // while the user was off in their authenticator app) means this
+        // attempt is over: discard it for them — the cleared pending state
+        // navigates back to sign-in, which shows the try-again note
+        expireMfaSignIn();
+      }
     } finally {
       setBusy(false);
     }
-  }, [completeMfaSignIn, isEnrol, code, navigateOnSuccess]);
+  }, [completeMfaSignIn, expireMfaSignIn, isEnrol, code, navigateOnSuccess]);
 
   const onCancel = useCallback(() => {
     cancelMfaSignIn();
@@ -184,12 +190,6 @@ export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement =>
                   <TranslatedText
                     stringId="mfa.totp.codeError"
                     fallback="Incorrect code. Please try again."
-                  />
-                )}
-                {error === 'expired' && (
-                  <TranslatedText
-                    stringId="mfa.totp.expiredError"
-                    fallback="This sign-in attempt has expired. Please cancel and log in again."
                   />
                 )}
                 {error === 'openFailed' && (

--- a/packages/mobile/App/ui/navigation/screens/signup/MfaTotp.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/MfaTotp.tsx
@@ -1,0 +1,204 @@
+import React, { FunctionComponent, ReactElement, useCallback, useEffect, useState } from 'react';
+import { KeyboardAvoidingView, Linking, StatusBar } from 'react-native';
+
+import {
+  FullView,
+  StyledSafeAreaView,
+  StyledText,
+  StyledTouchableOpacity,
+  StyledView,
+} from '/styled/common';
+import { Orientation, screenPercentageToDP } from '/helpers/screen';
+import { theme } from '/styled/theme';
+import { Routes } from '/helpers/routes';
+import { readConfig } from '~/services/config';
+import { useAuth } from '~/ui/contexts/AuthContext';
+import { Button } from '/components/Button';
+import { TextField } from '/components/TextField/TextField';
+import { TranslatedText } from '/components/Translations/TranslatedText';
+
+/**
+ * Second-factor step for a paused sign-in. Mobile completes MFA with an
+ * authenticator app (TOTP) only — native passkeys are a separate effort.
+ *
+ * For a challenge the user just enters a code. For forced enrolment the seed
+ * is set up first: the authenticator app usually lives on this same phone, so
+ * rather than a QR (which can't be scanned from the device displaying it) we
+ * open the otpauth:// URI directly — authenticator apps register that scheme —
+ * with the secret shown for manual entry as a fallback.
+ */
+export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement => {
+  const auth = useAuth();
+  const { mfaPending, beginMfaSignInStep, completeMfaSignIn, cancelMfaSignIn } = auth;
+
+  const isEnrol = mfaPending?.kind === 'enrol';
+  const [otpauthUrl, setOtpauthUrl] = useState<string | null>(null);
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<'enrolFailed' | 'badCode' | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!isEnrol) return;
+    beginMfaSignInStep('totp/enrol')
+      .then(({ otpauthUrl: url }) => setOtpauthUrl(url))
+      .catch(() => setError('enrolFailed'));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEnrol]);
+
+  // hermes' URL has no searchParams; the secret is base32 so a regex is safe
+  const secret = otpauthUrl ? (otpauthUrl.match(/[?&]secret=([A-Z2-7]+)/i)?.[1] ?? null) : null;
+
+  const onOpenAuthenticator = useCallback(() => {
+    if (otpauthUrl) Linking.openURL(otpauthUrl).catch(() => {});
+  }, [otpauthUrl]);
+
+  const navigateOnSuccess = useCallback(async () => {
+    const facilityId = await readConfig('facilityId', '');
+    if (!facilityId) {
+      navigation.navigate(Routes.SignUpStack.SelectFacility);
+    } else if (auth.checkFirstSession()) {
+      navigation.navigate(Routes.HomeStack.Index);
+    } else {
+      navigation.navigate(Routes.HomeStack.Index, {
+        screen: Routes.HomeStack.HomeTabs.Index,
+      });
+    }
+  }, [navigation, auth]);
+
+  const onSubmit = useCallback(async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      await completeMfaSignIn(isEnrol ? 'totp/confirm' : 'totp', { code });
+      await navigateOnSuccess();
+    } catch (_err) {
+      setError('badCode');
+    } finally {
+      setBusy(false);
+    }
+  }, [completeMfaSignIn, isEnrol, code, navigateOnSuccess]);
+
+  const onCancel = useCallback(() => {
+    cancelMfaSignIn();
+    navigation.navigate(Routes.SignUpStack.SignIn);
+  }, [cancelMfaSignIn, navigation]);
+
+  // e.g. after process death there is nothing to complete; go back to sign in
+  useEffect(() => {
+    if (!mfaPending) navigation.navigate(Routes.SignUpStack.SignIn);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mfaPending]);
+
+  if (!mfaPending) return null;
+
+  return (
+    <FullView background={theme.colors.PRIMARY_MAIN}>
+      <StatusBar barStyle="light-content" />
+      <StyledSafeAreaView>
+        <KeyboardAvoidingView behavior="padding">
+          <StyledView
+            marginTop={screenPercentageToDP(8, Orientation.Height)}
+            marginLeft={screenPercentageToDP(2.43, Orientation.Width)}
+            marginRight={screenPercentageToDP(2.43, Orientation.Width)}
+          >
+            <StyledText fontSize={30} fontWeight="bold" marginBottom={5} color={theme.colors.WHITE}>
+              {isEnrol ? (
+                <TranslatedText
+                  stringId="mfa.enrol.heading"
+                  fallback="Set up two-factor authentication"
+                />
+              ) : (
+                <TranslatedText stringId="mfa.challenge.heading" fallback="Two-factor authentication" />
+              )}
+            </StyledText>
+            <StyledText fontSize={14} color={theme.colors.WHITE} marginBottom={15}>
+              {isEnrol ? (
+                <TranslatedText
+                  stringId="mfa.totp.enrolInstructions.mobile"
+                  fallback="Add your account to an authenticator app, then enter the 6-digit code."
+                />
+              ) : (
+                <TranslatedText
+                  stringId="mfa.totp.challengeInstructions"
+                  fallback="Enter the 6-digit code from your authenticator app."
+                />
+              )}
+            </StyledText>
+
+            {isEnrol && (
+              <StyledView marginBottom={15}>
+                <Button
+                  onPress={onOpenAuthenticator}
+                  disabled={!otpauthUrl}
+                  buttonText={
+                    <TranslatedText
+                      stringId="mfa.totp.openAuthenticator"
+                      fallback="Open in authenticator app"
+                    />
+                  }
+                />
+                {secret && (
+                  <StyledText
+                    fontSize={12}
+                    color={theme.colors.WHITE}
+                    marginTop={10}
+                    textAlign="center"
+                  >
+                    <TranslatedText
+                      stringId="mfa.totp.manualKey"
+                      fallback="Or enter this key manually:"
+                    />
+                    {'\n'}
+                    {secret}
+                  </StyledText>
+                )}
+              </StyledView>
+            )}
+
+            <TextField
+              label={<TranslatedText stringId="mfa.totp.code.label" fallback="Authenticator code" />}
+              value={code}
+              onChange={setCode}
+              keyboardType="numeric"
+            />
+            {error && (
+              <StyledText color={theme.colors.ALERT} fontSize={12} marginTop={5}>
+                {error === 'enrolFailed' ? (
+                  <TranslatedText
+                    stringId="mfa.totp.enrolError"
+                    fallback="Could not start authenticator setup."
+                  />
+                ) : (
+                  <TranslatedText
+                    stringId="mfa.totp.codeError"
+                    fallback="Incorrect code. Please try again."
+                  />
+                )}
+              </StyledText>
+            )}
+            <StyledView marginTop={15}>
+              <Button
+                onPress={onSubmit}
+                disabled={busy || !code}
+                buttonText={
+                  <TranslatedText stringId="general.action.confirm" fallback="Confirm" />
+                }
+              />
+            </StyledView>
+            <StyledTouchableOpacity onPress={onCancel}>
+              <StyledText
+                width="100%"
+                textAlign="center"
+                marginTop={20}
+                fontSize={12}
+                color={theme.colors.WHITE}
+              >
+                <TranslatedText stringId="general.action.cancel" fallback="Cancel" />
+              </StyledText>
+            </StyledTouchableOpacity>
+          </StyledView>
+        </KeyboardAvoidingView>
+      </StyledSafeAreaView>
+    </FullView>
+  );
+};

--- a/packages/mobile/App/ui/navigation/screens/signup/MfaTotp.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/MfaTotp.tsx
@@ -105,10 +105,10 @@ export const MfaTotp: FunctionComponent<any> = ({ navigation }): ReactElement =>
               {isEnrol ? (
                 <TranslatedText
                   stringId="mfa.enrol.heading"
-                  fallback="Set up two-factor authentication"
+                  fallback="Set up multi-factor authentication"
                 />
               ) : (
-                <TranslatedText stringId="mfa.challenge.heading" fallback="Two-factor authentication" />
+                <TranslatedText stringId="mfa.challenge.heading" fallback="Multi-factor authentication" />
               )}
             </StyledText>
             <StyledText fontSize={14} color={theme.colors.WHITE} marginBottom={15}>

--- a/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
@@ -122,6 +122,9 @@ export const SignIn: FunctionComponent<any> = ({ navigation }: SignInProps) => {
                 buttonUrl: error.updateUrl,
               });
             }}
+            onMfaRequired={(): void => {
+              navigation.navigate(Routes.SignUpStack.MfaTotp);
+            }}
             onSuccess={(): void => {
               if (!facilityId) {
                 navigation.navigate(Routes.SignUpStack.SelectFacility);

--- a/packages/mobile/App/ui/navigation/stacks/SignUp.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/SignUp.tsx
@@ -7,6 +7,7 @@ import { IntroScreen } from '../screens/signup/Intro';
 import { SignIn } from '../screens/signup/SignIn';
 import { IndexStackProps } from '~/ui/interfaces/Screens/SignUpStack';
 
+import { MfaTotp } from '../screens/signup/MfaTotp';
 import { ResetPassword } from '../screens/signup/ResetPassword';
 import { ChangePassword } from '../screens/signup/ChangePassword';
 
@@ -29,6 +30,11 @@ export const SignUpStack = ({ route }: IndexStackProps): ReactElement => {
       <Stack.Screen
         name={Routes.SignUpStack.SignIn}
         component={SignIn}
+        options={TransitionStyle}
+      />
+      <Stack.Screen
+        name={Routes.SignUpStack.MfaTotp}
+        component={MfaTotp}
         options={TransitionStyle}
       />
       <Stack.Screen


### PR DESCRIPTION
### Changes

🤖 TAM-1652: mobile TOTP second factor, stacked on the main MFA PR (#9959). Supersedes #9974, which GitHub auto-marked as merged after an errant push briefly made the base branch contain its commits — the work was not actually reviewed/merged. Also now includes the mobile TypeORM mirror migration for users.totp_confirmed_at and MFA wording alignment.
 
Mobile only ever authenticates to central, and completes MFA with an authenticator app (TOTP) only — native passkeys are planned separately (`docs/plans/mfa-mobile-webauthn.md`).

- **Service layer** — `CentralServerConnection.login` returns the `mfaPending` state instead of erroring when central pauses a login; `completeMfaLogin` drives the `mfa/login` completion endpoints; `AuthService` surfaces the pending state from `remoteSignIn` and adds `completeMfaSignIn`, sharing one finalise step (local user save + session emit) with the plain path.
- **AuthContext** — holds the paused sign-in (pending state + connection params), exposes begin/complete/cancel; `signIn` reports `'mfa'` so `SignInForm` routes to the new screen. A reconnect that hits MFA asks the user to log in again.
- **MfaTotp screen** — challenge: code entry; forced enrolment: opens the `otpauth://` URI directly in the authenticator app on the same phone (a QR can't be scanned from the device displaying it), secret shown for manual entry, then code confirmation. Success navigates like a normal sign-in and triggers sync.

Not yet verified on a device/emulator — needs a run against an MFA-enabled central (`auth.mfa.enabled` + a TOTP-enrolled or `require Mfa` user).
 
### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->