### PR TITLE
ci(security): no-issue: add OWASP ZAP DAST scan to CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 ### Tests
 
 - [ ] **Run E2E tests** <!-- #e2e -->
+- [ ] **Run DAST scan** <!-- #dast -->
 
 ### Review Hero
 

--- a/.github/workflows/ci-dast.yml
+++ b/.github/workflows/ci-dast.yml
@@ -1,0 +1,216 @@
+name: DAST
+
+# Dynamic Application Security Testing with OWASP ZAP.
+#
+# Runs a *full active scan* (real attack payloads) against the central and
+# facility server APIs, both authenticated and unauthenticated. Because active
+# scanning mutates and can destroy data, it only ever runs against the throwaway
+# stack stood up here in CI — never against a real deployment.
+#
+# Opt-in on PRs via the `#dast` checkbox, and runs automatically in the merge
+# queue.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  merge_group:
+
+permissions:
+  contents: read
+
+env:
+  NODE_OPTIONS: "--max-old-space-size=6144"
+  NODE_ENV: e2e
+  NODE_MODULES_PATHS: |
+    node_modules
+    packages/*/node_modules
+    !packages/mobile/node_modules
+
+jobs:
+  plan:
+    name: Plan DAST
+    runs-on: ubuntu-latest
+    outputs:
+      requested: ${{ steps.plan.outputs.requested }}
+    steps:
+      - uses: actions/github-script@v7
+        id: plan
+        with:
+          script: |
+            // Merge-queue runs always scan. On PRs, scan only when the #dast
+            // checkbox is ticked. Parse the body line-by-line so the marker is
+            // load-bearing but the checkbox's label text is free to change.
+            if (context.eventName === 'merge_group') {
+              core.setOutput('requested', 'true');
+              return;
+            }
+            const body = context.payload.pull_request?.body ?? '';
+            const ticked = /^\s*-\s+\[x\]\s+.*<!--\s*#dast\s*-->/im.test(body);
+            core.info(`DAST requested: ${ticked}`);
+            core.setOutput('requested', String(ticked));
+
+  node_modules_cache:
+    needs: plan
+    if: needs.plan.outputs.requested == 'true'
+    name: Cache node modules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+      - uses: actions/cache/restore@v5
+        id: cache
+        with:
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          path: ${{ env.NODE_MODULES_PATHS }}
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          path: ${{ env.NODE_MODULES_PATHS }}
+
+  dast:
+    needs: [plan, node_modules_cache]
+    if: needs.plan.outputs.requested == 'true'
+    name: ZAP ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Facility servers are usually on a local network — authenticated
+          # coverage is the priority, but the anonymous surface is cheap signal.
+          - name: facility-authenticated
+            server: facility
+            target: http://localhost:4000
+            authenticated: true
+          - name: facility-unauthenticated
+            server: facility
+            target: http://localhost:4000
+            authenticated: false
+          # Central is often internet-exposed, so the unauthenticated (anonymous
+          # attacker) view matters most here.
+          - name: central-authenticated
+            server: central
+            target: http://localhost:3000
+            authenticated: true
+          - name: central-unauthenticated
+            server: central
+            target: http://localhost:3000
+            authenticated: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+      - uses: actions/cache/restore@v5
+        with:
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          path: ${{ env.NODE_MODULES_PATHS }}
+
+      - run: npm i
+      - run: npm run build-shared
+      - run: npm run --workspace @tamanu/central-server build
+      - run: npm run --workspace @tamanu/facility-server build
+
+      - name: Setup postgres dbs
+        run: |
+          source .github/scripts/install-postgres-ubuntu.sh 18
+          .github/scripts/e2e-test-setup.sh setup-postgres
+      - name: Setup central server
+        run: .github/scripts/e2e-test-setup.sh setup-central
+      - name: Setup facility server
+        run: .github/scripts/e2e-test-setup.sh setup-facility
+      - name: Start servers
+        run: .github/scripts/e2e-test-setup.sh start-servers
+
+      - name: Prepare scan auth
+        run: |
+          # Fail loudly on any error: a silently-empty token would make an
+          # 'authenticated' leg scan as anonymous while reporting as authed,
+          # producing meaningless results with no visible failure.
+          set -euo pipefail
+
+          # Unauthenticated run: nothing to inject, scan as an anonymous client.
+          if [ "${{ matrix.authenticated }}" != "true" ]; then
+            echo "ZAP_CMD_OPTIONS=" >> "$GITHUB_ENV"
+            echo "Scanning ${{ matrix.target }} unauthenticated."
+            exit 0
+          fi
+
+          # Authenticated run: log in as the provisioned admin so the scan
+          # exercises endpoints behind auth, not just the login page.
+          login_token=$(curl -sf -X POST ${{ matrix.target }}/api/login \
+            -H 'Content-Type: application/json' \
+            -d '{"email":"admin@tamanu.io","password":"admin","deviceId":"dast-scanner"}' \
+            | jq -er .token)
+          [ -n "$login_token" ] || { echo "Empty login token from ${{ matrix.target }}"; exit 1; }
+
+          if [ "${{ matrix.server }}" = "facility" ]; then
+            # Facility tokens carry a facility scope, obtained via setFacility.
+            token=$(curl -sf -X POST ${{ matrix.target }}/api/setFacility \
+              -H 'Content-Type: application/json' \
+              -H "Authorization: Bearer $login_token" \
+              -d '{"facilityId":"facility-1"}' \
+              | jq -er .token)
+          else
+            # Central's setFacility doesn't reissue a token — the login token is
+            # what authenticated central requests carry.
+            token="$login_token"
+          fi
+          [ -n "$token" ] || { echo "Empty auth token for ${{ matrix.server }}"; exit 1; }
+
+          # Keep the token out of the logs, then inject it on every request via a
+          # ZAP replacer rule so spidered and attacked requests are authenticated.
+          echo "::add-mask::$token"
+          echo "ZAP_CMD_OPTIONS=-z \"-config replacer.full_list(0).description=authheader -config replacer.full_list(0).enabled=true -config replacer.full_list(0).matchtype=REQ_HEADER -config replacer.full_list(0).matchstr=Authorization -config replacer.full_list(0).regex=false -config replacer.full_list(0).replacement=Bearer $token\"" >> "$GITHUB_ENV"
+
+      - name: OWASP ZAP full scan
+        uses: zaproxy/action-full-scan@v0.13.0
+        with:
+          target: ${{ matrix.target }}
+          rules_file_name: .zap/rules.tsv
+          cmd_options: ${{ env.ZAP_CMD_OPTIONS }}
+          # Fail the job on any non-ignored alert (suppress false positives in
+          # .zap/rules.tsv). Don't open GitHub issues from CI.
+          fail_action: true
+          allow_issue_writing: false
+          artifact_name: zap-dast-report-${{ matrix.name }}
+
+      - name: Print server logs on failure
+        if: failure()
+        run: |
+          echo "::group::central-server.out"
+          cat central-server.out || true
+          echo "::endgroup::"
+          echo "::group::facility-server.out"
+          cat facility-server.out || true
+          echo "::endgroup::"
+
+  # Single, stable check name (independent of the scan matrix) to require in
+  # branch protection so a failing scan blocks the merge.
+  dast-required:
+    name: DAST Required
+    if: always()
+    needs: [plan, dast]
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.plan.outputs.requested == 'true'
+        name: Enforce passing DAST scan
+        run: |
+          if [ "${{ needs.dast.result }}" != "success" ]; then
+            echo "DAST scan did not pass."
+            exit 1
+          fi
+
+          echo "DAST passed."

--- a/.zap/README.md
+++ b/.zap/README.md
@@ -1,0 +1,71 @@
+# DAST (OWASP ZAP) scanning
+
+The `DAST` workflow (`.github/workflows/ci-dast.yml`) runs OWASP ZAP **full
+active scans** against a throwaway central + facility stack stood up in CI.
+
+A full active scan sends real attack payloads (injection, traversal, etc.) and
+can mutate or destroy data, so it only ever runs against the disposable CI
+database — never a real deployment.
+
+## When it runs
+
+Opt-in on PRs by ticking **Run DAST scan** (`#dast`) in the PR body, and on
+every merge-queue run.
+
+The `dast-required` job exposes a single stable check name (**DAST Required**)
+that can be marked required in branch protection to block merges on a failing
+scan.
+
+## What it scans
+
+A matrix of four scans:
+
+| Target | Port | Auth | Why |
+|--------|------|------|-----|
+| facility API | 4000 | authenticated | Facility servers are usually LAN-only; authed coverage is the priority |
+| facility API | 4000 | unauthenticated | Cheap anonymous-surface signal |
+| central API | 3000 | authenticated | |
+| central API | 3000 | unauthenticated | Central is often internet-exposed, so the anonymous-attacker view matters most |
+
+Authenticated scans log in as the provisioned `admin@tamanu.io` user and inject
+the JWT on every request via a ZAP `replacer` rule. Facility tokens are scoped
+via `setFacility`; central uses the login token directly (central's
+`setFacility` doesn't reissue a token).
+
+## Gating and false positives
+
+Each scan runs with `fail_action: true`: any alert that isn't ignored fails that
+matrix job. Suppress confirmed false positives (and low/informational noise) in
+[`rules.tsv`](./rules.tsv) by setting the alert's plugin ID to `IGNORE` with a
+comment. The low-severity/informational passive rules are already ignored there
+to approximate "block on medium/high only".
+
+After a failing run, download the per-scan **`zap-dast-report-<name>`** artifact
+to see each alert's plugin ID and decide whether to fix it or ignore it.
+
+## Running locally
+
+Stand up the stack the same way CI does (see `.github/scripts/e2e-test-setup.sh`),
+then run the packaged scan against a server. For example, the facility API:
+
+```bash
+TOKEN=...  # mint via POST /api/login then POST /api/setFacility
+docker run --rm -v "$(pwd)/.zap:/zap/wrk/.zap" --network host \
+  ghcr.io/zaproxy/zaproxy:stable zap-full-scan.py \
+  -t http://localhost:4000 \
+  -c .zap/rules.tsv \
+  -z "-config replacer.full_list(0).description=authheader \
+      -config replacer.full_list(0).enabled=true \
+      -config replacer.full_list(0).matchtype=REQ_HEADER \
+      -config replacer.full_list(0).matchstr=Authorization \
+      -config replacer.full_list(0).regex=false \
+      -config 'replacer.full_list(0).replacement=Bearer ${TOKEN}'"
+```
+
+## Known limitations / follow-ups
+
+- **Endpoint discovery depth.** A REST API has no HTML links for the traditional
+  spider to follow, so active-scan coverage is bounded by what ZAP discovers
+  from the API root. For deeper coverage, export an OpenAPI/Swagger spec and
+  switch to `zaproxy/action-api-scan`, or seed a ZAP context with the routes the
+  web/mobile clients use.

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,24 @@
+# OWASP ZAP alert suppression rules for the DAST CI scan.
+#
+# Format (tab-separated): <pluginId>	<IGNORE|WARN|FAIL>	<comment>
+#   IGNORE  alert is dropped entirely (won't appear, won't fail the build)
+#   WARN    alert is reported (default) — with fail_action this FAILS the build
+#   FAIL    alert is reported and fails the build
+#
+# We run with fail_action: true, so *any* non-ignored alert blocks the merge.
+# To approximate "block on medium/high only", the low-severity and purely
+# informational passive rules below are set to IGNORE. Add a rule here (with a
+# comment explaining why) when you've confirmed an alert is a false positive.
+#
+# Plugin IDs: https://www.zaproxy.org/docs/alerts/
+#
+# Find an alert's plugin ID in the report artifact (zap-dast-report) produced by
+# a failing run, then decide IGNORE (false positive / accepted) vs leave it to
+# block (real finding to fix).
+
+10015	IGNORE	Incomplete or no cache-control header (low / informational)
+10027	IGNORE	Information disclosure - suspicious comments (informational)
+10049	IGNORE	Non-storable / storable & cacheable content (informational)
+10094	IGNORE	Base64 disclosure (informational)
+10096	IGNORE	Timestamp disclosure (low, very noisy false-positive prone)
+10109	IGNORE	Modern web application (informational)


### PR DESCRIPTION
### Changes

🤖 Adds a `DAST` GitHub Actions workflow that runs OWASP ZAP **full active scans** against throwaway central and facility servers stood up in CI (reusing the E2E stack setup), so real attack traffic only ever hits a disposable database.

Scans run as a matrix of four: central and facility APIs, each authenticated (logging in as the provisioned admin and injecting the JWT via a ZAP replacer rule) and unauthenticated (the anonymous-attacker view, most relevant for the internet-exposed central server). Findings are tuned via `.zap/rules.tsv`, which pre-ignores low/informational passive rules to approximate gating on medium/high only.

It is opt-in on PRs via a new `#dast` checkbox and also runs in the merge queue. The `dast-required` gate job is wired up but the check is **not required in branch protection yet** — that flip is the last step once the scan passes cleanly. See `.zap/README.md` for tuning, local runs, and the endpoint-discovery follow-up (OpenAPI spec → api-scan).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->
- [x] **Run DAST scan** <!-- #dast -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->