### PR TITLE
perf(importer): no-issue: speed up reference data import (HOTFIX 2.57)

### DIFF
--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -370,8 +370,11 @@ export async function importRows(
           await existing.save();
         }
       } else {
-        await Model.create(normalizedValues);
+        const created = await Model.create(normalizedValues);
         updateStat(stats, statkey(model, sheetName), 'created');
+        if (batchedModels.has(model) && created.id) {
+          existingByModelId.set(`${model}|${created.id}`, created);
+        }
       }
 
       const { createRecords, deleteClause } = generateTranslationsForData(

--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -67,9 +67,7 @@ function loadExisting(Model, values) {
   return loader(Model, values);
 }
 
-// Bulk-load existing rows for a chunk: one query per model (default-loader,
-// id-keyed models only), with deduplicated ids. Composite-key models fall back
-// to the per-row loadExisting.
+// One findAll per model; composite-key models (with custom loaders) fall back to per-row loadExisting.
 async function preloadExistingForChunk(models, chunkRows) {
   const idsByModel = new Map();
   for (const { model, values } of chunkRows) {
@@ -90,7 +88,6 @@ async function preloadExistingForChunk(models, chunkRows) {
   return { existingByModelId, batchedModels: new Set(idsByModel.keys()) };
 }
 
-// Cached when a foreign key value resolves to no record (negative result).
 const FK_NOT_FOUND = Symbol('fk-not-found');
 
 // Configuration for fields to ignore when checking for changes per model
@@ -151,8 +148,7 @@ export async function importRows(
   }
 
   log.debug('Resolving foreign keys', { rows: rows.length });
-  // Resolve each distinct foreign key value once (e.g. the handful of roles
-  // shared across thousands of permission rows).
+  // Resolve each distinct FK value once (e.g. the handful of roles shared across thousands of permission rows).
   const fkResolutionCache = new Map();
   const resolvedRows = [];
   for (const { model, sheetRow, values } of rows) {
@@ -289,8 +285,7 @@ export async function importRows(
   };
   await validateTableRows(models, validRows, pushErrorFn);
 
-  // Upsert in chunks, bulk-loading each chunk's existing rows just before it.
-  // Reassigning at each boundary keeps peak memory proportional to the chunk.
+  // Reassigning the chunk maps at each boundary keeps peak memory proportional to the chunk.
   log.debug('Upserting database rows', { rows: validRows.length });
   const UPSERT_CHUNK_SIZE = 1000;
   let existingByModelId = new Map();

--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -67,6 +67,32 @@ function loadExisting(Model, values) {
   return loader(Model, values);
 }
 
+// Bulk-load existing rows for a chunk: one query per model (default-loader,
+// id-keyed models only), with deduplicated ids. Composite-key models fall back
+// to the per-row loadExisting.
+async function preloadExistingForChunk(models, chunkRows) {
+  const idsByModel = new Map();
+  for (const { model, values } of chunkRows) {
+    if (existingRecordLoaders[models[model].name]) continue;
+    if (!values.id) continue;
+    if (!idsByModel.has(model)) idsByModel.set(model, new Set());
+    idsByModel.get(model).add(values.id);
+  }
+
+  const existingByModelId = new Map();
+  for (const [model, ids] of idsByModel) {
+    const found = await models[model].findAll({ where: { id: [...ids] }, paranoid: false });
+    for (const record of found) {
+      existingByModelId.set(`${model}|${record.id}`, record);
+    }
+  }
+
+  return { existingByModelId, batchedModels: new Set(idsByModel.keys()) };
+}
+
+// Cached when a foreign key value resolves to no record (negative result).
+const FK_NOT_FOUND = Symbol('fk-not-found');
+
 // Configuration for fields to ignore when checking for changes per model
 const IGNORED_FIELDS_BY_MODEL = {
   SurveyScreenComponent: ['componentIndex'],
@@ -125,6 +151,9 @@ export async function importRows(
   }
 
   log.debug('Resolving foreign keys', { rows: rows.length });
+  // Resolve each distinct foreign key value once (e.g. the handful of roles
+  // shared across thousands of permission rows).
+  const fkResolutionCache = new Map();
   const resolvedRows = [];
   for (const { model, sheetRow, values } of rows) {
     try {
@@ -147,41 +176,43 @@ export async function importRows(
             delete values[fkFieldName];
             values[fkNameLowerId] = idByLocalName;
           } else {
-            const hasRemoteId =
-              (fkSchema.model === 'ReferenceData'
-                ? await models.ReferenceData.count({
-                    where: { type: fkSchema.types, id: fkFieldValue },
-                  })
-                : await models[fkSchema.model].count({ where: { id: fkFieldValue } })) > 0;
-
-            if (hasRemoteId) {
-              delete values[fkFieldName];
-              values[fkNameLowerId] = fkFieldValue;
-            } else {
-              // Only fall back to the (expensive, unindexed ILIKE) name lookup
-              // when the value isn't already a valid id. Computing this for every
-              // row regardless was the main cost of large imports.
-              const idByRemoteName = (
-                fkSchema.model === 'ReferenceData'
-                  ? await models.ReferenceData.findOne({
-                      where: { type: fkSchema.types, name: { [Op.iLike]: fkFieldValue } },
+            const cacheKey = `${fkSchema.model}|${fkSchema.types ?? ''}|${fkFieldValue}`;
+            let resolvedId = fkResolutionCache.get(cacheKey);
+            if (resolvedId === undefined) {
+              const hasRemoteId =
+                (fkSchema.model === 'ReferenceData'
+                  ? await models.ReferenceData.count({
+                      where: { type: fkSchema.types, id: fkFieldValue },
                     })
-                  : await models[fkSchema.model].findOne({
-                      where: {
-                        name: { [Op.iLike]: fkFieldValue },
-                      },
-                    })
-              )?.id;
+                  : await models[fkSchema.model].count({ where: { id: fkFieldValue } })) > 0;
 
-              if (idByRemoteName) {
-                delete values[fkFieldName];
-                values[fkNameLowerId] = idByRemoteName;
+              if (hasRemoteId) {
+                resolvedId = fkFieldValue;
               } else {
-                throw new Error(
-                  `valid foreign key expected in column ${fkFieldName} (corresponding to ${fkNameLowerId}) but found: ${fkFieldValue}`,
-                );
+                // Fall back to the unindexed ILIKE name lookup only when needed.
+                const idByRemoteName = (
+                  fkSchema.model === 'ReferenceData'
+                    ? await models.ReferenceData.findOne({
+                        where: { type: fkSchema.types, name: { [Op.iLike]: fkFieldValue } },
+                      })
+                    : await models[fkSchema.model].findOne({
+                        where: {
+                          name: { [Op.iLike]: fkFieldValue },
+                        },
+                      })
+                )?.id;
+                resolvedId = idByRemoteName ?? FK_NOT_FOUND;
               }
+              fkResolutionCache.set(cacheKey, resolvedId);
             }
+
+            if (resolvedId === FK_NOT_FOUND) {
+              throw new Error(
+                `valid foreign key expected in column ${fkFieldName} (corresponding to ${fkNameLowerId}) but found: ${fkFieldValue}`,
+              );
+            }
+            delete values[fkFieldName];
+            values[fkNameLowerId] = resolvedId;
           }
         }
       }
@@ -258,10 +289,24 @@ export async function importRows(
   };
   await validateTableRows(models, validRows, pushErrorFn);
 
+  // Upsert in chunks, bulk-loading each chunk's existing rows just before it.
+  // Reassigning at each boundary keeps peak memory proportional to the chunk.
   log.debug('Upserting database rows', { rows: validRows.length });
-  for (const { model, sheetRow, values } of validRows) {
+  const UPSERT_CHUNK_SIZE = 1000;
+  let existingByModelId = new Map();
+  let batchedModels = new Set();
+  for (const [index, { model, sheetRow, values }] of validRows.entries()) {
+    if (index % UPSERT_CHUNK_SIZE === 0) {
+      ({ existingByModelId, batchedModels } = await preloadExistingForChunk(
+        models,
+        validRows.slice(index, index + UPSERT_CHUNK_SIZE),
+      ));
+    }
+
     const Model = models[model];
-    const existing = await loadExisting(Model, values);
+    const existing = batchedModels.has(model)
+      ? (values.id ? existingByModelId.get(`${model}|${values.id}`) ?? null : null)
+      : await loadExisting(Model, values);
 
     if (existing && skipExisting) {
       updateStat(stats, statkey(model, sheetName), 'skipped');


### PR DESCRIPTION
### Changes

Importing a permissions spreadsheet (~4k permission records) took ~27s because `importRows` issued ~16k sequential queries.

Two redundant query categories are collapsed:

- **Foreign-key resolution is memoised** per distinct value (e.g. the `role` column re-resolved the same ~35 roles for all ~4k rows). A negative-result sentinel caches misses, and the by-name lookup is skipped when the by-id lookup already matches.
- **Existence checks are bulk-loaded** with one chunked `findAll` per model instead of a `findByPk` per row. Models with composite-key custom loaders (User, UserFacility, etc.) keep the per-row path.

Net ~16k → ~4k queries; expect the permissions import to drop from ~27s into single-digit seconds. No behaviour change — all `referenceDataImporter` tests (43) pass. Benefits any reference-data import with repeated FK values, not just permissions.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->