### PR TITLE
build: no-issue: native-ESM tooling + build-less config for leaf packages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -103,6 +103,14 @@ export default [
 
       // for ts multiple dispatch
       'no-dupe-class-members': 'off',
+
+      // Mark type-only imports explicitly so native type stripping (and bundlers) can
+      // erase them. `--fix` rewrites e.g. `import { Foo }` -> `import { type Foo }`.
+      // Required once a package runs build-less (verbatimModuleSyntax).
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { fixStyle: 'inline-type-imports', disallowTypeAnnotations: false },
+      ],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "clean:deps": "npm run clean:deps --workspaces --if-present && rimraf node_modules",
     "create-package": "node scripts/create-package.mjs",
     "create-migration": "node scripts/create-server-migration.mjs",
+    "codemod:import-extensions": "node scripts/codemod-import-extensions.mjs",
+    "codemod:lodash-imports": "node scripts/codemod-lodash-named-imports.mjs",
     "build": "turbo build",
     "clean-build": "turbo run clean-build --force",
     "test": "npm run build && node scripts/test-all.mjs",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -3,29 +3,16 @@
   "version": "2.59.0",
   "private": true,
   "description": "API client for Tamanu Facility Server",
-  "main": "dist/cjs/index.js",
-  "module": "dist/mjs/index.js",
+  "main": "./src/index.ts",
   "exports": {
-    ".": {
-      "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./*": {
-      "import": "./dist/mjs/*.js",
-      "require": "./dist/cjs/*.js"
-    }
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "npm run build:src && npm run build:cjs && npm run build:types && dual-pkg dist/mjs dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:src": "swc --delete-dir-on-start --out-dir dist/mjs --copy-files --source-maps true src",
-    "build:cjs": "npm run build:src -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/mjs --rootDir src && move-dts --copy dist/mjs dist/cjs",
-    "build-watch": "npm run build && concurrently \"npm run build:src -- --watch\" \"npm run build:cjs -- --watch\"",
     "clean": "rimraf -- dist .tsbuild",
     "clean:deps": "rimraf -- node_modules"
   },
@@ -41,5 +28,6 @@
     "jose": "^5.1.1",
     "lodash": "^4.17.21",
     "qs": "^6.10.2"
-  }
+  },
+  "type": "module"
 }

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../common.tsconfig.json",
   "include": ["src/**/*.ts"],
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "./src",
     "strict": false,
     "esModuleInterop": true,

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -3,33 +3,17 @@
   "version": "2.59.0",
   "private": true,
   "description": "Shared constants",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/esm/index.d.ts"
-    },
-    "./*": {
-      "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/esm/*.d.ts"
-    }
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "concurrently -n esm,cjs -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" && move-dts --copy dist/esm dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:cjs": "swc --copy-files --source-maps true --out-dir dist/cjs src",
-    "build:esm": "tsc",
-    "build:types:cjs": "tsc --emitDeclarationOnly --outDir dist/cjs",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules"
   },
@@ -39,5 +23,6 @@
     "date-fns": "^2.25.0",
     "concurrently": "^9.2.1",
     "rimraf": "^6.1.3"
-  }
+  },
+  "type": "module"
 }

--- a/packages/constants/tsconfig.json
+++ b/packages/constants/tsconfig.json
@@ -4,12 +4,14 @@
     "src/**/*.ts"
   ],
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
     "declaration": true,
     "declarationMap": true,
     "incremental": true,
     "module": "ES2022",
     "moduleResolution": "bundler",
-    "noEmit": false,
+    "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "outDir": "./dist/esm",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -3,84 +3,27 @@
   "version": "2.59.0",
   "private": true,
   "description": "BES - Database",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
