### PR TITLE
fix(centralServer): no-issue: drop age from AI patient summary prompt

### DIFF
--- a/packages/settings/src/schema/definitions/patientSummary.ts
+++ b/packages/settings/src/schema/definitions/patientSummary.ts
@@ -34,7 +34,7 @@ for a receiving clinician as a single flowing paragraph.
 
 You will be given structured patient data in the following sections:
 
-- DEMOGRAPHICS: age, sex, village
+- DEMOGRAPHICS: first name, sex
 - ALLERGIES: allergens and reactions
 - CONDITIONS: ongoing diagnoses
 - ISSUES: flagged clinical concerns
@@ -59,11 +59,11 @@ Output only the summary paragraph — no preamble, headings, notes, or
 meta-commentary (e.g. explaining your reasoning or which rule applied, or text
 in asterisks or parentheses). One version only, nothing else.
 
-Open the paragraph with the patient's first name only, followed by age and sex
-as recorded in DEMOGRAPHICS (e.g. "Mike, 33, female, presented with..."). Do
-NOT include surname, patient ID, date of birth, address, phone, next of kin,
-or any other identifier, even if present in the input. If first name is not
-present in DEMOGRAPHICS, omit it and open with age and sex only.
+Open the paragraph with the patient's first name and sex as recorded in
+DEMOGRAPHICS (e.g. "Mike, female, presented with..."). Do NOT include surname,
+patient ID, date of birth, age, address, phone, next of kin, or any other
+identifier, even if present in the input. If first name is not present in
+DEMOGRAPHICS, omit it and open with sex only.
 
 After the opening clause, cover documented information in the following strict
 priority order. Include lower-priority sections only if the word limit permits:
@@ -104,7 +104,7 @@ thereafter.
    Do not infer, extrapolate, or fill gaps with clinical assumptions.
 
 2. **No inference from names or other indirect signals.** Treat structured
-   fields (sex, age, etc.) as the source of truth. Do not infer demographics,
+   fields (sex, etc.) as the source of truth. Do not infer demographics,
    identity, or clinical facts from a patient's name, address, or any other
    indirect cue. Do not flag "inconsistencies" derived from such inferences.
 
@@ -130,12 +130,9 @@ thereafter.
 If the current encounter is absent, null, or contains no documented clinical
 content (no presenting complaint, no findings, no diagnosis, no treatment —
 e.g. only survey responses or administrative entries), open with the standard
-clause (first name, age, sex), then include only Priority 1 background items
+clause (first name, sex), then include only Priority 1 background items
 that are actually present: active conditions and allergies. Omit any that are
-empty or null. Do not narrate absences anywhere in the paragraph — if nothing
-is present across all sections, output only the opening clause, with no note
-explaining that this case applied. No inferred reasons, no recommendations.
-All other rules apply.
+empty or null.
 
 # Encounter data
 


### PR DESCRIPTION
### Changes

The patient summary opening clause instructed the model to use "first name, age, sex", but the demographic data sent to it only contains first name and sex (plus date of death) — never age. Age would either go missing or risk being inferred. This removes age from the opening clause, the DEMOGRAPHICS description, and the insufficient-data clause, and lists age among the identifiers to exclude. (Also trims a couple of now-redundant trailing lines in the insufficient-data case that the global output-format / do-not-narrate-absences rules already cover.) Note: the prompt is settings-backed, so this updates the default; a deployment with a saved custom patientSummary.prompts value needs that setting updated too.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->