### PR TITLE
fix(sync): order changelog FK targets (users) first during pull

### DIFF
--- a/packages/database/__tests__/models/sortInDependencyOrder.test.ts
+++ b/packages/database/__tests__/models/sortInDependencyOrder.test.ts
@@ -17,13 +17,13 @@ function modelTrees() {
   // structure (letrec = "let recursive") by creating segments of structure and "tying"
   // them together at certain points. You can find this exact example in the fast-check
   // docs! https://dubzzz.github.io/fast-check/functions/letrec.html
-  const { tree } = fc.letrec((tie) => ({
+  const { tree } = fc.letrec(tie => ({
     tree: fc.oneof({ depthSize: 'large' }, tie('leaf'), tie('node')),
     node: fc.tuple(tie('tree'), tie('tree')),
     leaf: fc.constant('leaf'),
   }));
 
-  return tree.map((subTree) => pairsToModels(treeToPairs([subTree])));
+  return tree.map(subTree => pairsToModels(treeToPairs([subTree])));
 }
 
 class BaseSyncingModel extends Model {
@@ -45,7 +45,7 @@ class BaseSyncingModel extends Model {
 // higher nodes are models which are dependent on lower ones.
 function treeToPairs(tree, dependent = 0) {
   let i = 0;
-  return tree.flatMap((element) => {
+  return tree.flatMap(element => {
     if (element === 'leaf') {
       i += 1;
       return [[dependent, i].sort((a, b) => b - a)];
@@ -66,7 +66,7 @@ function pairsToUniqueItems(pairs) {
 function pairsToModels(pairs) {
   const models = Object.fromEntries(
     pairsToUniqueItems(pairs)
-      .map((i) => {
+      .map(i => {
         return [
           `Model${i}`,
           Object.defineProperty(
@@ -102,7 +102,7 @@ function pairsToModels(pairs) {
 describe('sortInDependencyOrder', () => {
   it('does not crash (fuzz test)', () => {
     fc.assert(
-      fc.property(modelTrees(), (models) => {
+      fc.property(modelTrees(), models => {
         const sorted = sortInDependencyOrder(models);
         expect(sorted.length).toEqual(Object.keys(models).length);
       }),
@@ -123,7 +123,7 @@ describe('sortInDependencyOrder', () => {
 
     const sorted = sortInDependencyOrder(models);
 
-    expect(sorted.map((model) => model.name)).toEqual(['Model4', 'Model3', 'Model2', 'Model1']);
+    expect(sorted.map(model => model.name)).toEqual(['Model4', 'Model3', 'Model2', 'Model1']);
   });
 
   it('sorts a reversed chain of models', () => {
@@ -140,7 +140,7 @@ describe('sortInDependencyOrder', () => {
 
     const sorted = sortInDependencyOrder(models);
 
-    expect(sorted.map((model) => model.name)).toEqual(['Model1', 'Model2', 'Model3', 'Model4']);
+    expect(sorted.map(model => model.name)).toEqual(['Model1', 'Model2', 'Model3', 'Model4']);
   });
 
   it('sorts a 2-chains tree', () => {
@@ -158,7 +158,7 @@ describe('sortInDependencyOrder', () => {
 
     const sorted = sortInDependencyOrder(models);
 
-    expect(sorted.map((model) => model.name)).toEqual([
+    expect(sorted.map(model => model.name)).toEqual([
       'Model4',
       'Model5',
       'Model2',
@@ -191,7 +191,7 @@ describe('sortInDependencyOrder', () => {
 
     const sorted = sortInDependencyOrder(models);
 
-    expect(sorted.map((model) => model.name)).toEqual(['Model3', 'Model4', 'Model1', 'Model2']);
+    expect(sorted.map(model => model.name)).toEqual(['Model3', 'Model4', 'Model1', 'Model2']);
   });
 
   // in these next ones, the node numbers are NM, where N is the depth of the node
@@ -219,7 +219,7 @@ describe('sortInDependencyOrder', () => {
 
     const sorted = sortInDependencyOrder(models);
 
-    expect(sorted.map((model) => model.name)).toEqual([
+    expect(sorted.map(model => model.name)).toEqual([
       'Model30',
       'Model31',
       'Model32',
@@ -282,7 +282,7 @@ describe('sortInDependencyOrder', () => {
     // group below, which roughly represent the levels of dependence. if you start from each
     // leaf in the graph, and count I, II, III, IV for each level of dependency, you can see
     // where the groups get made. these "reverse levels" are marked on the ascii art above.
-    expect(sorted.map((model) => model.name)).toEqual([
+    expect(sorted.map(model => model.name)).toEqual([
       // level 0 - no dependencies
       'Model31',
       'Model33',
@@ -312,5 +312,82 @@ describe('sortInDependencyOrder', () => {
       // level IV
       'Model10',
     ]);
+  });
+
+  it('emits ChangeLog FK targets (users) first even though they sort last alphabetically', () => {
+    const makeModel = (name, associations = {}) =>
+      Object.defineProperty(
+        class extends BaseSyncingModel {
+          static associations = associations;
+        },
+        'name',
+        { value: name },
+      );
+
+    const models = {
+      Appointment: makeModel('Appointment'),
+      InvoicePriceList: makeModel('InvoicePriceList'),
+      Patient: makeModel('Patient'),
+      User: makeModel('User'),
+    };
+
+    const changeLog = {
+      associations: {
+        updatedByUser: {
+          associationType: 'BelongsTo',
+          isSelfAssociation: false,
+          target: { name: 'User' },
+        },
+      },
+    };
+    const sequelize = { models: { ...models, ChangeLog: changeLog } };
+    for (const model of Object.values(models)) {
+      Object.defineProperty(model, 'sequelize', { value: sequelize, configurable: true });
+    }
+
+    const sorted = sortInDependencyOrder(models);
+
+    expect(sorted.map(model => model.name)).toEqual([
+      'User',
+      'Appointment',
+      'InvoicePriceList',
+      'Patient',
+    ]);
+  });
+
+  it('handles multiple ChangeLog FK targets without a dependency cycle', () => {
+    const makeModel = name =>
+      Object.defineProperty(
+        class extends BaseSyncingModel {
+          static associations = {};
+        },
+        'name',
+        { value: name },
+      );
+
+    const models = {
+      Appointment: makeModel('Appointment'),
+      Organization: makeModel('Organization'),
+      User: makeModel('User'),
+    };
+
+    const target = name => ({
+      associationType: 'BelongsTo',
+      isSelfAssociation: false,
+      target: { name },
+    });
+    const changeLog = {
+      associations: { updatedByUser: target('User'), organization: target('Organization') },
+    };
+    const sequelize = { models: { ...models, ChangeLog: changeLog } };
+    for (const model of Object.values(models)) {
+      Object.defineProperty(model, 'sequelize', { value: sequelize, configurable: true });
+    }
+
+    const sorted = sortInDependencyOrder(models).map(model => model.name);
+
+    expect(sorted).toHaveLength(3);
+    expect(sorted.indexOf('Appointment')).toBeGreaterThan(sorted.indexOf('User'));
+    expect(sorted.indexOf('Appointment')).toBeGreaterThan(sorted.indexOf('Organization'));
   });
 });

--- a/packages/database/src/utils/sortInDependencyOrder.ts
+++ b/packages/database/src/utils/sortInDependencyOrder.ts
@@ -1,19 +1,40 @@
 import type { Models } from '../types/model';
 
+const belongsToTargets = (associations: Record<string, any>): string[] =>
+  Object.values(associations)
+    .filter(a => a.associationType === 'BelongsTo' && !a.isSelfAssociation)
+    .map(a => a.target.name);
+
 export function sortInDependencyOrder(models: Models): Array<Models[keyof Models]> {
   const sorted: Array<Models[keyof Models]> = [];
   const stillToSort = new Map(Object.entries(models).sort((a, b) => a[0].localeCompare(b[0])));
 
+  // Changelog rows are replayed inside each record's batch and reference whatever ChangeLog
+  // belongs to (users, via updated_by_user_id). ChangeLog is DO_NOT_SYNC so the sort can't see
+  // that edge; derive the targets and make every other model depend on them.
+  const changeLog = (Object.values(models)[0] as any)?.sequelize?.models?.ChangeLog;
+  const changelogTargets = changeLog ? belongsToTargets(changeLog.associations) : [];
+
   while (stillToSort.size > 0) {
+    const remaining = stillToSort.size;
     for (const [name, model] of stillToSort) {
-      const dependsOn = Object.values(model.associations)
-        .filter((a) => a.associationType === 'BelongsTo' && !a.isSelfAssociation)
-        .map((a) => a.target.name);
-      const dependenciesStillToSort = dependsOn.filter((d) => !!stillToSort.has(d));
+      // Changelog targets only carry their own deps; injecting the target list into a target
+      // would make multiple targets depend on each other.
+      const isChangelogTarget = changelogTargets.includes(name);
+      const dependsOn = [
+        ...belongsToTargets(model.associations),
+        ...(isChangelogTarget ? [] : changelogTargets),
+      ];
+      const dependenciesStillToSort = dependsOn.filter(d => stillToSort.has(d));
       if (dependenciesStillToSort.length === 0) {
         sorted.push(model);
         stillToSort.delete(name);
       }
+    }
+    if (stillToSort.size === remaining) {
+      throw new Error(
+        `sortInDependencyOrder: unresolvable dependency cycle among ${[...stillToSort.keys()].join(', ')}`,
+      );
     }
   }
 


### PR DESCRIPTION
### Changes

Facility sync could dead-loop with:

```
insert or update on table "changes" violates foreign key constraint "changes_updated_by_user_id_fkey"
DETAIL: Key (updated_by_user_id)=(...) is not present in table "users".
```

**Why it happens.** Changelog rows are replayed during a pull attached to the records they describe and inserted by `insertChangelogRecords` during that model's batch. Each row's `updated_by_user_id` references `users(id)`. But `sortInDependencyOrder` emits ready models **alphabetically**, so `users` (`u`) is saved *after* models like `invoice_price_lists` (`i`) — whose changelog rows then reference users that aren't in the table yet. That violates `changes_updated_by_user_id_fkey` and aborts the whole pull transaction, which recurs every sync because the cursor only advances on success.

The `ChangeLog → User` dependency is invisible to the topological sort because `ChangeLog` is `DO_NOT_SYNC`, so it never appears as a `BelongsTo` edge on a pulled model.

**Fix.** Derive the dependency from `ChangeLog` itself: read its `BelongsTo` targets (currently just `User`, via `updated_by_user_id`) and treat every other model as depending on those targets. The existing topological sort then orders them first, and it stays correct automatically if `logs.changes` ever gains another FK. A guard throws a clear error instead of looping forever if a dependency cycle is ever introduced.

### Notes

Known limit: if a facility has more users than `persistedCacheBatchSize`, a changelog row in an earlier user batch could reference a user in a later user batch (user-edited-by-user across the batch boundary). This fixes the reported case (changelog on *other* tables referencing users) completely; that cross-user-batch edge is separate.

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)