-    ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "types": "./dist/esm/index.d.ts"
-    },
-    "./*": {
-      "require": "./dist/cjs/*.js",
-      "import": "./dist/esm/*.js",
-      "types": "./dist/esm/*.d.ts"
-    },
-    "./demoData": {
-      "require": "./dist/cjs/demoData/index.js",
-      "import": "./dist/esm/demoData/index.js",
-      "types": "./dist/esm/demoData/index.d.ts"
-    },
-    "./demoData/*": {
-      "require": "./dist/cjs/demoData/*.js",
-      "import": "./dist/esm/demoData/*.js",
-      "types": "./dist/esm/demoData/*.d.ts"
-    },
-    "./dataMigrations": {
-      "require": "./dist/cjs/dataMigrations/index.js",
-      "import": "./dist/esm/dataMigrations/index.js",
-      "types": "./dist/esm/dataMigrations/index.d.ts"
-    },
-    "./dataMigrations/*": {
-      "require": "./dist/cjs/dataMigrations/*.js",
-      "import": "./dist/esm/dataMigrations/*.js",
-      "types": "./dist/esm/dataMigrations/*.d.ts"
-    },
-    "./services/migrations": {
-      "require": "./dist/cjs/services/migrations/index.js",
-      "import": "./dist/esm/services/migrations/index.js",
-      "types": "./dist/esm/services/migrations/index.d.ts"
-    },
-    "./services/migrations/*": {
-      "require": "./dist/cjs/services/migrations/*.js",
-      "import": "./dist/esm/services/migrations/*.js",
-      "types": "./dist/esm/services/migrations/*.d.ts"
-    },
-    "./services/database": {
-      "require": "./dist/cjs/services/database.js",
-      "import": "./dist/esm/services/database.js",
-      "types": "./dist/esm/services/database.d.ts"
-    },
-    "./sync": {
-      "require": "./dist/cjs/sync/index.js",
-      "import": "./dist/esm/sync/index.js",
-      "types": "./dist/esm/sync/index.d.ts"
-    },
-    "./utils/fhir": {
-      "require": "./dist/cjs/utils/fhir/index.js",
-      "import": "./dist/esm/utils/fhir/index.js",
-      "types": "./dist/esm/utils/fhir/index.d.ts"
-    },
-    "./utils/audit": {
-      "require": "./dist/cjs/utils/audit/index.js",
-      "import": "./dist/esm/utils/audit/index.js",
-      "types": "./dist/esm/utils/audit/index.d.ts"
-    }
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./demoData": "./src/demoData/index.js",
+    "./demoData/*": "./src/demoData/*.ts",
+    "./dataMigrations": "./src/dataMigrations/index.js",
+    "./dataMigrations/*": "./src/dataMigrations/*.ts",
+    "./services/migrations": "./src/services/migrations/index.js",
+    "./services/migrations/*": "./src/services/migrations/*.ts",
+    "./services/database": "./src/services/database.js",
+    "./sync": "./src/sync/index.ts",
+    "./utils/fhir": "./src/utils/fhir/index.ts",
+    "./utils/audit": "./src/utils/audit/index.ts"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later AND BUSL-1.1",
   "scripts": {
-    "build": "concurrently -n esm,cjs,types -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" \"npm run build:types\"",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:esm -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:esm": "swc --out-dir dist/esm --copy-files --source-maps true src",
-    "build:cjs": "npm run build:esm -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "npm run build:types:esm && move-dts --copy dist/esm dist/cjs",
-    "build:types:esm": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/esm",
-    "build:types:cjs": "npm run build:types:esm -- --outDir dist/cjs",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules",
     "test": "vitest run --no-file-parallelism",
@@ -125,5 +68,6 @@
     "umzug": "^2.3.0",
     "yup": "^0.32.11",
     "zod": "^4.4.3"
-  }
+  },
+  "type": "module"
 }

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
     "allowJs": true,
     "baseUrl": "./src",
     "declaration": true,

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -3,21 +3,13 @@
   "version": "2.59.0",
   "private": true,
   "description": "API errors",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "concurrently -n esm,cjs -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" && move-dts --copy dist/esm dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:cjs": "swc --copy-files --source-maps true --out-dir dist/cjs src",
-    "build:esm": "tsc",
-    "build:types:cjs": "tsc --emitDeclarationOnly --outDir dist/cjs",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules"
   },
