### PR TITLE
chore: no-issue: document targeted sync_lookup rebuild for fkey conflicts

### DIFF
--- a/llm/docs/on-call-cheatsheet.md
+++ b/llm/docs/on-call-cheatsheet.md
@@ -274,6 +274,48 @@ respond @denied 429
 
 In this case there might be fkey conflict errors that don't make sense like somehow the server is not getting the rows it's requesting. This is probably due to the sync_lookup table for the device being "in the future" compared to the local sync status. An easy fix at the cost of longer sync for all devices for the next session is to truncate the sync_lookup table.
 
+## Rebuilding the sync_lookup for a single entity (targeted)
+
+When sync fails with a foreign key violation on pull — e.g. a child row arrives
+on the facility but its parent is missing:
+
+```
+insert or update on table "pharmacy_order_prescriptions" violates foreign key constraint "pharmacy_order_prescriptions_pharmacy_order_id_fkey"
+```
+
+it usually means the parent table's `sync_lookup` rows have diverged from the
+actual data (the child is flagged as belonging to the device but the parent
+isn't). Truncating the whole `sync_lookup` (above) fixes it but slows the next
+sync for **every** device. The surgical alternative is to rebuild the lookup for
+just the affected model(s).
+
+Run on **central** (in read-write mode):
+
+```sql
+SELECT flag_lookup_model_to_rebuild('pharmacy_orders');
+SELECT flag_lookup_model_to_rebuild('pharmacy_order_prescriptions');
+```
+
+Pass the **table name** (e.g. `pharmacy_orders`, `encounters`, `notes`). This
+appends the table to the `lookupModelsToRebuild` key in `local_system_facts`. On
+the next sync_lookup refresh, the central server fully rebuilds that model's
+lookup rows (reselecting every row instead of the incremental `since` filter),
+then clears the flag automatically. No restart needed — just wait for the next
+refresh, then have the affected facility sync again.
+
+Flag the parent and the child together when a fkey conflict points at the child:
+the parent's lookup is what's stale, but rebuilding both is safe and avoids a
+second round trip. To confirm the actual orphan before deciding, check central
+for a child whose parent is genuinely gone (that's a data problem, not a lookup
+one — rebuilding won't help):
+
+```sql
+SELECT pop.id, pop.pharmacy_order_id
+FROM pharmacy_order_prescriptions pop
+LEFT JOIN pharmacy_orders po ON po.id = pop.pharmacy_order_id
+WHERE po.id IS NULL;
+```
+
 ## Sync pull page limit is not scaling properly
 
 You might see in the sync log something like


### PR DESCRIPTION
### Changes

Adds an on-call cheatsheet section documenting `flag_lookup_model_to_rebuild('<table>')` — the targeted way to rebuild a single entity's `sync_lookup` rows on central, as the surgical alternative to truncating the whole table. Prompted by a recurring `pharmacy_order_prescriptions` foreign-key violation during facility pull. Docs only.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->