### PR TITLE
fix(web): no-issue: keep caret position when editing non-paginated form table inputs

### DIFF
--- a/packages/web/app/components/Table/TableFormFields.jsx
+++ b/packages/web/app/components/Table/TableFormFields.jsx
@@ -109,6 +109,8 @@ export const TableFormFields = React.memo(
       setPageRows(data.slice(0, newRowsPerPage));
     };
 
+    const displayRows = pagination ? pageRows : data;
+
     return (
       <>
         <TableContainer data-testid="tablecontainer-aex2">
@@ -132,8 +134,8 @@ export const TableFormFields = React.memo(
               </TableRow>
             </StyledTableHead>
             <TableBody data-testid="tablebody-l659">
-              {pageRows && pageRows.length > 0 ? (
-                pageRows.map((rowData, i) => (
+              {displayRows && displayRows.length > 0 ? (
+                displayRows.map((rowData, i) => (
                   <TableRow key={rowData.id || i} data-testid={`tablerow-r1a3-${i}`}>
                     {columns.map(({ key, accessor }) => (
                       <StyledTableDataCell


### PR DESCRIPTION
## Problem

On the medication dispense preset labels, after selecting a preset and then clicking inside a text box to edit it (e.g. the **Label text**), the cursor jumps to the end of the text — you have to click back to where you were typing. (Reported as issue 15, 2.57.)

## Root cause

`TableFormFields` mirrors its `data` prop into local `pageRows` **state**, synced via a `useEffect`. That mirror lags one render behind the prop. For a controlled input inside the table, each keystroke causes:

1. `data` updates with the new value → parent re-renders;
2. `TableFormFields` body still renders from the stale `pageRows` → React writes the **old** (shorter) value back into the field;
3. the effect fires → `setPageRows(new)` → re-render → React writes the **new** value.

That old→new double write on a controlled input resets the caret to the end. (The Quantity field dodged it only because `QuantityInput` keeps its own internal state.)

## Fix

Render the live `data` prop directly when the table isn't paginated, so the new value reaches the input in a single commit and the caret stays put:

```js
const displayRows = pagination ? pageRows : data;
```

Paginated tables still use the sliced `pageRows` state and are unaffected.

## Risk / scope

- Shared component, but the change only swaps which array the **non-paginated** body maps over — from a lagged state mirror to the live prop it was mirroring anyway. Strictly more correct; benefits every non-paginated form table with controlled inputs.
- Paginated callers unchanged.

## Test plan

- [ ] Dispense medication → pick a preset label → click into the middle of the Label text and type; caret stays where you typed.
- [ ] Confirm a paginated `TableFormFields` user still paginates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)