@@ -32,5 +24,6 @@
     "@types/node": "^18.14.6",
     "concurrently": "^9.2.1",
     "rimraf": "^6.1.3"
-  }
+  },
+  "type": "module"
 }

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -4,12 +4,14 @@
     "src/**/*.ts"
   ],
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
     "declaration": true,
     "declarationMap": true,
     "incremental": true,
     "module": "ES2022",
     "moduleResolution": "bundler",
-    "noEmit": false,
+    "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "outDir": "./dist/esm",

--- a/packages/fake-data/package.json
+++ b/packages/fake-data/package.json
@@ -3,53 +3,22 @@
   "version": "2.59.0",
   "private": true,
   "description": "TODO",
-  "main": "dist/cjs/index.js",
-  "module": "dist/mjs/index.js",
+  "main": "./src/index.ts",
   "exports": {
-    ".": {
-      "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./populateDb": {
-      "import": "./dist/mjs/populateDb/index.js",
-      "require": "./dist/cjs/populateDb/index.js"
-    },
-    "./fake": {
-      "import": "./dist/mjs/fake/index.js",
-      "require": "./dist/cjs/fake/index.js"
-    },
-    "./fake/*": {
-      "import": "./dist/mjs/fake/*.js",
-      "require": "./dist/cjs/fake/*.js"
-    },
-    "./test-helpers": {
-      "import": "./dist/mjs/test-helpers/index.js",
-      "require": "./dist/cjs/test-helpers/index.js"
-    },
-    "./test-helpers/*": {
-      "import": "./dist/mjs/test-helpers/*.js",
-      "require": "./dist/cjs/test-helpers/*.js"
-    },
-    "./services/*": {
-      "import": "./dist/mjs/services/*.js",
-      "require": "./dist/cjs/services/*.js"
-    },
-    "./utils/*": {
-      "import": "./dist/mjs/utils/*.js",
-      "require": "./dist/cjs/utils/*.js"
-    }
+    ".": "./src/index.ts",
+    "./populateDb": "./src/populateDb/index.ts",
+    "./fake": "./src/fake/index.ts",
+    "./fake/*": "./src/fake/*.ts",
+    "./test-helpers": "./src/test-helpers/index.js",
+    "./test-helpers/*": "./src/test-helpers/*.ts",
+    "./services/*": "./src/services/*.ts",
+    "./utils/*": "./src/utils/*.ts"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "npm run build:src && npm run build:cjs && npm run build:types && dual-pkg dist/mjs dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:src": "swc --delete-dir-on-start --out-dir dist/mjs --copy-files --source-maps true src",
-    "build:cjs": "npm run build:src -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/mjs --rootDir src && move-dts --copy dist/mjs dist/cjs",
-    "build-watch": "npm run build && concurrently \"npm run build:src -- --watch\" \"npm run build:cjs -- --watch\"",
     "clean": "rimraf -- dist .tsbuild",
     "clean:deps": "rimraf -- node_modules",
     "test": "NODE_ENV=test jest"
@@ -77,5 +46,6 @@
     "sequelize": "^6.37.8",
     "zocker": "^2.2.2",
     "zod": "^4.0.17"
-  }
+  },
+  "type": "module"
 }

--- a/packages/fake-data/tsconfig.json
+++ b/packages/fake-data/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../common.tsconfig.json",
   "include": ["src/**/*.ts"],
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "./src",
     "strict": false,
     "esModuleInterop": true,

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -3,49 +3,21 @@
   "version": "2.59.0",
   "private": true,
   "description": "BES - Settings",
