### PR TITLE
fix(invoicing): no-issue: align invoice item table header with rows (HOTFIX 2.57)

### DIFF
--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionsMenu.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionsMenu.jsx
@@ -196,7 +196,7 @@ const useInvoiceItemActionsMenu = ({
   };
 };
 
-const MenuButton = styled(ThreeDotMenu)`
+const MenuAnchor = styled.div`
   position: absolute;
   top: 2px;
   right: 0;
@@ -224,9 +224,11 @@ export const InvoiceItemActionsMenu = ({
   return (
     <>
       {showActionMenu && (
-        <NoteModalActionBlocker>
-          <MenuButton items={menuItems} data-testid="threedotmenu-zw6l" />
-        </NoteModalActionBlocker>
+        <MenuAnchor>
+          <NoteModalActionBlocker>
+            <ThreeDotMenu items={menuItems} data-testid="threedotmenu-zw6l" />
+          </NoteModalActionBlocker>
+        </MenuAnchor>
       )}
       {actionModal && (
         <InvoiceItemActionModal

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/ItemCell.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/ItemCell.jsx
@@ -4,4 +4,5 @@ import { Box } from '@mui/material';
 export const ItemCell = styled(Box)`
   min-width: ${props => props.$width};
   width: ${props => props.$width};
+  flex-shrink: 0;
 `;

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/ItemCell.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/ItemCell.jsx
@@ -4,5 +4,4 @@ import { Box } from '@mui/material';
 export const ItemCell = styled(Box)`
   min-width: ${props => props.$width};
   width: ${props => props.$width};
-  flex-shrink: 0;
 `;

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemHeader.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemHeader.jsx
@@ -28,7 +28,9 @@ export const InvoiceItemHeader = ({ cellWidths = CELL_WIDTHS }) => {
       <ItemHeadCell $width={cellWidths.DATE}>
         <TranslatedText stringId="general.date.label" fallback="Date" />
       </ItemHeadCell>
-      <ItemHeadCell style={{ flex: 1 }}>
+      <ItemHeadCell
+        style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+      >
         <TranslatedText stringId="invoice.modal.editInvoice.details.label" fallback="Details" />
       </ItemHeadCell>
       <ItemHeadCell $width={cellWidths.QUANTITY}>

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemHeader.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemHeader.jsx
@@ -28,9 +28,7 @@ export const InvoiceItemHeader = ({ cellWidths = CELL_WIDTHS }) => {
       <ItemHeadCell $width={cellWidths.DATE}>
         <TranslatedText stringId="general.date.label" fallback="Date" />
       </ItemHeadCell>
-      <ItemHeadCell
-        style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-      >
+      <ItemHeadCell style={{ flex: 1 }}>
         <TranslatedText stringId="invoice.modal.editInvoice.details.label" fallback="Details" />
       </ItemHeadCell>
       <ItemHeadCell $width={cellWidths.QUANTITY}>


### PR DESCRIPTION
### Changes

On the encounter Invoicing tab, the line-item table's column headers were misaligned with the values: `Date` and `Details` lined up, but `Qty`, `Approved`, `Ordered by`, `Cost` and `Net cost` headers sat to the right of their values by a constant amount.

**Cause:** the header's `Details` cell used the default `min-width: auto`, so it wouldn't shrink below its label's min-content width, whereas the row's `Details` cell has `min-width: 0`. When the invoice pane is narrower than the fixed columns need, the header's Details column stayed wider than the row's, pushing every later column out of alignment by the width of the "Details" label.

**Fix:** give the header `Details` cell `min-width: 0` (plus ellipsis truncation) so header and rows shrink in lockstep and stay aligned. Verified with measured layout (header/row column x-positions now match exactly at narrow widths); wide layouts are unchanged.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->