### PR TITLE
feat(auth): TAM-1652: IP allowlist and MFA network exemption

### DIFF
--- a/docs/plans/mfa.md
+++ b/docs/plans/mfa.md
@@ -495,10 +495,24 @@ in `config.proxy.trusted`, `req.ip` is the proxy's own address, which won't matc
 any intranet CIDR, so the MFA exemption simply doesn't apply and everyone gets
 MFA. A spoofed `X-Forwarded-For` cannot manufacture an exemption.
 
-**Where evaluated:** at the point of first contact, since that is where the
-user's real IP is visible — **facility** for facility logins (central only sees
-the facility's IP otherwise), **central** for direct/admin/mobile. CIDR settings
-sync, so a facility evaluates locally even offline.
+**Where evaluated:** the client IP is **captured** at the point of first
+contact — **facility** for facility logins (central only sees the facility's
+IP otherwise), **central** for direct/admin/mobile. The facility enforces
+`auth.ipAllowlist` locally at its own door (synced settings, works offline)
+and **forwards the captured client IP** with login/MFA forwards; central
+evaluates both knobs itself against the same synced settings.
+
+**Trusting the forwarded IP:** central only honours a forwarded client IP
+when the request proves it came from a facility server, else a browser could
+assert an exempt IP directly — a clean MFA bypass. The facility-channel proof
+reuses existing primitives: a new device scope (`facility_server`) carried by
+the facility's own registered device and presented with forwards; devices
+cannot self-upgrade scopes, so acquiring it requires the authenticating
+(sync) user's role to hold a dedicated literal permission, granted
+deliberately by the deployment and never to clinical roles (mobile devices
+register as `sync_client` under end users, who don't have it). Ungranted ⇒
+forwarded IPs ignored ⇒ the exemption never matches facility-mediated logins
+⇒ everyone gets MFA. Fail-closed at every step.
 
 **Deliberate trade-off:** MFA-exempt-by-IP makes *network position* a factor — a
 compromised host inside the trusted range bypasses MFA. This is an accepted

--- a/docs/plans/mfa.md
+++ b/docs/plans/mfa.md
@@ -672,14 +672,15 @@ Each PR lands with its tests; layered per the repo's testing rules
   login unchanged; `off` rejects passwordless assertions and `fallbackOnly`
   rejects TOTP on a WebAuthn-capable surface; facility forwards TOTP to central;
   invite-token redeem **requires token + password** and is single-use/expiring.
-- **E2E** (Playwright, critical journeys) — **self-service** enrolment via the
-  kebab modal for a *non-required* user (`write Mfa`, no `require Mfa`): enrol
-  a passkey, log out, get **challenged** on the next login and complete it —
-  and the same journey for TOTP. This covers the non-forced flows end to end;
-  having no UI to drive would fail these specs, which is exactly the point.
-  Plus: forced-enrolment interstitial (passkey-first) for a required user;
-  factor removal; passwordless (usernameless, UV) login (PR2); admin reset;
-  feature-flag-off path.
+- **E2E** (Playwright, critical journeys) — built: [MFA-0001] forced passkey
+  enrolment then challenge; [MFA-0002] forced TOTP enrolment; [MFA-0003]
+  self-service passkey enrolment via the kebab modal for a non-required user,
+  challenged on next login, then removal; [MFA-0004] admin-issued enrolment
+  invite redeemed at the login screen (admin reset exercised via API as
+  cleanup); [MFA-0005] passwordless usernameless UV login. NOT built (manual
+  coverage for now): an admin-reset journey driven through the admin UI, and
+  the feature-flag-off path; the self-service TOTP modal journey needs a
+  central-frontend harness the suite doesn't have.
 
 WebAuthn in Playwright uses the **Chromium CDP virtual authenticator**
 (`WebAuthn.addVirtualAuthenticator`) behind a fixture — it answers the real

--- a/package-lock.json
+++ b/package-lock.json
@@ -24732,6 +24732,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
@@ -44582,6 +44591,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
+        "@tamanu/utils": "*",
         "@types/lodash": "^4.14.197",
         "config": "^3.3.9",
         "date-fns": "^2.25.0",
@@ -45054,6 +45064,7 @@
         "@tamanu/constants": "*",
         "date-fns": "^4.1.0",
         "es-toolkit": "^1.31.0",
+        "ipaddr.js": "^2.4.0",
         "lodash": "^4.17.21",
         "nanoid": "^3.3.8",
         "temporal-polyfill": "^0.3.0",

--- a/packages/api-client/src/TamanuApi.ts
+++ b/packages/api-client/src/TamanuApi.ts
@@ -400,6 +400,11 @@ export class TamanuApi {
     return Boolean(this.#authToken);
   }
 
+  /** The current access token, e.g. to present as a forwarder credential. */
+  getAuthToken(): string | undefined {
+    return this.#authToken;
+  }
+
   async fetch(
     endpoint: string,
     query: Record<string, any> = {},

--- a/packages/central-server/__tests__/auth/deviceScopes.test.js
+++ b/packages/central-server/__tests__/auth/deviceScopes.test.js
@@ -1,0 +1,99 @@
+import { DEVICE_SCOPES } from '@tamanu/constants';
+import { fake } from '@tamanu/fake-data/fake';
+import { createTestContext } from '../utilities';
+
+/**
+ * The facility_server device scope is a trust anchor (it lets a connection
+ * forward end-client IPs for the IP policy), so acquiring it — at first
+ * registration or as an upgrade — requires the authenticating user's role to
+ * hold the literal `create FacilityDevice` grant. Without it the request
+ * degrades: the scope is dropped, the device still works as a sync client.
+ */
+describe('facility_server device scope', () => {
+  let ctx;
+  let baseApp;
+  let models;
+
+  const PASSWORD = 'device-scope-password';
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.store.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  const makeUser = async permissions => {
+    const role = await models.Role.create(fake(models.Role));
+    await models.Permission.bulkCreate(
+      permissions.map(([verb, noun]) => ({ roleId: role.id, verb, noun })),
+    );
+    return models.User.create(fake(models.User, { role: role.id, password: PASSWORD }));
+  };
+
+  const loginWithScopes = (user, deviceId, scopes) =>
+    baseApp.post('/api/login').send({ email: user.email, password: PASSWORD, deviceId, scopes });
+
+  it('drops the scope for ungranted users instead of failing the login', async () => {
+    const user = await makeUser([]);
+    const response = await loginWithScopes(user, 'plain-sync-device', [
+      DEVICE_SCOPES.SYNC_CLIENT,
+      DEVICE_SCOPES.FACILITY_SERVER,
+    ]);
+    expect(response).toHaveSucceeded();
+
+    const device = await models.Device.findByPk('plain-sync-device');
+    expect(device.scopes).toEqual([DEVICE_SCOPES.SYNC_CLIENT]);
+  });
+
+  it('grants the scope at first registration with create FacilityDevice', async () => {
+    const user = await makeUser([['create', 'FacilityDevice']]);
+    const response = await loginWithScopes(user, 'facility-device', [
+      DEVICE_SCOPES.SYNC_CLIENT,
+      DEVICE_SCOPES.FACILITY_SERVER,
+    ]);
+    expect(response).toHaveSucceeded();
+
+    const device = await models.Device.findByPk('facility-device');
+    expect(device.scopes).toEqual(
+      expect.arrayContaining([DEVICE_SCOPES.SYNC_CLIENT, DEVICE_SCOPES.FACILITY_SERVER]),
+    );
+  });
+
+  it('upgrades an existing device once the grant is added', async () => {
+    const user = await makeUser([]);
+    // registered before the deployment opted in: sync_client only
+    await loginWithScopes(user, 'upgradeable-device', [
+      DEVICE_SCOPES.SYNC_CLIENT,
+      DEVICE_SCOPES.FACILITY_SERVER,
+    ]);
+    expect((await models.Device.findByPk('upgradeable-device')).scopes).toEqual([
+      DEVICE_SCOPES.SYNC_CLIENT,
+    ]);
+
+    // the deployment grants the role the permission; the next connect upgrades
+    await models.Permission.create({
+      roleId: user.role,
+      verb: 'create',
+      noun: 'FacilityDevice',
+    });
+    const again = await loginWithScopes(user, 'upgradeable-device', [
+      DEVICE_SCOPES.SYNC_CLIENT,
+      DEVICE_SCOPES.FACILITY_SERVER,
+    ]);
+    expect(again).toHaveSucceeded();
+    expect((await models.Device.findByPk('upgradeable-device')).scopes).toEqual(
+      expect.arrayContaining([DEVICE_SCOPES.SYNC_CLIENT, DEVICE_SCOPES.FACILITY_SERVER]),
+    );
+  });
+
+  it('still refuses other scope expansions outright', async () => {
+    const user = await makeUser([]);
+    await loginWithScopes(user, 'no-upgrade-device', []);
+    const response = await loginWithScopes(user, 'no-upgrade-device', [
+      DEVICE_SCOPES.SYNC_CLIENT,
+    ]);
+    expect(response).toHaveRequestError();
+  });
+});

--- a/packages/central-server/__tests__/auth/deviceScopes.test.js
+++ b/packages/central-server/__tests__/auth/deviceScopes.test.js
@@ -1,4 +1,4 @@
-import { DEVICE_SCOPES } from '@tamanu/constants';
+import { DEVICE_SCOPES, SETTING_KEYS, SETTINGS_SCOPES } from '@tamanu/constants';
 import { fake } from '@tamanu/fake-data/fake';
 import { createTestContext } from '../utilities';
 
@@ -20,6 +20,13 @@ describe('facility_server device scope', () => {
     ctx = await createTestContext();
     baseApp = ctx.baseApp;
     models = ctx.store.models;
+    // sibling suites toggle the registration quota feature; scope behaviour
+    // is orthogonal to quotas, so pin it off here
+    await models.Setting.set(
+      SETTING_KEYS.FEATURES_DEVICE_REGISTRATION_QUOTA_ENABLED,
+      false,
+      SETTINGS_SCOPES.GLOBAL,
+    );
   });
 
   afterAll(() => ctx.close());
@@ -29,7 +36,9 @@ describe('facility_server device scope', () => {
     await models.Permission.bulkCreate(
       permissions.map(([verb, noun]) => ({ roleId: role.id, verb, noun })),
     );
-    return models.User.create(fake(models.User, { role: role.id, password: PASSWORD }));
+    return models.User.create(
+      fake(models.User, { role: role.id, password: PASSWORD, deviceRegistrationQuota: 10 }),
+    );
   };
 
   const loginWithScopes = (user, deviceId, scopes) =>

--- a/packages/central-server/__tests__/auth/ipPolicy.test.js
+++ b/packages/central-server/__tests__/auth/ipPolicy.test.js
@@ -163,6 +163,38 @@ describe('IP policy', () => {
       expect(response).toHaveSucceeded();
     });
 
+    it('exempts MFA by the forwarded client IP — the facility-mediated case', async () => {
+      // the primary use case: a facility user inside the trusted intranet
+      // range skips the challenge, decided at central from the forwarded IP
+      await setGlobal('auth.mfa.enabled', true);
+      await setGlobal('auth.mfa.ipExempt', ['10.0.0.0/8']);
+      const confirmedAt = new Date();
+      const user = await makeUser({ totpConfirmedAt: confirmedAt });
+      await models.TotpSecret.create({ userId: user.id, secret: 'S1:AAAA:BBBB', confirmedAt });
+
+      try {
+        const exempt = await baseApp
+          .post('/api/login')
+          .set('X-Tamanu-Client-Ip', '10.1.2.3')
+          .set('X-Tamanu-Forwarder-Auth', forwarderToken)
+          .send({ email: user.email, password: PASSWORD, deviceId: 'fwd-exempt-device' });
+        expect(exempt).toHaveSucceeded();
+        expect(exempt.body.mfaPending).toBeUndefined();
+        expect(exempt.body.token).toEqual(expect.any(String));
+
+        // same request without the forwarder credential: evaluated as
+        // loopback, outside the exempt range, so the challenge applies
+        const challenged = await baseApp
+          .post('/api/login')
+          .set('X-Tamanu-Client-Ip', '10.1.2.3')
+          .send({ email: user.email, password: PASSWORD, deviceId: 'fwd-exempt-device' });
+        expect(challenged.body.mfaPending).toBeTruthy();
+      } finally {
+        await setGlobal('auth.mfa.ipExempt', []);
+        await setGlobal('auth.mfa.enabled', false);
+      }
+    });
+
     it('ignores the forwarded IP without a trusted forwarder credential', async () => {
       const user = await makeUser();
       await setGlobal('auth.ipAllowlist', ['10.0.0.0/8']);

--- a/packages/central-server/__tests__/auth/ipPolicy.test.js
+++ b/packages/central-server/__tests__/auth/ipPolicy.test.js
@@ -1,0 +1,194 @@
+import { DEVICE_SCOPES, SETTINGS_SCOPES } from '@tamanu/constants';
+import { fake } from '@tamanu/fake-data/fake';
+import { createTestContext } from '../utilities';
+
+/**
+ * The IP policy: auth.ipAllowlist (login-level gate) and auth.mfa.ipExempt
+ * (skip the second factor inside trusted ranges). Supertest connects from
+ * loopback, so 127.0.0.0/8 stands in for "inside" and 10.0.0.0/8 for
+ * "outside".
+ */
+describe('IP policy', () => {
+  let ctx;
+  let baseApp;
+  let models;
+
+  const PASSWORD = 'ip-policy-password';
+
+  const setGlobal = (key, value) => models.Setting.set(key, value, SETTINGS_SCOPES.GLOBAL);
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.store.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  const makeUser = async (overrides = {}) =>
+    models.User.create(fake(models.User, { password: PASSWORD, ...overrides }));
+
+  let deviceSerial = 0;
+  const login = (user, extra = {}) =>
+    baseApp.post('/api/login').send({
+      email: user.email,
+      password: PASSWORD,
+      deviceId: `ip-policy-device-${(deviceSerial += 1)}`,
+      ...extra,
+    });
+
+  describe('login allowlist', () => {
+    afterEach(async () => {
+      await setGlobal('auth.ipAllowlist', []);
+    });
+
+    it('refuses logins from outside the ranges and allows inside', async () => {
+      const user = await makeUser();
+
+      await setGlobal('auth.ipAllowlist', ['10.0.0.0/8']);
+      expect(await login(user)).toBeForbidden();
+
+      await setGlobal('auth.ipAllowlist', ['127.0.0.0/8']);
+      expect(await login(user)).toHaveSucceeded();
+    });
+
+    it('an empty allowlist restricts nothing', async () => {
+      const user = await makeUser();
+      expect(await login(user)).toHaveSucceeded();
+    });
+
+    it('gates passwordless entry points too', async () => {
+      await setGlobal('auth.ipAllowlist', ['10.0.0.0/8']);
+      const response = await baseApp.post('/api/login/webauthn/assert-begin');
+      expect(response).toBeForbidden();
+    });
+  });
+
+  describe('MFA exemption', () => {
+    beforeAll(async () => {
+      await setGlobal('auth.mfa.enabled', true);
+    });
+    afterAll(async () => {
+      await setGlobal('auth.mfa.enabled', false);
+      await setGlobal('auth.mfa.ipExempt', []);
+    });
+
+    const withConfirmedTotp = async () => {
+      const confirmedAt = new Date();
+      const user = await makeUser({ totpConfirmedAt: confirmedAt });
+      await models.TotpSecret.create({ userId: user.id, secret: 'S1:AAAA:BBBB', confirmedAt });
+      return user;
+    };
+
+    it('an enrolled user is challenged off-network and exempt on it', async () => {
+      const user = await withConfirmedTotp();
+
+      await setGlobal('auth.mfa.ipExempt', []);
+      const challenged = await login(user);
+      expect(challenged).toHaveSucceeded();
+      expect(challenged.body.mfaPending).toBeTruthy();
+
+      await setGlobal('auth.mfa.ipExempt', ['127.0.0.0/8']);
+      const exempt = await login(user);
+      expect(exempt).toHaveSucceeded();
+      expect(exempt.body.mfaPending).toBeUndefined();
+      expect(exempt.body.token).toEqual(expect.any(String));
+    });
+
+    it('a required factorless user may skip enrolment only on the exempt network', async () => {
+      const role = await models.Role.create(fake(models.Role));
+      await models.Permission.create({ roleId: role.id, verb: 'require', noun: 'Mfa' });
+      const user = await makeUser({ role: role.id });
+      await setGlobal('auth.mfa.webauthn.rpid', 'localhost');
+
+      // off-network: forced enrolment, not skippable
+      await setGlobal('auth.mfa.ipExempt', []);
+      const forced = await login(user);
+      expect(forced.body.mfaPending).toMatchObject({ kind: 'enrol', skippable: false });
+
+      // on the exempt network: still nudged to enrol, but may skip
+      await setGlobal('auth.mfa.ipExempt', ['127.0.0.0/8']);
+      const nudged = await login(user);
+      expect(nudged.body.mfaPending).toMatchObject({ kind: 'enrol', skippable: true });
+
+      const skipped = await baseApp
+        .post('/api/mfa/login/skip')
+        .send({ mfaToken: nudged.body.mfaPending.token });
+      expect(skipped).toHaveSucceeded();
+      expect(skipped.body.token).toEqual(expect.any(String));
+    });
+  });
+
+  describe('forwarded client IP trust', () => {
+    let forwarderToken;
+    let plainToken;
+
+    beforeAll(async () => {
+      // a facility-like user whose role may register facility_server devices
+      const facilityRole = await models.Role.create(fake(models.Role));
+      await models.Permission.create({
+        roleId: facilityRole.id,
+        verb: 'create',
+        noun: 'FacilityDevice',
+      });
+      const facilityUser = await makeUser({ role: facilityRole.id });
+      const facilityLogin = await login(facilityUser, {
+        deviceId: 'trusted-forwarder-device',
+        scopes: [DEVICE_SCOPES.SYNC_CLIENT, DEVICE_SCOPES.FACILITY_SERVER],
+      });
+      forwarderToken = facilityLogin.body.token;
+
+      // an ordinary user session, sync-client only
+      const plainUser = await makeUser();
+      const plainLogin = await login(plainUser, {
+        deviceId: 'plain-device',
+        scopes: [DEVICE_SCOPES.SYNC_CLIENT],
+      });
+      plainToken = plainLogin.body.token;
+    });
+
+    afterEach(async () => {
+      await setGlobal('auth.ipAllowlist', []);
+    });
+
+    it('honours the forwarded IP from a facility_server-scoped session', async () => {
+      const user = await makeUser();
+      await setGlobal('auth.ipAllowlist', ['10.0.0.0/8']);
+
+      const response = await baseApp
+        .post('/api/login')
+        .set('X-Tamanu-Client-Ip', '10.1.2.3')
+        .set('X-Tamanu-Forwarder-Auth', forwarderToken)
+        .send({ email: user.email, password: PASSWORD, deviceId: 'fwd-trust-device' });
+      expect(response).toHaveSucceeded();
+    });
+
+    it('ignores the forwarded IP without a trusted forwarder credential', async () => {
+      const user = await makeUser();
+      await setGlobal('auth.ipAllowlist', ['10.0.0.0/8']);
+
+      // bare header: evaluated as the connection's own (loopback) address
+      const bare = await baseApp
+        .post('/api/login')
+        .set('X-Tamanu-Client-Ip', '10.1.2.3')
+        .send({ email: user.email, password: PASSWORD, deviceId: 'fwd-trust-device' });
+      expect(bare).toBeForbidden();
+
+      // a real session whose device lacks the facility_server scope
+      const wrongScope = await baseApp
+        .post('/api/login')
+        .set('X-Tamanu-Client-Ip', '10.1.2.3')
+        .set('X-Tamanu-Forwarder-Auth', plainToken)
+        .send({ email: user.email, password: PASSWORD, deviceId: 'fwd-trust-device' });
+      expect(wrongScope).toBeForbidden();
+
+      // garbage credential
+      const garbage = await baseApp
+        .post('/api/login')
+        .set('X-Tamanu-Client-Ip', '10.1.2.3')
+        .set('X-Tamanu-Forwarder-Auth', 'not-a-token')
+        .send({ email: user.email, password: PASSWORD, deviceId: 'fwd-trust-device' });
+      expect(garbage).toBeForbidden();
+    });
+  });
+});

--- a/packages/central-server/__tests__/auth/mfaLogin.test.js
+++ b/packages/central-server/__tests__/auth/mfaLogin.test.js
@@ -201,9 +201,9 @@ describe('Login with MFA', () => {
     });
 
     it('refuses /skip when the enrolment is not skippable', async () => {
-      // skip is only allowed for IP-exempt users (skippable: true), which is
-      // never the case until IP-exemption ships — prove the guard now, since
-      // the endpoint is already reachable with a valid enrol token
+      // skip is only allowed for IP-exempt users (skippable: true); no
+      // exemption is configured in this suite, so the guard must refuse
+      // (the exempt path is covered in ipPolicy.test.js)
       const response = await baseApp.post('/api/mfa/login/skip').send({ mfaToken });
       expect(response).toBeForbidden();
     });

--- a/packages/central-server/app/auth/clientIp.js
+++ b/packages/central-server/app/auth/clientIp.js
@@ -1,0 +1,68 @@
+import { createSecretKey } from 'node:crypto';
+import config from 'config';
+import * as jose from 'jose';
+
+import { DEVICE_SCOPES, JWT_TOKEN_TYPES } from '@tamanu/constants';
+import { ForbiddenError } from '@tamanu/errors';
+import { ipMatchesCidrList } from '@tamanu/utils';
+
+/**
+ * The end-client IP for IP-policy decisions (auth.ipAllowlist,
+ * auth.mfa.ipExempt).
+ *
+ * For facility-mediated logins central only sees the facility server's
+ * address, so the facility captures the client IP at first contact and
+ * forwards it in X-Tamanu-Client-Ip, authenticated by its own central session
+ * in X-Tamanu-Forwarder-Auth. The forwarded IP is honoured ONLY when that
+ * token verifies and its device carries the facility_server scope (which is
+ * permission-gated at registration — see Device.ensureRegistration);
+ * otherwise it is ignored and the connection's own address is used. A browser
+ * asserting the header gets evaluated as itself: fail-closed.
+ */
+
+export const CLIENT_IP_HEADER = 'x-tamanu-client-ip';
+export const FORWARDER_AUTH_HEADER = 'x-tamanu-forwarder-auth';
+
+export async function resolveClientIp(req) {
+  const forwardedIp = req.get(CLIENT_IP_HEADER);
+  const forwarderToken = req.get(FORWARDER_AUTH_HEADER);
+  if (!forwardedIp || !forwarderToken) return req.ip;
+
+  try {
+    const { payload } = await jose.jwtVerify(
+      forwarderToken,
+      createSecretKey(new TextEncoder().encode(config.auth.secret)),
+      { issuer: config.canonicalHostName, audience: JWT_TOKEN_TYPES.ACCESS },
+    );
+    const device = payload.deviceId
+      ? await req.store.models.Device.findByPk(payload.deviceId)
+      : null;
+    if (device?.scopes?.includes(DEVICE_SCOPES.FACILITY_SERVER)) {
+      return forwardedIp;
+    }
+  } catch (_err) {
+    // fall through: an invalid forwarder credential is treated as absent
+  }
+  return req.ip;
+}
+
+/**
+ * The login-level gate: with a non-empty auth.ipAllowlist, refuse logins from
+ * outside every listed range.
+ */
+export async function assertIpAllowed(req, clientIp) {
+  const allowlist = await req.settings.get('auth.ipAllowlist');
+  if (!Array.isArray(allowlist) || allowlist.length === 0) return;
+  if (!ipMatchesCidrList(clientIp, allowlist)) {
+    throw new ForbiddenError('Logins are not allowed from this network');
+  }
+}
+
+/**
+ * Whether this client skips the second factor (auth.mfa.ipExempt). Empty
+ * list: no one is exempt.
+ */
+export async function isIpExempt(req, clientIp) {
+  const exempt = await req.settings.get('auth.mfa.ipExempt');
+  return ipMatchesCidrList(clientIp, exempt);
+}

--- a/packages/central-server/app/auth/clientIp.js
+++ b/packages/central-server/app/auth/clientIp.js
@@ -4,7 +4,7 @@ import * as jose from 'jose';
 
 import { DEVICE_SCOPES, JWT_TOKEN_TYPES } from '@tamanu/constants';
 import { ForbiddenError } from '@tamanu/errors';
-import { ipMatchesCidrList } from '@tamanu/utils';
+import { ipMatchesCidrList, isValidIpAddress } from '@tamanu/utils';
 
 /**
  * The end-client IP for IP-policy decisions (auth.ipAllowlist,
@@ -26,7 +26,9 @@ export const FORWARDER_AUTH_HEADER = 'x-tamanu-forwarder-auth';
 export async function resolveClientIp(req) {
   const forwardedIp = req.get(CLIENT_IP_HEADER);
   const forwarderToken = req.get(FORWARDER_AUTH_HEADER);
-  if (!forwardedIp || !forwarderToken) return req.ip;
+  // defence in depth: never let a non-IP header value flow downstream, even
+  // though the CIDR matcher would reject it anyway
+  if (!forwardedIp || !isValidIpAddress(forwardedIp) || !forwarderToken) return req.ip;
 
   try {
     const { payload } = await jose.jwtVerify(

--- a/packages/central-server/app/auth/login.js
+++ b/packages/central-server/app/auth/login.js
@@ -11,6 +11,7 @@ import { getLocalisation } from '../localisation';
 import { convertFromDbRecord } from '../convertDbRecord';
 import { getRandomBase64String, getRandomU32, buildToken, stripUser } from './utils';
 import { resolveLoginMfaPolicy } from './mfa';
+import { assertIpAllowed, isIpExempt, resolveClientIp } from './clientIp';
 
 // short — long enough to complete a fumbly forced enrolment (scan/add to an
 // authenticator app, type a code), but the pass is also single-use (consumed
@@ -135,6 +136,11 @@ export const login = asyncHandler(async (req, res) => {
     settings,
   } = req;
 
+  // IP policy first: the allowlist refuses out-of-range logins before any
+  // credential handling, and exemption feeds the MFA decision below
+  const clientIp = await resolveClientIp(req);
+  await assertIpAllowed(req, clientIp);
+
   const {
     token,
     user,
@@ -150,7 +156,9 @@ export const login = asyncHandler(async (req, res) => {
   );
 
   // The password checked out; does this login owe a second factor?
-  const decision = await resolveLoginMfaPolicy(req, user);
+  const decision = await resolveLoginMfaPolicy(req, user, {
+    ipExempt: await isIpExempt(req, clientIp),
+  });
   if (decision.kind === 'blocked') {
     // nothing the user has can be verified or enrolled here — never downgrade
     // to password-only

--- a/packages/central-server/app/auth/mfa.js
+++ b/packages/central-server/app/auth/mfa.js
@@ -73,7 +73,7 @@ export async function requireTotpAvailable(req) {
  * than the compiled ability, so a wildcard grant (`manage all`) doesn't
  * silently make every admin MFA-required.
  */
-export async function resolveLoginMfaPolicy(req, user, { authMethod = 'password' } = {}) {
+export async function resolveLoginMfaPolicy(req, user, { authMethod = 'password', ipExempt = false } = {}) {
   const { settings, store } = req;
   const mfaEnabled = await settings.get('auth.mfa.enabled');
   if (!mfaEnabled) return { kind: 'none' };
@@ -94,6 +94,7 @@ export async function resolveLoginMfaPolicy(req, user, { authMethod = 'password'
   return resolveMfaPolicy({
     mfaEnabled,
     authMethod,
+    ipExempt,
     totpAvailability,
     webAuthnAvailable: originIsUnderRpId(config.canonicalHostName, rpId),
     centralReachable: true, // we are central

--- a/packages/central-server/app/auth/mfaLogin.js
+++ b/packages/central-server/app/auth/mfaLogin.js
@@ -16,7 +16,7 @@ import {
 } from '@tamanu/shared/auth/webauthnCeremonies';
 
 import { sendLoginSuccessResponse } from './login';
-import { isIpExempt, resolveClientIp } from './clientIp';
+import { assertIpAllowed, isIpExempt, resolveClientIp } from './clientIp';
 import {
   getWebAuthnContext,
   requireMfaEnabled,
@@ -39,6 +39,16 @@ import { confirmTotp, enrolTotp, verifyTotp } from './totp';
  */
 
 export const mfaLogin = express.Router();
+
+// completions are part of a login: the IP allowlist applies here exactly as
+// at /login, or an exfiltrated pending pass could be finished from a blocked
+// network (the facility mounts its gate on the whole /mfa/login path too)
+mfaLogin.use(
+  asyncHandler(async (req, _res, next) => {
+    await assertIpAllowed(req, await resolveClientIp(req));
+    next();
+  }),
+);
 
 const pendingFromBody = async req => {
   const mfaToken = req.body?.mfaToken;

--- a/packages/central-server/app/auth/mfaLogin.js
+++ b/packages/central-server/app/auth/mfaLogin.js
@@ -16,6 +16,7 @@ import {
 } from '@tamanu/shared/auth/webauthnCeremonies';
 
 import { sendLoginSuccessResponse } from './login';
+import { isIpExempt, resolveClientIp } from './clientIp';
 import {
   getWebAuthnContext,
   requireMfaEnabled,
@@ -124,17 +125,20 @@ const userSettingsFor = async (req, payload) =>
   payload.withSettings ? await req.settings.getFrontEndSettings() : undefined;
 
 // Skip a forced enrolment without enrolling. Only succeeds when the policy,
-// re-evaluated now, genuinely allows it (an IP-exempt required user): the
-// interstitial is a nudge there, not a gate. The pending token's kind is not
-// trusted — the live decision is — so this can never be used to bypass a real
-// requirement. (Until IP-exemption ships, this always refuses.)
+// re-evaluated now with the live IP exemption, genuinely allows it (an
+// IP-exempt required user): the interstitial is a nudge there, not a gate.
+// The pending token's kind is not trusted — the live decision is — so this
+// can never be used to bypass a real requirement.
 mfaLogin.post(
   '/skip',
   asyncHandler(async (req, res) => {
     await requireMfaEnabled(req);
     const { user, payload } = await pendingFromBody(req);
 
-    const decision = await resolveLoginMfaPolicy(req, user);
+    const clientIp = await resolveClientIp(req);
+    const decision = await resolveLoginMfaPolicy(req, user, {
+      ipExempt: await isIpExempt(req, clientIp),
+    });
     if (!(decision.kind === 'enrol' && decision.skippable)) {
       throw new ForbiddenError('Enrolment cannot be skipped');
     }

--- a/packages/central-server/app/auth/passwordlessLogin.js
+++ b/packages/central-server/app/auth/passwordlessLogin.js
@@ -14,6 +14,7 @@ import {
 import { log } from '@tamanu/shared/services/logging';
 
 import { getWebAuthnContext, resolveLoginMfaPolicy } from './mfa';
+import { assertIpAllowed, resolveClientIp } from './clientIp';
 import { sendLoginSuccessResponse } from './login';
 
 /**
@@ -46,6 +47,7 @@ export const passwordlessLogin = express.Router();
 passwordlessLogin.post(
   '/assert-begin',
   asyncHandler(async (req, res) => {
+    await assertIpAllowed(req, await resolveClientIp(req));
     const { rpId } = await requirePasswordlessAvailable(req);
     // no user: discoverable-credential ceremony, the authenticator picks
     const options = await beginWebAuthnAssertion({ models: req.store.models, rpId });
@@ -62,6 +64,7 @@ const assertFinishSchema = yup.object({
 passwordlessLogin.post(
   '/assert-finish',
   asyncHandler(async (req, res) => {
+    await assertIpAllowed(req, await resolveClientIp(req));
     const { rpId } = await requirePasswordlessAvailable(req);
     const { models } = req.store;
     const { assertionResponse, deviceId, facilityIds } = await assertFinishSchema.validate(

--- a/packages/constants/src/auth.ts
+++ b/packages/constants/src/auth.ts
@@ -36,6 +36,11 @@ export const CAN_ACCESS_ALL_FACILITIES = 'ALL';
 // we'll all work together to figure this thing out! 🤞
 export const DEVICE_SCOPES = {
   SYNC_CLIENT: 'sync_client',
+  // a facility server's own device: marks a connection trusted to forward
+  // end-client IPs for the IP policy. Never self-acquired — registration or
+  // expansion to this scope requires the authenticating user's role to hold
+  // `create FacilityDevice` (granted deliberately to facility sync users)
+  FACILITY_SERVER: 'facility_server',
 } as const;
 export type DeviceScope = (typeof DEVICE_SCOPES)[keyof typeof DEVICE_SCOPES];
 

--- a/packages/constants/src/permissions.ts
+++ b/packages/constants/src/permissions.ts
@@ -163,6 +163,9 @@ export const PERMISSION_SCHEMA: Record<string, readonly PermissionVerb[]> = {
   Triage: [List, Read, Write, Create],
   User: [List, Read, Write, Create],
   UserDesignation: [List, Read, Write, Create],
+  // register/upgrade a device with the facility_server scope (trusted to
+  // forward end-client IPs); for facility servers' sync users, never clinical roles
+  FacilityDevice: [Create],
   // own MFA factors (write = enrol/remove own; require = role must have MFA)
   Mfa: [Write, Require],
   // another user's MFA factors (admin reset / provisioning)

--- a/packages/database/src/models/Device.ts
+++ b/packages/database/src/models/Device.ts
@@ -143,28 +143,29 @@ export class Device extends Model {
         // or as an upgrade. Ungranted requests degrade rather than fail —
         // the scope is dropped and the device works as a plain sync client —
         // so deployments that haven't opted in are unaffected.
-        let effectiveScopes = scopes;
-        if (scopes.includes(DEVICE_SCOPES.FACILITY_SERVER)) {
-          const granted =
-            (await this.sequelize.models.Permission.count({
-              where: { roleId: user.role, verb: 'create', noun: 'FacilityDevice' },
-            })) > 0;
-          if (!granted) {
-            effectiveScopes = scopes.filter(scope => scope !== DEVICE_SCOPES.FACILITY_SERVER);
-          }
-        }
+        const facilityScopeGranted =
+          scopes.includes(DEVICE_SCOPES.FACILITY_SERVER) &&
+          (await this.sequelize.models.Permission.count({
+            where: { roleId: user.role, verb: 'create', noun: 'FacilityDevice' },
+          })) > 0;
+        const effectiveScopes =
+          scopes.includes(DEVICE_SCOPES.FACILITY_SERVER) && !facilityScopeGranted
+            ? scopes.filter(scope => scope !== DEVICE_SCOPES.FACILITY_SERVER)
+            : scopes;
 
         const syncDevice = await Device.findByPk(deviceId);
         if (syncDevice) {
           const requestedNew = difference(effectiveScopes, syncDevice.scopes);
           if (requestedNew.length > 0) {
             // devices never self-upgrade; the only permitted expansion is the
-            // permission-gated facility_server scope filtered above
-            if (requestedNew.every(scope => scope === DEVICE_SCOPES.FACILITY_SERVER)) {
-              await syncDevice.update({ scopes: [...syncDevice.scopes, ...requestedNew] });
-            } else {
+            // single permission-gated facility_server scope (anything
+            // ungranted was already filtered out of effectiveScopes above)
+            const onlyTheFacilityScope =
+              requestedNew.length === 1 && requestedNew[0] === DEVICE_SCOPES.FACILITY_SERVER;
+            if (!onlyTheFacilityScope) {
               throw new AuthPermissionError('Requested more scopes than the device has');
             }
+            await syncDevice.update({ scopes: [...syncDevice.scopes, ...requestedNew] });
           }
 
           await syncDevice.markSeen();

--- a/packages/database/src/models/Device.ts
+++ b/packages/database/src/models/Device.ts
@@ -137,10 +137,34 @@ export class Device extends Model {
         // If the same user tries to register two devices concurrently, the second will wait until the first is complete.
         await Device.acquireRegistrationLockForUser(user.id);
 
+        // the facility_server scope is a trust anchor (forwarded-IP trust for
+        // the IP policy): it is only ever stored when the authenticating
+        // user's role holds the literal grant, whether at first registration
+        // or as an upgrade. Ungranted requests degrade rather than fail —
+        // the scope is dropped and the device works as a plain sync client —
+        // so deployments that haven't opted in are unaffected.
+        let effectiveScopes = scopes;
+        if (scopes.includes(DEVICE_SCOPES.FACILITY_SERVER)) {
+          const granted =
+            (await this.sequelize.models.Permission.count({
+              where: { roleId: user.role, verb: 'create', noun: 'FacilityDevice' },
+            })) > 0;
+          if (!granted) {
+            effectiveScopes = scopes.filter(scope => scope !== DEVICE_SCOPES.FACILITY_SERVER);
+          }
+        }
+
         const syncDevice = await Device.findByPk(deviceId);
         if (syncDevice) {
-          if (difference(scopes, syncDevice.scopes).length > 0) {
-            throw new AuthPermissionError('Requested more scopes than the device has');
+          const requestedNew = difference(effectiveScopes, syncDevice.scopes);
+          if (requestedNew.length > 0) {
+            // devices never self-upgrade; the only permitted expansion is the
+            // permission-gated facility_server scope filtered above
+            if (requestedNew.every(scope => scope === DEVICE_SCOPES.FACILITY_SERVER)) {
+              await syncDevice.update({ scopes: [...syncDevice.scopes, ...requestedNew] });
+            } else {
+              throw new AuthPermissionError('Requested more scopes than the device has');
+            }
           }
 
           await syncDevice.markSeen();
@@ -150,7 +174,7 @@ export class Device extends Model {
         const device = new Device({
           id: deviceId,
           registeredById: user.id,
-          scopes,
+          scopes: effectiveScopes,
         });
 
         const deviceRegistrationQuotaEnabled = await settings.get(

--- a/packages/facility-server/__tests__/apiv1/ipAllowlist.test.js
+++ b/packages/facility-server/__tests__/apiv1/ipAllowlist.test.js
@@ -1,0 +1,48 @@
+import { SETTINGS_SCOPES } from '@tamanu/constants';
+import { fake } from '@tamanu/fake-data/fake';
+import { createTestContext } from '../utilities';
+
+describe('Facility login IP allowlist', () => {
+  let ctx;
+  let baseApp;
+  let models;
+
+  const PASSWORD = 'allowlist-password';
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  afterEach(async () => {
+    await models.Setting.set('auth.ipAllowlist', [], SETTINGS_SCOPES.GLOBAL);
+  });
+
+  it('refuses out-of-range logins at the facility door, before any credential handling', async () => {
+    await models.Setting.set('auth.ipAllowlist', ['10.0.0.0/8'], SETTINGS_SCOPES.GLOBAL);
+    const response = await baseApp
+      .post('/api/login')
+      .send({ email: 'whoever@example.com', password: 'irrelevant', deviceId: 'd' });
+    expect(response).toBeForbidden();
+  });
+
+  it('lets in-range logins through (and works offline — this is all local)', async () => {
+    const user = await models.User.create(fake(models.User, { password: PASSWORD }));
+    await models.Setting.set('auth.ipAllowlist', ['127.0.0.0/8'], SETTINGS_SCOPES.GLOBAL);
+    const response = await baseApp
+      .post('/api/login')
+      .send({ email: user.email, password: PASSWORD, deviceId: 'allowlist-device' });
+    expect(response).toHaveSucceeded();
+  });
+
+  it('gates the MFA completion and passwordless surfaces too', async () => {
+    await models.Setting.set('auth.ipAllowlist', ['10.0.0.0/8'], SETTINGS_SCOPES.GLOBAL);
+    const completion = await baseApp.post('/api/mfa/login/totp').send({ mfaToken: 'x', code: '1' });
+    expect(completion).toBeForbidden();
+    const passwordless = await baseApp.post('/api/login/webauthn/assert-begin');
+    expect(passwordless).toBeForbidden();
+  });
+});

--- a/packages/facility-server/__tests__/sync/forwarderHeaders.test.js
+++ b/packages/facility-server/__tests__/sync/forwarderHeaders.test.js
@@ -1,0 +1,49 @@
+/**
+ * Forwards to central carry the end-client IP plus the facility's own central
+ * session as the forwarder credential — and degrade to IP-only (which central
+ * ignores) when the facility can't authenticate.
+ */
+const { CentralServerConnection } = jest.requireActual('../../dist/sync/CentralServerConnection');
+
+describe('forwarderHeaders', () => {
+  const makeConnection = () => {
+    const connection = new CentralServerConnection({ deviceId: 'facility-own-device' });
+    connection.fetch = jest.fn(async () => ({ ok: 'ok' }));
+    return connection;
+  };
+  const req = { method: 'POST', body: { mfaToken: 'x' }, ip: '10.1.2.3' };
+
+  it('carries the client IP and the facility credential', async () => {
+    const connection = makeConnection();
+    connection.loginData = jest.fn(async () => ({}));
+    connection.getAuthToken = jest.fn(() => 'facility-session-token');
+
+    await connection.forwardRequest(req, 'mfa/login/totp');
+    expect(connection.fetch).toHaveBeenCalledWith(
+      'mfa/login/totp',
+      expect.objectContaining({
+        method: 'POST',
+        body: { mfaToken: 'x' },
+        headers: {
+          'X-Tamanu-Client-Ip': '10.1.2.3',
+          'X-Tamanu-Forwarder-Auth': 'facility-session-token',
+        },
+      }),
+    );
+  });
+
+  it('degrades to IP-only when the facility cannot authenticate', async () => {
+    const connection = makeConnection();
+    connection.loginData = jest.fn(async () => {
+      throw new Error('central unreachable');
+    });
+
+    await connection.forwardRequest(req, 'mfa/login/totp');
+    expect(connection.fetch).toHaveBeenCalledWith(
+      'mfa/login/totp',
+      expect.objectContaining({
+        headers: { 'X-Tamanu-Client-Ip': '10.1.2.3' },
+      }),
+    );
+  });
+});

--- a/packages/facility-server/app/middleware/auth.js
+++ b/packages/facility-server/app/middleware/auth.js
@@ -17,6 +17,7 @@ import { version } from '../../package.json';
 import { initAuditActions } from '@tamanu/database/utils/audit';
 
 import { CentralServerConnection } from '../sync';
+import { getForwarderConnection } from '../sync/forwarderConnection';
 
 const { tokenDuration, secret } = config.auth;
 
@@ -113,10 +114,10 @@ export async function centralServerLogin({
 }) {
   // try logging in to central server
   const centralServer = new CentralServerConnection({ deviceId });
-  // the forwarder credential comes from the facility's OWN session (its
-  // device id), separate from this user-credentialed login call
+  // the forwarder credential comes from the facility's OWN session (the
+  // shared forwarder connection), separate from this user-credentialed login
   const forwarderHeaders = req
-    ? await new CentralServerConnection({ deviceId: facilityDeviceId }).forwarderHeaders(req)
+    ? await getForwarderConnection(facilityDeviceId).forwarderHeaders(req)
     : {};
   const response = await centralServer.login(email, password, {
     scopes: [],

--- a/packages/facility-server/app/middleware/auth.js
+++ b/packages/facility-server/app/middleware/auth.js
@@ -109,15 +109,22 @@ export async function centralServerLogin({
   deviceId,
   facilityDeviceId,
   settings,
+  req,
 }) {
   // try logging in to central server
   const centralServer = new CentralServerConnection({ deviceId });
+  // the forwarder credential comes from the facility's OWN session (its
+  // device id), separate from this user-credentialed login call
+  const forwarderHeaders = req
+    ? await new CentralServerConnection({ deviceId: facilityDeviceId }).forwarderHeaders(req)
+    : {};
   const response = await centralServer.login(email, password, {
     scopes: [],
     body: {
       facilityIds: selectFacilityIds(config),
       facilityDeviceId,
     },
+    headers: forwarderHeaders,
     backoff: {
       maxAttempts: 1,
     },
@@ -200,6 +207,7 @@ async function centralServerLoginWithLocalFallback({
   password,
   deviceId,
   facilityDeviceId,
+  req,
 }) {
   // always log in locally when testing
   if (shouldSkipCentralLoginForTest()) {
@@ -214,6 +222,7 @@ async function centralServerLoginWithLocalFallback({
       deviceId,
       facilityDeviceId,
       settings,
+      req,
     });
   } catch (e) {
     // if we get an authentication error from central server, throw instead of
@@ -253,6 +262,7 @@ export async function loginHandler(req, res, next) {
       password,
       deviceId,
       facilityDeviceId,
+      req,
     });
 
     // central paused the login pending a second factor: hand the client the

--- a/packages/facility-server/app/middleware/ipAllowlist.js
+++ b/packages/facility-server/app/middleware/ipAllowlist.js
@@ -1,0 +1,19 @@
+import asyncHandler from 'express-async-handler';
+
+import { ForbiddenError } from '@tamanu/errors';
+import { ReadSettings } from '@tamanu/settings';
+import { ipMatchesCidrList } from '@tamanu/utils';
+
+/**
+ * The login-level IP gate, enforced at the facility's own door (first
+ * contact): with a non-empty auth.ipAllowlist, refuse login attempts from
+ * outside every listed range. The setting syncs, so this works offline too.
+ * Central applies the same gate to logins that reach it directly.
+ */
+export const ipAllowlistGate = asyncHandler(async (req, _res, next) => {
+  const allowlist = await new ReadSettings(req.models).get('auth.ipAllowlist');
+  if (Array.isArray(allowlist) && allowlist.length > 0 && !ipMatchesCidrList(req.ip, allowlist)) {
+    throw new ForbiddenError('Logins are not allowed from this network');
+  }
+  next();
+});

--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -42,6 +42,7 @@ import { medication } from './medication';
 import { mfa } from './mfa';
 import { mfaEnrolInvite } from './mfaEnrolInvite';
 import { passwordlessLogin } from './passwordlessLogin';
+import { ipAllowlistGate } from '../../middleware/ipAllowlist';
 import { effectivePasswordlessMode } from '@tamanu/shared/auth/mfaPolicy';
 import { mfaLogin } from './mfaLogin';
 import { notes } from './note';
@@ -94,14 +95,14 @@ export function createApiv1({ authLimiter } = {}) {
   const syncRoutes = express.Router();
 
   // auth endpoints (added pre auth check)
-  apiv1.post('/login', limiter, loginHandler);
+  apiv1.post('/login', limiter, ipAllowlistGate, loginHandler);
   apiv1.use('/resetPassword', limiter, resetPassword);
   apiv1.use('/changePassword', limiter, changePassword);
-  apiv1.use('/mfa/login', limiter, mfaLogin);
+  apiv1.use('/mfa/login', limiter, ipAllowlistGate, mfaLogin);
   apiv1.use('/mfa/enrolInvite', limiter, mfaEnrolInvite);
   // pre-auth: a user-verifying passkey assertion IS the credential, verified
   // fully locally against the synced public keys
-  apiv1.use('/login/webauthn', limiter, passwordlessLogin);
+  apiv1.use('/login/webauthn', limiter, ipAllowlistGate, passwordlessLogin);
   
   apiv1.get(
     '/public/ping',

--- a/packages/facility-server/app/routes/apiv1/mfaLogin.js
+++ b/packages/facility-server/app/routes/apiv1/mfaLogin.js
@@ -3,7 +3,7 @@ import asyncHandler from 'express-async-handler';
 
 import { ReadSettings } from '@tamanu/settings';
 
-import { CentralServerConnection } from '../../sync';
+import { getForwarderConnection } from '../../sync/forwarderConnection';
 import { finaliseCentralLogin, sendFacilityLoginResponse } from '../../middleware/auth';
 
 /**
@@ -30,7 +30,7 @@ export const forwardThrough = endpoint =>
     // authority (mfa_login pending pass or mfa_enrol session)
     req.flagPermissionChecked();
 
-    const centralServer = new CentralServerConnection({ deviceId });
+    const centralServer = getForwarderConnection(deviceId);
     const response = await centralServer.forwardRequest(req, endpoint);
 
     res.send(response);
@@ -42,7 +42,7 @@ const forwardAndFinalise = endpoint =>
     // no permission needed: the mfa_login token in the body is the authority
     req.flagPermissionChecked();
 
-    const centralServer = new CentralServerConnection({ deviceId });
+    const centralServer = getForwarderConnection(deviceId);
     const response = await centralServer.forwardRequest(req, endpoint);
 
     // central only sends the full payload once the factor has been satisfied

--- a/packages/facility-server/app/sync/CentralServerConnection.js
+++ b/packages/facility-server/app/sync/CentralServerConnection.js
@@ -225,10 +225,29 @@ export class CentralServerConnection extends TamanuApi {
     return this.fetch('whoami');
   }
 
+  /**
+   * Headers that let central trust the end-client IP we saw: the IP itself,
+   * authenticated by our own central session (whose device carries the
+   * permission-gated facility_server scope when the deployment has opted in).
+   * If we can't authenticate, the IP still travels but central ignores it —
+   * fail-closed into "evaluated as the facility's own address".
+   */
+  async forwarderHeaders(req) {
+    const headers = { 'X-Tamanu-Client-Ip': req.ip };
+    try {
+      await this.loginData();
+      headers['X-Tamanu-Forwarder-Auth'] = this.getAuthToken();
+    } catch (err) {
+      log.warn(`forwarderHeaders: could not authenticate as forwarder: ${err}`);
+    }
+    return headers;
+  }
+
   async forwardRequest(req, endpoint) {
     return this.fetch(endpoint, {
       method: req.method,
       body: req.body,
+      headers: await this.forwarderHeaders(req),
     });
   }
 }

--- a/packages/facility-server/app/sync/CentralServerConnection.js
+++ b/packages/facility-server/app/sync/CentralServerConnection.js
@@ -89,7 +89,10 @@ export class CentralServerConnection extends TamanuApi {
     return await this.login(email, password, {
       backoff,
       timeout,
-      scopes: [DEVICE_SCOPES.SYNC_CLIENT],
+      // facility_server is the forwarded-IP trust for the IP policy; central
+      // only grants it when this server's sync user holds create FacilityDevice,
+      // and silently drops it otherwise — requesting it is always safe
+      scopes: [DEVICE_SCOPES.SYNC_CLIENT, DEVICE_SCOPES.FACILITY_SERVER],
     }).then(loginData => {
       return (this.#loginData = loginData);
     });

--- a/packages/facility-server/app/sync/forwarderConnection.js
+++ b/packages/facility-server/app/sync/forwarderConnection.js
@@ -1,0 +1,18 @@
+import { CentralServerConnection } from './CentralServerConnection';
+
+/**
+ * The shared central connection used for forwarding requests on behalf of
+ * end clients (MFA completions, invite redemption, forwarder headers on
+ * logins). One per process: it holds the facility's own central session —
+ * whose device carries the facility_server scope where granted — so forwards
+ * don't pay a fresh sync-login round trip to central on every user login.
+ * The connection re-authenticates itself on expiry via its own retryAuth.
+ */
+let connection = null;
+
+export function getForwarderConnection(deviceId) {
+  if (!connection) {
+    connection = new CentralServerConnection({ deviceId });
+  }
+  return connection;
+}

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -66,9 +66,10 @@
   },
   "dependencies": {
     "@tamanu/constants": "*",
+    "@tamanu/utils": "*",
+    "@types/lodash": "^4.14.197",
     "config": "^3.3.9",
     "date-fns": "^2.25.0",
-    "@types/lodash": "^4.14.197",
     "lodash": "^4.17.21",
     "yup": "^1.4.0"
   }

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -1,4 +1,5 @@
 import * as yup from 'yup';
+import { isValidCidr } from '@tamanu/utils';
 import { extractDefaults } from './utils';
 import {
   ageDisplayFormatDefault,
@@ -88,6 +89,14 @@ export const globalSettings = {
           type: yup.boolean(),
           defaultValue: false,
         },
+        ipAllowlist: {
+          name: 'Login IP allowlist',
+          description:
+            'CIDR ranges (e.g. "10.0.0.0/8") that logins are allowed from; anyone outside every range is refused outright. Empty means no restriction. Evaluated where the client connects: at the facility server for facility logins, at central otherwise. WARNING: a wrong entry here can lock everyone out',
+          type: yup.array(yup.string().test('is-cidr', 'must be a CIDR range', isValidCidr)),
+          defaultValue: [],
+          highRisk: true,
+        },
         mfa: {
           description: 'Multi-factor authentication',
           properties: {
@@ -124,6 +133,14 @@ export const globalSettings = {
                   defaultValue: MFA_USER_VERIFICATION.REQUIRED,
                 },
               },
+            },
+            ipExempt: {
+              name: 'MFA-exempt IP ranges',
+              description:
+                'CIDR ranges (e.g. an intranet) from which logins skip the second factor; everywhere else MFA applies as normal. Empty means no one is exempt. This deliberately makes network position a factor — a compromised host inside the range bypasses MFA — so enable it knowingly. For facility logins this requires the facility server to be granted the forwarded-IP trust (facility_server device scope)',
+              type: yup.array(yup.string().test('is-cidr', 'must be a CIDR range', isValidCidr)),
+              defaultValue: [],
+              highRisk: true,
             },
             passwordless: {
               name: 'Passwordless passkey login',

--- a/packages/utils/__test__/ipPolicy.test.ts
+++ b/packages/utils/__test__/ipPolicy.test.ts
@@ -1,0 +1,53 @@
+import { ipMatchesCidrList, isValidCidr } from '../src/ipPolicy';
+import { describe, expect, it } from 'vitest';
+
+describe('ipMatchesCidrList', () => {
+  it('matches IPv4 inside a range and not outside', () => {
+    expect(ipMatchesCidrList('10.1.2.3', ['10.0.0.0/8'])).toBe(true);
+    expect(ipMatchesCidrList('11.1.2.3', ['10.0.0.0/8'])).toBe(false);
+    expect(ipMatchesCidrList('192.168.1.50', ['10.0.0.0/8', '192.168.1.0/24'])).toBe(true);
+  });
+
+  it('matches an exact /32', () => {
+    expect(ipMatchesCidrList('203.0.113.7', ['203.0.113.7/32'])).toBe(true);
+    expect(ipMatchesCidrList('203.0.113.8', ['203.0.113.7/32'])).toBe(false);
+  });
+
+  it('matches IPv6 ranges', () => {
+    expect(ipMatchesCidrList('2001:db8::1', ['2001:db8::/32'])).toBe(true);
+    expect(ipMatchesCidrList('2001:db9::1', ['2001:db8::/32'])).toBe(false);
+  });
+
+  it('unwraps IPv4-mapped IPv6 client addresses', () => {
+    // Node reports v4 clients this way on dual-stack sockets
+    expect(ipMatchesCidrList('::ffff:10.1.2.3', ['10.0.0.0/8'])).toBe(true);
+    expect(ipMatchesCidrList('::ffff:11.1.2.3', ['10.0.0.0/8'])).toBe(false);
+  });
+
+  it('does not cross address families', () => {
+    expect(ipMatchesCidrList('10.1.2.3', ['2001:db8::/32'])).toBe(false);
+    expect(ipMatchesCidrList('2001:db8::1', ['10.0.0.0/8'])).toBe(false);
+  });
+
+  it('fails closed on garbage', () => {
+    // unparsable client IP never matches
+    expect(ipMatchesCidrList('not-an-ip', ['10.0.0.0/8'])).toBe(false);
+    expect(ipMatchesCidrList(undefined, ['10.0.0.0/8'])).toBe(false);
+    // malformed CIDR entries never match, valid siblings still do
+    expect(ipMatchesCidrList('10.1.2.3', ['garbage'])).toBe(false);
+    expect(ipMatchesCidrList('10.1.2.3', ['garbage', '10.0.0.0/8'])).toBe(true);
+    // empty list matches nothing
+    expect(ipMatchesCidrList('10.1.2.3', [])).toBe(false);
+    expect(ipMatchesCidrList('10.1.2.3', undefined)).toBe(false);
+  });
+});
+
+describe('isValidCidr', () => {
+  it('accepts well-formed CIDRs and rejects the rest', () => {
+    expect(isValidCidr('10.0.0.0/8')).toBe(true);
+    expect(isValidCidr('2001:db8::/32')).toBe(true);
+    expect(isValidCidr('10.0.0.0')).toBe(false); // bare IP, no prefix
+    expect(isValidCidr('10.0.0.0/33')).toBe(false);
+    expect(isValidCidr('banana')).toBe(false);
+  });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -49,6 +49,7 @@
     "@tamanu/constants": "*",
     "date-fns": "^4.1.0",
     "es-toolkit": "^1.31.0",
+    "ipaddr.js": "^2.4.0",
     "lodash": "^4.17.21",
     "nanoid": "^3.3.8",
     "temporal-polyfill": "^0.3.0",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
+export { ipMatchesCidrList, isValidCidr } from './ipPolicy';
 export { generateId, generateIdFromPattern } from './generateId';
 export * from './invoice';
 export {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,4 @@
-export { ipMatchesCidrList, isValidCidr } from './ipPolicy';
+export { ipMatchesCidrList, isValidCidr, isValidIpAddress } from './ipPolicy';
 export { generateId, generateIdFromPattern } from './generateId';
 export * from './invoice';
 export {

--- a/packages/utils/src/ipPolicy.ts
+++ b/packages/utils/src/ipPolicy.ts
@@ -1,0 +1,53 @@
+import ipaddr from 'ipaddr.js';
+
+/**
+ * CIDR matching for the IP policy settings (auth.ipAllowlist,
+ * auth.mfa.ipExempt). Handles IPv4, IPv6, and IPv4-mapped-IPv6 (Node reports
+ * v4 clients as ::ffff:a.b.c.d on dual-stack sockets) by normalising the
+ * client address before comparison.
+ *
+ * Fail-closed throughout: an unparsable client IP or a malformed CIDR entry
+ * never matches — a garbage allowlist entry can't open the door, and a
+ * garbage exempt entry can't skip MFA.
+ */
+
+const parseClientIp = (ip: unknown): ipaddr.IPv4 | ipaddr.IPv6 | null => {
+  if (typeof ip !== 'string' || !ipaddr.isValid(ip)) return null;
+  // unwraps IPv4-mapped IPv6 to plain IPv4
+  return ipaddr.process(ip);
+};
+
+const matchesCidr = (addr: ipaddr.IPv4 | ipaddr.IPv6, cidr: string): boolean => {
+  try {
+    const [range, bits] = ipaddr.parseCIDR(cidr);
+    if (range.kind() !== addr.kind()) return false;
+    return (addr as ipaddr.IPv4).match([range as ipaddr.IPv4, bits]);
+  } catch (_err) {
+    // a malformed entry in the list never matches
+    return false;
+  }
+};
+
+/**
+ * Whether the client IP falls inside any of the CIDR ranges. An empty or
+ * missing list matches nothing.
+ */
+export function ipMatchesCidrList(ip: unknown, cidrs: unknown): boolean {
+  if (!Array.isArray(cidrs) || cidrs.length === 0) return false;
+  const addr = parseClientIp(ip);
+  if (!addr) return false;
+  return cidrs.some(cidr => typeof cidr === 'string' && matchesCidr(addr, cidr));
+}
+
+/**
+ * Whether a string is a well-formed CIDR (for settings validation).
+ */
+export function isValidCidr(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  try {
+    ipaddr.parseCIDR(value);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}

--- a/packages/utils/src/ipPolicy.ts
+++ b/packages/utils/src/ipPolicy.ts
@@ -51,3 +51,10 @@ export function isValidCidr(value: unknown): boolean {
     return false;
   }
 }
+
+/**
+ * Whether a string is a syntactically valid IP address (v4 or v6).
+ */
+export function isValidIpAddress(value: unknown): boolean {
+  return typeof value === 'string' && ipaddr.isValid(value);
+}


### PR DESCRIPTION
### Changes

🤖 TAM-1652 PR3: IP-range conditional access, stacked on #9976 (passwordless), completing the planned three-PR MFA sequence.

Two independent, fail-closed CIDR knobs (both default empty = feature off):

- **`auth.ipAllowlist`** — login-level gate: refuse logins from outside the listed ranges. Enforced at the facilitys own door (settings sync, works offline) and again at central for direct logins; covers password, passwordless, and MFA-completion surfaces.
- **`auth.mfa.ipExempt`** — conditional access: inside a trusted range (e.g. intranet) the second factor is skipped; a `require Mfa` user with no factor is still nudged to enrol but may skip (the hybrid behaviour from the plan, re-checked live at `/mfa/login/skip`).

**Forwarded-IP trust.** For facility logins central only sees the facilitys address, so the facility captures the end-client IP at first contact and forwards it, authenticated by its own central session. Central honours it only when that sessions device carries the new **`facility_server` scope** — which devices can never self-acquire: registration or upgrade to it requires the sync users role to hold a literal `create FacilityDevice` permission, granted deliberately by the deployment. Ungranted → forwarded IPs ignored → exemption never matches facility-mediated logins → everyone gets MFA. Existing deployments are unaffected: the facility requests the scope opportunistically and central silently drops it until the grant exists, after which the next connect upgrades it.

CIDR matching (IPv4/IPv6/v4-mapped) lives in `@tamanu/utils` with unit tests; integration tests cover the gate, the exemption (including skip-on-exempt-network), and the full trust matrix (bare header / wrong scope / garbage credential).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->