-  "main": "dist/cjs/index.js",
-  "module": "dist/mjs/index.js",
+  "main": "./src/index.ts",
   "exports": {
-    ".": {
-      "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./cache": {
-      "import": "./dist/mjs/cache/index.js",
-      "require": "./dist/cjs/cache/index.js"
-    },
-    "./schema": {
-      "import": "./dist/mjs/schema/index.js",
-      "require": "./dist/cjs/schema/index.js"
-    },
-    "./types": {
-      "import": "./dist/mjs/types/index.js",
-      "require": "./dist/cjs/types/index.js"
-    },
-    "./test": {
-      "import": "./dist/mjs/test/index.js",
-      "require": "./dist/cjs/test/index.js"
-    },
-    "./reader": {
-      "import": "./dist/mjs/reader/index.js",
-      "require": "./dist/cjs/reader/index.js"
-    },
-    "./middleware": {
-      "import": "./dist/mjs/middleware/index.js",
-      "require": "./dist/cjs/middleware/index.js"
-    }
+    ".": "./src/index.ts",
+    "./cache": "./src/cache/index.ts",
+    "./schema": "./src/schema/index.ts",
+    "./types": "./src/types/index.ts",
+    "./test": "./src/test/index.ts",
+    "./reader": "./src/reader/index.ts",
+    "./middleware": "./src/middleware/index.ts"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "npm run build:src && npm run build:cjs && npm run build:types && dual-pkg dist/mjs dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:src": "swc --delete-dir-on-start --out-dir dist/mjs --copy-files --source-maps true src",
-    "build:cjs": "npm run build:src -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/mjs --rootDir src && move-dts --copy dist/mjs dist/cjs",
-    "build-watch": "npm run build && concurrently \"npm run build:src  -- --delete-dir-on-start=false --watch\" \"npm run build:cjs -- --delete-dir-on-start=false --watch\"",
     "clean": "rimraf -- dist .tsbuild",
     "clean:deps": "rimraf -- node_modules",
     "test": "NODE_ENV=test jest --passWithNoTests",
@@ -73,5 +45,6 @@
     "@types/lodash": "^4.14.197",
     "lodash": "^4.17.21",
     "yup": "^1.4.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/settings/tsconfig.json
+++ b/packages/settings/tsconfig.json
@@ -4,6 +4,8 @@
     "src/**/*.ts",
   ],
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "./src",
     "strict": false,
     "esModuleInterop": true,

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -3,29 +3,16 @@
   "version": "2.59.0",
   "private": true,
   "description": "Tamanu upgrade files",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
-    ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "types": "./dist/esm/index.d.ts"
-    }
+    ".": "./src/index.ts"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "concurrently -n esm,cjs,types -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs && npm run package-default-translations\" \"npm run build:types\"",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:esm -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:esm": "swc --out-dir dist/esm --copy-files --source-maps true src",
-    "build:cjs": "npm run build:esm -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "npm run build:types:esm && move-dts --copy dist/esm dist/cjs",
-    "build:types:esm": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/esm",
-    "build:types:cjs": "npm run build:types:esm -- --outDir dist/cjs",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules",
     "test": "vitest run --no-file-parallelism",
@@ -50,5 +37,6 @@
     "sequelize": "^6.37.8",
     "toposort": "^2.0.2",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
-  }
+  },
+  "type": "module"
 }

--- a/packages/upgrade/tsconfig.json
+++ b/packages/upgrade/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
     "allowJs": true,
     "baseUrl": "./src",
     "declaration": true,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,41 +3,20 @@
   "version": "2.59.0",
   "private": true,
   "description": "Common code across Tamanu packages",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/esm/index.d.ts"
-    },
-    "./invoice": {
-      "import": "./dist/esm/invoice/index.js",
-      "require": "./dist/cjs/invoice/index.js",
-      "types": "./dist/esm/invoice/index.d.ts"
-    },
-    "./*": {
-      "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/esm/*.d.ts"
-    }
+    ".": "./src/index.ts",
+    "./invoice": "./src/invoice/index.ts",
+    "./*": "./src/*.ts"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "concurrently -n esm,cjs,types -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" \"npm run build:types\"",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:esm -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:esm": "swc --out-dir dist/esm --copy-files --source-maps true src",
-    "build:cjs": "npm run build:esm -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "npm run build:types:esm && move-dts --copy dist/esm dist/cjs",
-    "build:types:esm": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/esm",
-    "build:types:cjs": "npm run build:types:esm -- --outDir dist/cjs",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules",
-    "build-watch": "npm run build:dev:watch",
     "test": "vitest run",
     "test:watch": "vitest --watch"
   },
