### PR TITLE
repo: embed node runtime in Windows packages instead of via npm

### DIFF
--- a/.github/workflows/cd-package-servers.yml
+++ b/.github/workflows/cd-package-servers.yml
@@ -177,6 +177,12 @@ jobs:
           export NODE_ENV=production
           npm install --userconfig .npmrc.timeout --package-lock
 
+      # Embed the official Windows Node runtime (pm2's interpreter); .node-version
+      # is read from the checked-out repo, the release bundle is the destination.
+      - name: Embed Node runtime (windows)
+        shell: bash
+        run: scripts/embed-node-runtime.sh win-x64 'release-v${{ needs.linux.outputs.version }}'
+
       - name: Prepare final output
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - name: Check package.json against .node-version
-        run: |
-          json=$(jq -r .dependencies.node package.json | cut -c2-)
-          file=$(cat .node-version | cut -c2-)
-          echo "Node.js in package.json:  $json"
-          echo "Node.js in .node-version: $file"
-          test "$json" = "$file"
       - name: Check dockerfile against .node-version
         run: |
           file=$(cat .node-version | cut -c2- | cut -d. -f1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "GPL-3.0-and-later AND BUSL-1.1",
       "dependencies": {
         "concurrently": "^9.2.1",
-        "node": "^20.19.4",
         "patch-package": "^8.0.0"
       },
       "devDependencies": {
@@ -29981,22 +29980,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/node": {
-      "version": "20.20.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-20.20.0.tgz",
-      "integrity": "sha512-gZZuks0CnzTQ2d8t8wLmzTDg8uTxK1z0GjodXhdoEf59FgwmXxewMGy00XIpjmQPED993htSvgEky4QEloGd+Q==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-bin-setup": "^1.0.0"
-      },
-      "bin": {
-        "node": "bin/node"
-      },
-      "engines": {
-        "npm": ">=5.0.0"
-      }
-    },
     "node_modules/node-abi": {
       "version": "3.67.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
@@ -30031,12 +30014,6 @@
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
-    },
-    "node_modules/node-bin-setup": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.4.tgz",
-      "integrity": "sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA==",
-      "license": "ISC"
     },
     "node_modules/node-cache": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
   },
   "dependencies": {
     "concurrently": "^9.2.1",
-    "node": "^20.19.4",
     "patch-package": "^8.0.0"
   },
   "overrides": {

--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -1,6 +1,17 @@
 const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
+
+// Use the Node runtime bundled in runtime/ next to this config if present,
+// otherwise the node running this process.
+const embeddedNode = path.join(
+  __dirname,
+  'runtime',
+  process.platform === 'win32' ? 'node.exe' : path.join('bin', 'node'),
+);
+const interpreter = fs.existsSync(embeddedNode) ? embeddedNode : process.execPath;
 
 // NOTE: We also explicitly set this value in the Dockerfile for when running in containers
 // but the two values should resolve to the same path
@@ -24,7 +35,7 @@ function task(name, args, instances = 1, env = {}) {
     cwd,
     script: './dist/index.js',
     args,
-    interpreter: require.resolve('node/bin/node'),
+    interpreter,
     interpreter_args: `--max_old_space_size=${memory}`,
     instances,
     exec_mode: 'fork',

--- a/packages/facility-server/pm2.config.cjs
+++ b/packages/facility-server/pm2.config.cjs
@@ -1,4 +1,6 @@
 const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const totalMemoryMB = Math.round(os.totalmem() / (1024**2));
 const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6).toFixed(0);
@@ -11,13 +13,22 @@ const defaultApiScale = Math.min(maximumApiScale, Math.max(minimumApiScale, Math
 
 const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
 
+// Use the Node runtime bundled in runtime/ next to this config if present,
+// otherwise the node running this process.
+const embeddedNode = path.join(
+  __dirname,
+  'runtime',
+  process.platform === 'win32' ? 'node.exe' : path.join('bin', 'node'),
+);
+const interpreter = fs.existsSync(embeddedNode) ? embeddedNode : process.execPath;
+
 function task(name, args, instances = 1, env = {}) {
   const base = {
     name,
     cwd,
     script: './dist/index.js',
     args,
-    interpreter: require.resolve('node/bin/node'),
+    interpreter,
     interpreter_args: `--max_old_space_size=${memory}`,
     instances,
     exec_mode: 'fork',

--- a/scripts/embed-node-runtime.sh
+++ b/scripts/embed-node-runtime.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Download a Node.js runtime (version from .node-version) from nodejs.org, verify
+# it against the published SHASUMS256.txt, and place it in a server release
+# bundle's runtime/ directory for pm2 to use as its interpreter
+# (see packages/*/pm2.config.cjs).
+#
+# Usage: scripts/embed-node-runtime.sh <platform> <release-dir>
+#   platform:    win-x64 | linux-x64 | linux-arm64 | darwin-arm64 | ...
+#   release-dir: the release bundle root (gets a runtime/ subdirectory)
+set -euo pipefail
+
+platform="${1:?Expected platform, e.g. win-x64 or linux-x64}"
+release_dir="${2:?Expected release directory}"
+
+version="$(tr -d 'v \t\r\n' < .node-version)"
+base="https://nodejs.org/dist/v${version}"
+runtime="${release_dir}/runtime"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+case "$platform" in
+  win-*) archive="node-v${version}-${platform}.zip" ;;
+  *) archive="node-v${version}-${platform}.tar.xz" ;;
+esac
+
+curl -fsSL -o "${work}/${archive}" "${base}/${archive}"
+curl -fsSL -o "${work}/SHASUMS256.txt" "${base}/SHASUMS256.txt"
+
+# fail-closed: grep exits non-zero (and pipefail trips) if the archive isn't listed.
+# -F so the dots in the version aren't treated as regex; the leading space anchors
+# the filename field (SHASUMS lines are "<hash>  <filename>").
+( cd "$work" && grep -F " ${archive}" SHASUMS256.txt | sha256sum -c - )
+
+mkdir -p "$runtime"
+extracted="${work}/node-v${version}-${platform}"
+case "$platform" in
+  win-*)
+    ( cd "$work" && unzip -q "$archive" )
+    cp -p "${extracted}/node.exe" "${runtime}/node.exe"
+    ;;
+  *)
+    ( cd "$work" && tar -xf "$archive" )
+    mkdir -p "${runtime}/bin"
+    cp -p "${extracted}/bin/node" "${runtime}/bin/node"
+    ;;
+esac
+
+echo "Embedded official Node ${version} (${platform}) into ${runtime}"


### PR DESCRIPTION
### Changes

🤖 Replace the `node` npm **dependency** with the official Node runtime embedded into the Windows server pack.

**Why.** The `node` dependency is a single-maintainer community republish of the Node binary (aredridel / `node-bin-gen`). Its only runtime consumer is pm2's interpreter on **container-less deploys** — containers run `node dist` on the base image's official Node, and dev/CI never use it. So it was dead weight everywhere except the Windows container-less hosts, while adding supply-chain surface, the `node_modules/.bin/node` PATH shadowing, and `npm ls` extraneous noise.

**What.**
- Drop `node` from `package.json` (and the lockfile) — gone from CI, dev, and the container images entirely.
- `scripts/embed-node-runtime.sh`: download the official runtime from **nodejs.org**, **verify it against the published `SHASUMS256.txt`**, and place it in the release bundle's `runtime/`. Version comes from `.node-version` (single source of truth).
- The **Windows** server packaging job (`cd-package-servers.yml`) embeds the runtime; pm2 (`packages/*/pm2.config.cjs`) points its `interpreter` at it, **falling back to `process.execPath`** everywhere else.
- The `node_version` CI check drops its now-obsolete package.json comparison; `.node-version` + the Dockerfile major remain the consistency anchors.

**Linux container-less hosts** (the two arm64 machines, which we want to move to containers anyway) use their own system node via the `process.execPath` fallback. Embedding a Linux runtime in the package wouldn't help them regardless — the Linux server package is amd64 (built from the amd64 image, with amd64 native modules), so an arm64 host can't run it.

**Validation (in containers):** the embed script was verified on both platforms — the linux runtime runs `node --version` with its exec bit preserved, the windows `node.exe` is a valid PE32+ x86-64 binary, and the `SHASUMS256` check passes; the lockfile regenerates cleanly under Node 20's npm with only `node`/`node-bin-setup` removed. The full `npm ci` + build without the dependency is exercised by the Docker image build on this PR (the `node` dep is runtime-only, so it can't affect the build).

Based on `main`; once it lands we'll rebase the Node 24 upgrade (#10069) on top, which then no longer manages the `node` dependency at all.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
