### PR TITLE
fix(sync): no-issue: drop user_login_attempts.user_id FK to stop sync failures

### DIFF
--- a/packages/database/src/migrations/1781600000000-removeUserFkFromUserLoginAttempts.ts
+++ b/packages/database/src/migrations/1781600000000-removeUserFkFromUserLoginAttempts.ts
@@ -1,0 +1,34 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // user_login_attempts is PUSH_TO_CENTRAL: rows are recorded on the facility and pushed up.
+  // The hard FK to users breaks the whole sync session when the referenced user is missing on
+  // the receiving side (e.g. not yet synced, or removed). Drop the constraint, keep an index.
+  await query.sequelize.query(`
+    ALTER TABLE user_login_attempts
+    DROP CONSTRAINT IF EXISTS user_login_attempts_user_id_fkey;
+  `);
+  await query.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS user_login_attempts_user_id ON user_login_attempts (user_id);
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeIndex('user_login_attempts', ['user_id']);
+  // DESTRUCTIVE: removes any login attempts whose user is missing so the constraint can be re-added.
+  await query.sequelize.query(`
+    DELETE FROM user_login_attempts
+    WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.id = user_login_attempts.user_id);
+  `);
+  await query.addConstraint('user_login_attempts', {
+    fields: ['user_id'],
+    type: 'foreign key',
+    name: 'user_login_attempts_user_id_fkey',
+    references: {
+      table: 'users',
+      field: 'id',
+    },
+    onDelete: 'NO ACTION',
+    onUpdate: 'NO ACTION',
+  });
+}


### PR DESCRIPTION
### Changes

`user_login_attempts` is `PUSH_TO_CENTRAL` — rows are recorded on the facility (`User.loginFromCredential`) and pushed to central. The hard FK `user_login_attempts_user_id_fkey → users.id` aborts the **entire sync session** when the referenced user is absent on the receiving side (not yet synced, or removed), surfacing on the facility as:

> Manual sync failed — insert or update on table "user_login_attempts" violates foreign key constraint "user_login_attempts_user_id_fkey"

(Seen on the release-2-57 CD env on facility-1.)

This is the same bug class already fixed for `device_id` in migration `1768858451324-removeDeviceFkFromUserLoginAttempts` — a hard FK on a sync-replicated audit table. This migration does the same for `user_id`: drops the constraint and keeps an index.

- **No mobile migration** — mobile has no `user_login_attempts` table (same as the device fix).
- **No dbt change** — constraint/index only, no column change.
- **Model unchanged** — `belongsTo(User)` stays so the relation is still queryable (the association is FK-free; only the DB-level hard constraint is removed). The user is always a real entity, unlike the unregistered-device case.
- `down` re-adds the constraint and is marked DESTRUCTIVE (it deletes orphaned rows first so the constraint can be restored).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->