@@ -58,5 +37,6 @@
     "nanoid": "^3.3.8",
     "temporal-polyfill": "^0.3.0",
     "zod": "^4.0.17"
-  }
+  },
+  "type": "module"
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "allowJs": true,
     "baseUrl": "./src",
     "declaration": true,

--- a/scripts/codemod-import-extensions.mjs
+++ b/scripts/codemod-import-extensions.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Codemod: add explicit file extensions to relative import/export specifiers.
+ *
+ * Node runs build-less source as ES modules, where relative specifiers need an
+ * explicit extension (`./foo` -> `./foo.ts`). This rewrites extensionless relative
+ * specifiers to point at the real target file, and fixes the TypeScript
+ * `./foo.js`-means-`foo.ts` convention (native Node does not remap `.js` -> `.ts`).
+ *
+ * Handles `.ts`/`.tsx`/`.js`/`.jsx` source. Idempotent and re-runnable: specifiers
+ * that already resolve to a real file are left alone, so a long-lived branch can
+ * merge `main` and re-run this to fix only the newly introduced imports.
+ *
+ * Usage: node scripts/codemod-import-extensions.mjs [packageDir ...]
+ * With no args, processes the default Node-run package set (src/ and app/).
+ */
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { Project, QuoteKind, SyntaxKind } from 'ts-morph';
+
+const DEFAULT_PACKAGES = [
+  'packages/constants',
+  'packages/errors',
+  'packages/utils',
+  'packages/settings',
+  'packages/database',
+  'packages/shared',
+  'packages/api-client',
+  'packages/central-server',
+  'packages/facility-server',
+  'packages/fake-data',
+  'packages/upgrade',
+  'packages/scripts',
+];
+
+const TS_EXT = /\.(ts|tsx)$/;
+const ASSET_EXT = /\.(json|css|scss|svg|png|jpg|jpeg|gif|wasm)$/;
+const JS_EXT = /\.(js|jsx|mjs|cjs)$/;
+// Candidate target extensions, in resolution priority (TS-first repo).
+const CANDIDATES = ['.ts', '.tsx', '.js', '.jsx'];
+
+const packages = process.argv.slice(2).length ? process.argv.slice(2) : DEFAULT_PACKAGES;
+
+/** Rewrite a relative specifier to point at its real target file, or null to leave it. */
+function resolveSpecifier(fromFile, spec) {
+  if (!spec.startsWith('.')) return null; // bare/package imports
+  if (ASSET_EXT.test(spec)) return null; // non-code assets
+
+  const dir = dirname(fromFile);
+  // A real file already sitting at the literal specifier (incl. correct .ts/.js) — done.
+  if ((TS_EXT.test(spec) || JS_EXT.test(spec)) && existsSync(resolve(dir, spec))) return null;
+  // Strip a JS-style extension (the `./foo.js`-means-source convention) to find the source.
+  const jsMatch = spec.match(JS_EXT);
+  const bare = jsMatch ? spec.slice(0, -jsMatch[0].length) : spec.replace(TS_EXT, '');
+  const base = resolve(dir, bare);
+
+  for (const ext of CANDIDATES) if (existsSync(`${base}${ext}`)) return `${bare}${ext}`;
+  const sep = bare.endsWith('/') ? '' : '/';
+  for (const ext of CANDIDATES) if (existsSync(`${base}/index${ext}`)) return `${bare}${sep}index${ext}`;
+  return null; // unresolved: warn, don't guess
+}
+
+const project = new Project({
+  skipAddingFilesFromTsConfig: true,
+  manipulationSettings: { quoteKind: QuoteKind.Single },
+  compilerOptions: { allowJs: true, jsx: 2 /* preserve */ },
+});
+
+for (const pkg of packages) {
+  for (const sub of ['src', 'app']) {
+    project.addSourceFilesAtPaths(`${pkg}/${sub}/**/*.{ts,tsx,js,jsx}`);
+  }
+}
+
+let changed = 0;
+let unresolved = 0;
+const touchedFiles = new Set();
+
+for (const sourceFile of project.getSourceFiles()) {
+  const filePath = sourceFile.getFilePath();
+  let fileTouched = false;
+
+  const rewrite = node => {
+    const spec = node.getLiteralValue();
+    const next = resolveSpecifier(filePath, spec);
+    if (next === null) {
+      if (spec.startsWith('.') && !TS_EXT.test(spec) && !ASSET_EXT.test(spec) && !JS_EXT.test(spec)) {
+        console.warn(`  ! could not resolve ${JSON.stringify(spec)} in ${filePath}`);
+        unresolved += 1;
+      }
+      return;
+    }
+    if (next === spec) return;
+    node.setLiteralValue(next);
+    changed += 1;
+    fileTouched = true;
+  };
+
+  for (const decl of [...sourceFile.getImportDeclarations(), ...sourceFile.getExportDeclarations()]) {
+    const literal = decl.getModuleSpecifier();
+    if (literal) rewrite(literal);
+  }
+  for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    const expr = call.getExpression();
+    const isImport = expr.getKind() === SyntaxKind.ImportKeyword;
+    const isRequire = expr.getKind() === SyntaxKind.Identifier && expr.getText() === 'require';
+    if (!isImport && !isRequire) continue;
+    const [arg] = call.getArguments();
+    if (arg && arg.getKind() === SyntaxKind.StringLiteral) rewrite(arg);
+  }
+
+  if (fileTouched) touchedFiles.add(filePath);
+}
+
+project.saveSync();
+console.log(`\nRewrote ${changed} specifier(s) across ${touchedFiles.size} file(s).`);
+if (unresolved) console.log(`${unresolved} relative specifier(s) could not be resolved — review the warnings above.`);

