### PR TITLE
fix(medication): no-issue: add missing space in medication "Ends on" date tooltip

### DIFF
--- a/packages/web/app/components/Medication/Mar/MarStatus.jsx
+++ b/packages/web/app/components/Medication/Mar/MarStatus.jsx
@@ -417,7 +417,7 @@ export const MarStatus = ({
     if (isEnd) {
       return (
         <Box maxWidth={105}>
-          <TranslatedText stringId="medication.mar.endsOn.tooltip" fallback="Ends on" />
+          <TranslatedText stringId="medication.mar.endsOn.tooltip" fallback="Ends on" />{' '}
           <DateDisplay date={endDate} timeFormat="default" noTooltip />
         </Box>
       );

--- a/packages/web/app/components/Medication/MedicationTable.jsx
+++ b/packages/web/app/components/Medication/MedicationTable.jsx
@@ -237,7 +237,7 @@ const getMedicationColumns = (
               visible={tooltipTitle}
               title={<Box fontWeight={400}>{tooltipTitle}</Box>}
             >
-              <DateDisplay date={trimToDate(date)} format="shortest" />
+              <DateDisplay date={trimToDate(date)} format="shortest" noTooltip />
             </ConditionalTooltip>
           </NoWrapCell>
         );

--- a/packages/web/app/components/Medication/MedicationTable.jsx
+++ b/packages/web/app/components/Medication/MedicationTable.jsx
@@ -216,7 +216,7 @@ const getMedicationColumns = (
         if (endDate) {
           tooltipTitle = (
             <>
-              <TranslatedText stringId="medication.table.endsOn.label" fallback="Ends on" />
+              <TranslatedText stringId="medication.table.endsOn.label" fallback="Ends on" />{' '}
               <DateDisplay date={endDate} format="shortest" timeFormat="default" noTooltip />
             </>
           );


### PR DESCRIPTION
### Changes

The encounter medication table date-column tooltip rendered the "Ends on" label and the date with no space between them, producing "Ends on25/06/26 02:39pm" when hovering a date cell (reproduced on 2.56 and 2.57). Added an explicit space between the `TranslatedText` label and `DateDisplay` so it reads "Ends on 25/06/26 02:39pm". Applied the same fix to the MAR "Ends on" tooltip, which had the identical pattern.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->