### PR TITLE
fix(facility): no-issue: pass patient age into AI summary data

### DIFF
--- a/packages/facility-server/app/services/patientSummaryData.js
+++ b/packages/facility-server/app/services/patientSummaryData.js
@@ -1,5 +1,6 @@
 import { Op } from 'sequelize';
 import { VACCINE_STATUS, VISIBILITY_STATUSES } from '@tamanu/constants';
+import { ageInYears } from '@tamanu/utils/dateTime';
 
 const PATIENT_SUMMARY_DATA_LIMIT = 20;
 
@@ -196,6 +197,7 @@ function formatPatient(p) {
   if (!p) return null;
   return {
     firstName: p.firstName,
+    age: p.dateOfBirth ? ageInYears(p.dateOfBirth) : undefined,
     dateOfDeath: p.dateOfDeath,
     sex: p.sex,
   };

--- a/packages/facility-server/app/services/patientSummaryData.js
+++ b/packages/facility-server/app/services/patientSummaryData.js
@@ -1,3 +1,4 @@
+import { differenceInYears, parseISO } from 'date-fns';
 import { Op } from 'sequelize';
 import { VACCINE_STATUS, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { ageInYears } from '@tamanu/utils/dateTime';
@@ -193,11 +194,18 @@ export async function fetchPatientSummaryData(patientId, models) {
   };
 }
 
+function getPatientAge({ dateOfBirth, dateOfDeath }) {
+  if (!dateOfBirth) return undefined;
+  // For a deceased patient, report age at death rather than current age.
+  if (dateOfDeath) return differenceInYears(parseISO(dateOfDeath), parseISO(dateOfBirth));
+  return ageInYears(dateOfBirth);
+}
+
 function formatPatient(p) {
   if (!p) return null;
   return {
     firstName: p.firstName,
-    age: p.dateOfBirth ? ageInYears(p.dateOfBirth) : undefined,
+    age: getPatientAge(p),
     dateOfDeath: p.dateOfDeath,
     sex: p.sex,
   };


### PR DESCRIPTION
### Changes

The AI patient summary prompt opens with "first name, age, sex" (e.g. "Mike, 33, female…"), but the demographic data sent to the model only contained first name, sex and date of death — age was never provided, so it went missing. This derives age from the patient's date of birth (via ageInYears) and includes it in the summary data. The raw date of birth is still withheld — the prompt excludes it as a direct identifier, and a derived age is not identifying. Supersedes #9992 (which took the opposite approach of removing age from the prompt).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->