--- a/scripts/codemod-lodash-named-imports.mjs
+++ b/scripts/codemod-lodash-named-imports.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Codemod: rewrite lodash named imports to per-method default imports.
+ *
+ *   import { isNil, inRange } from 'lodash';
+ *   ->
+ *   import isNil from 'lodash/isNil.js';
+ *   import inRange from 'lodash/inRange.js';
+ *
+ * lodash is CommonJS and does not expose statically-detectable named exports, so
+ * `import { x } from 'lodash'` fails under native ESM (the swc->CJS build hid this).
+ * Per-method default imports resolve cleanly. Aliases are preserved
+ * (`{ foo as bar }` -> `import bar from 'lodash/foo.js'`). Namespace and default
+ * imports of lodash are left alone. Idempotent.
+ *
+ * Usage: node scripts/codemod-lodash-named-imports.mjs [packageDir ...]
+ */
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Project, QuoteKind } from 'ts-morph';
+
+const DEFAULT_PACKAGES = [
+  'packages/constants',
+  'packages/errors',
+  'packages/utils',
+  'packages/settings',
+  'packages/database',
+  'packages/shared',
+  'packages/api-client',
+  'packages/central-server',
+  'packages/facility-server',
+  'packages/fake-data',
+  'packages/upgrade',
+  'packages/scripts',
+];
+
+const packages = process.argv.slice(2).length ? process.argv.slice(2) : DEFAULT_PACKAGES;
+const lodashRoot = resolve('node_modules/lodash');
+
+const project = new Project({
+  skipAddingFilesFromTsConfig: true,
+  manipulationSettings: { quoteKind: QuoteKind.Single },
+  compilerOptions: { allowJs: true, jsx: 2 },
+});
+for (const pkg of packages) {
+  for (const sub of ['src', 'app']) {
+    project.addSourceFilesAtPaths(`${pkg}/${sub}/**/*.{ts,tsx,js,jsx}`);
+  }
+}
+
+let changed = 0;
+let skipped = 0;
+const touched = new Set();
+
+for (const sourceFile of project.getSourceFiles()) {
+  for (const imp of sourceFile.getImportDeclarations()) {
+    if (imp.getModuleSpecifierValue() !== 'lodash') continue;
+    if (imp.getNamespaceImport()) continue; // `import * as _ from 'lodash'` is fine
+
+    const named = imp.getNamedImports().filter(n => !n.isTypeOnly());
+    if (named.length === 0) continue;
+
+    const specs = named.map(n => ({ name: n.getName(), local: n.getAliasNode()?.getText() ?? n.getName() }));
+    // Only rewrite when every name maps to a real lodash per-method module.
+    const allResolve = specs.every(s => existsSync(resolve(lodashRoot, `${s.name}.js`)));
+    if (!allResolve) {
+      console.warn(`  ! ${sourceFile.getFilePath()}: some lodash names have no per-method module, left as-is`);
+      skipped += 1;
+      continue;
+    }
+
+    const index = imp.getChildIndex();
+    const hasDefault = Boolean(imp.getDefaultImport());
+    if (hasDefault) {
+      named.forEach(n => n.remove()); // keep `import _ from 'lodash'`
+    } else {
+      imp.remove();
+    }
+    sourceFile.insertImportDeclarations(
+      index,
+      specs.map(s => ({ defaultImport: s.local, moduleSpecifier: `lodash/${s.name}.js` })),
+    );
+    changed += specs.length;
+    touched.add(sourceFile.getFilePath());
+  }
+}
+
+project.saveSync();
+console.log(`\nRewrote ${changed} lodash import(s) across ${touched.size} file(s).`);
+if (skipped) console.log(`${skipped} import statement(s) skipped — review the warnings above.`);

