### PR TITLE
fix(sync): avoid stack overflow in runFunctionInBatches on large batches

### DIFF
--- a/packages/utils/src/runFunctionInBatches.ts
+++ b/packages/utils/src/runFunctionInBatches.ts
@@ -13,7 +13,9 @@ export async function runFunctionInBatches<T, R>(
   for (let i = 0; i < arrayToBeBatched.length; i += batchSize) {
     const batch = arrayToBeBatched.slice(i, i + batchSize);
     const chunkedResult = await functionToRun(batch);
-    results.push(...chunkedResult);
+    for (const item of chunkedResult) {
+      results.push(item);
+    }
   }
   return results;
 }


### PR DESCRIPTION
### Changes

`runFunctionInBatches` appended each batch's results with `results.push(...chunkedResult)`. Spreading passes every element as a separate function argument, which overflows V8's call-stack limit on large batches — surfacing as `RangeError: Maximum call stack size exceeded`.

This took down central sync: on a full re-pull (`since=-1`, ~328k records) the `/api/sync/.../pull` 500s inside `attachChangelogToSnapshotRecords` → `runFunctionInBatches`, the `StaleSyncSessionCleaner` reconnects every ~120s, and the whole pull restarts in an endless loop.

Fix: append with a `for...of` loop instead of a spread.

```diff
-    results.push(...chunkedResult);
+    for (const item of chunkedResult) {
+      results.push(item);
+    }
```

Manually verified the previous code throws the exact production error on a large (200k) batch and the fix clears it.

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)