### PR TITLE
fix(medications): TAM-4435: return to dispense modal on back from patient record

### DIFF
--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -688,8 +688,6 @@ export const DispenseMedicationWorkflowModal = memo(
       if (!name && !patientIdentifier) return null;
       const handleViewPatient = () => {
         if (!patient.id) return;
-        // Don't close the modal here: leaving the dispense URL in the history
-        // stack means the in-app and browser Back buttons re-open this modal.
         navigateToPatient(patient.id);
       };
       return (

--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -688,8 +688,9 @@ export const DispenseMedicationWorkflowModal = memo(
       if (!name && !patientIdentifier) return null;
       const handleViewPatient = () => {
         if (!patient.id) return;
+        // Don't close the modal here: leaving the dispense URL in the history
+        // stack means the in-app and browser Back buttons re-open this modal.
         navigateToPatient(patient.id);
-        onClose();
       };
       return (
         <PatientSummaryPanel data-testid="dispense-modal-patient-context">
@@ -722,7 +723,7 @@ export const DispenseMedicationWorkflowModal = memo(
           ) : null}
         </PatientSummaryPanel>
       );
-    }, [patient, navigateToPatient, onClose]);
+    }, [patient, navigateToPatient]);
 
     const dispenseWithoutLabelsButton = (
       <OutlinedButton

--- a/packages/web/app/components/MedicationRequestsTable.jsx
+++ b/packages/web/app/components/MedicationRequestsTable.jsx
@@ -143,9 +143,6 @@ export const MedicationRequestsTable = () => {
   const { searchParameters } = useMedicationsContext(MEDICATIONS_SEARCH_KEYS.ACTIVE);
   const { getSetting } = useSettings();
   const [medicationRequests, setMedicationRequests] = useState([]);
-  // The dispense modal is driven by a URL param so that navigating to the
-  // patient record and pressing Back (in-app or browser) re-opens it. The
-  // selected patient is fetched by id, so it survives the round trip.
   const navigate = useNavigate();
   const { search } = useLocation();
   const queryClient = useQueryClient();
@@ -354,8 +351,6 @@ export const MedicationRequestsTable = () => {
   const handleRowClick = (_, data) => {
     const patient = data?.pharmacyOrder?.encounter?.patient;
     if (!patient?.id) return;
-    // Prime the cache from the row so the modal opens instantly; the query
-    // refreshes it (and serves it on Back) from the patient record.
     queryClient.setQueryData(['patientDetails', patient.id], patient);
     setDispensePatientParam(patient.id);
   };

--- a/packages/web/app/components/MedicationRequestsTable.jsx
+++ b/packages/web/app/components/MedicationRequestsTable.jsx
@@ -1,6 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
 import { SearchTableWithPermissionCheck } from './Table';
+import { useUrlSearchParams } from '../utils/useUrlSearchParams';
+import { usePatientDataQuery } from '../api/queries/usePatientDataQuery';
 import { DateDisplay } from './DateDisplay';
 import { PatientNameDisplay } from './PatientNameDisplay';
 import { useMedicationsContext } from '../contexts/Medications';
@@ -25,6 +29,8 @@ import { getStockStatus } from '../utils/medications';
 import { getApprovalStatus } from '../utils/invoice';
 import { ApprovedColumnTitle } from './ApprovedColumnTitle';
 import { useSettings } from '../contexts/Settings';
+
+const DISPENSE_PATIENT_PARAM = 'dispensePatientId';
 
 const NoDataContainer = styled.div`
   height: 500px;
@@ -137,8 +143,15 @@ export const MedicationRequestsTable = () => {
   const { searchParameters } = useMedicationsContext(MEDICATIONS_SEARCH_KEYS.ACTIVE);
   const { getSetting } = useSettings();
   const [medicationRequests, setMedicationRequests] = useState([]);
-  const [isDispenseOpen, setIsDispenseOpen] = useState(false);
-  const [selectedPatient, setSelectedPatient] = useState(null);
+  // The dispense modal is driven by a URL param so that navigating to the
+  // patient record and pressing Back (in-app or browser) re-opens it. The
+  // selected patient is fetched by id, so it survives the round trip.
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  const queryClient = useQueryClient();
+  const urlParams = useUrlSearchParams();
+  const dispensePatientId = urlParams.get(DISPENSE_PATIENT_PARAM);
+  const { data: dispensePatient } = usePatientDataQuery(dispensePatientId);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedRequestId, setSelectedRequestId] = useState(null);
   const [refreshCount, setRefreshCount] = useState(0);
@@ -327,22 +340,32 @@ export const MedicationRequestsTable = () => {
     [searchParameters, facilityId],
   );
 
+  const setDispensePatientParam = (patientId, { replace = false } = {}) => {
+    const params = new URLSearchParams(search);
+    if (patientId) {
+      params.set(DISPENSE_PATIENT_PARAM, patientId);
+    } else {
+      params.delete(DISPENSE_PATIENT_PARAM);
+    }
+    const nextSearch = params.toString();
+    navigate({ search: nextSearch ? `?${nextSearch}` : '' }, { replace });
+  };
+
   const handleRowClick = (_, data) => {
     const patient = data?.pharmacyOrder?.encounter?.patient;
     if (!patient?.id) return;
-    setSelectedPatient(patient);
-    setIsDispenseOpen(true);
+    // Prime the cache from the row so the modal opens instantly; the query
+    // refreshes it (and serves it on Back) from the patient record.
+    queryClient.setQueryData(['patientDetails', patient.id], patient);
+    setDispensePatientParam(patient.id);
   };
 
   return (
     <>
       <DispenseMedicationWorkflowModal
-        open={isDispenseOpen}
-        onClose={() => {
-          setIsDispenseOpen(false);
-          setSelectedPatient(null);
-        }}
-        patient={selectedPatient}
+        open={Boolean(dispensePatientId) && Boolean(dispensePatient)}
+        onClose={() => setDispensePatientParam(null, { replace: true })}
+        patient={dispensePatient}
         onDispenseSuccess={handleTableRefresh}
       />
       <DeleteMedicationRequestModal


### PR DESCRIPTION
### Changes

TAM-4435 requires that after using "View patient" from the Dispense medication modal, the in-app and browser **Back** buttons return the user to the dispense modal. They were landing on the Active requests list instead, because the modal's open state was local React state (lost on navigation) and "View patient" explicitly closed it.

Fix: drive the dispense modal from a `dispensePatientId` URL param instead of local state, and stop calling `onClose()` when navigating to the patient. The dispense URL stays in the history stack, so Back (in-app or browser) returns to it; the table reads the param and reopens the modal, fetching the patient by id (primed from the row for an instant first open). No modal content is retained on return, as the card specifies.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->