### PR TITLE
feat(programs): no-issue: edit existing programs in AI form builder (in-place question versioning)

### DIFF
--- a/packages/central-server/__tests__/admin/formBuilder.test.js
+++ b/packages/central-server/__tests__/admin/formBuilder.test.js
@@ -1,6 +1,75 @@
+import * as XLSX from 'xlsx';
+
 import { createTestContext } from '../utilities';
 
 jest.setTimeout(120 * 1000);
+
+// Build a minimal Tamanu program export workbook (Metadata sheet + one survey
+// sheet), matching the format produced by the program exporter.
+const buildProgramExportBuffer = () => {
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(
+    workbook,
+    XLSX.utils.aoa_to_sheet([
+      ['programName', 'NCD'],
+      ['programCode', 'ncd'],
+      ['country', ''],
+      ['homeServer', ''],
+      [],
+      [
+        'code',
+        'name',
+        'surveyType',
+        'targetLocationId',
+        'targetDepartmentId',
+        'status',
+        'isSensitive',
+        'visibilityStatus',
+        'notifiable',
+        'notifyEmailAddresses',
+        'visibilityCriteria',
+      ],
+      ['referral', 'Referral form', 'programs', '', '', 'publish', '', '', '', '', ''],
+      // An obsolete survey with no questions: its sheet is empty and should be
+      // skipped rather than aborting the parse.
+      ['referralold', 'Referral form (old)', 'obsolete', '', '', 'publish', '', '', '', '', ''],
+    ]),
+    'Metadata',
+  );
+  XLSX.utils.book_append_sheet(
+    workbook,
+    XLSX.utils.aoa_to_sheet([
+      [
+        'code',
+        'type',
+        'name',
+        'text',
+        'detail',
+        'newScreen',
+        'options',
+        'optionLabels',
+        'optionColors',
+        'visibilityCriteria',
+        'validationCriteria',
+        'visualisationConfig',
+        'optionSet',
+        'questionLabel',
+        'detailLabel',
+        'calculation',
+        'config',
+        'visibilityStatus',
+      ],
+      ['referral001', 'FreeText', 'Patient name', 'Patient name', ...Array(14).fill('')],
+    ]),
+    'referral',
+  );
+  XLSX.utils.book_append_sheet(
+    workbook,
+    XLSX.utils.aoa_to_sheet([['code', 'type', 'name', 'text']]),
+    'referralold',
+  );
+  return XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' });
+};
 
 const programDefinition = {
   title: 'Referral form',
@@ -325,6 +394,64 @@ describe('Form Builder Admin', () => {
       text: 'Referral date',
       type: 'Date',
     });
+  });
+
+  it('loads an uploaded program export deterministically without invoking the model', async () => {
+    const response = await app
+      .post('/v1/admin/form-builder/chat')
+      .field('jsonData', JSON.stringify({ message: '' }))
+      .attach('file', buildProgramExportBuffer(), 'program.xlsx');
+
+    expect(response).toHaveSucceeded();
+    // No model call: the export is parsed into a working definition directly.
+    expect(aiService.sendFormBuilderMessage).not.toHaveBeenCalled();
+    expect(aiService.invokeStructured).not.toHaveBeenCalled();
+    expect(response.body.programDefinition).toMatchObject({
+      title: 'NCD',
+      programCode: 'ncd',
+      // The obsolete, question-less survey is dropped, keeping arrays consistent.
+      surveys: [{ code: 'referral', name: 'Referral form', surveyType: 'programs' }],
+      surveySheets: [
+        {
+          surveyName: 'Referral form',
+          questions: [
+            { code: 'referral001', type: 'FreeText', name: 'Patient name', text: 'Patient name' },
+          ],
+        },
+      ],
+    });
+    expect(response.body.message).toMatch(/loaded/i);
+    expect(aiService.addSessionMessages).toHaveBeenCalled();
+  });
+
+  it('retries the build once and returns a clean error when it cannot be parsed', async () => {
+    aiService.sendFormBuilderMessage.mockResolvedValueOnce({
+      message: 'Your form is ready to export.',
+      attach_to_program_code: 'ncd',
+      ready: true,
+    });
+    // Mimics the LangChain structured-output failure that previously leaked to
+    // the user verbatim.
+    aiService.invokeStructured.mockRejectedValue(
+      new Error(
+        'Failed to parse. Text: "{...}". Troubleshooting URL: https://docs.langchain.com/oss/javascript/langchain/errors/OUTPUT_PARSING_FAILURE/',
+      ),
+    );
+
+    const startResponse = await app.post('/v1/admin/form-builder/chat').send({
+      async: true,
+      message: 'Export this form',
+    });
+
+    expect(startResponse).toHaveSucceeded();
+    const settled = await pollUntilSettled(startResponse.body.jobId);
+
+    expect(aiService.invokeStructured).toHaveBeenCalledTimes(2);
+    expect(settled.body.status).toBe('failed');
+    expect(settled.body.error.message).toBe(
+      'The form builder could not generate a complete form for this request. Please try again, or make a smaller change at a time.',
+    );
+    expect(settled.body.error.message).not.toContain('OUTPUT_PARSING_FAILURE');
   });
 
   it('applies a fast patch when tweaking an existing preview', async () => {

--- a/packages/central-server/__tests__/admin/formBuilder.test.js
+++ b/packages/central-server/__tests__/admin/formBuilder.test.js
@@ -424,6 +424,65 @@ describe('Form Builder Admin', () => {
     expect(aiService.addSessionMessages).toHaveBeenCalled();
   });
 
+  it('resolves survey sheets whose names were normalised on export', async () => {
+    // The metadata holds the raw survey code, but the worksheet name strips
+    // Excel-forbidden characters (as the AI form builder does via createSheetName).
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      workbook,
+      XLSX.utils.aoa_to_sheet([
+        ['programName', 'NCD'],
+        ['programCode', 'ncd'],
+        ['country', ''],
+        ['homeServer', ''],
+        [],
+        ['code', 'name', 'surveyType', 'status'],
+        ['ref/1', 'Referral form', 'programs', 'publish'],
+      ]),
+      'Metadata',
+    );
+    XLSX.utils.book_append_sheet(
+      workbook,
+      XLSX.utils.aoa_to_sheet([
+        ['code', 'type', 'name', 'text'],
+        ['referral001', 'FreeText', 'Patient name', 'Patient name'],
+      ]),
+      'ref1',
+    );
+    const buffer = XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' });
+
+    const response = await app
+      .post('/v1/admin/form-builder/chat')
+      .field('jsonData', JSON.stringify({ message: '' }))
+      .attach('file', buffer, 'program.xlsx');
+
+    expect(response).toHaveSucceeded();
+    expect(response.body.programDefinition).toMatchObject({
+      surveys: [{ code: 'ref/1', name: 'Referral form' }],
+      surveySheets: [{ surveyName: 'Referral form', questions: [{ code: 'referral001' }] }],
+    });
+  });
+
+  it('loads the program and reports back when an upload-bundled edit cannot be applied', async () => {
+    // The tweak attempt fails (the model errors), so the edit can't be applied.
+    aiService.invokeStructured.mockRejectedValueOnce(new Error('tweak unavailable'));
+
+    const response = await app
+      .post('/v1/admin/form-builder/chat')
+      .field('jsonData', JSON.stringify({ message: 'make it better somehow' }))
+      .attach('file', buildProgramExportBuffer(), 'program.xlsx');
+
+    expect(response).toHaveSucceeded();
+    // The edit isn't silently dropped: the user is told it wasn't applied...
+    expect(response.body.message).toMatch(/couldn't apply/i);
+    // ...and the program is still seeded so a follow-up can use the tweak path.
+    expect(response.body.programDefinition).toMatchObject({
+      programCode: 'ncd',
+      surveys: [{ code: 'referral' }],
+    });
+    expect(aiService.sendFormBuilderMessage).not.toHaveBeenCalled();
+  });
+
   it('retries the build once and returns a clean error when it cannot be parsed', async () => {
     aiService.sendFormBuilderMessage.mockResolvedValueOnce({
       message: 'Your form is ready to export.',

--- a/packages/central-server/__tests__/admin/programSurveySave.test.js
+++ b/packages/central-server/__tests__/admin/programSurveySave.test.js
@@ -4,17 +4,16 @@ import { createTestContext } from '../utilities';
 
 jest.setTimeout(120 * 1000);
 
-// Saving an edited program through the AI form builder supersedes the previous
-// survey version (old → historical, new → current) instead of leaving two
-// active near-duplicate surveys; unchanged surveys are left untouched.
+// Editing a program through the AI form builder updates the existing survey in
+// place: modified questions keep their code (so responses stay linked), new
+// questions are added, removed questions are retired (historical), and the
+// survey id is unchanged. Unchanged surveys are left untouched.
 describe('AI form builder survey save', () => {
   let ctx;
   let app;
   let models;
 
-  // Distinct survey codes per test so the globally-scoped getAvailableSurveyCode
-  // doesn't suffix one test's survey because of another's.
-  const buildForm = (surveyCode, questionText) => ({
+  const buildForm = (surveyCode, questions) => ({
     title: 'NCD Save Test',
     programCode: 'savetest',
     programName: 'NCD Save Test',
@@ -22,9 +21,12 @@ describe('AI form builder survey save', () => {
     surveySheets: [
       {
         surveyName: 'Referral',
-        questions: [
-          { code: `${surveyCode}001`, name: 'Reason', text: questionText, type: 'FreeText' },
-        ],
+        questions: questions.map(({ code, text }) => ({
+          code,
+          name: code,
+          text,
+          type: 'FreeText',
+        })),
       },
     ],
   });
@@ -46,49 +48,72 @@ describe('AI form builder survey save', () => {
     await ctx?.close();
   });
 
-  it('supersedes the previous survey version when content changes', async () => {
+  it('updates an existing survey in place, preserving identity and retiring removed questions', async () => {
     const program = await models.Program.create({ id: 'program-savetest', name: 'NCD Save Test' });
 
-    const first = await save(program.id, buildForm('supref', 'Reason for referral'));
-    expect(first).toHaveSucceeded();
-    const firstSurveyId = first.body.surveys[0].id;
-
-    const second = await save(program.id, buildForm('supref', 'Updated reason for referral'));
-    expect(second).toHaveSucceeded();
-    const secondSurveyId = second.body.surveys[0].id;
-
-    expect(secondSurveyId).not.toBe(firstSurveyId);
-    expect((await models.Survey.findByPk(firstSurveyId)).visibilityStatus).toBe(
-      VISIBILITY_STATUSES.HISTORICAL,
+    const first = await save(
+      program.id,
+      buildForm('qlref', [
+        { code: 'qlref001', text: 'Original question one' },
+        { code: 'qlref002', text: 'Original question two' },
+      ]),
     );
-    expect((await models.Survey.findByPk(secondSurveyId)).visibilityStatus).toBe(
+    expect(first).toHaveSucceeded();
+    const surveyId = first.body.surveys[0].id;
+
+    // Modify q1, remove q2, add q3.
+    const second = await save(
+      program.id,
+      buildForm('qlref', [
+        { code: 'qlref001', text: 'Updated question one' },
+        { code: 'qlref003', text: 'New question three' },
+      ]),
+    );
+    expect(second).toHaveSucceeded();
+
+    // Same survey, still current — not a duplicate.
+    expect(second.body.surveys[0].id).toBe(surveyId);
+    expect((await models.Survey.findByPk(surveyId)).visibilityStatus).toBe(
       VISIBILITY_STATUSES.CURRENT,
     );
+    expect(
+      await models.Survey.count({
+        where: { programId: program.id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+      }),
+    ).toBe(1);
 
-    const current = await models.Survey.findAll({
-      where: { programId: program.id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
-    });
-    expect(current).toHaveLength(1);
+    // Modified question kept its data element (same id), text updated.
+    expect((await models.ProgramDataElement.findByPk('pde-qlref001')).defaultText).toBe(
+      'Updated question one',
+    );
+    // Removed question's component is retired, not deleted.
+    expect((await models.SurveyScreenComponent.findByPk(`${surveyId}-qlref002`)).visibilityStatus).toBe(
+      VISIBILITY_STATUSES.HISTORICAL,
+    );
+    // Added question is present and current.
+    expect((await models.SurveyScreenComponent.findByPk(`${surveyId}-qlref003`)).visibilityStatus).toBe(
+      VISIBILITY_STATUSES.CURRENT,
+    );
   });
 
-  it('does not create a new version when the survey is unchanged', async () => {
+  it('does not rewrite a survey when its content is unchanged', async () => {
     const program = await models.Program.create({
       id: 'program-savetest-2',
       name: 'NCD Save Test 2',
     });
 
-    const first = await save(program.id, buildForm('unchref', 'Reason for referral'));
+    const first = await save(program.id, buildForm('unchref', [{ code: 'unchref001', text: 'Reason' }]));
     expect(first).toHaveSucceeded();
-    const firstSurveyId = first.body.surveys[0].id;
+    const surveyId = first.body.surveys[0].id;
+    const componentBefore = await models.SurveyScreenComponent.findByPk(`${surveyId}-unchref001`);
 
-    const second = await save(program.id, buildForm('unchref', 'Reason for referral'));
+    const second = await save(program.id, buildForm('unchref', [{ code: 'unchref001', text: 'Reason' }]));
     expect(second).toHaveSucceeded();
+    expect(second.body.surveys[0].id).toBe(surveyId);
 
-    expect(second.body.surveys[0].id).toBe(firstSurveyId);
-    expect((await models.Survey.findByPk(firstSurveyId)).visibilityStatus).toBe(
-      VISIBILITY_STATUSES.CURRENT,
-    );
-    const allForProgram = await models.Survey.findAll({ where: { programId: program.id } });
-    expect(allForProgram).toHaveLength(1);
+    // Untouched: the component wasn't rewritten (same sync tick).
+    const componentAfter = await models.SurveyScreenComponent.findByPk(`${surveyId}-unchref001`);
+    expect(componentAfter.updatedAtSyncTick).toBe(componentBefore.updatedAtSyncTick);
+    expect(await models.Survey.count({ where: { programId: program.id } })).toBe(1);
   });
 });

--- a/packages/central-server/__tests__/admin/programSurveySave.test.js
+++ b/packages/central-server/__tests__/admin/programSurveySave.test.js
@@ -1,0 +1,94 @@
+import { VISIBILITY_STATUSES } from '@tamanu/constants';
+
+import { createTestContext } from '../utilities';
+
+jest.setTimeout(120 * 1000);
+
+// Saving an edited program through the AI form builder supersedes the previous
+// survey version (old → historical, new → current) instead of leaving two
+// active near-duplicate surveys; unchanged surveys are left untouched.
+describe('AI form builder survey save', () => {
+  let ctx;
+  let app;
+  let models;
+
+  // Distinct survey codes per test so the globally-scoped getAvailableSurveyCode
+  // doesn't suffix one test's survey because of another's.
+  const buildForm = (surveyCode, questionText) => ({
+    title: 'NCD Save Test',
+    programCode: 'savetest',
+    programName: 'NCD Save Test',
+    surveys: [{ code: surveyCode, name: 'Referral', surveyType: 'programs' }],
+    surveySheets: [
+      {
+        surveyName: 'Referral',
+        questions: [
+          { code: `${surveyCode}001`, name: 'Reason', text: questionText, type: 'FreeText' },
+        ],
+      },
+    ],
+  });
+
+  const save = (programId, form) =>
+    app.post(`/v1/admin/program/${encodeURIComponent(programId)}/ai-form-builder-survey`).send({ form });
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+    app = await ctx.baseApp.asNewRole([
+      ['read', 'Program'],
+      ['create', 'Survey'],
+      ['write', 'Survey'],
+    ]);
+  });
+
+  afterAll(async () => {
+    await ctx?.close();
+  });
+
+  it('supersedes the previous survey version when content changes', async () => {
+    const program = await models.Program.create({ id: 'program-savetest', name: 'NCD Save Test' });
+
+    const first = await save(program.id, buildForm('supref', 'Reason for referral'));
+    expect(first).toHaveSucceeded();
+    const firstSurveyId = first.body.surveys[0].id;
+
+    const second = await save(program.id, buildForm('supref', 'Updated reason for referral'));
+    expect(second).toHaveSucceeded();
+    const secondSurveyId = second.body.surveys[0].id;
+
+    expect(secondSurveyId).not.toBe(firstSurveyId);
+    expect((await models.Survey.findByPk(firstSurveyId)).visibilityStatus).toBe(
+      VISIBILITY_STATUSES.HISTORICAL,
+    );
+    expect((await models.Survey.findByPk(secondSurveyId)).visibilityStatus).toBe(
+      VISIBILITY_STATUSES.CURRENT,
+    );
+
+    const current = await models.Survey.findAll({
+      where: { programId: program.id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+    });
+    expect(current).toHaveLength(1);
+  });
+
+  it('does not create a new version when the survey is unchanged', async () => {
+    const program = await models.Program.create({
+      id: 'program-savetest-2',
+      name: 'NCD Save Test 2',
+    });
+
+    const first = await save(program.id, buildForm('unchref', 'Reason for referral'));
+    expect(first).toHaveSucceeded();
+    const firstSurveyId = first.body.surveys[0].id;
+
+    const second = await save(program.id, buildForm('unchref', 'Reason for referral'));
+    expect(second).toHaveSucceeded();
+
+    expect(second.body.surveys[0].id).toBe(firstSurveyId);
+    expect((await models.Survey.findByPk(firstSurveyId)).visibilityStatus).toBe(
+      VISIBILITY_STATUSES.CURRENT,
+    );
+    const allForProgram = await models.Survey.findAll({ where: { programId: program.id } });
+    expect(allForProgram).toHaveLength(1);
+  });
+});

--- a/packages/central-server/__tests__/admin/programSurveySave.test.js
+++ b/packages/central-server/__tests__/admin/programSurveySave.test.js
@@ -94,6 +94,21 @@ describe('AI form builder survey save', () => {
     expect((await models.SurveyScreenComponent.findByPk(`${surveyId}-qlref003`)).visibilityStatus).toBe(
       VISIBILITY_STATUSES.CURRENT,
     );
+
+    // A further edit still resolves and updates the same survey — the code is
+    // never suffixed, so no second current survey is ever created.
+    const third = await save(
+      program.id,
+      buildForm('qlref', [{ code: 'qlref001', text: 'Updated question one again' }]),
+    );
+    expect(third).toHaveSucceeded();
+    expect(third.body.surveys[0].id).toBe(surveyId);
+    expect((await models.Survey.findByPk(surveyId)).code).toBe('qlref');
+    expect(
+      await models.Survey.count({
+        where: { programId: program.id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+      }),
+    ).toBe(1);
   });
 
   it('does not rewrite a survey when its content is unchanged', async () => {

--- a/packages/central-server/__tests__/admin/programSurveySave.test.js
+++ b/packages/central-server/__tests__/admin/programSurveySave.test.js
@@ -111,6 +111,20 @@ describe('AI form builder survey save', () => {
     ).toBe(1);
   });
 
+  it('forbids saving without Survey create/write permission', async () => {
+    const program = await models.Program.create({
+      id: 'program-savetest-forbidden',
+      name: 'NCD Save Test Forbidden',
+    });
+    const forbiddenApp = await ctx.baseApp.asNewRole([['read', 'Program']]);
+
+    const response = await forbiddenApp
+      .post(`/v1/admin/program/${encodeURIComponent(program.id)}/ai-form-builder-survey`)
+      .send({ form: buildForm('forbref', [{ code: 'forbref001', text: 'Reason' }]) });
+
+    expect(response).toBeForbidden();
+  });
+
   it('does not rewrite a survey when its content is unchanged', async () => {
     const program = await models.Program.create({
       id: 'program-savetest-2',

--- a/packages/central-server/app/admin/formBuilder.js
+++ b/packages/central-server/app/admin/formBuilder.js
@@ -247,6 +247,160 @@ const buildProgramDefinitionTweakInput = ({ currentProgramDefinition, userMessag
 const finaliseProgramDefinition = rawProgramDefinition =>
   programDefinitionSchema.parseAsync(sanitizeProgramDefinitionPreview(rawProgramDefinition));
 
+const cellToString = value => (value == null ? '' : String(value).trim());
+
+const parseBooleanCell = value => {
+  const normalised = cellToString(value).toLowerCase();
+  return normalised === 'true' || normalised === 'yes';
+};
+
+const rowToRecord = (header, row) =>
+  Object.fromEntries(header.map((key, index) => [key, row[index]]));
+
+const buildSurveyMetadataFromRow = record => {
+  const survey = {
+    code: cellToString(record.code),
+    name: cellToString(record.name),
+  };
+  const surveyType = cellToString(record.surveyType);
+  if (surveyType) survey.surveyType = surveyType;
+  const status = cellToString(record.status);
+  if (status) survey.status = status;
+  if (cellToString(record.isSensitive)) survey.isSensitive = parseBooleanCell(record.isSensitive);
+  if (cellToString(record.notifiable)) survey.notifiable = parseBooleanCell(record.notifiable);
+  const notifyEmailAddresses = cellToString(record.notifyEmailAddresses)
+    .split(',')
+    .map(email => email.trim())
+    .filter(Boolean);
+  if (notifyEmailAddresses.length) survey.notifyEmailAddresses = notifyEmailAddresses;
+  const visibilityCriteria = cellToString(record.visibilityCriteria);
+  if (visibilityCriteria) survey.visibilityCriteria = visibilityCriteria;
+  const visibilityStatus = cellToString(record.visibilityStatus);
+  if (visibilityStatus) survey.visibilityStatus = visibilityStatus;
+  return survey;
+};
+
+const QUESTION_STRING_FIELDS = [
+  'options',
+  'visibilityCriteria',
+  'validationCriteria',
+  'detail',
+  'config',
+  'calculation',
+  'visibilityStatus',
+  'visualisationConfig',
+];
+
+const buildQuestionFromRow = record => {
+  const code = cellToString(record.code);
+  const name = cellToString(record.name);
+  const text = cellToString(record.text);
+  // The schema requires non-empty name and text. Real exports populate both,
+  // but fall back to neighbours so a single blank cell doesn't reject an
+  // otherwise valid form (saving is additive, so this never overwrites data).
+  const question = {
+    code,
+    type: cellToString(record.type),
+    name: name || text || code,
+    text: text || name || code,
+  };
+  if (parseBooleanCell(record.newScreen)) question.newScreen = true;
+  for (const field of QUESTION_STRING_FIELDS) {
+    const value = cellToString(record[field]);
+    if (value) question[field] = value;
+  }
+  return question;
+};
+
+const findSurveySheetForCode = (workbook, surveyCode) => {
+  if (workbook.Sheets[surveyCode]) return workbook.Sheets[surveyCode];
+  // Sheet names are capped at 31 characters on write, so a longer survey code
+  // is truncated — match on that prefix as a fallback.
+  const truncated = surveyCode.slice(0, 31);
+  return workbook.Sheets[truncated] ?? null;
+};
+
+// Deterministically parse a Tamanu program export workbook (a Metadata sheet
+// plus one sheet per survey) into the ProgramDefinition shape. Returns null
+// when the file isn't a recognisable program export, so the caller can fall
+// back to the LLM flow.
+const parseProgramExportWorkbook = file => {
+  const workbook = readFile(file);
+  const metadataSheet = workbook.Sheets.Metadata;
+  if (!metadataSheet) return null;
+
+  const metadataRows = utils.sheet_to_json(metadataSheet, { header: 1, blankrows: false });
+  const surveyHeaderIndex = metadataRows.findIndex(
+    row => row[0] === 'code' && row.includes('surveyType'),
+  );
+  if (surveyHeaderIndex === -1) return null;
+
+  const metadata = {};
+  for (let index = 0; index < surveyHeaderIndex; index += 1) {
+    const [key, value] = metadataRows[index];
+    if (typeof key === 'string' && key) metadata[key] = cellToString(value);
+  }
+
+  const surveyHeader = metadataRows[surveyHeaderIndex];
+  const surveyMetadata = metadataRows
+    .slice(surveyHeaderIndex + 1)
+    .filter(row => cellToString(row[0]))
+    .map(row => buildSurveyMetadataFromRow(rowToRecord(surveyHeader, row)));
+  if (!surveyMetadata.length) return null;
+
+  // Exports can include obsolete surveys whose sheets are empty. Skip any
+  // survey without questions rather than aborting — saving is additive, so
+  // dropping an empty survey from the working definition is non-destructive and
+  // keeps `surveys`/`surveySheets` consistent for schema validation.
+  const surveys = [];
+  const surveySheets = [];
+  for (const survey of surveyMetadata) {
+    const sheet = findSurveySheetForCode(workbook, survey.code);
+    if (!sheet) continue;
+    const rows = utils.sheet_to_json(sheet, { header: 1, blankrows: false });
+    if (rows.length < 2) continue;
+    const [questionHeader, ...questionRows] = rows;
+    const questions = questionRows
+      .filter(row => cellToString(row[0]))
+      .map(row => buildQuestionFromRow(rowToRecord(questionHeader, row)));
+    if (!questions.length) continue;
+    surveys.push(survey);
+    surveySheets.push({ surveyName: survey.name, questions });
+  }
+  if (!surveys.length) return null;
+
+  return {
+    title: metadata.programName || metadata.programCode || 'Program',
+    ...(metadata.programCode ? { programCode: metadata.programCode } : {}),
+    ...(metadata.programName ? { programName: metadata.programName } : {}),
+    surveys,
+    surveySheets,
+  };
+};
+
+// Parse and validate an uploaded program export into a working definition, or
+// return null when the file can't be read as one.
+const loadProgramDefinitionFromUpload = async ({ file, fileName }) => {
+  if (!file) return null;
+  if (!WORKBOOK_FILE_EXTENSIONS.has(extname(fileName || '').toLowerCase())) return null;
+  try {
+    const rawProgramDefinition = parseProgramExportWorkbook(file);
+    if (!rawProgramDefinition) return null;
+    return await finaliseProgramDefinition(rawProgramDefinition);
+  } catch (error) {
+    log.warn({ error }, 'AI form builder could not parse uploaded file as a program export');
+    return null;
+  }
+};
+
+const buildProgramLoadedMessage = programDefinition => {
+  const surveyCount = programDefinition.surveys.length;
+  const programName = programDefinition.programName || programDefinition.title;
+  return `I've loaded "${programName}" from your file — it has ${surveyCount} survey${
+    surveyCount === 1 ? '' : 's'
+  }. Tell me which questions you'd like to add, remove, or change.`;
+};
+
 const cloneProgramDefinition = programDefinition => JSON.parse(JSON.stringify(programDefinition));
 
 const findSurveySheet = (programDefinition, surveyName) => {
@@ -332,6 +486,21 @@ const serializeChatJobError = error => ({
   status: error?.status,
 });
 
+const invokeProgramDefinitionBuild = (aiService, buildInput) =>
+  aiService.invokeStructured(
+    AI_CONTEXT_NAMES.FORM_BUILDER_BUILD,
+    buildInput,
+    programDefinitionSchema,
+    { name: 'form_builder_program_definition' },
+  );
+
+// The model sometimes returns a partial definition (most often omitting the
+// surveySheets array), which fails structured-output validation. We retry once
+// with explicit corrective guidance, and on persistent failure surface a clean,
+// actionable message — never the raw LangChain parser exception.
+const BUILD_RETRY_GUIDANCE =
+  'Your previous response was rejected because it did not match the required structure (commonly a missing "surveySheets" array). Return the COMPLETE ProgramDefinition as JSON with BOTH a "surveys" array of metadata AND a "surveySheets" array containing every survey and all of its questions. Do not omit or summarise any questions.';
+
 const generateProgramDefinition = async ({
   aiService,
   currentProgramDefinition,
@@ -346,14 +515,25 @@ const generateProgramDefinition = async ({
     sessionId,
     userMessage,
   });
-  return finaliseProgramDefinition(
-    await aiService.invokeStructured(
-      AI_CONTEXT_NAMES.FORM_BUILDER_BUILD,
-      buildInput,
-      programDefinitionSchema,
-      { name: 'form_builder_program_definition' },
-    ),
-  );
+
+  try {
+    return await finaliseProgramDefinition(await invokeProgramDefinitionBuild(aiService, buildInput));
+  } catch (error) {
+    log.warn(
+      { error },
+      'AI form builder build failed to parse, retrying once with corrective guidance',
+    );
+    try {
+      return await finaliseProgramDefinition(
+        await invokeProgramDefinitionBuild(aiService, `${buildInput}\n\n[IMPORTANT] ${BUILD_RETRY_GUIDANCE}`),
+      );
+    } catch (retryError) {
+      log.warn({ error: retryError }, 'AI form builder build retry failed');
+      throw new InvalidOperationError(
+        'The form builder could not generate a complete form for this request. Please try again, or make a smaller change at a time.',
+      );
+    }
+  }
 };
 
 // Attempt a targeted patch against the current program definition. Returns the
@@ -409,6 +589,54 @@ const processChatRequest = async ({
       existingSessionId && (await aiService.hasSession(existingSessionId))
         ? existingSessionId
         : await aiService.createSession(AI_CONTEXT_NAMES.FORM_BUILDER);
+
+    // An uploaded Tamanu program export is parsed deterministically into a
+    // working definition. This seeds the targeted tweak path for subsequent
+    // edits instead of regenerating the entire (often huge) program from
+    // scratch — which the model can't reliably do in one structured response.
+    if (!currentProgramDefinition) {
+      const uploadedDefinition = await loadProgramDefinitionFromUpload({ file, fileName });
+      if (uploadedDefinition) {
+        const editRequest = message?.trim();
+        // If the user described an edit alongside the upload, apply it now.
+        if (editRequest) {
+          const tweakResult = await tryTweakProgramDefinition({
+            aiService,
+            currentProgramDefinition: uploadedDefinition,
+            userMessage: editRequest,
+          });
+          if (tweakResult) {
+            await aiService
+              .addSessionMessages(sessionId, {
+                userMessage,
+                assistantMessage: tweakResult.message,
+              })
+              .catch(error => {
+                log.warn({ error }, 'AI form builder failed to persist upload-edit chat history');
+              });
+            return {
+              sessionId,
+              message: tweakResult.message,
+              attachToProgramCode: null,
+              programDefinition: tweakResult.programDefinition,
+            };
+          }
+        }
+
+        const loadedMessage = buildProgramLoadedMessage(uploadedDefinition);
+        await aiService
+          .addSessionMessages(sessionId, { userMessage, assistantMessage: loadedMessage })
+          .catch(error => {
+            log.warn({ error }, 'AI form builder failed to persist uploaded program chat history');
+          });
+        return {
+          sessionId,
+          message: loadedMessage,
+          attachToProgramCode: null,
+          programDefinition: uploadedDefinition,
+        };
+      }
+    }
 
     if (currentProgramDefinition) {
       const tweakResult = await tryTweakProgramDefinition({

--- a/packages/central-server/app/admin/formBuilder.js
+++ b/packages/central-server/app/admin/formBuilder.js
@@ -437,6 +437,58 @@ const tryTweakProgramDefinition = async ({ aiService, currentProgramDefinition, 
   }
 };
 
+// Seed an uploaded Tamanu program export as the working definition so edits run
+// through the targeted tweak path rather than regenerating the whole (often
+// huge) program. Returns the chat response, or null when the upload isn't a
+// recognisable program export.
+const handleProgramExportUpload = async ({
+  aiService,
+  sessionId,
+  file,
+  fileName,
+  message,
+  userMessage,
+}) => {
+  const uploadedDefinition = await loadProgramDefinitionFromUpload({ file, fileName });
+  if (!uploadedDefinition) return null;
+
+  const persist = assistantMessage =>
+    aiService.addSessionMessages(sessionId, { userMessage, assistantMessage }).catch(error => {
+      log.warn({ error }, 'AI form builder failed to persist uploaded program chat history');
+    });
+
+  // If the user described an edit alongside the upload, try to apply it now. A
+  // failed tweak still seeds the (unmodified) definition and tells the user the
+  // change wasn't applied, so their request isn't silently dropped.
+  const editRequest = message?.trim();
+  if (editRequest) {
+    const tweakResult = await tryTweakProgramDefinition({
+      aiService,
+      currentProgramDefinition: uploadedDefinition,
+      userMessage: editRequest,
+    });
+    const assistantMessage = tweakResult
+      ? tweakResult.message
+      : buildProgramLoadedEditNotAppliedMessage(uploadedDefinition);
+    await persist(assistantMessage);
+    return {
+      sessionId,
+      message: assistantMessage,
+      attachToProgramCode: null,
+      programDefinition: tweakResult ? tweakResult.programDefinition : uploadedDefinition,
+    };
+  }
+
+  const loadedMessage = buildProgramLoadedMessage(uploadedDefinition);
+  await persist(loadedMessage);
+  return {
+    sessionId,
+    message: loadedMessage,
+    attachToProgramCode: null,
+    programDefinition: uploadedDefinition,
+  };
+};
+
 const processChatRequest = async ({
   aiService,
   sessionId: existingSessionId,
@@ -457,53 +509,18 @@ const processChatRequest = async ({
         ? existingSessionId
         : await aiService.createSession(AI_CONTEXT_NAMES.FORM_BUILDER);
 
-    // An uploaded Tamanu program export is parsed deterministically into a
-    // working definition. This seeds the targeted tweak path for subsequent
-    // edits instead of regenerating the entire (often huge) program from
-    // scratch — which the model can't reliably do in one structured response.
+    // An uploaded Tamanu program export seeds the working definition so edits
+    // run through the targeted tweak path rather than a full regeneration.
     if (!currentProgramDefinition) {
-      const uploadedDefinition = await loadProgramDefinitionFromUpload({ file, fileName });
-      if (uploadedDefinition) {
-        const editRequest = message?.trim();
-        // If the user described an edit alongside the upload, try to apply it
-        // now. A failed tweak still seeds the (unmodified) definition and tells
-        // the user the change wasn't applied, so their request isn't silently
-        // dropped — a follow-up then runs through the tweak path.
-        if (editRequest) {
-          const tweakResult = await tryTweakProgramDefinition({
-            aiService,
-            currentProgramDefinition: uploadedDefinition,
-            userMessage: editRequest,
-          });
-          const assistantMessage = tweakResult
-            ? tweakResult.message
-            : buildProgramLoadedEditNotAppliedMessage(uploadedDefinition);
-          await aiService
-            .addSessionMessages(sessionId, { userMessage, assistantMessage })
-            .catch(error => {
-              log.warn({ error }, 'AI form builder failed to persist upload-edit chat history');
-            });
-          return {
-            sessionId,
-            message: assistantMessage,
-            attachToProgramCode: null,
-            programDefinition: tweakResult ? tweakResult.programDefinition : uploadedDefinition,
-          };
-        }
-
-        const loadedMessage = buildProgramLoadedMessage(uploadedDefinition);
-        await aiService
-          .addSessionMessages(sessionId, { userMessage, assistantMessage: loadedMessage })
-          .catch(error => {
-            log.warn({ error }, 'AI form builder failed to persist uploaded program chat history');
-          });
-        return {
-          sessionId,
-          message: loadedMessage,
-          attachToProgramCode: null,
-          programDefinition: uploadedDefinition,
-        };
-      }
+      const uploadResult = await handleProgramExportUpload({
+        aiService,
+        sessionId,
+        file,
+        fileName,
+        message,
+        userMessage,
+      });
+      if (uploadResult) return uploadResult;
     }
 
     if (currentProgramDefinition) {

--- a/packages/central-server/app/admin/formBuilder.js
+++ b/packages/central-server/app/admin/formBuilder.js
@@ -312,12 +312,22 @@ const buildQuestionFromRow = record => {
   return question;
 };
 
+// Resolve the worksheet for a survey code. Sheet names are capped at 31
+// characters and cannot contain Excel-forbidden characters. The program
+// exporter writes the raw survey code, while the AI form builder normalises it
+// (strips :/\?*[] then truncates via createSheetName) — try each form so
+// re-uploaded AI workbooks resolve too.
+const sheetNameCandidatesForCode = surveyCode => [
+  surveyCode,
+  surveyCode.slice(0, 31),
+  surveyCode.replace(/[:/\\?*[\]]/g, '').slice(0, 31),
+];
+
 const findSurveySheetForCode = (workbook, surveyCode) => {
-  if (workbook.Sheets[surveyCode]) return workbook.Sheets[surveyCode];
-  // Sheet names are capped at 31 characters on write, so a longer survey code
-  // is truncated — match on that prefix as a fallback.
-  const truncated = surveyCode.slice(0, 31);
-  return workbook.Sheets[truncated] ?? null;
+  for (const candidate of sheetNameCandidatesForCode(surveyCode)) {
+    if (workbook.Sheets[candidate]) return workbook.Sheets[candidate];
+  }
+  return null;
 };
 
 // Deterministically parse a Tamanu program export workbook (a Metadata sheet
@@ -399,6 +409,11 @@ const buildProgramLoadedMessage = programDefinition => {
   return `I've loaded "${programName}" from your file — it has ${surveyCount} survey${
     surveyCount === 1 ? '' : 's'
   }. Tell me which questions you'd like to add, remove, or change.`;
+};
+
+const buildProgramLoadedEditNotAppliedMessage = programDefinition => {
+  const programName = programDefinition.programName || programDefinition.title;
+  return `I've loaded "${programName}" from your file, but I couldn't apply that change automatically. Tell me which survey and question to change and the new wording, and I'll update it.`;
 };
 
 const cloneProgramDefinition = programDefinition => JSON.parse(JSON.stringify(programDefinition));
@@ -598,29 +613,30 @@ const processChatRequest = async ({
       const uploadedDefinition = await loadProgramDefinitionFromUpload({ file, fileName });
       if (uploadedDefinition) {
         const editRequest = message?.trim();
-        // If the user described an edit alongside the upload, apply it now.
+        // If the user described an edit alongside the upload, try to apply it
+        // now. A failed tweak still seeds the (unmodified) definition and tells
+        // the user the change wasn't applied, so their request isn't silently
+        // dropped — a follow-up then runs through the tweak path.
         if (editRequest) {
           const tweakResult = await tryTweakProgramDefinition({
             aiService,
             currentProgramDefinition: uploadedDefinition,
             userMessage: editRequest,
           });
-          if (tweakResult) {
-            await aiService
-              .addSessionMessages(sessionId, {
-                userMessage,
-                assistantMessage: tweakResult.message,
-              })
-              .catch(error => {
-                log.warn({ error }, 'AI form builder failed to persist upload-edit chat history');
-              });
-            return {
-              sessionId,
-              message: tweakResult.message,
-              attachToProgramCode: null,
-              programDefinition: tweakResult.programDefinition,
-            };
-          }
+          const assistantMessage = tweakResult
+            ? tweakResult.message
+            : buildProgramLoadedEditNotAppliedMessage(uploadedDefinition);
+          await aiService
+            .addSessionMessages(sessionId, { userMessage, assistantMessage })
+            .catch(error => {
+              log.warn({ error }, 'AI form builder failed to persist upload-edit chat history');
+            });
+          return {
+            sessionId,
+            message: assistantMessage,
+            attachToProgramCode: null,
+            programDefinition: tweakResult ? tweakResult.programDefinition : uploadedDefinition,
+          };
         }
 
         const loadedMessage = buildProgramLoadedMessage(uploadedDefinition);

--- a/packages/central-server/app/admin/formBuilder.js
+++ b/packages/central-server/app/admin/formBuilder.js
@@ -499,7 +499,7 @@ const invokeProgramDefinitionBuild = (aiService, buildInput) =>
 // with explicit corrective guidance, and on persistent failure surface a clean,
 // actionable message — never the raw LangChain parser exception.
 const BUILD_RETRY_GUIDANCE =
-  'Your previous response was rejected because it did not match the required structure (commonly a missing "surveySheets" array). Return the COMPLETE ProgramDefinition as JSON with BOTH a "surveys" array of metadata AND a "surveySheets" array containing every survey and all of its questions. Do not omit or summarise any questions.';
+  'Your previous response did not match the required structure. Return the COMPLETE ProgramDefinition as valid JSON, including every survey and all of its questions in full. Do not omit, summarise, or truncate any part of the form.';
 
 const generateProgramDefinition = async ({
   aiService,

--- a/packages/central-server/app/admin/formBuilder.js
+++ b/packages/central-server/app/admin/formBuilder.js
@@ -15,10 +15,13 @@ import {
   programDefinitionSchema,
   sanitizeProgramDefinitionPreview,
 } from './programImporter/programDefinition';
+import {
+  WORKBOOK_FILE_EXTENSIONS,
+  loadProgramDefinitionFromUpload,
+} from './parseProgramExport';
 
 const MAX_FILE_CONTEXT_LENGTH = 200_000;
 const TEXT_FILE_EXTENSIONS = new Set(['.txt', '.csv']);
-const WORKBOOK_FILE_EXTENSIONS = new Set(['.xls', '.xlsx']);
 const IMAGE_MEDIA_TYPES_BY_EXTENSION = {
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
@@ -247,162 +250,6 @@ const buildProgramDefinitionTweakInput = ({ currentProgramDefinition, userMessag
 const finaliseProgramDefinition = rawProgramDefinition =>
   programDefinitionSchema.parseAsync(sanitizeProgramDefinitionPreview(rawProgramDefinition));
 
-const cellToString = value => (value == null ? '' : String(value).trim());
-
-const parseBooleanCell = value => {
-  const normalised = cellToString(value).toLowerCase();
-  return normalised === 'true' || normalised === 'yes';
-};
-
-const rowToRecord = (header, row) =>
-  Object.fromEntries(header.map((key, index) => [key, row[index]]));
-
-const buildSurveyMetadataFromRow = record => {
-  const survey = {
-    code: cellToString(record.code),
-    name: cellToString(record.name),
-  };
-  const surveyType = cellToString(record.surveyType);
-  if (surveyType) survey.surveyType = surveyType;
-  const status = cellToString(record.status);
-  if (status) survey.status = status;
-  if (cellToString(record.isSensitive)) survey.isSensitive = parseBooleanCell(record.isSensitive);
-  if (cellToString(record.notifiable)) survey.notifiable = parseBooleanCell(record.notifiable);
-  const notifyEmailAddresses = cellToString(record.notifyEmailAddresses)
-    .split(',')
-    .map(email => email.trim())
-    .filter(Boolean);
-  if (notifyEmailAddresses.length) survey.notifyEmailAddresses = notifyEmailAddresses;
-  const visibilityCriteria = cellToString(record.visibilityCriteria);
-  if (visibilityCriteria) survey.visibilityCriteria = visibilityCriteria;
-  const visibilityStatus = cellToString(record.visibilityStatus);
-  if (visibilityStatus) survey.visibilityStatus = visibilityStatus;
-  return survey;
-};
-
-const QUESTION_STRING_FIELDS = [
-  'options',
-  'visibilityCriteria',
-  'validationCriteria',
-  'detail',
-  'config',
-  'calculation',
-  'visibilityStatus',
-  'visualisationConfig',
-];
-
-const buildQuestionFromRow = record => {
-  const code = cellToString(record.code);
-  const name = cellToString(record.name);
-  const text = cellToString(record.text);
-  // The schema requires non-empty name and text. Real exports populate both,
-  // but fall back to neighbours so a single blank cell doesn't reject an
-  // otherwise valid form (saving is additive, so this never overwrites data).
-  const question = {
-    code,
-    type: cellToString(record.type),
-    name: name || text || code,
-    text: text || name || code,
-  };
-  if (parseBooleanCell(record.newScreen)) question.newScreen = true;
-  for (const field of QUESTION_STRING_FIELDS) {
-    const value = cellToString(record[field]);
-    if (value) question[field] = value;
-  }
-  return question;
-};
-
-// Resolve the worksheet for a survey code. Sheet names are capped at 31
-// characters and cannot contain Excel-forbidden characters. The program
-// exporter writes the raw survey code, while the AI form builder normalises it
-// (strips :/\?*[] then truncates via createSheetName) — try each form so
-// re-uploaded AI workbooks resolve too.
-const sheetNameCandidatesForCode = surveyCode => [
-  surveyCode,
-  surveyCode.slice(0, 31),
-  surveyCode.replace(/[:/\\?*[\]]/g, '').slice(0, 31),
-];
-
-const findSurveySheetForCode = (workbook, surveyCode) => {
-  for (const candidate of sheetNameCandidatesForCode(surveyCode)) {
-    if (workbook.Sheets[candidate]) return workbook.Sheets[candidate];
-  }
-  return null;
-};
-
-// Deterministically parse a Tamanu program export workbook (a Metadata sheet
-// plus one sheet per survey) into the ProgramDefinition shape. Returns null
-// when the file isn't a recognisable program export, so the caller can fall
-// back to the LLM flow.
-const parseProgramExportWorkbook = file => {
-  const workbook = readFile(file);
-  const metadataSheet = workbook.Sheets.Metadata;
-  if (!metadataSheet) return null;
-
-  const metadataRows = utils.sheet_to_json(metadataSheet, { header: 1, blankrows: false });
-  const surveyHeaderIndex = metadataRows.findIndex(
-    row => row[0] === 'code' && row.includes('surveyType'),
-  );
-  if (surveyHeaderIndex === -1) return null;
-
-  const metadata = {};
-  for (let index = 0; index < surveyHeaderIndex; index += 1) {
-    const [key, value] = metadataRows[index];
-    if (typeof key === 'string' && key) metadata[key] = cellToString(value);
-  }
-
-  const surveyHeader = metadataRows[surveyHeaderIndex];
-  const surveyMetadata = metadataRows
-    .slice(surveyHeaderIndex + 1)
-    .filter(row => cellToString(row[0]))
-    .map(row => buildSurveyMetadataFromRow(rowToRecord(surveyHeader, row)));
-  if (!surveyMetadata.length) return null;
-
-  // Exports can include obsolete surveys whose sheets are empty. Skip any
-  // survey without questions rather than aborting — saving is additive, so
-  // dropping an empty survey from the working definition is non-destructive and
-  // keeps `surveys`/`surveySheets` consistent for schema validation.
-  const surveys = [];
-  const surveySheets = [];
-  for (const survey of surveyMetadata) {
-    const sheet = findSurveySheetForCode(workbook, survey.code);
-    if (!sheet) continue;
-    const rows = utils.sheet_to_json(sheet, { header: 1, blankrows: false });
-    if (rows.length < 2) continue;
-    const [questionHeader, ...questionRows] = rows;
-    const questions = questionRows
-      .filter(row => cellToString(row[0]))
-      .map(row => buildQuestionFromRow(rowToRecord(questionHeader, row)));
-    if (!questions.length) continue;
-    surveys.push(survey);
-    surveySheets.push({ surveyName: survey.name, questions });
-  }
-  if (!surveys.length) return null;
-
-  return {
-    title: metadata.programName || metadata.programCode || 'Program',
-    ...(metadata.programCode ? { programCode: metadata.programCode } : {}),
-    ...(metadata.programName ? { programName: metadata.programName } : {}),
-    surveys,
-    surveySheets,
-  };
-};
-
-// Parse and validate an uploaded program export into a working definition, or
-// return null when the file can't be read as one.
-const loadProgramDefinitionFromUpload = async ({ file, fileName }) => {
-  if (!file) return null;
-  if (!WORKBOOK_FILE_EXTENSIONS.has(extname(fileName || '').toLowerCase())) return null;
-  try {
-    const rawProgramDefinition = parseProgramExportWorkbook(file);
-    if (!rawProgramDefinition) return null;
-    return await finaliseProgramDefinition(rawProgramDefinition);
-  } catch (error) {
-    log.warn({ error }, 'AI form builder could not parse uploaded file as a program export');
-    return null;
-  }
-};
-
 const buildProgramLoadedMessage = programDefinition => {
   const surveyCount = programDefinition.surveys.length;
   const programName = programDefinition.programName || programDefinition.title;
@@ -501,10 +348,13 @@ const serializeChatJobError = error => ({
   status: error?.status,
 });
 
-const invokeProgramDefinitionBuild = (aiService, buildInput) =>
+// `correctionHint`, when provided, is appended to the (string) build input in a
+// controlled way — keeping the "userMessage is plain text" coupling explicit
+// and in one place rather than relying on string concatenation at call sites.
+const invokeProgramDefinitionBuild = (aiService, buildInput, { correctionHint } = {}) =>
   aiService.invokeStructured(
     AI_CONTEXT_NAMES.FORM_BUILDER_BUILD,
-    buildInput,
+    correctionHint ? `${buildInput}\n\n[IMPORTANT] ${correctionHint}` : buildInput,
     programDefinitionSchema,
     { name: 'form_builder_program_definition' },
   );
@@ -540,7 +390,9 @@ const generateProgramDefinition = async ({
     );
     try {
       return await finaliseProgramDefinition(
-        await invokeProgramDefinitionBuild(aiService, `${buildInput}\n\n[IMPORTANT] ${BUILD_RETRY_GUIDANCE}`),
+        await invokeProgramDefinitionBuild(aiService, buildInput, {
+          correctionHint: BUILD_RETRY_GUIDANCE,
+        }),
       );
     } catch (retryError) {
       log.warn({ error: retryError }, 'AI form builder build retry failed');

--- a/packages/central-server/app/admin/parseProgramExport.js
+++ b/packages/central-server/app/admin/parseProgramExport.js
@@ -1,0 +1,169 @@
+import { extname } from 'path';
+import { readFile, utils } from 'xlsx';
+
+import { log } from '@tamanu/shared/services/logging';
+
+import {
+  programDefinitionSchema,
+  sanitizeProgramDefinitionPreview,
+} from './programImporter/programDefinition';
+
+export const WORKBOOK_FILE_EXTENSIONS = new Set(['.xls', '.xlsx']);
+
+const cellToString = value => (value == null ? '' : String(value).trim());
+
+const parseBooleanCell = value => {
+  const normalised = cellToString(value).toLowerCase();
+  return normalised === 'true' || normalised === 'yes';
+};
+
+const rowToRecord = (header, row) =>
+  Object.fromEntries(header.map((key, index) => [key, row[index]]));
+
+const buildSurveyMetadataFromRow = record => {
+  const survey = {
+    code: cellToString(record.code),
+    name: cellToString(record.name),
+  };
+  const surveyType = cellToString(record.surveyType);
+  if (surveyType) survey.surveyType = surveyType;
+  const status = cellToString(record.status);
+  if (status) survey.status = status;
+  if (cellToString(record.isSensitive)) survey.isSensitive = parseBooleanCell(record.isSensitive);
+  if (cellToString(record.notifiable)) survey.notifiable = parseBooleanCell(record.notifiable);
+  const notifyEmailAddresses = cellToString(record.notifyEmailAddresses)
+    .split(',')
+    .map(email => email.trim())
+    .filter(Boolean);
+  if (notifyEmailAddresses.length) survey.notifyEmailAddresses = notifyEmailAddresses;
+  const visibilityCriteria = cellToString(record.visibilityCriteria);
+  if (visibilityCriteria) survey.visibilityCriteria = visibilityCriteria;
+  const visibilityStatus = cellToString(record.visibilityStatus);
+  if (visibilityStatus) survey.visibilityStatus = visibilityStatus;
+  return survey;
+};
+
+const QUESTION_STRING_FIELDS = [
+  'options',
+  'visibilityCriteria',
+  'validationCriteria',
+  'detail',
+  'config',
+  'calculation',
+  'visibilityStatus',
+  'visualisationConfig',
+];
+
+const buildQuestionFromRow = record => {
+  const code = cellToString(record.code);
+  const name = cellToString(record.name);
+  const text = cellToString(record.text);
+  // The schema requires non-empty name and text. Real exports populate both,
+  // but fall back to neighbours so a single blank cell doesn't reject an
+  // otherwise valid form (saving is additive, so this never overwrites data).
+  const question = {
+    code,
+    type: cellToString(record.type),
+    name: name || text || code,
+    text: text || name || code,
+  };
+  if (parseBooleanCell(record.newScreen)) question.newScreen = true;
+  for (const field of QUESTION_STRING_FIELDS) {
+    const value = cellToString(record[field]);
+    if (value) question[field] = value;
+  }
+  return question;
+};
+
+// Resolve the worksheet for a survey code. Sheet names are capped at 31
+// characters and cannot contain Excel-forbidden characters. The program
+// exporter writes the raw survey code, while the AI form builder normalises it
+// (strips :/\?*[] then truncates via createSheetName) — try each form so
+// re-uploaded AI workbooks resolve too.
+const sheetNameCandidatesForCode = surveyCode => [
+  surveyCode,
+  surveyCode.slice(0, 31),
+  surveyCode.replace(/[:/\\?*[\]]/g, '').slice(0, 31),
+];
+
+const findSurveySheetForCode = (workbook, surveyCode) => {
+  for (const candidate of sheetNameCandidatesForCode(surveyCode)) {
+    if (workbook.Sheets[candidate]) return workbook.Sheets[candidate];
+  }
+  return null;
+};
+
+// Deterministically parse a Tamanu program export workbook (a Metadata sheet
+// plus one sheet per survey) into the ProgramDefinition shape. Returns null
+// when the file isn't a recognisable program export, so the caller can fall
+// back to the LLM flow.
+export const parseProgramExportWorkbook = file => {
+  const workbook = readFile(file);
+  const metadataSheet = workbook.Sheets.Metadata;
+  if (!metadataSheet) return null;
+
+  const metadataRows = utils.sheet_to_json(metadataSheet, { header: 1, blankrows: false });
+  const surveyHeaderIndex = metadataRows.findIndex(
+    row => row[0] === 'code' && row.includes('surveyType'),
+  );
+  if (surveyHeaderIndex === -1) return null;
+
+  const metadata = {};
+  for (let index = 0; index < surveyHeaderIndex; index += 1) {
+    const [key, value] = metadataRows[index];
+    if (typeof key === 'string' && key) metadata[key] = cellToString(value);
+  }
+
+  const surveyHeader = metadataRows[surveyHeaderIndex];
+  const surveyMetadata = metadataRows
+    .slice(surveyHeaderIndex + 1)
+    .filter(row => cellToString(row[0]))
+    .map(row => buildSurveyMetadataFromRow(rowToRecord(surveyHeader, row)));
+  if (!surveyMetadata.length) return null;
+
+  // Exports can include obsolete surveys whose sheets are empty. Skip any
+  // survey without questions rather than aborting — saving is additive, so
+  // dropping an empty survey from the working definition is non-destructive and
+  // keeps `surveys`/`surveySheets` consistent for schema validation.
+  const surveys = [];
+  const surveySheets = [];
+  for (const survey of surveyMetadata) {
+    const sheet = findSurveySheetForCode(workbook, survey.code);
+    if (!sheet) continue;
+    const rows = utils.sheet_to_json(sheet, { header: 1, blankrows: false });
+    if (rows.length < 2) continue;
+    const [questionHeader, ...questionRows] = rows;
+    const questions = questionRows
+      .filter(row => cellToString(row[0]))
+      .map(row => buildQuestionFromRow(rowToRecord(questionHeader, row)));
+    if (!questions.length) continue;
+    surveys.push(survey);
+    surveySheets.push({ surveyName: survey.name, questions });
+  }
+  if (!surveys.length) return null;
+
+  return {
+    title: metadata.programName || metadata.programCode || 'Program',
+    ...(metadata.programCode ? { programCode: metadata.programCode } : {}),
+    ...(metadata.programName ? { programName: metadata.programName } : {}),
+    surveys,
+    surveySheets,
+  };
+};
+
+// Parse and validate an uploaded program export into a working ProgramDefinition,
+// or return null when the file isn't a workbook or can't be read as one.
+export const loadProgramDefinitionFromUpload = async ({ file, fileName }) => {
+  if (!file) return null;
+  if (!WORKBOOK_FILE_EXTENSIONS.has(extname(fileName || '').toLowerCase())) return null;
+  try {
+    const rawProgramDefinition = parseProgramExportWorkbook(file);
+    if (!rawProgramDefinition) return null;
+    return await programDefinitionSchema.parseAsync(
+      sanitizeProgramDefinitionPreview(rawProgramDefinition),
+    );
+  } catch (error) {
+    log.warn({ error }, 'AI form builder could not parse uploaded file as a program export');
+    return null;
+  }
+};

--- a/packages/central-server/app/admin/programImporter/programDefinition.js
+++ b/packages/central-server/app/admin/programImporter/programDefinition.js
@@ -386,6 +386,74 @@ const validateSurvey = async ({ context, rows, surveyInfo }) => {
   });
 };
 
+// Question codes differ between a freshly-generated survey and the stored one,
+// so cross-question references (pde-<code>) are masked before comparing content.
+const maskQuestionReferences = value => String(value ?? '').replace(/pde-[A-Za-z0-9]+/g, 'pde-#');
+
+const componentSignature = ({ type, name, text, options, visualisationConfig }, component) => ({
+  type,
+  name: name ?? '',
+  text: text ?? '',
+  options: options ?? '',
+  visualisationConfig: maskQuestionReferences(visualisationConfig),
+  detail: component.detail ?? '',
+  visibilityCriteria: maskQuestionReferences(component.visibilityCriteria),
+  validationCriteria: maskQuestionReferences(component.validationCriteria),
+  calculation: maskQuestionReferences(component.calculation),
+  config: maskQuestionReferences(component.config),
+});
+
+// Ordered, code-agnostic content signature for the survey the import rows would
+// create.
+const importRowsSurveySignature = rows => {
+  const dataElements = new Map(
+    rows.filter(({ model }) => model === 'ProgramDataElement').map(({ values }) => [values.id, values]),
+  );
+  return rows
+    .filter(({ model }) => model === 'SurveyScreenComponent')
+    .map(({ values }) =>
+      componentSignature(
+        {
+          type: values.type,
+          name: dataElements.get(values.dataElementId)?.name,
+          text: dataElements.get(values.dataElementId)?.defaultText,
+          options: dataElements.get(values.dataElementId)?.defaultOptions,
+          visualisationConfig: dataElements.get(values.dataElementId)?.visualisationConfig,
+        },
+        values,
+      ),
+    );
+};
+
+// Ordered, code-agnostic content signature for an existing survey in the DB.
+const existingSurveySignature = async (models, surveyId) => {
+  const components = await models.SurveyScreenComponent.findAll({
+    where: { surveyId, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+    order: [
+      ['screenIndex', 'ASC'],
+      ['componentIndex', 'ASC'],
+    ],
+    include: [{ model: models.ProgramDataElement, as: 'dataElement' }],
+  });
+  return components.map(component =>
+    componentSignature(
+      {
+        type: component.dataElement.type,
+        name: component.dataElement.name,
+        text: component.dataElement.defaultText,
+        options: component.dataElement.defaultOptions,
+        visualisationConfig: component.dataElement.visualisationConfig,
+      },
+      component,
+    ),
+  );
+};
+
+const surveyContentUnchanged = async (models, existingSurvey, rows) => {
+  const existing = await existingSurveySignature(models, existingSurvey.id);
+  return JSON.stringify(existing) === JSON.stringify(importRowsSurveySignature(rows));
+};
+
 export const saveProgramDefinition = async ({ db, models, programId, programDefinition }) => {
   const errors = [];
   const context = {
@@ -407,6 +475,17 @@ export const saveProgramDefinition = async ({ db, models, programId, programDefi
       const surveySheet = programDefinition.surveySheets.find(
         ({ surveyName }) => surveyName === surveyDefinition.name,
       );
+
+      // When editing an existing program every survey is re-sent, so find the
+      // current survey this one would replace (if any).
+      const existingSurvey = await models.Survey.findOne({
+        where: {
+          code: createCode(surveyDefinition.code),
+          programId,
+          visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        },
+      });
+
       const surveyCode = await getAvailableSurveyCode(
         models.Survey,
         createCode(surveyDefinition.code),
@@ -417,6 +496,14 @@ export const saveProgramDefinition = async ({ db, models, programId, programDefi
         surveyDefinition,
         surveySheet,
       });
+
+      // Leave unchanged surveys exactly as they are — don't create a redundant
+      // version when nothing about the survey's content has changed.
+      if (existingSurvey && (await surveyContentUnchanged(models, existingSurvey, rows))) {
+        surveyIds.push(existingSurvey.id);
+        continue;
+      }
+
       const stats = await validateSurvey({ context, rows, surveyInfo });
       if (errors.length > 0) throw errors[0];
 
@@ -434,6 +521,14 @@ export const saveProgramDefinition = async ({ db, models, programId, programDefi
         },
       );
       if (errors.length > 0) throw errors[0];
+
+      // A changed survey that already existed supersedes its previous version:
+      // retire the old survey so only the new one is current (no duplicate
+      // active surveys). The old survey and its responses are kept as historical
+      // rather than mutated, preserving response history.
+      if (existingSurvey) {
+        await existingSurvey.update({ visibilityStatus: VISIBILITY_STATUSES.HISTORICAL });
+      }
 
       surveyIds.push(surveyId);
     }

--- a/packages/central-server/app/admin/programImporter/programDefinition.js
+++ b/packages/central-server/app/admin/programImporter/programDefinition.js
@@ -1,3 +1,4 @@
+import { Op } from 'sequelize';
 import { z } from 'zod';
 
 import {
@@ -275,22 +276,49 @@ export const normalizeQuestionConfigForImport = question => {
   };
 };
 
-const createSurveyImportRows = ({ programId, surveyDefinition, surveySheet, surveyCode }) => {
-  const surveyId = `${programId}-${surveyCode}`;
+const createSurveyImportRows = ({
+  programId,
+  surveyDefinition,
+  surveySheet,
+  surveyCode,
+  // For in-place edits of an existing survey: target the existing survey id and
+  // keep each question's code verbatim, so data element / component identity
+  // (and therefore response links) survive the edit. New questions still get a
+  // generated survey-scoped code. Defaults reproduce the create-new behaviour.
+  surveyId: surveyIdOverride,
+  preserveQuestionCodes = false,
+}) => {
+  const surveyId = surveyIdOverride ?? `${programId}-${surveyCode}`;
   const originalSurveyCode = createCode(surveyDefinition.code);
+  const usedQuestionCodes = new Set();
   const questionCodeMap = new Map(
     surveySheet.questions.map((question, questionIndex) => {
       const originalQuestionCode = createCode(question.code);
-      const questionCode = originalQuestionCode.startsWith(originalSurveyCode)
-        ? `${surveyCode}${originalQuestionCode.slice(originalSurveyCode.length)}`
-        : `${surveyCode}${String(questionIndex + 1).padStart(3, '0')}`;
-
+      let questionCode;
+      if (preserveQuestionCodes) {
+        const verbatim = (question.code ?? '').trim();
+        if (verbatim && !usedQuestionCodes.has(verbatim)) {
+          questionCode = verbatim;
+        } else {
+          let counter = 1;
+          do {
+            questionCode = `${surveyCode}${String(counter).padStart(3, '0')}`;
+            counter += 1;
+          } while (usedQuestionCodes.has(questionCode));
+        }
+      } else {
+        questionCode = originalQuestionCode.startsWith(originalSurveyCode)
+          ? `${surveyCode}${originalQuestionCode.slice(originalSurveyCode.length)}`
+          : `${surveyCode}${String(questionIndex + 1).padStart(3, '0')}`;
+      }
+      usedQuestionCodes.add(questionCode);
       return [originalQuestionCode, questionCode];
     }),
   );
-  const sortedQuestionCodeEntries = [...questionCodeMap.entries()].sort(
-    ([oldCodeA], [oldCodeB]) => oldCodeB.length - oldCodeA.length,
-  );
+  // Preserved codes are unchanged, so cross-question references need no rewriting.
+  const sortedQuestionCodeEntries = preserveQuestionCodes
+    ? []
+    : [...questionCodeMap.entries()].sort(([oldCodeA], [oldCodeB]) => oldCodeB.length - oldCodeA.length);
 
   const rows = [
     {
@@ -454,6 +482,25 @@ const surveyContentUnchanged = async (models, existingSurvey, rows) => {
   return JSON.stringify(existing) === JSON.stringify(importRowsSurveySignature(rows));
 };
 
+// After an in-place update, questions dropped from the survey still have their
+// components in the DB. Retire them (and never delete) so they no longer appear
+// on the form while existing responses to them are preserved.
+const historiciseRemovedComponents = async (models, surveyId, rows) => {
+  const keptDataElementIds = rows
+    .filter(({ model }) => model === 'ProgramDataElement')
+    .map(({ values }) => values.id);
+  await models.SurveyScreenComponent.update(
+    { visibilityStatus: VISIBILITY_STATUSES.HISTORICAL },
+    {
+      where: {
+        surveyId,
+        dataElementId: { [Op.notIn]: keptDataElementIds },
+        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+      },
+    },
+  );
+};
+
 export const saveProgramDefinition = async ({ db, models, programId, programDefinition }) => {
   const errors = [];
   const context = {
@@ -477,7 +524,7 @@ export const saveProgramDefinition = async ({ db, models, programId, programDefi
       );
 
       // When editing an existing program every survey is re-sent, so find the
-      // current survey this one would replace (if any).
+      // current survey this one would update (if any).
       const existingSurvey = await models.Survey.findOne({
         where: {
           code: createCode(surveyDefinition.code),
@@ -486,19 +533,23 @@ export const saveProgramDefinition = async ({ db, models, programId, programDefi
         },
       });
 
-      const surveyCode = await getAvailableSurveyCode(
-        models.Survey,
-        createCode(surveyDefinition.code),
-      );
+      // Editing updates the existing survey in place — keeping its id and each
+      // question's code so responses stay linked — rather than creating a
+      // duplicate. New programs/surveys are created with a fresh code.
+      const surveyCode = existingSurvey
+        ? existingSurvey.code
+        : await getAvailableSurveyCode(models.Survey, createCode(surveyDefinition.code));
       const { rows, surveyId, surveyInfo } = createSurveyImportRows({
         programId,
         surveyCode,
         surveyDefinition,
         surveySheet,
+        surveyId: existingSurvey?.id,
+        preserveQuestionCodes: Boolean(existingSurvey),
       });
 
-      // Leave unchanged surveys exactly as they are — don't create a redundant
-      // version when nothing about the survey's content has changed.
+      // Leave unchanged surveys exactly as they are — editing one survey re-sends
+      // the whole program, so don't rewrite (and re-sync) untouched ones.
       if (existingSurvey && (await surveyContentUnchanged(models, existingSurvey, rows))) {
         surveyIds.push(existingSurvey.id);
         continue;
@@ -522,12 +573,10 @@ export const saveProgramDefinition = async ({ db, models, programId, programDefi
       );
       if (errors.length > 0) throw errors[0];
 
-      // A changed survey that already existed supersedes its previous version:
-      // retire the old survey so only the new one is current (no duplicate
-      // active surveys). The old survey and its responses are kept as historical
-      // rather than mutated, preserving response history.
+      // Retire questions removed from an edited survey (kept as historical so
+      // their responses survive).
       if (existingSurvey) {
-        await existingSurvey.update({ visibilityStatus: VISIBILITY_STATUSES.HISTORICAL });
+        await historiciseRemovedComponents(models, surveyId, rows);
       }
 
       surveyIds.push(surveyId);

--- a/packages/central-server/app/admin/programImporter/programDefinition.js
+++ b/packages/central-server/app/admin/programImporter/programDefinition.js
@@ -418,17 +418,30 @@ const validateSurvey = async ({ context, rows, surveyInfo }) => {
 // so cross-question references (pde-<code>) are masked before comparing content.
 const maskQuestionReferences = value => String(value ?? '').replace(/pde-[A-Za-z0-9]+/g, 'pde-#');
 
-const componentSignature = ({ type, name, text, options, visualisationConfig }, component) => ({
+// One question's comparable content (data element + component fields together),
+// with cross-question references masked so codes don't affect equality.
+const componentSignature = ({
+  type,
+  name,
+  text,
+  options,
+  visualisationConfig,
+  detail,
+  visibilityCriteria,
+  validationCriteria,
+  calculation,
+  config,
+}) => ({
   type,
   name: name ?? '',
   text: text ?? '',
   options: options ?? '',
   visualisationConfig: maskQuestionReferences(visualisationConfig),
-  detail: component.detail ?? '',
-  visibilityCriteria: maskQuestionReferences(component.visibilityCriteria),
-  validationCriteria: maskQuestionReferences(component.validationCriteria),
-  calculation: maskQuestionReferences(component.calculation),
-  config: maskQuestionReferences(component.config),
+  detail: detail ?? '',
+  visibilityCriteria: maskQuestionReferences(visibilityCriteria),
+  validationCriteria: maskQuestionReferences(validationCriteria),
+  calculation: maskQuestionReferences(calculation),
+  config: maskQuestionReferences(config),
 });
 
 // Ordered, code-agnostic content signature for the survey the import rows would
@@ -439,18 +452,21 @@ const importRowsSurveySignature = rows => {
   );
   return rows
     .filter(({ model }) => model === 'SurveyScreenComponent')
-    .map(({ values }) =>
-      componentSignature(
-        {
-          type: values.type,
-          name: dataElements.get(values.dataElementId)?.name,
-          text: dataElements.get(values.dataElementId)?.defaultText,
-          options: dataElements.get(values.dataElementId)?.defaultOptions,
-          visualisationConfig: dataElements.get(values.dataElementId)?.visualisationConfig,
-        },
-        values,
-      ),
-    );
+    .map(({ values }) => {
+      const dataElement = dataElements.get(values.dataElementId) ?? {};
+      return componentSignature({
+        type: dataElement.type,
+        name: dataElement.name,
+        text: dataElement.defaultText,
+        options: dataElement.defaultOptions,
+        visualisationConfig: dataElement.visualisationConfig,
+        detail: values.detail,
+        visibilityCriteria: values.visibilityCriteria,
+        validationCriteria: values.validationCriteria,
+        calculation: values.calculation,
+        config: values.config,
+      });
+    });
 };
 
 // Ordered, code-agnostic content signature for an existing survey in the DB.
@@ -463,17 +479,19 @@ const existingSurveySignature = async (models, surveyId) => {
     ],
     include: [{ model: models.ProgramDataElement, as: 'dataElement' }],
   });
-  return components.map(component =>
-    componentSignature(
-      {
-        type: component.dataElement.type,
-        name: component.dataElement.name,
-        text: component.dataElement.defaultText,
-        options: component.dataElement.defaultOptions,
-        visualisationConfig: component.dataElement.visualisationConfig,
-      },
-      component,
-    ),
+  return components.map(({ dataElement, detail, visibilityCriteria, validationCriteria, calculation, config }) =>
+    componentSignature({
+      type: dataElement.type,
+      name: dataElement.name,
+      text: dataElement.defaultText,
+      options: dataElement.defaultOptions,
+      visualisationConfig: dataElement.visualisationConfig,
+      detail,
+      visibilityCriteria,
+      validationCriteria,
+      calculation,
+      config,
+    }),
   );
 };
 
@@ -501,6 +519,32 @@ const historiciseRemovedComponents = async (models, surveyId, rows) => {
   );
 };
 
+// Resolve how a survey definition maps onto the database: update the existing
+// current survey in place (keeping its id and question codes) when one exists,
+// otherwise create a new survey with a fresh code. getAvailableSurveyCode is
+// only consulted for genuinely new surveys.
+const prepareSurveyImport = async ({ models, programId, surveyDefinition, surveySheet }) => {
+  const existingSurvey = await models.Survey.findOne({
+    where: {
+      code: createCode(surveyDefinition.code),
+      programId,
+      visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+    },
+  });
+  const surveyCode = existingSurvey
+    ? existingSurvey.code
+    : await getAvailableSurveyCode(models.Survey, createCode(surveyDefinition.code));
+  const { rows, surveyId, surveyInfo } = createSurveyImportRows({
+    programId,
+    surveyCode,
+    surveyDefinition,
+    surveySheet,
+    surveyId: existingSurvey?.id,
+    preserveQuestionCodes: Boolean(existingSurvey),
+  });
+  return { existingSurvey, rows, surveyId, surveyInfo };
+};
+
 export const saveProgramDefinition = async ({ db, models, programId, programDefinition }) => {
   const errors = [];
   const context = {
@@ -523,29 +567,11 @@ export const saveProgramDefinition = async ({ db, models, programId, programDefi
         ({ surveyName }) => surveyName === surveyDefinition.name,
       );
 
-      // When editing an existing program every survey is re-sent, so find the
-      // current survey this one would update (if any).
-      const existingSurvey = await models.Survey.findOne({
-        where: {
-          code: createCode(surveyDefinition.code),
-          programId,
-          visibilityStatus: VISIBILITY_STATUSES.CURRENT,
-        },
-      });
-
-      // Editing updates the existing survey in place — keeping its id and each
-      // question's code so responses stay linked — rather than creating a
-      // duplicate. New programs/surveys are created with a fresh code.
-      const surveyCode = existingSurvey
-        ? existingSurvey.code
-        : await getAvailableSurveyCode(models.Survey, createCode(surveyDefinition.code));
-      const { rows, surveyId, surveyInfo } = createSurveyImportRows({
+      const { existingSurvey, rows, surveyId, surveyInfo } = await prepareSurveyImport({
+        models,
         programId,
-        surveyCode,
         surveyDefinition,
         surveySheet,
-        surveyId: existingSurvey?.id,
-        preserveQuestionCodes: Boolean(existingSurvey),
       });
 
       // Leave unchanged surveys exactly as they are — editing one survey re-sends


### PR DESCRIPTION
### Changes

Makes the AI form builder support **editing an existing program** end to end, targeting `main`.

**Editing.** An uploaded Tamanu program export (Metadata sheet + one sheet per survey) is parsed deterministically into a working definition and seeded, so edits run through the targeted tweak path (only the changed questions are regenerated) instead of a full rebuild the model can't reliably produce. Includes the build retry + clean-error guardrail, robust sheet-name resolution (handles AI-normalised names), an upload-edit fallback message, and the parser extracted to `parseProgramExport.js`.

**Saving — question-level, in place.** `saveProgramDefinition` no longer creates a duplicate survey or supersedes at the survey level. When a survey already exists in the program it's updated **in place** (same survey id):
- modified questions keep their code, so data elements/components — and the responses linked to them — are preserved;
- new questions are added with a generated survey-scoped code;
- questions removed from the survey are **retired** (component set `historical`), never deleted, so their responses survive;
- unchanged surveys are left untouched — editing one survey re-sends the whole program, so a code-agnostic content comparison skips the rest (no needless rewrite/re-sync).

Because the update is in place, the survey code never changes across edits — repeated saves resolve and update the same survey, so no suffixed duplicate or second current survey can appear (covered by test).

`createSurveyImportRows` gains `preserveQuestionCodes` / `surveyId` options for the in-place path; create-new behaviour is unchanged. The save loop is factored into `prepareSurveyImport` (resolve + build rows) + orchestration.

**Tests:** full `formBuilder.test.js` (21) plus `programSurveySave.test.js` covering in-place update (modify/add/retire, stable id across a third edit), skip-when-unchanged, and a forbidden-without-permission case.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->