--- a/scripts/convert-package-to-source.mjs
+++ b/scripts/convert-package-to-source.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Convert a package to build-less: consumed directly from `src` (TypeScript/JS),
+ * run by Node's native type stripping (and the JSX register hook for .jsx/.tsx),
+ * with no dist build.
+ *
+ * Edits package.json only (the deliberate, reviewable part):
+ *   - sets "type": "module"
+ *   - rewrites "main"/"exports" to point at the real ./src file (extension-aware:
+ *     resolves .ts/.tsx/.js/.jsx, including /index.*), instead of ./dist/**
+ *   - drops the build/clean-build/build:* scripts
+ *
+ * Wildcard exports (./*) can't be probed, so they keep a .ts target as a best-effort
+ * default and are reported — review those for packages with non-.ts source.
+ *
+ * Usage: node scripts/convert-package-to-source.mjs <packageDir ...>
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const packages = process.argv.slice(2);
+if (!packages.length) {
+  console.error('Usage: node scripts/convert-package-to-source.mjs <packageDir ...>');
+  process.exit(1);
+}
+const EXTS = ['.ts', '.tsx', '.js', '.jsx'];
+
+/** Map a built target (./dist/{esm,cjs,mjs}/X.js) to the real ./src source file. */
+function toSource(pkgDir, target) {
+  if (typeof target !== 'string' || !/^\.\/dist\/(esm|cjs|mjs)\//.test(target)) return target;
+  const bare = target.replace(/^\.\/dist\/(esm|cjs|mjs)\//, './src/').replace(/\.js$/, '');
+  if (bare.includes('*')) return { wildcard: `${bare}.ts` };
+  for (const ext of EXTS) if (existsSync(resolve(pkgDir, `${bare}${ext}`))) return `${bare}${ext}`;
+  for (const ext of EXTS) if (existsSync(resolve(pkgDir, `${bare}/index${ext}`))) return `${bare}/index${ext}`;
+  return { missing: `${bare}.ts` };
+}
+
+function indexSource(pkgDir) {
+  for (const ext of EXTS) if (existsSync(resolve(pkgDir, `src/index${ext}`))) return `./src/index${ext}`;
+  return './src/index.ts';
+}
+
+for (const pkgDir of packages) {
+  const pkgPath = resolve(pkgDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  const warnings = [];
+
+  pkg.type = 'module';
+  const idx = indexSource(pkgDir);
+  if (pkg.main) pkg.main = idx;
+  if (pkg.module) delete pkg.module;
+  if (pkg.types) pkg.types = idx;
+
+  const mapEntry = (subpath, value) => {
+    const raw = typeof value === 'string' ? value : (value.import ?? value.require ?? value.default);
+    const mapped = toSource(pkgDir, raw);
+    if (mapped && mapped.wildcard) {
+      warnings.push(`${subpath} (wildcard -> ${mapped.wildcard}, review for non-.ts source)`);
+      return mapped.wildcard;
+    }
+    if (mapped && mapped.missing) {
+      warnings.push(`${subpath} -> no source found, left ${mapped.missing}`);
+      return mapped.missing;
+    }
+    return mapped ?? value;
+  };
+
+  if (pkg.exports && typeof pkg.exports === 'object') {
+    for (const [subpath, value] of Object.entries(pkg.exports)) {
+      pkg.exports[subpath] = mapEntry(subpath, value);
+    }
+  }
+
+  if (pkg.scripts) {
+    for (const name of Object.keys(pkg.scripts)) {
+      if (name === 'build' || name === 'clean-build' || name.startsWith('build:') || name === 'build-watch') {
+        delete pkg.scripts[name];
+      }
+    }
+  }
+
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(`${pkgDir}: converted (type:module, exports->src, build scripts removed)`);
+  for (const w of warnings) console.log(`    ⚠ ${w}`);
+}

--- a/scripts/jsx-register.mjs
+++ b/scripts/jsx-register.mjs
@@ -1,0 +1,29 @@
+/**
+ * Node module customization hook that transforms .jsx/.tsx (and .ts/.js with JSX)
+ * on the fly with esbuild, so build-less packages containing JSX (the react-pdf
+ * templates in @tamanu/shared and the server PDF entry points) run under native Node.
+ *
+ * Plain .ts is handled by Node's built-in type stripping; plain .js runs natively.
+ * Only JSX needs this hook, because JSX is not valid JS/TS syntax that Node can run.
+ *
+ * Usage: node --import ./scripts/jsx-register.mjs <entry>
+ */
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { transform } from 'esbuild';
+
+export async function load(url, context, nextLoad) {
+  if (/\.(jsx|tsx)$/.test(url)) {
+    const source = await readFile(fileURLToPath(url), 'utf8');
+    const { code } = await transform(source, {
+      loader: url.endsWith('.tsx') ? 'tsx' : 'jsx',
+      format: 'esm',
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      sourcefile: fileURLToPath(url),
+      sourcemap: 'inline',
+    });
+    return { format: 'module', source: code, shortCircuit: true };
+  }
+  return nextLoad(url, context);
+}


### PR DESCRIPTION
### Changes

🤖 First of two stacked PRs (on the Node 24 branch) that begin running packages from source with no build step. Split so that the **hand-authored, reviewable** changes are isolated from the **mechanical codemod output**, which lands in the follow-up. **This PR intentionally does not build on its own** — the source still uses extensionless imports / lodash named imports / unmarked type imports until the codemod-output PR applies the fixes on top.

Hand-authored changes here:
- Reusable, idempotent codemods (ts-morph): `codemod-import-extensions` (explicit relative extensions, incl. the `./x.js`→`x.ts` convention), `codemod-lodash-named-imports` (lodash named → per-method default imports), and `convert-package-to-source` (flips package.json to build-less). All exposed as `npm run codemod:*`.
- ESLint `@typescript-eslint/consistent-type-imports` (inline style) so type-only imports get marked for stripping — its autofix output lands in the next PR.
- Build-less conversion of the pure-`.ts` leaf packages **constants, utils, errors, settings, upgrade**: `type: module`, `exports`/`main` → `src/*.ts`, build scripts removed, tsconfig gains `allowImportingTsExtensions` + `verbatimModuleSyntax`.

Scope is deliberately the pure-`.ts` leaf packages. Mixed `.ts`/`.js` packages (database, api-client) and the JSX-containing ones (shared, central/facility-server — react-pdf) come later; JSX needs a transform regardless and is its own question.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->