### PR TITLE
feat(build): no-issue: vite consumes shared package source for instant HMR

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -7,10 +7,12 @@
   "module": "dist/mjs/index.js",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "import": "./dist/mjs/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./*": {
+      "source": "./src/*.ts",
       "import": "./dist/mjs/*.js",
       "require": "./dist/cjs/*.js"
     }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -8,11 +8,13 @@
   "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/esm/index.d.ts"
     },
     "./*": {
+      "source": "./src/*.ts",
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/esm/*.d.ts"

--- a/packages/patient-portal/vite.config.ts
+++ b/packages/patient-portal/vite.config.ts
@@ -35,6 +35,10 @@ export default async () =>
         '@components': path.resolve(__dirname, 'src/components'),
         '@routes': path.resolve(__dirname, 'src/routes'),
       },
+      // Consume @tamanu/* workspace packages' TypeScript source directly (via their
+      // `source` export condition) so edits to shared packages hot-reload without a
+      // rebuild. Node/jest/swc don't honour this condition and keep using built dist.
+      conditions: ['source', 'module', 'browser', 'development|production'],
       dedupe: ['@mui/x-date-pickers'],
     },
     server: {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -7,30 +7,37 @@
   "module": "dist/mjs/index.js",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "import": "./dist/mjs/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./cache": {
+      "source": "./src/cache/index.ts",
       "import": "./dist/mjs/cache/index.js",
       "require": "./dist/cjs/cache/index.js"
     },
     "./schema": {
+      "source": "./src/schema/index.ts",
       "import": "./dist/mjs/schema/index.js",
       "require": "./dist/cjs/schema/index.js"
     },
     "./types": {
+      "source": "./src/types/index.ts",
       "import": "./dist/mjs/types/index.js",
       "require": "./dist/cjs/types/index.js"
     },
     "./test": {
+      "source": "./src/test/index.ts",
       "import": "./dist/mjs/test/index.js",
       "require": "./dist/cjs/test/index.js"
     },
     "./reader": {
+      "source": "./src/reader/index.ts",
       "import": "./dist/mjs/reader/index.js",
       "require": "./dist/cjs/reader/index.js"
     },
     "./middleware": {
+      "source": "./src/middleware/index.ts",
       "import": "./dist/mjs/middleware/index.js",
       "require": "./dist/cjs/middleware/index.js"
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,16 +7,19 @@
   "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/esm/index.d.ts"
     },
     "./invoice": {
+      "source": "./src/invoice/index.ts",
       "import": "./dist/esm/invoice/index.js",
       "require": "./dist/cjs/invoice/index.js",
       "types": "./dist/esm/invoice/index.d.ts"
     },
     "./*": {
+      "source": "./src/*.ts",
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/esm/*.d.ts"

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -53,6 +53,10 @@ export default async () => {
     },
     plugins: [react(), json5Plugin(), svgr()],
     resolve: {
+      // Consume @tamanu/* workspace packages' TypeScript source directly (via their
+      // `source` export condition) so edits to shared packages hot-reload without a
+      // rebuild. Node/jest/swc don't honour this condition and keep using built dist.
+      conditions: ['source', 'module', 'browser', 'development|production'],
       dedupe: ['@mui/x-date-pickers'],
     },
 

--- a/scripts/add-source-condition.mjs
+++ b/scripts/add-source-condition.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Add a `source` export condition to packages so bundlers (vite) can consume the
+ * TypeScript source directly for instant HMR, while Node/jest/swc keep resolving to
+ * the built `dist` via the existing `import`/`require` conditions.
+ *
+ * For each entry in a package's `exports` map it derives the source path from the
+ * existing target (`./dist/{esm,cjs,mjs}/X.js` -> `./src/X.ts`) and inserts `source`
+ * as the first condition. Idempotent: entries that already have `source` are skipped,
+ * and entries whose derived source file does not exist on disk are left untouched.
+ *
+ * Usage: node scripts/add-source-condition.mjs <packageDir ...>
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const packages = process.argv.slice(2);
+if (!packages.length) {
+  console.error('Usage: node scripts/add-source-condition.mjs <packageDir ...>');
+  process.exit(1);
+}
+
+/** Turn a built target into its TS source equivalent, or null if it isn't a dist path. */
+function toSource(target) {
+  if (typeof target !== 'string' || !/^\.\/dist\/(esm|cjs|mjs)\//.test(target)) return null;
+  return target.replace(/^\.\/dist\/(esm|cjs|mjs)\//, './src/').replace(/\.js$/, '.ts');
+}
+
+for (const pkgDir of packages) {
+  const pkgPath = resolve(pkgDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  if (!pkg.exports || typeof pkg.exports !== 'object') {
+    console.warn(`${pkgDir}: no exports map — skipped (add one manually if needed)`);
+    continue;
+  }
+
+  let added = 0;
+  let skipped = 0;
+  for (const [subpath, value] of Object.entries(pkg.exports)) {
+    if (typeof value !== 'object' || value === null) continue; // string target: leave
+    if ('source' in value) continue; // idempotent
+    const src = toSource(value.import ?? value.require ?? value.default);
+    if (!src) continue;
+    // For concrete (non-wildcard) paths, only add when the source actually exists.
+    if (!src.includes('*') && !existsSync(resolve(pkgDir, src))) {
+      console.warn(`${pkgDir}: ${subpath} -> ${src} missing, left dist-only`);
+      skipped += 1;
+      continue;
+    }
+    // Reinsert with `source` first so it takes precedence in resolvers that honour it.
+    pkg.exports[subpath] = { source: src, ...value };
+    added += 1;
+  }
+
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(`${pkgDir}: added source to ${added} entr${added === 1 ? 'y' : 'ies'}${skipped ? `, skipped ${skipped}` : ''}`);
+}


### PR DESCRIPTION
### Changes

🤖 Frontend devs currently have to rebuild the shared `@tamanu/*` packages (or run `watch-shared-and`) before an edit to shared code shows up in web/patient-portal. This PR makes vite consume those packages' **TypeScript source directly** instead of their built `dist`, so shared edits hot-reload instantly with no rebuild.

The mechanism is a `source` export condition added to each package's `exports`, pointing at `src`. Vite is configured (`resolve.conditions: ['source', ...]`) to prefer it. Crucially, **nothing else changes**: Node, jest, swc and metro don't honour the `source` condition, so they keep resolving to `dist` exactly as before — servers and tests are untouched. No build-step removal, no codemod, no Node 24 requirement (verified on Node 20).

Scope: the four pure-TypeScript, browser-safe shared packages — `@tamanu/constants`, `@tamanu/utils`, `@tamanu/settings`, `@tamanu/api-client`. A small helper (`scripts/add-source-condition.mjs`) derives the `source` target from each existing export entry and is idempotent (re-runnable as packages adopt it).

Verified on Node 20:
- `vite build` of web succeeds with `constants/dist` removed — proving source is genuinely consumed, not a silent dist fallback.
- web dev server serves the shared source transformed (HMR path).
- web unit tests (vitest, which inherits the config) pass 52/52.

Deliberately out of scope (follow-ups): `@tamanu/shared` and `@tamanu/database` are mostly `.js`/`.jsx` with non-mirror source layouts and pull node-oriented code (react-pdf, sequelize) — they need extension-aware mapping and per-subpath browser-safety review. `@tamanu/ui-components` already exports source. Live cross-package **types** on edit (tsc `customConditions`) is a separate nicety, not included here.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->