### PR TITLE
fix(mobile): no-issue: remove obsolete dietId column from encounter (backport 2.53)

### DIFF
--- a/packages/mobile/App/migrations/1781501076000-removeDietIdFromEncounter.ts
+++ b/packages/mobile/App/migrations/1781501076000-removeDietIdFromEncounter.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+const TABLE_NAME = 'encounters';
+const COLUMN_NAME = 'dietId';
+
+export class removeDietIdFromEncounter1781501076000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+    await queryRunner.dropColumn(table, COLUMN_NAME);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+    await queryRunner.addColumn(
+      table,
+      new TableColumn({
+        name: COLUMN_NAME,
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -85,7 +85,7 @@ import { addSecondaryResultToLabTest1768527821000 } from './1768527821000-addSec
 import { updateEncountersTableSetPatientIdNotNull1771277667000 } from './1771277667000-updateEncountersTableSetPatientIdNotNull';
 import { removePatientTitleColumn1778199200000 } from './1778199200000-removePatientTitleColumn';
 import { addLabTestReferenceRangeColumns1778546880000 } from './1778546880000-addLabTestReferenceRangeColumns';
-
+import { removeDietIdFromEncounter1781501076000 } from './1781501076000-removeDietIdFromEncounter';
 export const migrationList = [
   databaseSetup1661160427226,
   updatePatientDateTimeColumns1661717539000,
@@ -173,4 +173,5 @@ export const migrationList = [
   updateEncountersTableSetPatientIdNotNull1771277667000,
   removePatientTitleColumn1778199200000,
   addLabTestReferenceRangeColumns1778546880000,
+  removeDietIdFromEncounter1781501076000,
 ];

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -82,12 +82,6 @@ export class Encounter extends BaseModel implements IEncounter {
   @IdRelation()
   patientBillingTypeId?: string | null;
 
-  @ReferenceDataRelation()
-  diet?: ReferenceData;
-
-  @IdRelation()
-  dietId?: string | null;
-
   @ManyToOne(() => Location)
   location: Location;
 


### PR DESCRIPTION
### Changes

🤖 Backport of #10052 to `release/2.53`.

Mobile still carried a `dietId` column and `diet`/`dietId` fields on the encounter entity, left over from the original single-diet implementation. The server moved diet to the `encounter_diets` join table and dropped `encounters.diet_id` back around 2.14 (EPI-871, #6213), but mobile was never updated — it has been including `dietId` in every encounter sync push ever since.

This was silently ignored on central until #9711 added `hooks: false` to the sync persist path, which disabled the Sequelize validation step that used to filter unknown columns out of `UPDATE` statements. Encounter **updates** from mobile now fail on the central server with `column "dietId" of relation "encounters" does not exist`, breaking the whole sync session (new encounters still succeed, because `bulkCreate` restricts to known columns). This release line received #9711, so it carries the regression.

This removes the dead `dietId` column (new mobile TypeORM migration) and the `diet`/`dietId` model fields, so mobile stops sending a column the server hasn't had for years. The field was never wired to any mobile UI, so there is no data to preserve.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
