### PR TITLE
fix(triage): no-issue: roll back encounter when triage submission fails

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Triage.test.js
+++ b/packages/facility-server/__tests__/apiv1/Triage.test.js
@@ -281,8 +281,6 @@ describe('Triage', () => {
 
   it('should not leave an orphaned encounter when the vitals default location is misconfigured', async () => {
     const [facilityId] = selectFacilityIds(config);
-    // Point the default location code at something that doesn't exist so resolving
-    // the vitals default throws, reproducing the misconfigured-facility report.
     await models.Setting.set(
       'survey.defaultCodes.location',
       'nonexistent-location-code',
@@ -302,8 +300,6 @@ describe('Triage', () => {
         .send({ ...triageBody, facilityId, vitals: {} });
       expect(response).toHaveStatus(500);
 
-      // The encounter creation must have rolled back, so the patient has no active
-      // encounter and can be re-triaged once the config is fixed.
       const encounters = await models.Encounter.findAll({
         where: { patientId: encounterPatient.id },
       });

--- a/packages/facility-server/__tests__/apiv1/Triage.test.js
+++ b/packages/facility-server/__tests__/apiv1/Triage.test.js
@@ -7,7 +7,7 @@ import {
   randomReferenceId,
 } from '@tamanu/database/demoData';
 import { fake } from '@tamanu/fake-data/fake';
-import { ENCOUNTER_TYPES } from '@tamanu/constants';
+import { ENCOUNTER_TYPES, SETTINGS_SCOPES } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import { createTestContext } from '../utilities';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
@@ -277,6 +277,50 @@ describe('Triage', () => {
     );
 
     await emergencyDepartment.update({ facilityId: facility.id });
+  });
+
+  it('should not leave an orphaned encounter when the vitals default location is misconfigured', async () => {
+    const [facilityId] = selectFacilityIds(config);
+    // Point the default location code at something that doesn't exist so resolving
+    // the vitals default throws, reproducing the misconfigured-facility report.
+    await models.Setting.set(
+      'survey.defaultCodes.location',
+      'nonexistent-location-code',
+      SETTINGS_SCOPES.FACILITY,
+      facilityId,
+    );
+
+    try {
+      const encounterPatient = await models.Patient.create(await createDummyPatient(models));
+      const triageBody = await createDummyTriage(models, {
+        patientId: encounterPatient.id,
+        departmentId: await randomRecordId(models, 'Department'),
+      });
+
+      const response = await app
+        .post('/api/triage')
+        .send({ ...triageBody, facilityId, vitals: {} });
+      expect(response).toHaveStatus(500);
+
+      // The encounter creation must have rolled back, so the patient has no active
+      // encounter and can be re-triaged once the config is fixed.
+      const encounters = await models.Encounter.findAll({
+        where: { patientId: encounterPatient.id },
+      });
+      expect(encounters).toHaveLength(0);
+
+      const retry = await app
+        .post('/api/triage')
+        .send({ ...triageBody, facilityId });
+      expect(retry).toHaveSucceeded();
+    } finally {
+      await models.Setting.set(
+        'survey.defaultCodes.location',
+        'GeneralClinic',
+        SETTINGS_SCOPES.FACILITY,
+        facilityId,
+      );
+    }
   });
 
   describe('Listing & filtering', () => {

--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -59,59 +59,76 @@ triage.post(
     };
     const departmentId = await getDepartmentId();
 
-    const triageRecord = await models.Triage.create({ ...body, departmentId, actorId: user.id });
-
-    if (vitals) {
+    // Resolve the vitals survey response's default location/department from
+    // settings (survey.defaultCodes.*) before any writes. getDefaultId throws if
+    // the configured code doesn't exist for the facility; doing it up front means a
+    // config error fails before the encounter is created rather than after, which
+    // previously left the patient with an orphaned active encounter they couldn't
+    // re-triage.
+    const resolveVitalsDefaults = async () => {
       const getDefaultId = async type =>
         models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId]);
-      const updatedBody = {
+      return {
         locationId: vitals.locationId || (await getDefaultId('location')),
         departmentId: vitals.departmentId || (await getDefaultId('department')),
-        encounterId: triageRecord.encounterId,
-        userId: req.user.id,
-        facilityId,
-        ...vitals,
       };
-      await db.transaction(async () => {
-        return models.SurveyResponse.createWithAnswers(updatedBody);
+    };
+    const vitalsDefaults = vitals ? await resolveVitalsDefaults() : null;
+
+    // Create the triage, its encounter and all derived records atomically. If any
+    // step fails the whole thing rolls back, so the patient isn't left with a
+    // half-created active encounter that blocks them from being re-triaged.
+    const triageRecord = await db.transaction(async () => {
+      const triage = await models.Triage.create({ ...body, departmentId, actorId: user.id });
+
+      if (vitals) {
+        await models.SurveyResponse.createWithAnswers({
+          ...vitalsDefaults,
+          encounterId: triage.encounterId,
+          userId: req.user.id,
+          facilityId,
+          ...vitals,
+        });
+      }
+
+      // The triage form groups notes as a single string for submission
+      // so put it into a single note record
+      if (notes) {
+        await triage.createNote({
+          noteTypeId: NOTE_TYPES.OTHER,
+          content: notes,
+        });
+      }
+
+      const encounter = await models.Encounter.findOne({
+        where: { id: triage.encounterId },
       });
-    }
 
-    // The triage form groups notes as a single string for submission
-    // so put it into a single note record
-    if (notes) {
-      await triageRecord.createNote({
-        noteTypeId: NOTE_TYPES.OTHER,
-        content: notes,
+      const department = await models.Department.findOne({
+        where: { id: encounter.departmentId },
       });
-    }
 
-    const encounter = await models.Encounter.findOne({
-      where: { id: triageRecord.encounterId },
-    });
+      if (!department) {
+        throw new InvalidOperationError(
+          `Couldn’t record triage score as system note; no department found with with ID ‘${encounter.departmentId}’`,
+        );
+      }
 
-    const department = await models.Department.findOne({
-      where: { id: encounter.departmentId },
-    });
-
-    if (!department) {
-      throw new InvalidOperationError(
-        `Couldn’t record triage score as system note; no department found with with ID ‘${encounter.departmentId}’`,
+      await encounter.addSystemNote(
+        `${department.name} triage score: ${triage.score}`,
+        triage.triageTime,
+        user,
       );
-    }
 
-    await encounter.addSystemNote(
-      `${department.name} triage score: ${triageRecord.score}`,
-      triageRecord.triageTime,
-      user,
-    );
+      await models.Invoice.automaticallyCreateForEncounter(
+        encounter.id,
+        encounter.encounterType,
+        encounter.startDate,
+        settings[facilityId],
+      );
 
-    await models.Invoice.automaticallyCreateForEncounter(
-      encounter.id,
-      encounter.encounterType,
-      encounter.startDate,
-      settings[facilityId],
-    );
+      return triage;
+    });
 
     res.send(triageRecord);
   }),

--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -59,12 +59,7 @@ triage.post(
     };
     const departmentId = await getDepartmentId();
 
-    // Resolve the vitals survey response's default location/department from
-    // settings (survey.defaultCodes.*) before any writes. getDefaultId throws if
-    // the configured code doesn't exist for the facility; doing it up front means a
-    // config error fails before the encounter is created rather than after, which
-    // previously left the patient with an orphaned active encounter they couldn't
-    // re-triage.
+    // Resolve defaults before any writes so a bad config fails before the encounter is created.
     const resolveVitalsDefaults = async () => {
       const getDefaultId = async type =>
         models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId]);
@@ -75,9 +70,7 @@ triage.post(
     };
     const vitalsDefaults = vitals ? await resolveVitalsDefaults() : null;
 
-    // Create the triage, its encounter and all derived records atomically. If any
-    // step fails the whole thing rolls back, so the patient isn't left with a
-    // half-created active encounter that blocks them from being re-triaged.
+    // Single transaction so any failure rolls the encounter back rather than orphaning it.
     const triageRecord = await db.transaction(async () => {
       const triage = await models.Triage.create({ ...body, departmentId, actorId: user.id });
 


### PR DESCRIPTION
### Changes

Triage submission wasn't atomic. `Triage.create` created and committed the encounter before the handler resolved the vitals survey response's default location/department from `survey.defaultCodes.*`. When that default code doesn't exist for the facility (as reported on facility-2, where `location` is set to `GeneralClinic`), `getDefaultId` threw **after** the encounter was already persisted — leaving the patient with an orphaned active encounter, so re-submitting failed with *"patient has an active encounter"*.

This resolves the vitals defaults up front (failing before any write) and wraps all triage writes — encounter, survey response, notes, system note and invoice — in a single managed transaction, so any failure rolls the encounter back and the user can retry once config is corrected.

Note: the underlying `GeneralClinic`-not-found error is still a genuine config issue for that facility; this change just stops it from corrupting state. Added a regression test asserting no orphaned encounter is left behind and the patient can be re-triaged.

Couldn't run the facility test suite locally (needs a Postgres test DB + branch dep install); relying on CI. Lint is clean.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->