### PR TITLE
perf(admin): no-issue: skip redundant FK name lookup during import

### DIFF
--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -154,28 +154,33 @@ export async function importRows(
                   })
                 : await models[fkSchema.model].count({ where: { id: fkFieldValue } })) > 0;
 
-            const idByRemoteName = (
-              fkSchema.model === 'ReferenceData'
-                ? await models.ReferenceData.findOne({
-                    where: { type: fkSchema.types, name: { [Op.iLike]: fkFieldValue } },
-                  })
-                : await models[fkSchema.model].findOne({
-                    where: {
-                      name: { [Op.iLike]: fkFieldValue },
-                    },
-                  })
-            )?.id;
-
             if (hasRemoteId) {
               delete values[fkFieldName];
               values[fkNameLowerId] = fkFieldValue;
-            } else if (idByRemoteName) {
-              delete values[fkFieldName];
-              values[fkNameLowerId] = idByRemoteName;
             } else {
-              throw new Error(
-                `valid foreign key expected in column ${fkFieldName} (corresponding to ${fkNameLowerId}) but found: ${fkFieldValue}`,
-              );
+              // Only fall back to the (expensive, unindexed ILIKE) name lookup
+              // when the value isn't already a valid id. Computing this for every
+              // row regardless was the main cost of large imports.
+              const idByRemoteName = (
+                fkSchema.model === 'ReferenceData'
+                  ? await models.ReferenceData.findOne({
+                      where: { type: fkSchema.types, name: { [Op.iLike]: fkFieldValue } },
+                    })
+                  : await models[fkSchema.model].findOne({
+                      where: {
+                        name: { [Op.iLike]: fkFieldValue },
+                      },
+                    })
+              )?.id;
+
+              if (idByRemoteName) {
+                delete values[fkFieldName];
+                values[fkNameLowerId] = idByRemoteName;
+              } else {
+                throw new Error(
+                  `valid foreign key expected in column ${fkFieldName} (corresponding to ${fkNameLowerId}) but found: ${fkFieldValue}`,
+                );
+              }
             }
           }
         }


### PR DESCRIPTION
### Changes

Importing a permissions export (272 permission + 39 role rows) was hitting the gateway timeout. The bulk importer's foreign-key resolution ran two queries per row — an id `count` and an **unindexed ILIKE name lookup** — but computed the ILIKE lookup unconditionally and threw the result away whenever the id `count` already resolved the FK. For a re-imported export (every FK is already a valid id), that's one wasted ILIKE query per row, the dominant cost.

This only runs the name fallback when the id check misses. Behaviour is identical (the name lookup was only ever used in the `else if` branch). Benefits every import that resolves FKs by id, the permissions sheet most of all.

Note: this removes the biggest per-row waste, but the importer is still inherently per-row (a `count`, a `loadExisting`, and a write per row, in one transaction). If large imports remain slow, the next steps are batching those lookups or making the import async — flagged as follow-up rather than reworked here.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->