### PR TITLE
feat(auth): TAM-1652: passwordless passkey login

### DIFF
--- a/packages/api-client/src/TamanuApi.ts
+++ b/packages/api-client/src/TamanuApi.ts
@@ -327,6 +327,32 @@ export class TamanuApi {
     return await this.#handleLoginResponse(response, {});
   }
 
+  /**
+   * Begin a passwordless (usernameless) passkey login: returns the WebAuthn
+   * request options for the browser/platform to answer. Pre-auth.
+   */
+  async beginPasswordlessLogin(): Promise<any> {
+    return await this.post(
+      'login/webauthn/assert-begin',
+      {},
+      { useAuthToken: false, waitForAuth: false },
+    );
+  }
+
+  /**
+   * Finish a passwordless passkey login: a verified assertion is the complete
+   * credential, so the server answers with the full login payload, finalised
+   * into a session exactly as a password login would be.
+   */
+  async finishPasswordlessLogin(assertionResponse: object): Promise<LoginResponse> {
+    const response = (await this.post(
+      'login/webauthn/assert-finish',
+      { assertionResponse, deviceId: this.deviceId },
+      { returnResponse: true, useAuthToken: false, waitForAuth: false },
+    )) as Response;
+    return (await this.#handleLoginResponse(response, {})) as LoginResponse;
+  }
+
   async fetchUserData(
     permissions: string[],
     config: FetchOptions = {},

--- a/packages/central-server/__tests__/auth/passwordlessLogin.test.js
+++ b/packages/central-server/__tests__/auth/passwordlessLogin.test.js
@@ -1,0 +1,138 @@
+import { SETTINGS_SCOPES, MFA_CHALLENGE_TYPES, MFA_PASSWORDLESS } from '@tamanu/constants';
+import { createTestContext } from '../utilities';
+
+describe('Passwordless login', () => {
+  let ctx;
+  let baseApp;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.store.models;
+
+    await models.Setting.set('auth.mfa.enabled', true, SETTINGS_SCOPES.GLOBAL);
+    await models.Setting.set('auth.mfa.webauthn.rpid', 'localhost', SETTINGS_SCOPES.GLOBAL);
+    // the default is onRequest, but be explicit: these tests are about the gate
+    await models.Setting.set(
+      'auth.mfa.passwordless',
+      MFA_PASSWORDLESS.ON_REQUEST,
+      SETTINGS_SCOPES.GLOBAL,
+    );
+  });
+
+  afterAll(() => ctx.close());
+
+  describe('gating', () => {
+    it('is refused when MFA is disabled', async () => {
+      await models.Setting.set('auth.mfa.enabled', false, SETTINGS_SCOPES.GLOBAL);
+      try {
+        const response = await baseApp.post('/api/login/webauthn/assert-begin');
+        expect(response).toBeForbidden();
+      } finally {
+        await models.Setting.set('auth.mfa.enabled', true, SETTINGS_SCOPES.GLOBAL);
+      }
+    });
+
+    it('is refused when passwordless is off — the server-enforced boundary', async () => {
+      await models.Setting.set(
+        'auth.mfa.passwordless',
+        MFA_PASSWORDLESS.OFF,
+        SETTINGS_SCOPES.GLOBAL,
+      );
+      try {
+        const begin = await baseApp.post('/api/login/webauthn/assert-begin');
+        expect(begin).toBeForbidden();
+        const finish = await baseApp
+          .post('/api/login/webauthn/assert-finish')
+          .send({ assertionResponse: { id: 'x', response: {} } });
+        expect(finish).toBeForbidden();
+      } finally {
+        await models.Setting.set(
+          'auth.mfa.passwordless',
+          MFA_PASSWORDLESS.ON_REQUEST,
+          SETTINGS_SCOPES.GLOBAL,
+        );
+      }
+    });
+
+    it('is refused when this server is not under the rpid stem', async () => {
+      await models.Setting.set('auth.mfa.webauthn.rpid', 'foo.bar.com', SETTINGS_SCOPES.GLOBAL);
+      try {
+        const response = await baseApp.post('/api/login/webauthn/assert-begin');
+        expect(response).toBeForbidden();
+      } finally {
+        await models.Setting.set('auth.mfa.webauthn.rpid', 'localhost', SETTINGS_SCOPES.GLOBAL);
+      }
+    });
+
+    it('promoted is also accepted server-side (only off rejects)', async () => {
+      await models.Setting.set(
+        'auth.mfa.passwordless',
+        MFA_PASSWORDLESS.PROMOTED,
+        SETTINGS_SCOPES.GLOBAL,
+      );
+      try {
+        const response = await baseApp.post('/api/login/webauthn/assert-begin');
+        expect(response).toHaveSucceeded();
+      } finally {
+        await models.Setting.set(
+          'auth.mfa.passwordless',
+          MFA_PASSWORDLESS.ON_REQUEST,
+          SETTINGS_SCOPES.GLOBAL,
+        );
+      }
+    });
+  });
+
+  describe('ceremony', () => {
+    it('issues a usernameless challenge: no allowCredentials, UV required', async () => {
+      const response = await baseApp.post('/api/login/webauthn/assert-begin');
+      expect(response).toHaveSucceeded();
+
+      const { body } = response;
+      expect(body.challenge).toEqual(expect.any(String));
+      expect(body.allowCredentials ?? []).toHaveLength(0);
+      expect(body.userVerification).toBe('required');
+
+      // the challenge is user-unbound: who is logging in is only known once
+      // the authenticator answers
+      const challenge = await models.MfaChallenge.findOne({
+        where: { token: body.challenge, type: MFA_CHALLENGE_TYPES.WEBAUTHN_ASSERT },
+      });
+      expect(challenge).toBeTruthy();
+      expect(challenge.userId).toBeNull();
+    });
+
+    it('rejects an unparsable finish', async () => {
+      const response = await baseApp.post('/api/login/webauthn/assert-finish').send({
+        assertionResponse: { id: 'x', response: { clientDataJSON: '%%%' } },
+      });
+      expect(response).toHaveRequestError();
+    });
+
+    it('rejects an unknown credential and consumes the challenge', async () => {
+      const begin = await baseApp.post('/api/login/webauthn/assert-begin');
+      const { challenge } = begin.body;
+
+      const clientDataJSON = Buffer.from(
+        JSON.stringify({ type: 'webauthn.get', challenge, origin: 'http://localhost:3000' }),
+      ).toString('base64url');
+      const finish = await baseApp.post('/api/login/webauthn/assert-finish').send({
+        assertionResponse: {
+          id: 'unknown-credential',
+          rawId: 'unknown-credential',
+          type: 'public-key',
+          clientExtensionResults: {},
+          response: { clientDataJSON, authenticatorData: 'AAAA', signature: 'AAAA' },
+        },
+      });
+      expect(finish).toHaveRequestError();
+      // no token of any kind leaks on the failure path
+      expect(finish.body.token).toBeUndefined();
+
+      const row = await models.MfaChallenge.findOne({ where: { token: challenge } });
+      expect(row.usedAt).not.toBeNull();
+    });
+  });
+});

