### PR TITLE
fix(medication): no-issue: order preset label suggester by code

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -4,6 +4,7 @@ import {
   SURVEY_TYPES,
   VISIBILITY_STATUSES,
   REFERENCE_DATA_TRANSLATION_PREFIX,
+  REFERENCE_TYPES,
   INVOICE_ITEMS_CATEGORIES,
   INVOICE_ITEMS_CATEGORIES_MODELS,
 } from '@tamanu/constants';
@@ -436,6 +437,39 @@ describe('Suggestions', () => {
       expect(result).toHaveSucceeded();
       expect(result.body.length).toEqual(1);
       expect(result.body[0].name).toEqual('AA-used');
+    });
+  });
+
+  describe('medicationPresetLabel', () => {
+    it('should order preset labels by code, numbers before letters and numerically', async () => {
+      await models.ReferenceData.destroy({
+        where: { type: REFERENCE_TYPES.MEDICATION_PRESET_LABEL },
+        force: true,
+      });
+
+      // Created out of order, mixing numeric prefixes, letters and multi-digit runs.
+      const codes = ['Q12H', 'W17', 'AMA', '2Q4H', 'Q6H', 'W1P1', '1Q4H'];
+      for (const code of codes) {
+        await models.ReferenceData.create({
+          id: `medicationPresetLabel-${code}`,
+          type: REFERENCE_TYPES.MEDICATION_PRESET_LABEL,
+          code,
+          name: `Preset ${code}`,
+          visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        });
+      }
+
+      const result = await userApp.get('/api/suggestions/medicationPresetLabel');
+      expect(result).toHaveSucceeded();
+      expect(result.body.map(({ code }) => code)).toEqual([
+        '1Q4H',
+        '2Q4H',
+        'AMA',
+        'Q6H',
+        'Q12H',
+        'W1P1',
+        'W17',
+      ]);
     });
   });
 

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -282,6 +282,21 @@ const DEFAULT_MAPPER = ({ name, code, id }) => ({
   id,
 });
 
+// Natural sort by code using the en_numeric ICU collation (as locations.name does).
+const codeNaturalOrder = Sequelize.literal('"ReferenceData"."code" COLLATE public.en_numeric');
+
+// Per-type order overrides consulted by the reference data suggester below.
+const REFERENCE_DATA_ORDER_OVERRIDES = {
+  // Prioritise treatment plan at the top.
+  [REFERENCE_TYPES.NOTE_TYPE]: [
+    Sequelize.literal(
+      `CASE "ReferenceData"."id" WHEN '${NOTE_TYPES.TREATMENT_PLAN}' THEN 0 ELSE 1 END`,
+    ),
+  ],
+  // The dropdown displays the code, so order by code rather than the translatable name.
+  [REFERENCE_TYPES.MEDICATION_PRESET_LABEL]: [codeNaturalOrder],
+};
+
 // Add a new suggester for a particular model at the given endpoint.
 // Records will be filtered based on the whereSql parameter. The user's search term
 // will be passed to the sql query as ":search" - see the existing suggestion
@@ -630,16 +645,7 @@ REFERENCE_TYPE_VALUES.forEach(typeName => {
       creatingBodyBuilder: req => referenceDataBodyBuilder({ type: typeName, name: req.body.name }),
       afterCreated: afterCreatedReferenceData,
       mapper: item => item,
-      orderBuilder: () => {
-        if (typeName === REFERENCE_TYPES.NOTE_TYPE) {
-          return [
-            // Prioritize treatment plan at the top
-            Sequelize.literal(`
-              CASE "ReferenceData"."id" WHEN '${NOTE_TYPES.TREATMENT_PLAN}' THEN 0 ELSE 1 END
-              `),
-          ];
-        }
-      },
+      orderBuilder: () => REFERENCE_DATA_ORDER_OVERRIDES[typeName],
     },
     true,
   );


### PR DESCRIPTION
### Changes

The dispense medication preset label dropdown displays each option's `code`, but the suggester ordered results by the (translatable) `name`, so the codes appeared unsorted to users.

This orders the `medicationPresetLabel` suggester by `code` using the existing `en_numeric` ICU collation — the same natural-sort strategy `locations.name` already uses — so numbers sort ahead of letters and numeric runs compare numerically (e.g. `Q6H` before `Q12H`). Adds an integration test covering the ordering.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->