### PR TITLE
fix(sync): no-issue: preserve relation FKs in mobile sync insert fallback (HOTFIX 2.54)

### DIFF
--- a/packages/mobile/App/services/sync/utils/executePreparedQuery.test.ts
+++ b/packages/mobile/App/services/sync/utils/executePreparedQuery.test.ts
@@ -46,9 +46,12 @@ describe('executePreparedQuery', () => {
       expect(getEffectiveBatchSize).toHaveBeenCalledWith(500, 3);
     });
 
-    it('falls back to repository.insert when raw query fails', async () => {
+    it('falls back to per-row raw insert when the batch query fails', async () => {
       const repository = makeRepository();
-      repository.query.mockRejectedValue(new Error('raw insert failed'));
+      // Batch insert rejects, per-row inserts succeed.
+      repository.query
+        .mockRejectedValueOnce(new Error('batch insert failed'))
+        .mockResolvedValue(undefined);
       const rows = [
         { id: '1', name: 'Dog Man', deletedAt: null },
         { id: '2', name: 'Muffin Man', deletedAt: null },
@@ -56,9 +59,26 @@ describe('executePreparedQuery', () => {
 
       await executePreparedInsert(repository, rows as any, 500, progress);
 
-      expect(repository.insert).toHaveBeenCalledTimes(2);
-      expect(repository.insert).toHaveBeenNthCalledWith(1, rows[0]);
-      expect(repository.insert).toHaveBeenNthCalledWith(2, rows[1]);
+      // 1 batch attempt + 2 per-row inserts, all via raw query (never repository.insert)
+      expect(repository.query).toHaveBeenCalledTimes(3);
+      const [row1Sql, row1Params] = repository.query.mock.calls[1];
+      expect(row1Sql).toContain('INSERT INTO "test_table"');
+      expect(row1Sql).toContain('VALUES (?, ?, ?)');
+      expect(row1Params).toEqual(['1', 'Dog Man', null]);
+      expect(repository.query.mock.calls[2][1]).toEqual(['2', 'Muffin Man', null]);
+      expect(repository.insert).not.toHaveBeenCalled();
+    });
+
+    it('throws with the recordId when a per-row insert fails', async () => {
+      const repository = makeRepository();
+      repository.query
+        .mockRejectedValueOnce(new Error('batch insert failed'))
+        .mockRejectedValueOnce(new Error('UNIQUE constraint failed'));
+      const rows = [{ id: 'rec-1', name: 'Dog Man', deletedAt: null }];
+
+      await expect(executePreparedInsert(repository, rows as any, 500, progress)).rejects.toThrow(
+        "Insert failed with 'UNIQUE constraint failed', recordId: rec-1",
+      );
     });
   });
 
@@ -86,9 +106,23 @@ describe('executePreparedQuery', () => {
       expect(getEffectiveBatchSize).toHaveBeenCalledWith(500, 3);
     });
 
-    it('falls back to repository.update when raw query fails', async () => {
+    it('skips rows with no updatable columns instead of emitting invalid SQL', async () => {
       const repository = makeRepository();
-      repository.query.mockRejectedValue(new Error('raw update failed'));
+      const rows = [{ id: 'only-id' }];
+
+      await executePreparedUpdate(repository, rows as any, 500, progress);
+
+      expect(repository.query).not.toHaveBeenCalled();
+      expect(repository.update).not.toHaveBeenCalled();
+      expect(progress).toHaveBeenCalledWith(1);
+    });
+
+    it('falls back to per-row raw update when the batch query fails', async () => {
+      const repository = makeRepository();
+      // Batch update rejects, per-row updates succeed.
+      repository.query
+        .mockRejectedValueOnce(new Error('batch update failed'))
+        .mockResolvedValue(undefined);
       const rows = [
         { id: '1', name: 'Dog Man', deletedAt: null },
         { id: '2', name: 'Muffin Man', deletedAt: null },
@@ -96,9 +130,15 @@ describe('executePreparedQuery', () => {
 
       await executePreparedUpdate(repository, rows as any, 500, progress);
 
-      expect(repository.update).toHaveBeenCalledTimes(2);
-      expect(repository.update).toHaveBeenNthCalledWith(1, { id: '1' }, rows[0]);
-      expect(repository.update).toHaveBeenNthCalledWith(2, { id: '2' }, rows[1]);
+      // 1 batch attempt + 2 per-row updates, all via raw query (never repository.update)
+      expect(repository.query).toHaveBeenCalledTimes(3);
+      const [row1Sql, row1Params] = repository.query.mock.calls[1];
+      expect(row1Sql).toContain('UPDATE "test_table" SET');
+      expect(row1Sql).toContain('WHERE id = ?');
+      // updatable columns first, then id
+      expect(row1Params).toEqual(['Dog Man', null, '1']);
+      expect(repository.query.mock.calls[2][1]).toEqual(['Muffin Man', null, '2']);
+      expect(repository.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mobile/App/services/sync/utils/executePreparedQuery.ts
+++ b/packages/mobile/App/services/sync/utils/executePreparedQuery.ts
@@ -14,6 +14,23 @@ const quote = (identifier: string): string => `"${identifier}"`;
 // Since sync only sends populated columns, we need to check all rows to get all columns
 const getAllColumns = (rows: DataToPersist[]): string[] => [...new Set(rows.flatMap(Object.keys))];
 
+// Raw per-row insert: preserves @RelationId-backed FK columns that repository.insert drops.
+const insertRow = (repository: Repository<any>, row: DataToPersist): Promise<unknown> => {
+  const columns = Object.keys(row);
+  const sql = `INSERT INTO ${quote(repository.metadata.tableName)} (${columns
+    .map(quote)
+    .join(', ')}) VALUES (${columns.map(() => '?').join(', ')})`;
+  return repository.query(sql, columns.map(col => row[col]));
+};
+
+const updateRow = (repository: Repository<any>, row: DataToPersist): Promise<unknown> => {
+  const columns = Object.keys(row).filter(col => col !== 'id');
+  const sql = `UPDATE ${quote(repository.metadata.tableName)} SET ${columns
+    .map(col => `${quote(col)} = ?`)
+    .join(', ')} WHERE id = ?`;
+  return repository.query(sql, [...columns.map(col => row[col]), row.id]);
+};
+
 /**
  * Much faster than typeorm bulk insert or save
  * Prepare a raw query and execute it with the values
@@ -42,15 +59,13 @@ export const executePreparedInsert = async (
     try {
       await repository.query(query, parameters);
     } catch (e: any) {
-      await Promise.all(
-        chunkRows.map(async row => {
-          try {
-            await repository.insert(row);
-          } catch (error: any) {
-            throw new Error(`Insert failed with '${error.message}', recordId: ${row.id}`);
-          }
-        }),
-      );
+      for (const row of chunkRows) {
+        try {
+          await insertRow(repository, row);
+        } catch (error: any) {
+          throw new Error(`Insert failed with '${error.message}', recordId: ${row.id}`);
+        }
+      }
     }
     progressCallback(chunkRows.length);
   }
@@ -85,6 +100,11 @@ export const executePreparedUpdate = async (
   for (const groupRows of rowsByColumnSignature.values()) {
     const columns = Object.keys(groupRows[0]);
     const updatableColumns = columns.filter(col => col !== 'id');
+    if (updatableColumns.length === 0) {
+      // Row carries only id, nothing to update; count as processed and skip (empty SET is invalid SQL).
+      progressCallback(groupRows.length);
+      continue;
+    }
     const updateColumnsQuoted = updatableColumns.map(quote);
     const cteColumns = [quote('id'), ...updateColumnsQuoted];
 
@@ -112,15 +132,13 @@ export const executePreparedUpdate = async (
       try {
         await repository.query(query, parameters);
       } catch (e: any) {
-        await Promise.all(
-          chunkRows.map(async row => {
-            try {
-              await repository.update({ id: row.id }, row);
-            } catch (error: any) {
-              throw new Error(`Update failed with '${error.message}', recordId: ${row.id}`);
-            }
-          }),
-        );
+        for (const row of chunkRows) {
+          try {
+            await updateRow(repository, row);
+          } catch (error: any) {
+            throw new Error(`Update failed with '${error.message}', recordId: ${row.id}`);
+          }
+        }
       }
       progressCallback(chunkRows.length);
     }


### PR DESCRIPTION
### Changes

Mobile sync (2.54.10) crashed: `NOT NULL constraint failed: reference_drugs.referenceDataId`.

**Cause:** when a batch insert fails, the persist layer retried each row via `repository.insert`/`update`, which ignores read-only `@RelationId` FK properties — so the FK was written `NULL`. Affects 120+ FKs across sync models; aborts sync on a NOT NULL one.

**Fix:** the fallback now retries with a raw per-row `INSERT`/`UPDATE` that binds by column name, preserving FKs and surfacing the real error. Verified: released 2.54.10 errors, this build syncs. No schema change.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->