--- a/packages/central-server/__tests__/auth/passwordlessLogin.test.js
+++ b/packages/central-server/__tests__/auth/passwordlessLogin.test.js
@@ -85,6 +85,32 @@ describe('Passwordless login', () => {
     });
   });
 
+  describe('public loginFeatures', () => {
+    it('reports the effective mode for the login screen', async () => {
+      const response = await baseApp.get('/api/public/loginFeatures');
+      expect(response).toHaveSucceeded();
+      expect(response.body).toEqual({ passwordless: MFA_PASSWORDLESS.ON_REQUEST });
+    });
+
+    it('reports off when MFA is disabled or the rpid does not cover this server', async () => {
+      await models.Setting.set('auth.mfa.enabled', false, SETTINGS_SCOPES.GLOBAL);
+      try {
+        const disabled = await baseApp.get('/api/public/loginFeatures');
+        expect(disabled.body).toEqual({ passwordless: MFA_PASSWORDLESS.OFF });
+      } finally {
+        await models.Setting.set('auth.mfa.enabled', true, SETTINGS_SCOPES.GLOBAL);
+      }
+
+      await models.Setting.set('auth.mfa.webauthn.rpid', 'foo.bar.com', SETTINGS_SCOPES.GLOBAL);
+      try {
+        const outOfZone = await baseApp.get('/api/public/loginFeatures');
+        expect(outOfZone.body).toEqual({ passwordless: MFA_PASSWORDLESS.OFF });
+      } finally {
+        await models.Setting.set('auth.mfa.webauthn.rpid', 'localhost', SETTINGS_SCOPES.GLOBAL);
+      }
+    });
+  });
+
   describe('ceremony', () => {
     it('issues a usernameless challenge: no allowCredentials, UV required', async () => {
       const response = await baseApp.post('/api/login/webauthn/assert-begin');

--- a/packages/central-server/app/auth/index.js
+++ b/packages/central-server/app/auth/index.js
@@ -7,6 +7,7 @@ import { convertFromDbRecord } from '../convertDbRecord';
 import { changePassword } from './changePassword';
 import { enrolInvite } from './enrolInvite';
 import { resetPassword } from './resetPassword';
+import { passwordlessLogin } from './passwordlessLogin';
 import { login } from './login';
 import { mfa } from './mfa';
 import { mfaLogin } from './mfaLogin';
@@ -35,6 +36,8 @@ export const authModule = ({ authLimiter } = {}) => {
   // pre-auth: authorised by the short-lived mfa_login token from /login
   router.use('/mfa/login', limiter, mfaLogin);
   router.post('/login', limiter, login);
+  // pre-auth: a user-verifying passkey assertion IS the credential
+  router.use('/login/webauthn', limiter, passwordlessLogin);
   router.post('/refresh', limiter, refresh);
 
   router.use(userMiddleware);

--- a/packages/central-server/app/auth/mfa.js
+++ b/packages/central-server/app/auth/mfa.js
@@ -73,7 +73,7 @@ export async function requireTotpAvailable(req) {
  * than the compiled ability, so a wildcard grant (`manage all`) doesn't
  * silently make every admin MFA-required.
  */
-export async function resolveLoginMfaPolicy(req, user) {
+export async function resolveLoginMfaPolicy(req, user, { authMethod = 'password' } = {}) {
   const { settings, store } = req;
   const mfaEnabled = await settings.get('auth.mfa.enabled');
   if (!mfaEnabled) return { kind: 'none' };
@@ -93,6 +93,7 @@ export async function resolveLoginMfaPolicy(req, user) {
 
   return resolveMfaPolicy({
     mfaEnabled,
+    authMethod,
     totpAvailability,
     webAuthnAvailable: originIsUnderRpId(config.canonicalHostName, rpId),
     centralReachable: true, // we are central

--- a/packages/central-server/app/auth/passwordlessLogin.js
+++ b/packages/central-server/app/auth/passwordlessLogin.js
@@ -1,0 +1,110 @@
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import * as yup from 'yup';
+
+import config from 'config';
+
+import { MFA_PASSWORDLESS } from '@tamanu/constants';
+import { ForbiddenError, InvalidCredentialError } from '@tamanu/errors';
+import { effectivePasswordlessMode } from '@tamanu/shared/auth/mfaPolicy';
+import {
+  beginWebAuthnAssertion,
+  finishWebAuthnAssertion,
+} from '@tamanu/shared/auth/webauthnCeremonies';
+import { log } from '@tamanu/shared/services/logging';
+
+import { getWebAuthnContext, resolveLoginMfaPolicy } from './mfa';
+import { sendLoginSuccessResponse } from './login';
+
+/**
+ * Passwordless login: a user-verifying passkey assertion as the complete
+ * login, no password. UV (biometric/PIN, enforced by the shared ceremony's
+ * requireUserVerification) makes the assertion possession + inherence, so the
+ * policy counts it as fully authenticated — no second factor.
+ *
+ * The ceremony is usernameless: the begin step issues a challenge with no
+ * allowCredentials (discoverable credentials), and the finish step learns who
+ * is logging in from the credential the authenticator answers with.
+ *
+ * Gated server-side by `auth.mfa.passwordless`: `off` rejects assertions
+ * outright; `onRequest` and `promoted` differ only in client presentation.
+ */
+
+const requirePasswordlessAvailable = async req => {
+  const mode = await effectivePasswordlessMode({
+    settings: req.settings,
+    origin: config.canonicalHostName,
+  });
+  if (mode === MFA_PASSWORDLESS.OFF) {
+    throw new ForbiddenError('Passwordless login is not available');
+  }
+  return getWebAuthnContext(req);
+};
+
+export const passwordlessLogin = express.Router();
+
+passwordlessLogin.post(
+  '/assert-begin',
+  asyncHandler(async (req, res) => {
+    const { rpId } = await requirePasswordlessAvailable(req);
+    // no user: discoverable-credential ceremony, the authenticator picks
+    const options = await beginWebAuthnAssertion({ models: req.store.models, rpId });
+    res.send(options);
+  }),
+);
+
+const assertFinishSchema = yup.object({
+  assertionResponse: yup.object().required(),
+  deviceId: yup.string().nullable(),
+  facilityIds: yup.array().of(yup.string()).nullable(),
+});
+
+passwordlessLogin.post(
+  '/assert-finish',
+  asyncHandler(async (req, res) => {
+    const { rpId } = await requirePasswordlessAvailable(req);
+    const { models } = req.store;
+    const { assertionResponse, deviceId, facilityIds } = await assertFinishSchema.validate(
+      req.body,
+    );
+
+    const credential = await finishWebAuthnAssertion({ models, rpId, assertionResponse });
+    const user = await models.User.findByPk(credential.userId);
+    if (!user) {
+      // the credential outlived its user somehow; same class as a bad assertion
+      throw new InvalidCredentialError('Passkey assertion could not be verified');
+    }
+
+    // a UV passkey assertion satisfies the policy outright; evaluated anyway
+    // so every login flows through the same decision point
+    const decision = await resolveLoginMfaPolicy(req, user, { authMethod: 'webauthn' });
+    if (decision.kind !== 'none') {
+      // cannot happen with authMethod webauthn; belt-and-braces over a silent
+      // policy bypass if that ever changes
+      throw new ForbiddenError('Multi-factor authentication is required');
+    }
+
+    const {
+      device,
+      internalClient,
+      settings: userSettings,
+    } = await models.User.loginFromVerifiedPasskey(
+      {
+        user,
+        deviceId,
+        facilityIds,
+        clientHeader: req.header('X-Tamanu-Client'),
+      },
+      { settings: req.settings },
+    );
+
+    log.info(`Passwordless login: ${user.id}`);
+    await sendLoginSuccessResponse(res, {
+      models,
+      user,
+      deviceId: device?.id,
+      internalClient,
+      userSettings,
+    });
+  }),
+);

--- a/packages/central-server/app/publicRoutes/index.js
+++ b/packages/central-server/app/publicRoutes/index.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import asyncHandler from 'express-async-handler';
 import config from 'config';
 import { log } from '@tamanu/shared/services/logging';
 import { ReadSettings } from '@tamanu/settings';
@@ -30,13 +31,16 @@ publicRoutes.get('/ping', (_req, res) => {
 
 // what the login screen may offer before anyone is authenticated; computed
 // server-side so off stays server-enforced
-publicRoutes.get('/loginFeatures', async (req, res) => {
-  const passwordless = await effectivePasswordlessMode({
-    settings: new ReadSettings(req.models),
-    origin: config.canonicalHostName,
-  });
-  res.send({ passwordless });
-});
+publicRoutes.get(
+  '/loginFeatures',
+  asyncHandler(async (req, res) => {
+    const passwordless = await effectivePasswordlessMode({
+      settings: new ReadSettings(req.models),
+      origin: config.canonicalHostName,
+    });
+    res.send({ passwordless });
+  }),
+);
 
 publicRoutes.get('/translation/languageOptions', async (req, res) => {
   const { TranslatedString } = req.models;

--- a/packages/central-server/app/publicRoutes/index.js
+++ b/packages/central-server/app/publicRoutes/index.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import config from 'config';
 import { log } from '@tamanu/shared/services/logging';
+import { ReadSettings } from '@tamanu/settings';
+import { effectivePasswordlessMode } from '@tamanu/shared/auth/mfaPolicy';
 import { keyBy, mapValues } from 'lodash';
 
 import { labResultWidgetRoutes } from './labResultWidget';
@@ -24,6 +26,16 @@ if (cors.allowedOrigin) {
 
 publicRoutes.get('/ping', (_req, res) => {
   res.send({ ok: true });
+});
+
+// what the login screen may offer before anyone is authenticated; computed
+// server-side so off stays server-enforced
+publicRoutes.get('/loginFeatures', async (req, res) => {
+  const passwordless = await effectivePasswordlessMode({
+    settings: new ReadSettings(req.models),
+    origin: config.canonicalHostName,
+  });
+  res.send({ passwordless });
 });
 
 publicRoutes.get('/translation/languageOptions', async (req, res) => {

--- a/packages/constants/src/auth.ts
+++ b/packages/constants/src/auth.ts
@@ -76,7 +76,6 @@ export const MFA_TOTP_AVAILABILITY = {
 } as const;
 export type MfaTotpAvailability =
   (typeof MFA_TOTP_AVAILABILITY)[keyof typeof MFA_TOTP_AVAILABILITY];
-
 // Values for auth.mfa.webauthn.residentKey: how hard enrolment pushes for a
 // discoverable (resident) credential, which is what passwordless login needs.
 // 'preferred' enrols permissively and records actual capability via credProps;
@@ -111,3 +110,15 @@ export const MFA_USER_VERIFICATION = {
 } as const;
 export type MfaUserVerification =
   (typeof MFA_USER_VERIFICATION)[keyof typeof MFA_USER_VERIFICATION];
+
+// Whether a user-verifying passkey can be a complete login by itself (no
+// password). off vs (onRequest|promoted) is server-enforced (whether
+// passwordless assertions are accepted at all); onRequest vs promoted is
+// client presentation only (whether conditional-UI autofill actively offers
+// it).
+export const MFA_PASSWORDLESS = {
+  OFF: 'off',
+  ON_REQUEST: 'onRequest',
+  PROMOTED: 'promoted',
+} as const;
+export type MfaPasswordless = (typeof MFA_PASSWORDLESS)[keyof typeof MFA_PASSWORDLESS];

--- a/packages/database/src/models/User.ts
+++ b/packages/database/src/models/User.ts
@@ -500,6 +500,50 @@ export class User extends Model {
     };
   }
 
+  /**
+   * The non-password half of a login, for a passwordless passkey assertion the
+   * CALLER HAS ALREADY VERIFIED (possession + user verification proven by the
+   * authenticator). Handles what loginFromCredential does minus the
+   * password/lockout machinery, which doesn't apply — assertions aren't
+   * guessable. Token minting stays with the caller (central and facility mint
+   * differently).
+   */
+  static async loginFromVerifiedPasskey(
+    payload: Record<string, any>,
+    { settings }: Pick<LoginContext, 'settings'>,
+  ): Promise<Pick<LoginReturn, 'user' | 'device' | 'internalClient' | 'settings'>> {
+    const { Device, UserLoginAttempt } = this.sequelize.models;
+    const { user, facilityIds, deviceId, scopes = [], clientHeader } = payload;
+
+    const internalClient = Boolean(
+      clientHeader && (Object.values(SERVER_TYPES) as string[]).includes(clientHeader),
+    );
+    if (internalClient && !deviceId) {
+      throw new MissingCredentialError('Missing deviceId');
+    }
+
+    if (user.visibilityStatus !== VISIBILITY_STATUSES.CURRENT) {
+      throw new AuthPermissionError('User no longer exists');
+    }
+
+    const device = await Device.ensureRegistration({ settings, user, deviceId, scopes });
+    await UserLoginAttempt.create({
+      userId: user.id,
+      deviceId,
+      outcome: LOGIN_ATTEMPT_OUTCOMES.SUCCEEDED,
+    });
+
+    const shouldReturnSettings =
+      clientHeader &&
+      (
+        [SERVER_TYPES.WEBAPP, SERVER_TYPES.FACILITY, SERVER_TYPES.MOBILE] as string[]
+      ).includes(clientHeader) &&
+      !facilityIds;
+    const frontEndSettings = shouldReturnSettings ? await settings.getFrontEndSettings() : undefined;
+
+    return { user, device, internalClient, settings: frontEndSettings };
+  }
+
   static async loginFromToken(
     token: string,
     { tokenSecret, tokenIssuer }: LoginContext,

--- a/packages/e2e-tests/tests/auth/mfa.spec.ts
+++ b/packages/e2e-tests/tests/auth/mfa.spec.ts
@@ -169,6 +169,41 @@ test.describe('MFA login', () => {
     await expect(page).toHaveURL(constructFacilityUrl(routes.dashboard));
   });
 
+  test('[MFA-0005] passwordless: enrol a passkey, then sign in with it alone', async ({
+    page,
+  }) => {
+    test.skip(
+      !selfServiceEmail,
+      'set MFA_SELFSERVICE_EMAIL/PASSWORD (write Mfa, no factor) to run; needs auth.mfa.passwordless != off',
+    );
+    const settingsPage = new MfaSettingsPage(page);
+
+    // arrange: enrol a passkey the ordinary way (password login + modal)
+    await new LoginPage(page).goto();
+    await page.locator('input[name="email"]').fill(selfServiceEmail);
+    await page.locator('input[name="password"]').fill(selfServicePassword);
+    await page.getByTestId('loginbutton-gx21').click();
+    await expect(page).toHaveURL(constructFacilityUrl(routes.dashboard));
+    await settingsPage.openFromKebab();
+    await settingsPage.addPasskey(1, 'Passwordless key');
+    await page.keyboard.press('Escape');
+    await new SidebarPage(page).logOutButton.click();
+
+    try {
+      // act: no email, no password — the passkey IS the login. The virtual
+      // authenticator is discoverable + user-verifying, so the usernameless
+      // ceremony resolves the account on its own
+      await new LoginPage(page).goto();
+      await page.getByTestId('passwordless-login-button').click();
+      await expect(page).toHaveURL(constructFacilityUrl(routes.dashboard));
+    } finally {
+      // clean up so the user is factorless for re-runs
+      await settingsPage.openFromKebab();
+      await settingsPage.removeFirstPasskey(0);
+      await page.keyboard.press('Escape');
+    }
+  });
+
   test('[MFA-0004] enrolment invite: admin issues, user redeems at the login screen', async ({
     page,
   }) => {

--- a/packages/facility-server/__tests__/apiv1/passwordlessLogin.test.js
+++ b/packages/facility-server/__tests__/apiv1/passwordlessLogin.test.js
@@ -1,0 +1,109 @@
+import { SETTINGS_SCOPES, MFA_CHALLENGE_TYPES, MFA_PASSWORDLESS } from '@tamanu/constants';
+import { createTestContext } from '../utilities';
+
+/**
+ * Facility passwordless login is FULLY LOCAL: the central connection is never
+ * involved (createTestContext mocks it, and nothing here configures the mock
+ * — any attempt to call central would fail loudly).
+ */
+describe('Facility passwordless login', () => {
+  let ctx;
+  let baseApp;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.models;
+
+    await models.Setting.set('auth.mfa.enabled', true, SETTINGS_SCOPES.GLOBAL);
+    await models.Setting.set('auth.mfa.webauthn.rpid', 'localhost', SETTINGS_SCOPES.GLOBAL);
+    await models.Setting.set(
+      'auth.mfa.passwordless',
+      MFA_PASSWORDLESS.ON_REQUEST,
+      SETTINGS_SCOPES.GLOBAL,
+    );
+  });
+
+  afterAll(() => ctx.close());
+
+  describe('gating', () => {
+    it('is refused when MFA is disabled', async () => {
+      await models.Setting.set('auth.mfa.enabled', false, SETTINGS_SCOPES.GLOBAL);
+      try {
+        const response = await baseApp.post('/api/login/webauthn/assert-begin');
+        expect(response).toBeForbidden();
+      } finally {
+        await models.Setting.set('auth.mfa.enabled', true, SETTINGS_SCOPES.GLOBAL);
+      }
+    });
+
+    it('is refused when passwordless is off', async () => {
+      await models.Setting.set(
+        'auth.mfa.passwordless',
+        MFA_PASSWORDLESS.OFF,
+        SETTINGS_SCOPES.GLOBAL,
+      );
+      try {
+        const response = await baseApp.post('/api/login/webauthn/assert-begin');
+        expect(response).toBeForbidden();
+      } finally {
+        await models.Setting.set(
+          'auth.mfa.passwordless',
+          MFA_PASSWORDLESS.ON_REQUEST,
+          SETTINGS_SCOPES.GLOBAL,
+        );
+      }
+    });
+
+    it('is refused out-of-zone (facility origin not under the rpid)', async () => {
+      await models.Setting.set('auth.mfa.webauthn.rpid', 'foo.bar.com', SETTINGS_SCOPES.GLOBAL);
+      try {
+        const response = await baseApp.post('/api/login/webauthn/assert-begin');
+        expect(response).toBeForbidden();
+      } finally {
+        await models.Setting.set('auth.mfa.webauthn.rpid', 'localhost', SETTINGS_SCOPES.GLOBAL);
+      }
+    });
+  });
+
+  describe('local ceremony', () => {
+    it('issues a usernameless challenge from the local table', async () => {
+      const response = await baseApp.post('/api/login/webauthn/assert-begin');
+      expect(response).toHaveSucceeded();
+      expect(response.body.challenge).toEqual(expect.any(String));
+      expect(response.body.allowCredentials ?? []).toHaveLength(0);
+      expect(response.body.userVerification).toBe('required');
+
+      // local challenge: verification never needs central
+      const challenge = await models.MfaChallenge.findOne({
+        where: { token: response.body.challenge, type: MFA_CHALLENGE_TYPES.WEBAUTHN_ASSERT },
+      });
+      expect(challenge).toBeTruthy();
+      expect(challenge.userId).toBeNull();
+    });
+
+    it('rejects an unknown credential and consumes the challenge', async () => {
+      const begin = await baseApp.post('/api/login/webauthn/assert-begin');
+      const { challenge } = begin.body;
+
+      const clientDataJSON = Buffer.from(
+        JSON.stringify({ type: 'webauthn.get', challenge, origin: 'http://localhost' }),
+      ).toString('base64url');
+      const finish = await baseApp.post('/api/login/webauthn/assert-finish').send({
+        assertionResponse: {
+          id: 'unknown-credential',
+          rawId: 'unknown-credential',
+          type: 'public-key',
+          clientExtensionResults: {},
+          response: { clientDataJSON, authenticatorData: 'AAAA', signature: 'AAAA' },
+        },
+      });
+      expect(finish).toHaveRequestError();
+      expect(finish.body.token).toBeUndefined();
+
+      const row = await models.MfaChallenge.findOne({ where: { token: challenge } });
+      expect(row.usedAt).not.toBeNull();
+    });
+  });
+});

--- a/packages/facility-server/__tests__/apiv1/passwordlessLogin.test.js
+++ b/packages/facility-server/__tests__/apiv1/passwordlessLogin.test.js
@@ -67,6 +67,30 @@ describe('Facility passwordless login', () => {
     });
   });
 
+  describe('public loginFeatures', () => {
+    it('reports the effective mode, off when disabled or out-of-zone', async () => {
+      const enabled = await baseApp.get('/api/public/loginFeatures');
+      expect(enabled).toHaveSucceeded();
+      expect(enabled.body).toEqual({ passwordless: MFA_PASSWORDLESS.ON_REQUEST });
+
+      await models.Setting.set('auth.mfa.enabled', false, SETTINGS_SCOPES.GLOBAL);
+      try {
+        const disabled = await baseApp.get('/api/public/loginFeatures');
+        expect(disabled.body).toEqual({ passwordless: MFA_PASSWORDLESS.OFF });
+      } finally {
+        await models.Setting.set('auth.mfa.enabled', true, SETTINGS_SCOPES.GLOBAL);
+      }
+
+      await models.Setting.set('auth.mfa.webauthn.rpid', 'foo.bar.com', SETTINGS_SCOPES.GLOBAL);
+      try {
+        const outOfZone = await baseApp.get('/api/public/loginFeatures');
+        expect(outOfZone.body).toEqual({ passwordless: MFA_PASSWORDLESS.OFF });
+      } finally {
+        await models.Setting.set('auth.mfa.webauthn.rpid', 'localhost', SETTINGS_SCOPES.GLOBAL);
+      }
+    });
+  });
+
   describe('local ceremony', () => {
     it('issues a usernameless challenge from the local table', async () => {
       const response = await baseApp.post('/api/login/webauthn/assert-begin');

--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -1,7 +1,8 @@
 import express from 'express';
+import config from 'config';
 
 import { constructPermission } from '@tamanu/shared/permissions/middleware';
-import { settingsCache } from '@tamanu/settings';
+import { ReadSettings, settingsCache } from '@tamanu/settings';
 import { attachAuditUserToDbSession } from '@tamanu/database/utils/audit';
 import { suggestions } from '@tamanu/shared/services/suggestions';
 
@@ -40,6 +41,8 @@ import { locationGroup } from './locationGroup';
 import { medication } from './medication';
 import { mfa } from './mfa';
 import { mfaEnrolInvite } from './mfaEnrolInvite';
+import { passwordlessLogin } from './passwordlessLogin';
+import { effectivePasswordlessMode } from '@tamanu/shared/auth/mfaPolicy';
 import { mfaLogin } from './mfaLogin';
 import { notes } from './note';
 import { ongoingCondition } from './ongoingCondition';
@@ -96,12 +99,29 @@ export function createApiv1({ authLimiter } = {}) {
   apiv1.use('/changePassword', limiter, changePassword);
   apiv1.use('/mfa/login', limiter, mfaLogin);
   apiv1.use('/mfa/enrolInvite', limiter, mfaEnrolInvite);
+  // pre-auth: a user-verifying passkey assertion IS the credential, verified
+  // fully locally against the synced public keys
+  apiv1.use('/login/webauthn', limiter, passwordlessLogin);
   
   apiv1.get(
     '/public/ping',
     asyncHandler((req, res) => {
       req.flagPermissionChecked();
       return res.send({ ok: 'ok' });
+    }),
+  );
+  
+  // what the login screen may offer before anyone is authenticated; computed
+  // server-side so off stays server-enforced
+  apiv1.get(
+    '/public/loginFeatures',
+    asyncHandler(async (req, res) => {
+      req.flagPermissionChecked();
+      const passwordless = await effectivePasswordlessMode({
+        settings: new ReadSettings(req.models),
+        origin: config.canonicalHostName ?? 'localhost',
+      });
+      res.send({ passwordless });
     }),
   );
   

--- a/packages/facility-server/app/routes/apiv1/passwordlessLogin.js
+++ b/packages/facility-server/app/routes/apiv1/passwordlessLogin.js
@@ -1,0 +1,97 @@
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import config from 'config';
+import * as yup from 'yup';
+
+import { MFA_PASSWORDLESS } from '@tamanu/constants';
+import { ForbiddenError, InvalidCredentialError } from '@tamanu/errors';
+import { ReadSettings } from '@tamanu/settings';
+import { effectivePasswordlessMode } from '@tamanu/shared/auth/mfaPolicy';
+import {
+  beginWebAuthnAssertion,
+  finishWebAuthnAssertion,
+} from '@tamanu/shared/auth/webauthnCeremonies';
+import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
+
+import { sendFacilityLoginResponse } from '../../middleware/auth';
+
+/**
+ * Passwordless passkey login at a facility — fully local, by design: the
+ * public keys sync here, the challenge lives in the local table, and the
+ * gating settings sync too, so a user-verifying passkey logs in even with
+ * central unreachable. Strictly better offline than password (which needs the
+ * synced hash) + TOTP (which needs central).
+ *
+ * Pre-auth: the verified assertion is the credential.
+ */
+
+// matches the default in middleware/auth.js — facility configs may not set it
+const { canonicalHostName = 'localhost' } = config;
+
+// auth.mfa.* are global-schema settings; read with a plain global reader
+const globalSettings = req => new ReadSettings(req.models);
+
+const requirePasswordlessAvailable = async req => {
+  const settings = globalSettings(req);
+  const mode = await effectivePasswordlessMode({ settings, origin: canonicalHostName });
+  if (mode === MFA_PASSWORDLESS.OFF) {
+    throw new ForbiddenError('Passwordless login is not available');
+  }
+  const rpId = await settings.get('auth.mfa.webauthn.rpid');
+  return { rpId, settings };
+};
+
+export const passwordlessLogin = express.Router();
+
+passwordlessLogin.post(
+  '/assert-begin',
+  asyncHandler(async (req, res) => {
+    // no permission needed: this IS the authentication step
+    req.flagPermissionChecked();
+    const { rpId } = await requirePasswordlessAvailable(req);
+
+    // no user: discoverable-credential ceremony, the authenticator picks
+    const options = await beginWebAuthnAssertion({ models: req.models, rpId });
+    res.send(options);
+  }),
+);
+
+const assertFinishSchema = yup.object({
+  assertionResponse: yup.object().required(),
+  deviceId: yup.string().nullable(),
+});
+
+passwordlessLogin.post(
+  '/assert-finish',
+  asyncHandler(async (req, res) => {
+    req.flagPermissionChecked();
+    const { rpId, settings } = await requirePasswordlessAvailable(req);
+    const { models } = req;
+    const { assertionResponse, deviceId } = await assertFinishSchema.validate(req.body);
+
+    const credential = await finishWebAuthnAssertion({ models, rpId, assertionResponse });
+    const user = await models.User.findByPk(credential.userId);
+    if (!user) {
+      throw new InvalidCredentialError('Passkey assertion could not be verified');
+    }
+
+    const { device } = await models.User.loginFromVerifiedPasskey(
+      { user, deviceId, clientHeader: req.header('X-Tamanu-Client') },
+      { settings },
+    );
+
+    // same response shape as a central-down password login: everything is
+    // sourced locally
+    const loginResult = {
+      central: false,
+      user: user.get({ plain: true }),
+      allowedFacilities: await user.allowedFacilities(),
+      localisation: await models.UserLocalisationCache.getLocalisation({
+        where: { userId: user.id },
+        order: [['createdAt', 'DESC']],
+      }),
+      primaryTimeZone: getPrimaryTimeZone(config),
+    };
+    await sendFacilityLoginResponse(req, res, { deviceId: device?.id, loginResult });
+  }),
+);

--- a/packages/facility-server/app/routes/apiv1/passwordlessLogin.js
+++ b/packages/facility-server/app/routes/apiv1/passwordlessLogin.js
@@ -6,7 +6,8 @@ import * as yup from 'yup';
 import { MFA_PASSWORDLESS } from '@tamanu/constants';
 import { ForbiddenError, InvalidCredentialError } from '@tamanu/errors';
 import { ReadSettings } from '@tamanu/settings';
-import { effectivePasswordlessMode } from '@tamanu/shared/auth/mfaPolicy';
+import { effectivePasswordlessMode, resolveMfaPolicy } from '@tamanu/shared/auth/mfaPolicy';
+import { getPermissionsForRoles } from '@tamanu/shared/permissions/rolesToPermissions';
 import {
   beginWebAuthnAssertion,
   finishWebAuthnAssertion,
@@ -73,6 +74,26 @@ passwordlessLogin.post(
     const user = await models.User.findByPk(credential.userId);
     if (!user) {
       throw new InvalidCredentialError('Passkey assertion could not be verified');
+    }
+
+    // belt-and-braces, mirroring central: a UV passkey assertion satisfies the
+    // policy outright, but evaluate it anyway (all inputs are local/synced) so
+    // a future policy change can't be silently bypassed on facilities
+    const permissions = await getPermissionsForRoles(models, user.role);
+    const decision = resolveMfaPolicy({
+      mfaEnabled: true, // the availability gate above already required it
+      authMethod: 'webauthn',
+      totpAvailability: await settings.get('auth.mfa.totp.availability'),
+      webAuthnAvailable: true, // in-zone, per the gate above
+      centralReachable: false, // not needed locally; the conservative input
+      hasWebAuthnCredential: true, // they just asserted with one
+      hasConfirmedTotp: Boolean(user.totpConfirmedAt),
+      mfaRequired: permissions.some(
+        permission => permission.verb === 'require' && permission.noun === 'Mfa',
+      ),
+    });
+    if (decision.kind !== 'none') {
+      throw new ForbiddenError('Multi-factor authentication is required');
     }
 
     const { device } = await models.User.loginFromVerifiedPasskey(

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -28,6 +28,7 @@ import {
 import {
   ADMINISTRATION_FREQUENCIES,
   isValidAdditionalSearchField,
+  MFA_PASSWORDLESS,
   MFA_RESIDENT_KEY,
   MFA_TOTP_AVAILABILITY,
   MFA_USER_VERIFICATION,
@@ -123,6 +124,13 @@ export const globalSettings = {
                   defaultValue: MFA_USER_VERIFICATION.REQUIRED,
                 },
               },
+            },
+            passwordless: {
+              name: 'Passwordless passkey login',
+              description:
+                'Whether a user-verifying passkey can be a complete login by itself, with no password: "off" = never (passkeys serve only as a second factor); "onRequest" = available behind a "Sign in with a passkey" action on the login screen; "promoted" = additionally offered proactively via browser autofill',
+              type: yup.string().oneOf(Object.values(MFA_PASSWORDLESS)),
+              defaultValue: MFA_PASSWORDLESS.ON_REQUEST,
             },
             totp: {
               description: 'Authenticator app (TOTP) options',

--- a/packages/shared/src/auth/mfaPolicy.js
+++ b/packages/shared/src/auth/mfaPolicy.js
@@ -1,4 +1,5 @@
-import { MFA_FACTORS, MFA_TOTP_AVAILABILITY } from '@tamanu/constants';
+import { MFA_FACTORS, MFA_PASSWORDLESS, MFA_TOTP_AVAILABILITY } from '@tamanu/constants';
+import { originIsUnderRpId } from './webauthn';
 
 /**
  * @typedef {Object} MfaPolicyContext
@@ -126,4 +127,17 @@ export function resolveMfaPolicy({
   }
 
   return { kind: 'blocked' };
+}
+
+/**
+ * The effective passwordless mode for a given server origin: `off` unless MFA
+ * is enabled, the origin is under the rpid stem, and the setting allows it.
+ * One definition for the login gates and the public capability endpoint, on
+ * both servers.
+ */
+export async function effectivePasswordlessMode({ settings, origin }) {
+  if (!(await settings.get('auth.mfa.enabled'))) return MFA_PASSWORDLESS.OFF;
+  const rpId = await settings.get('auth.mfa.webauthn.rpid');
+  if (!originIsUnderRpId(origin, rpId)) return MFA_PASSWORDLESS.OFF;
+  return (await settings.get('auth.mfa.passwordless')) ?? MFA_PASSWORDLESS.OFF;
 }

--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -1,4 +1,7 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useQuery } from '@tanstack/react-query';
+import { startAuthentication } from '@simplewebauthn/browser';
 import * as yup from 'yup';
 import styled from 'styled-components';
 
@@ -14,12 +17,16 @@ import {
   Form,
   FormGrid,
   FormSubmitButton,
+  OutlinedButton,
   TextButton,
 } from '@tamanu/ui-components';
+import { MFA_PASSWORDLESS } from '@tamanu/constants';
 import { Colors } from '../constants/styles';
 import { LanguageSelector } from '../components/LanguageSelector';
 import { TranslatedText } from '../components/Translation/TranslatedText';
 import { useTranslation } from '../contexts/Translation';
+import { useApi } from '../api';
+import { passwordlessLogin } from '../store';
 
 export const LoginAlert = styled(({ children, ...props }) => (
   <Alert severity="error" icon={false} data-testid="loginerror-ppw6" {...props}>
@@ -42,6 +49,12 @@ const LoginHeading = styled(Typography)`
 const LoginSubtext = styled(BodyText)`
   color: ${Colors.midText};
   padding-top: 10px;
+`;
+
+const PasskeyLoginButton = styled(OutlinedButton)`
+  font-size: 14px;
+  line-height: 18px;
+  padding: 12px 0;
 `;
 
 const LoginButton = styled(FormSubmitButton)`
@@ -103,6 +116,49 @@ const LoginFormComponent = ({
   rememberEmail,
 }) => {
   const { getTranslation } = useTranslation();
+  const api = useApi();
+  const dispatch = useDispatch();
+  const [passkeyError, setPasskeyError] = useState(null);
+
+  // what the server is willing to offer pre-auth (off is server-enforced; this
+  // only drives presentation)
+  const { data: loginFeatures } = useQuery({
+    queryKey: ['loginFeatures'],
+    queryFn: () => api.get('public/loginFeatures'),
+    staleTime: 60_000,
+    retry: false,
+  });
+  const passwordlessMode = loginFeatures?.passwordless ?? MFA_PASSWORDLESS.OFF;
+
+  const signInWithPasskey = useCallback(
+    async ({ conditional = false } = {}) => {
+      setPasskeyError(null);
+      try {
+        const optionsJSON = await api.beginPasswordlessLogin();
+        const assertionResponse = await startAuthentication({
+          optionsJSON,
+          useBrowserAutofill: conditional,
+        });
+        await dispatch(passwordlessLogin(assertionResponse));
+        // success unmounts this form
+      } catch (e) {
+        // a conditional (autofill) ceremony aborts routinely — never surface it
+        if (!conditional) {
+          setPasskeyError(
+            getTranslation('mfa.webauthn.error', 'Passkey could not be used. Please try again.'),
+          );
+        }
+      }
+    },
+    [api, dispatch, getTranslation],
+  );
+
+  useEffect(() => {
+    // promoted: actively offer passkeys from the email field's autofill
+    if (passwordlessMode === MFA_PASSWORDLESS.PROMOTED) {
+      signInWithPasskey({ conditional: true });
+    }
+  }, [passwordlessMode, signInWithPasskey]);
 
   const removeValidation = () => {
     setFieldError('email', '');
@@ -135,6 +191,7 @@ const LoginFormComponent = ({
           />
         </LoginSubtext>
         {!!errorMessage && <LoginAlert>{errorMessage}</LoginAlert>}
+        {!!passkeyError && <LoginAlert data-testid="passkey-error">{passkeyError}</LoginAlert>}
       </div>
       <StyledField
         name="email"
@@ -150,7 +207,7 @@ const LoginFormComponent = ({
         component={TextField}
         placeholder={getTranslation('login.email.placeholder', 'Enter your email address')}
         onChange={() => removeValidation()}
-        autoComplete="off"
+        autoComplete="username webauthn"
         enablePasting
         data-testid="styledfield-dwnl"
       />
@@ -197,6 +254,14 @@ const LoginFormComponent = ({
         }
         data-testid="loginbutton-gx21"
       />
+      {passwordlessMode !== MFA_PASSWORDLESS.OFF && (
+        <PasskeyLoginButton
+          onClick={() => signInWithPasskey()}
+          data-testid="passwordless-login-button"
+        >
+          <TranslatedText stringId="login.passkey.label" fallback="Sign in with a passkey" />
+        </PasskeyLoginButton>
+      )}
       <LanguageSelector data-testid="languageselector-9z0j" />
       <ForgotPasswordButton
         onClick={onNavToResetPassword}

--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -118,7 +118,7 @@ const LoginFormComponent = ({
   const { getTranslation } = useTranslation();
   const api = useApi();
   const dispatch = useDispatch();
-  const [passkeyError, setPasskeyError] = useState(null);
+  const [passkeyError, setPasskeyError] = useState(false);
 
   // what the server is willing to offer pre-auth (off is server-enforced; this
   // only drives presentation)
@@ -132,7 +132,7 @@ const LoginFormComponent = ({
 
   const signInWithPasskey = useCallback(
     async ({ conditional = false } = {}) => {
-      setPasskeyError(null);
+      setPasskeyError(false);
       try {
         const optionsJSON = await api.beginPasswordlessLogin();
         const assertionResponse = await startAuthentication({
@@ -144,13 +144,13 @@ const LoginFormComponent = ({
       } catch (e) {
         // a conditional (autofill) ceremony aborts routinely — never surface it
         if (!conditional) {
-          setPasskeyError(
-            getTranslation('mfa.webauthn.error', 'Passkey could not be used. Please try again.'),
-          );
+          setPasskeyError(true);
         }
       }
     },
-    [api, dispatch, getTranslation],
+    // deliberately small: a new identity here restarts the conditional
+    // (autofill) ceremony via the effect below, aborting an in-flight prompt
+    [api, dispatch],
   );
 
   useEffect(() => {
@@ -191,7 +191,14 @@ const LoginFormComponent = ({
           />
         </LoginSubtext>
         {!!errorMessage && <LoginAlert>{errorMessage}</LoginAlert>}
-        {!!passkeyError && <LoginAlert data-testid="passkey-error">{passkeyError}</LoginAlert>}
+        {passkeyError && (
+          <LoginAlert data-testid="passkey-error">
+            <TranslatedText
+              stringId="mfa.webauthn.error"
+              fallback="Passkey could not be used. Please try again."
+            />
+          </LoginAlert>
+        )}
       </div>
       <StyledField
         name="email"

--- a/packages/web/app/store/auth.js
+++ b/packages/web/app/store/auth.js
@@ -54,6 +54,17 @@ export const login = (email, password) => async (dispatch, getState, { api }) =>
 };
 
 /**
+ * Passwordless login: the component has already run the browser WebAuthn
+ * ceremony (it involves user-interaction prompts); this finishes it against
+ * the server and lands the session exactly like a password login. Throws on
+ * failure so the login screen can surface the error inline.
+ */
+export const passwordlessLogin = assertionResponse => async (dispatch, getState, { api }) => {
+  const loginInfo = await api.finishPasswordlessLogin(assertionResponse);
+  await handleLoginSuccess(dispatch, loginInfo);
+};
+
+/**
  * Complete a terminal MFA login step (verify a code / finish an assertion /
  * confirm an enrolment) using the pending token held in state. Throws on
  * failure so the MFA screen can surface "wrong code" etc. inline; the


### PR DESCRIPTION
### Changes

🤖 TAM-1652 PR2: passwordless passkey login, stacked on #9959.

A user-verifying passkey assertion as the complete login — no password. The ceremony is usernameless (discoverable credentials; the authenticator identifies the account) and UV-required, so it counts as possession + inherence and the policy asks for nothing further.

- **Setting**: `auth.mfa.passwordless` = `off | onRequest | promoted` (default `onRequest`). `off` is server-enforced (assertions rejected); `onRequest` vs `promoted` only changes presentation.
- **Central**: pre-auth `/api/login/webauthn/assert-begin|finish`; the verified assertion feeds the same policy decision point (`authMethod: webauthn` → no second factor) and the standard login response. `/api/public/loginFeatures` tells the login screen what it may offer.
- **Facility**: the same pair verified **fully locally** (synced public keys, local challenge, synced settings) — a passkey logs in offline at an in-zone facility, which password+TOTP cannot.
- **Web**: `Sign in with a passkey` button at `onRequest`; at `promoted` the email field also offers passkeys via browser autofill (conditional UI).
- **E2E**: [MFA-0005] enrol a passkey, log out, sign back in with no email and no password.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->