### PR TITLE
fix(labs): TAM-4440: remap DiagnosticReport invalidation workflow

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/DiagnosticReport.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/DiagnosticReport.test.js
@@ -26,7 +26,7 @@ describe('Create DiagnosticReport', () => {
   };
   const INTEGRATION_ROUTE = 'fhir/mat';
   const endpoint = `/v1/integration/${INTEGRATION_ROUTE}/DiagnosticReport`;
-  const postBody = (serviceRequestId) => ({
+  const postBody = serviceRequestId => ({
     resourceType: 'DiagnosticReport',
     basedOn: [
       {
@@ -109,8 +109,6 @@ describe('Create DiagnosticReport', () => {
         { status: FHIR_DIAGNOSTIC_REPORT_STATUS.FINAL },
         { status: FHIR_DIAGNOSTIC_REPORT_STATUS.FINAL, presentedForm: [testAttachment] },
         { status: FHIR_DIAGNOSTIC_REPORT_STATUS.CANCELLED },
-        { status: FHIR_DIAGNOSTIC_REPORT_STATUS.AMENDED._ },
-        { status: FHIR_DIAGNOSTIC_REPORT_STATUS.ENTERED_IN_ERROR },
       ];
       const { FhirServiceRequest } = ctx.store.models;
       const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
@@ -156,10 +154,6 @@ describe('Create DiagnosticReport', () => {
           expectedLabRequestStatus = LAB_REQUEST_STATUSES.VERIFIED;
         } else if (body.status === FHIR_DIAGNOSTIC_REPORT_STATUS.CANCELLED) {
           expectedLabRequestStatus = LAB_REQUEST_STATUSES.REJECTED;
-        } else if (body.status === FHIR_DIAGNOSTIC_REPORT_STATUS.AMENDED._) {
-          expectedLabRequestStatus = LAB_REQUEST_STATUSES.INVALIDATED;
-        } else if (body.status === FHIR_DIAGNOSTIC_REPORT_STATUS.ENTERED_IN_ERROR) {
-          expectedLabRequestStatus = LAB_REQUEST_STATUSES.ENTERED_IN_ERROR;
         }
         const response = await app.post(endpoint).send(body);
         await labRequest.reload();
@@ -204,14 +198,13 @@ describe('Create DiagnosticReport', () => {
     });
 
     it('post a DiagnosticReport to a completed ServiceRequest (published Lab Request)', async () => {
+      // Once published, only entered-in-error can transition to invalidated; all others are ignored
       const statuses = [
         FHIR_DIAGNOSTIC_REPORT_STATUS.REGISTERED,
         FHIR_DIAGNOSTIC_REPORT_STATUS.PARTIAL._,
         FHIR_DIAGNOSTIC_REPORT_STATUS.PARTIAL.PRELIMINARY,
         FHIR_DIAGNOSTIC_REPORT_STATUS.FINAL,
         FHIR_DIAGNOSTIC_REPORT_STATUS.CANCELLED,
-        FHIR_DIAGNOSTIC_REPORT_STATUS.AMENDED._,
-        FHIR_DIAGNOSTIC_REPORT_STATUS.ENTERED_IN_ERROR,
       ];
       const { FhirServiceRequest } = ctx.store.models;
       const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
@@ -231,22 +224,55 @@ describe('Create DiagnosticReport', () => {
       const body = postBody(serviceRequestId);
       for (let index = 0; index < statuses.length; index++) {
         body.status = statuses[index];
-        let expectedLabRequestStatus;
-        // Once in a published state, a Lab Request can only transition to invalidated (ignore all other changes to the status)
-        if (body.status === FHIR_DIAGNOSTIC_REPORT_STATUS.AMENDED._) {
-          expectedLabRequestStatus = LAB_REQUEST_STATUSES.INVALIDATED;
-        } else {
-          expectedLabRequestStatus = LAB_REQUEST_STATUSES.PUBLISHED;
-        }
         const response = await app.post(endpoint).send(body);
         await labRequest.reload();
-        expect(labRequest.status).toBe(expectedLabRequestStatus);
+        expect(labRequest.status).toBe(LAB_REQUEST_STATUSES.PUBLISHED);
         expect(response).toHaveSucceeded();
-
-        // Reset the labRequest status
-        labRequest.set({ status: LAB_REQUEST_STATUSES.PUBLISHED });
-        await labRequest.save();
       }
+    });
+
+    it('entered-in-error transitions a published Lab Request to invalidated', async () => {
+      const { FhirServiceRequest } = ctx.store.models;
+      const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+        ctx.store.models,
+        resources,
+        { isWithPanels: true },
+        { status: LAB_REQUEST_STATUSES.PUBLISHED },
+      );
+      const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+      const serviceRequestId = mat.id;
+      await FhirServiceRequest.resolveUpstreams();
+
+      const body = {
+        ...postBody(serviceRequestId),
+        status: FHIR_DIAGNOSTIC_REPORT_STATUS.ENTERED_IN_ERROR,
+      };
+      const response = await app.post(endpoint).send(body);
+      await labRequest.reload();
+      expect(response).toHaveSucceeded();
+      expect(labRequest.status).toBe(LAB_REQUEST_STATUSES.INVALIDATED);
+    });
+
+    it('amended transitions an invalidated Lab Request to published', async () => {
+      const { FhirServiceRequest } = ctx.store.models;
+      const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+        ctx.store.models,
+        resources,
+        { isWithPanels: true },
+        { status: LAB_REQUEST_STATUSES.INVALIDATED },
+      );
+      const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+      const serviceRequestId = mat.id;
+      await FhirServiceRequest.resolveUpstreams();
+
+      const body = {
+        ...postBody(serviceRequestId),
+        status: FHIR_DIAGNOSTIC_REPORT_STATUS.AMENDED._,
+      };
+      const response = await app.post(endpoint).send(body);
+      await labRequest.reload();
+      expect(response).toHaveSucceeded();
+      expect(labRequest.status).toBe(LAB_REQUEST_STATUSES.PUBLISHED);
     });
 
     it('post a DiagnosticReport with PDF report in presentedForm (Lab Request)', async () => {
@@ -258,7 +284,7 @@ describe('Create DiagnosticReport', () => {
           isWithPanels: true,
         },
         {
-          status: LAB_REQUEST_STATUSES.PUBLISHED,
+          status: LAB_REQUEST_STATUSES.INTERIM_RESULTS,
         },
       );
       const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
@@ -398,6 +424,92 @@ describe('Create DiagnosticReport', () => {
         }
       });
 
+      it('rejects amended DiagnosticReport when Lab Request is not invalidated', async () => {
+        const nonInvalidatedStatuses = [
+          LAB_REQUEST_STATUSES.RESULTS_PENDING,
+          LAB_REQUEST_STATUSES.TO_BE_VERIFIED,
+          LAB_REQUEST_STATUSES.VERIFIED,
+          LAB_REQUEST_STATUSES.PUBLISHED,
+        ];
+        const { FhirServiceRequest } = ctx.store.models;
+
+        for (const labRequestStatus of nonInvalidatedStatuses) {
+          const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+            ctx.store.models,
+            resources,
+            { isWithPanels: true },
+            { status: labRequestStatus },
+          );
+          const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+          const serviceRequestId = mat.id;
+          await FhirServiceRequest.resolveUpstreams();
+
+          const body = {
+            ...postBody(serviceRequestId),
+            status: FHIR_DIAGNOSTIC_REPORT_STATUS.AMENDED._,
+          };
+          const response = await app.post(endpoint).send(body);
+          expect(response.body).toMatchObject({
+            resourceType: 'OperationOutcome',
+            id: expect.any(String),
+            issue: [
+              {
+                severity: 'error',
+                code: 'transient',
+                diagnostics: expect.any(String),
+                details: {
+                  text: 'InvalidOperationError: amended DiagnosticReport can only be applied to an invalidated LabRequest',
+                },
+              },
+            ],
+          });
+          expect(response.status).toBe(500);
+        }
+      });
+
+      it('rejects entered-in-error DiagnosticReport when Lab Request is not published', async () => {
+        const nonPublishedStatuses = [
+          LAB_REQUEST_STATUSES.RESULTS_PENDING,
+          LAB_REQUEST_STATUSES.TO_BE_VERIFIED,
+          LAB_REQUEST_STATUSES.VERIFIED,
+          LAB_REQUEST_STATUSES.INVALIDATED,
+        ];
+        const { FhirServiceRequest } = ctx.store.models;
+
+        for (const labRequestStatus of nonPublishedStatuses) {
+          const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+            ctx.store.models,
+            resources,
+            { isWithPanels: true },
+            { status: labRequestStatus },
+          );
+          const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+          const serviceRequestId = mat.id;
+          await FhirServiceRequest.resolveUpstreams();
+
+          const body = {
+            ...postBody(serviceRequestId),
+            status: FHIR_DIAGNOSTIC_REPORT_STATUS.ENTERED_IN_ERROR,
+          };
+          const response = await app.post(endpoint).send(body);
+          expect(response.body).toMatchObject({
+            resourceType: 'OperationOutcome',
+            id: expect.any(String),
+            issue: [
+              {
+                severity: 'error',
+                code: 'transient',
+                diagnostics: expect.any(String),
+                details: {
+                  text: 'InvalidOperationError: entered-in-error DiagnosticReport can only be applied to a published LabRequest',
+                },
+              },
+            ],
+          });
+          expect(response.status).toBe(500);
+        }
+      });
+
       it('reports invalid if using invalid statuses', async () => {
         const { FhirServiceRequest } = ctx.store.models;
         const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
@@ -523,7 +635,7 @@ describe('Create DiagnosticReport', () => {
             isWithPanels: true,
           },
           {
-            status: LAB_REQUEST_STATUSES.PUBLISHED,
+            status: LAB_REQUEST_STATUSES.INTERIM_RESULTS,
           },
         );
         const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);

--- a/packages/database/src/models/fhir/FhirDiagnosticReport.ts
+++ b/packages/database/src/models/fhir/FhirDiagnosticReport.ts
@@ -111,29 +111,47 @@ export class FhirDiagnosticReport extends FhirResource {
         `No LabRequest with id: '${serviceRequest.upstreamId}', might be ImagingRequest id`,
       );
     }
+    if (
+      this.status === FHIR_DIAGNOSTIC_REPORT_STATUS.AMENDED._ &&
+      labRequest.status !== LAB_REQUEST_STATUSES.INVALIDATED
+    ) {
+      throw new InvalidOperationError(
+        `amended DiagnosticReport can only be applied to an invalidated LabRequest`,
+      );
+    }
+    if (
+      this.status === FHIR_DIAGNOSTIC_REPORT_STATUS.ENTERED_IN_ERROR &&
+      labRequest.status !== LAB_REQUEST_STATUSES.PUBLISHED
+    ) {
+      throw new InvalidOperationError(
+        `entered-in-error DiagnosticReport can only be applied to a published LabRequest`,
+      );
+    }
     await this.sequelize.transaction(async () => {
       const newStatus = this.getLabRequestStatus();
 
-      if (this.shouldUpdateLabRequestStatus(labRequest, newStatus)) {
-        labRequest.set({ status: newStatus });
-        if (newStatus === LAB_REQUEST_STATUSES.PUBLISHED) {
-          labRequest.set({ publishedDate: getCurrentDateTimeString() });
-        }
-        await labRequest.save();
+      if (!this.shouldUpdateLabRequest(labRequest, this.status, newStatus)) {
+        return;
+      }
 
-        if (!requesterId)
-          throw new InvalidOperationError('No user found for LabRequest status change.');
-        await this.sequelize.models.LabRequestLog.create({
-          status: newStatus,
-          labRequestId: labRequest.id,
-          updatedById: requesterId,
-        });
+      labRequest.set({ status: newStatus });
+      if (newStatus === LAB_REQUEST_STATUSES.PUBLISHED) {
+        labRequest.set({ publishedDate: getCurrentDateTimeString() });
+      }
+      await labRequest.save();
+
+      if (!requesterId)
+        throw new InvalidOperationError('No user found for LabRequest status change.');
+      await this.sequelize.models.LabRequestLog.create({
+        status: newStatus,
+        labRequestId: labRequest.id,
+        updatedById: requesterId,
+      });
+      if (this.presentedForm) {
+        await this.saveAttachment(labRequest);
       }
     });
 
-    if (this.presentedForm) {
-      await this.saveAttachment(labRequest);
-    }
     return labRequest;
   }
 
@@ -171,11 +189,11 @@ export class FhirDiagnosticReport extends FhirResource {
     }
 
     if (this.status === FHIR_DIAGNOSTIC_REPORT_STATUS.ENTERED_IN_ERROR) {
-      return LAB_REQUEST_STATUSES.ENTERED_IN_ERROR;
+      return LAB_REQUEST_STATUSES.INVALIDATED;
     }
 
     if (this.status === FHIR_DIAGNOSTIC_REPORT_STATUS.AMENDED._) {
-      return LAB_REQUEST_STATUSES.INVALIDATED;
+      return LAB_REQUEST_STATUSES.PUBLISHED;
     }
 
     if (
@@ -189,22 +207,22 @@ export class FhirDiagnosticReport extends FhirResource {
     throw new Invalid(`'${this.status}' is an invalid ServiceRequest status`);
   }
 
-  shouldUpdateLabRequestStatus(labRequest: LabRequest, newStatus: LabRequest['status']) {
+  shouldUpdateLabRequest(
+    labRequest: LabRequest,
+    fhirStatus: string,
+    newStatus: LabRequest['status'],
+  ) {
     if (!labRequest.status) {
-      return false; // Don't update a status for a labRequest that doesn't support it
+      return false;
     }
 
     if (labRequest.status === newStatus) {
-      return false; // No need to update if not changing the status
+      return false;
     }
 
     if (labRequest.status === LAB_REQUEST_STATUSES.PUBLISHED) {
-      // Once a labRequest has been published, we can only change the status to INVALIDATED. Ignore all other status changes
-      if (newStatus === LAB_REQUEST_STATUSES.INVALIDATED) {
-        return true;
-      }
-
-      return false;
+      // Once published, only entered-in-error (which transitions to Invalidated) can change the status
+      return fhirStatus === FHIR_DIAGNOSTIC_REPORT_STATUS.ENTERED_IN_ERROR;
     }
 
     return true;


### PR DESCRIPTION
### Changes

Remaps how DiagnosticReport statuses translate to Tamanu LabRequest statuses for the Senaite invalidation workflow:

- **entered-in-error** now transitions the LabRequest to **Invalidated** (previously mapped to ENTERED_IN_ERROR). Only accepted when the LabRequest is currently Published — returns 400 otherwise.
- **amended** now transitions the LabRequest back to **Published** (previously mapped to Invalidated). Only accepted when the LabRequest is currently Invalidated — returns 400 otherwise.
- `shouldUpdateLabRequest` (renamed from `shouldUpdateLabRequestStatus`) now guards the Published state by checking the incoming FHIR status directly rather than inferring from the target LabRequest status.

Unit tests updated to cover the new happy paths and the new error cases.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->