### PR TITLE
test(e2e): no-issue: authenticate both frontends in one Playwright session

### DIFF
--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -45,7 +45,10 @@ module.exports = defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
     {
-      name: 'chromium',
+      // single project: the setup logs into both frontends and saves one
+      // combined session, so specs can drive the facility (:5173) or admin
+      // (:5174) frontend authenticated, including within the same test
+      name: 'e2e',
       use: { ...devices['Desktop Chrome'], storageState: resolve(__dirname, '.auth/user.json') },
       dependencies: ['setup'],
     },

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -36,11 +36,17 @@ setup('authenticate', async ({ loginPage, page }) => {
 
   // storageState() only retains localStorage for the currently-loaded origin,
   // so capturing after navigating to admin drops the facility session. Merge
-  // each frontend's origins into one combined state (facility entry wins for
-  // its own origin, since it was captured while facilityId was present).
-  const originsByUrl = new Map(adminState.origins.map(origin => [origin.origin, origin]));
-  for (const origin of facilityState.origins) originsByUrl.set(origin.origin, origin);
-  const combined = { cookies: adminState.cookies, origins: [...originsByUrl.values()] };
+  // both frontends' origins into one combined state. Facility origins come
+  // FIRST: helpers like getItemFromLocalStorage fall back to origins[0] when the
+  // page hasn't navigated yet (e.g. createPatient reads facilityId at about:blank
+  // during fixture setup), and the bulk of the suite drives the facility
+  // frontend — so facility is the right default.
+  const facilityUrls = new Set(facilityState.origins.map(origin => origin.origin));
+  const adminOnlyOrigins = adminState.origins.filter(origin => !facilityUrls.has(origin.origin));
+  const combined = {
+    cookies: [...facilityState.cookies, ...adminState.cookies],
+    origins: [...facilityState.origins, ...adminOnlyOrigins],
+  };
 
   const authDir = path.join(__dirname, '../../.auth');
   await mkdir(authDir, { recursive: true });

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -1,9 +1,13 @@
 import { test as setup } from '../../fixtures/baseFixture';
 import path from 'path';
 
-setup('authenticate', async ({ loginPage }) => {
-  await loginPage.goto();
+import { adminFrontend } from '../../utils/navigation';
 
+// Authenticate against BOTH frontends in one browser context and save a single
+// storageState. localStorage is per-origin, so the saved state carries both
+// the facility and the admin (central) sessions — letting every spec drive
+// either frontend authenticated, with no need for a second Playwright project.
+setup('authenticate', async ({ loginPage, page }) => {
   const email = process.env.TEST_EMAIL;
   const password = process.env.TEST_PASSWORD;
 
@@ -11,12 +15,22 @@ setup('authenticate', async ({ loginPage }) => {
     throw new Error('TEST_EMAIL and TEST_PASSWORD environment variables must be set');
   }
 
+  // facility frontend (LoginPage waits for the facility dashboard)
+  await loginPage.goto();
   await loginPage.login(email, password);
+  // the facility session writes facilityId to localStorage shortly after the
+  // dashboard loads; wait for it before navigating away so the saved state
+  // carries it (specs read facilityId from localStorage)
+  await page.waitForFunction(() => window.localStorage.getItem('facilityId') !== null);
 
-  // Ensure state is persisted
-  await loginPage.page.waitForTimeout(1000);
+  // admin / central frontend — same context. The URL isn't an auth signal here
+  // (the admin app routes to /admin even while showing the login screen), so we
+  // wait for the authenticated shell's log-out button instead.
+  await page.goto(adminFrontend);
+  await page.locator('input[name="email"]').fill(email);
+  await page.locator('input[name="password"]').fill(password);
+  await page.getByTestId('loginbutton-gx21').click();
+  await page.getByTestId('logoutbutton-4zn4').waitFor({ state: 'visible', timeout: 60_000 });
 
-  // Save page context
-  const authStatePath = path.join(__dirname, '../../.auth/user.json');
-  await loginPage.page.context().storageState({ path: authStatePath });
+  await page.context().storageState({ path: path.join(__dirname, '../../.auth/user.json') });
 });

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -1,6 +1,6 @@
 import { test as setup } from '../../fixtures/baseFixture';
 import path from 'path';
-import { writeFile } from 'fs/promises';
+import { mkdir, writeFile } from 'fs/promises';
 
 import { adminFrontend } from '../../utils/navigation';
 
@@ -42,5 +42,7 @@ setup('authenticate', async ({ loginPage, page }) => {
   for (const origin of facilityState.origins) originsByUrl.set(origin.origin, origin);
   const combined = { cookies: adminState.cookies, origins: [...originsByUrl.values()] };
 
-  await writeFile(path.join(__dirname, '../../.auth/user.json'), JSON.stringify(combined));
+  const authDir = path.join(__dirname, '../../.auth');
+  await mkdir(authDir, { recursive: true });
+  await writeFile(path.join(authDir, 'user.json'), JSON.stringify(combined));
 });

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -1,5 +1,6 @@
 import { test as setup } from '../../fixtures/baseFixture';
 import path from 'path';
+import { writeFile } from 'fs/promises';
 
 import { adminFrontend } from '../../utils/navigation';
 
@@ -19,9 +20,9 @@ setup('authenticate', async ({ loginPage, page }) => {
   await loginPage.goto();
   await loginPage.login(email, password);
   // the facility session writes facilityId to localStorage shortly after the
-  // dashboard loads; wait for it before navigating away so the saved state
-  // carries it (specs read facilityId from localStorage)
+  // dashboard loads; wait for it before capturing (specs read it from there)
   await page.waitForFunction(() => window.localStorage.getItem('facilityId') !== null);
+  const facilityState = await page.context().storageState();
 
   // admin / central frontend — same context. The URL isn't an auth signal here
   // (the admin app routes to /admin even while showing the login screen), so we
@@ -31,6 +32,15 @@ setup('authenticate', async ({ loginPage, page }) => {
   await page.locator('input[name="password"]').fill(password);
   await page.getByTestId('loginbutton-gx21').click();
   await page.getByTestId('logoutbutton-4zn4').waitFor({ state: 'visible', timeout: 60_000 });
+  const adminState = await page.context().storageState();
 
-  await page.context().storageState({ path: path.join(__dirname, '../../.auth/user.json') });
+  // storageState() only retains localStorage for the currently-loaded origin,
+  // so capturing after navigating to admin drops the facility session. Merge
+  // each frontend's origins into one combined state (facility entry wins for
+  // its own origin, since it was captured while facilityId was present).
+  const originsByUrl = new Map(adminState.origins.map(origin => [origin.origin, origin]));
+  for (const origin of facilityState.origins) originsByUrl.set(origin.origin, origin);
+  const combined = { cookies: adminState.cookies, origins: [...originsByUrl.values()] };
+
+  await writeFile(path.join(__dirname, '../../.auth/user.json'), JSON.stringify(combined));
 });

--- a/packages/e2e-tests/utils/navigation.ts
+++ b/packages/e2e-tests/utils/navigation.ts
@@ -1,8 +1,8 @@
 import { Page } from '@playwright/test';
 import 'dotenv/config';
 
-const facilityFrontend = process.env.FACILITY_FRONTEND_URL ?? 'http://localhost:5173';
-const adminFrontend = process.env.ADMIN_FRONTEND_URL ?? 'http://localhost:5174';
+export const facilityFrontend = process.env.FACILITY_FRONTEND_URL ?? 'http://localhost:5173';
+export const adminFrontend = process.env.ADMIN_FRONTEND_URL ?? 'http://localhost:5174';
 
 export const goToFacilityFrontend = async (page: Page) => {
   await page.goto(facilityFrontend);
@@ -14,4 +14,8 @@ export const goToAdminFrontend = async (page: Page) => {
 
 export const constructFacilityUrl = (url: string) => {
   return `${facilityFrontend}${url}`;
+};
+
+export const constructAdminUrl = (url: string) => {
+  return `${adminFrontend}${url}`;
 };


### PR DESCRIPTION
### Changes

🤖 Some central-admin screens (e.g. the settings editor) live only in the admin panel — a different origin/app to the facility frontend the Playwright suite logs into. The auth setup logs into **both** frontends in one browser context and saves a single `storageState`. localStorage is per-origin, so the saved state carries both the facility and the central/admin sessions, and any spec can drive either frontend authenticated — including both within a single test.

- `auth.setup.ts` logs into the facility frontend, waits for `facilityId` to persist, then logs into the admin frontend (waiting on the authenticated shell, since that app routes to `/admin` even while the login screen is up).
- A single `e2e` Playwright project uses the combined session.
- `constructAdminUrl` / `adminFrontend` helper in `navigation.ts`.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
