### PR TITLE
feat(web): support all recent Chromium browsers in gate

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -67,7 +67,11 @@ jobs:
       run: |
         set -ex
         git switch --create "$NEW_BRANCH_NAME"
-        git commit --allow-empty -m "release: Cut-off for $NEW_BRANCH_NAME"
+        # Refresh caniuse-lite so the web bundle's runtime browser gate (see
+        # packages/web/vite.config.js) reflects Chrome as of this cut. Carried by
+        # the cut-off commit; --allow-empty covers the case where it's unchanged.
+        npx --yes update-browserslist-db@latest
+        git commit -am "release: Cut-off for $NEW_BRANCH_NAME" --allow-empty
         git push origin "$NEW_BRANCH_NAME"
         git switch main
 
@@ -75,6 +79,10 @@ jobs:
       run: |
         node scripts/version.mjs '${{ inputs.version }}'
         npm install
+        # Also refresh caniuse-lite on main (not just the release branch above),
+        # otherwise main's browser gate data drifts permanently out of date.
+        # Committed alongside the version bump by the next step.
+        npx --yes update-browserslist-db@latest
 
     - name: Commit and push
       run: |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -143,6 +143,7 @@ export default [
       globals: {
         ...globals.browser,
         __VERSION__: 'readonly',
+        __MIN_CHROME_VERSION__: 'readonly',
         module: 'readonly',
 
         // polyfilled by vite

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@playwright/test": "1.59.1",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
+        "browserslist": "^4.28.0",
         "eslint": "^8.55.0",
         "eslint-plugin-markdown": "^3.0.1",
         "eslint-plugin-react": "^7.33.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@playwright/test": "1.59.1",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
+    "browserslist": "^4.28.0",
     "eslint": "^8.55.0",
     "eslint-plugin-markdown": "^3.0.1",
     "eslint-plugin-react": "^7.33.2",

--- a/packages/web/app/App.jsx
+++ b/packages/web/app/App.jsx
@@ -20,6 +20,7 @@ import {
 } from './components/StatusPage';
 import { useCheckServerAliveQuery } from './api/queries/useCheckServerAliveQuery';
 import { useSingleTab } from './utils/singleTab';
+import { MIN_CHROME_VERSION } from './utils/env';
 import { SERVER_TYPES } from '@tamanu/constants';
 
 const AppContainer = styled.div`
@@ -44,11 +45,13 @@ export function App({ sidebar, children }) {
     localStorage.getItem('DISABLE_SINGLE_TAB') || process.env.DISABLE_SINGLE_TAB === 'true';
 
   const browser = Bowser.getParser(window.navigator.userAgent);
-  // Early 2022 releases. Arbitrarily chosen as recentish.
+  // MIN_CHROME_VERSION is resolved at build time to the oldest of the most recent
+  // few Chrome majors as of when this bundle was built (see vite.config.js), so
+  // the gate rolls forward automatically with each release branch.
   const isChromish = browser.satisfies({
-    chrome: '>=100',
-    chromium: '>=100',
-    edge: '>=100',
+    chrome: `>=${MIN_CHROME_VERSION}`,
+    chromium: `>=${MIN_CHROME_VERSION}`,
+    edge: `>=${MIN_CHROME_VERSION}`,
   });
   const platformType = browser.getPlatformType();
   const isMobile = platformType === 'mobile';

--- a/packages/web/app/App.jsx
+++ b/packages/web/app/App.jsx
@@ -45,14 +45,23 @@ export function App({ sidebar, children }) {
     localStorage.getItem('DISABLE_SINGLE_TAB') || process.env.DISABLE_SINGLE_TAB === 'true';
 
   const browser = Bowser.getParser(window.navigator.userAgent);
-  // MIN_CHROME_VERSION is resolved at build time to the oldest of the most recent
-  // few Chrome majors as of when this bundle was built (see vite.config.js), so
-  // the gate rolls forward automatically with each release branch.
-  const isChromish = browser.satisfies({
-    chrome: `>=${MIN_CHROME_VERSION}`,
-    chromium: `>=${MIN_CHROME_VERSION}`,
-    edge: `>=${MIN_CHROME_VERSION}`,
-  });
+  // Accept any sufficiently recent Chromium-based browser (Chrome, Edge, Brave,
+  // Opera, Vivaldi, Yandex, ...) by checking the real Blink engine version. We
+  // can't use bowser's per-browser version: branded Chromium browsers report
+  // their own product version (e.g. "Opera 120"), not the Chromium major — but
+  // they all carry the true Chromium major in a Chrome/Chromium/HeadlessChrome UA
+  // token (some Linux and headless builds expose Chromium/ or HeadlessChrome/
+  // rather than Chrome/). MIN_CHROME_VERSION is resolved at build time (see
+  // vite.config.js) so the gate rolls forward with each release branch.
+  // Safari/Firefox aren't Blink and lack the token, so they remain unsupported.
+  const chromiumVersionMatch = /(?:HeadlessChrome|Chromium|Chrome)\/(\d+)/.exec(
+    window.navigator.userAgent,
+  );
+  const chromiumMajor = chromiumVersionMatch ? Number(chromiumVersionMatch[1]) : null;
+  const isChromish =
+    browser.getEngineName() === 'Blink' &&
+    chromiumMajor !== null &&
+    chromiumMajor >= MIN_CHROME_VERSION;
   const platformType = browser.getPlatformType();
   const isMobile = platformType === 'mobile';
   const isDebugMode = localStorage.getItem('DEBUG_PROD');

--- a/packages/web/app/utils/env.js
+++ b/packages/web/app/utils/env.js
@@ -18,6 +18,7 @@ const readEnv = (name) => {
 export const NODE_ENV = readEnv('NODE_ENV');
 export const BUGSNAG_API_KEY = readEnv('BUGSNAG_API_KEY');
 export const VERSION = __VERSION__;
+export const MIN_CHROME_VERSION = __MIN_CHROME_VERSION__;
 export const REVISION = readEnv('REVISION');
 export const FULL_VERSION = [VERSION, REVISION].filter(Boolean).join('-');
 export const IS_DEVELOPMENT = NODE_ENV === 'development';

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
+import browserslist from 'browserslist';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import svgr from 'vite-plugin-svgr';
@@ -40,6 +41,19 @@ export default async () => {
     },
   };
 
+  // Minimum Chrome/Chromium/Edge major version accepted by the runtime browser
+  // gate (see app/App.jsx). Resolved at build time as the lowest of the three
+  // most recent Chrome majors in browserslist's bundled caniuse-lite data — i.e.
+  // current Chrome at the time this bundle was built (when the release branch was
+  // cut). Baked into the bundle so each release branch keeps its own threshold.
+  // To move it forward, refresh caniuse-lite (cut-release-branch.yml runs
+  // `update-browserslist-db`). Stale data only ever lowers the floor, never
+  // wrongly blocks a current browser.
+  const recentChromeMajors = browserslist('last 3 chrome versions')
+    .map((entry) => Number(entry.split(' ')[1]))
+    .filter(Number.isFinite);
+  const minChromeVersion = recentChromeMajors.length ? Math.min(...recentChromeMajors) : 100;
+
   // Preview defaults to HTTPS (so local previews mimic production). E2E needs
   // plain HTTP on localhost — opt out via env var rather than flipping the
   // default and changing local-dev behaviour for everyone else.
@@ -66,6 +80,7 @@ export default async () => {
           .then(JSON.parse)
           .then(({ version }) => version),
       ),
+      __MIN_CHROME_VERSION__: JSON.stringify(minChromeVersion),
       process: JSON.stringify({
         env: {
           NODE_ENV: process.env.NODE_ENV,


### PR DESCRIPTION
### Changes

🤖 The runtime browser gate (`packages/web/app/App.jsx`) hardcoded Chrome/Chromium/Edge `>=100` — an arbitrary early-2022 threshold that drifts further out of date every year.

This resolves the minimum at **build time** from browserslist (the lowest of the last 3 Chromium-based majors in the bundled caniuse-lite data) and bakes it into the bundle as `__MIN_CHROME_VERSION__`, so each release ships a threshold appropriate to when it was cut. `cut-release-branch.yml` now runs `update-browserslist-db` when a release branch is cut, so the floor tracks Chrome as of the cut. Stale caniuse-lite data only ever lowers the floor (more lenient) — it can never wrongly block a current browser.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
