### PR TITLE
refactor(facility): TAM-6862: open reporting connections after migrations

### DIFF
--- a/packages/facility-server/__tests__/utilities.js
+++ b/packages/facility-server/__tests__/utilities.js
@@ -130,16 +130,17 @@ export function extendExpect(expect) {
 
 export async function createTestContext({ enableReportInstances, databaseOverrides } = {}) {
   const context = await new ApplicationContext().init({ databaseOverrides });
-  // create mock reporting schema + roles if test requires it
-  // init reporting instances for these roles
-  if (enableReportInstances) {
-    await createMockReportingSchemaAndRoles(context);
-    context.reportSchemaStores = await initReporting(context.store);
-  }
 
   const { models, sequelize } = context;
 
   await sequelize.migrate('up');
+
+  // create mock reporting schema + roles if test requires it, then init reporting
+  // instances for these roles (after migrate, matching the server startup order)
+  if (enableReportInstances) {
+    await createMockReportingSchemaAndRoles(context);
+    context.reportSchemaStores = await initReporting(context.store);
+  }
 
   await showError(deleteAllTestIds(context));
 

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -53,10 +53,14 @@ export class ApplicationContext {
       return acc;
     }, {});
     this.settings.global = new ReadSettings(this.models);
+    return this;
+  }
+
+  // Opens the reporting connections. Call after migrations so reporting can rely on migrated state.
+  async initReportingStores() {
     if (config.db.reportSchemas?.enabled) {
       this.reportSchemaStores = await initReporting(this.store);
     }
-    return this;
   }
 
   onClose(hook) {

--- a/packages/facility-server/app/subCommands/startAll.js
+++ b/packages/facility-server/app/subCommands/startAll.js
@@ -35,6 +35,7 @@ async function startAll({ skipMigrationCheck }) {
   } else {
     await context.sequelize.assertUpToDate({ skipMigrationCheck });
   }
+  await context.initReportingStores();
 
   await initDeviceId({ context, deviceType: DEVICE_TYPES.FACILITY_SERVER });
   await checkConfig(context);

--- a/packages/facility-server/app/subCommands/startApp.js
+++ b/packages/facility-server/app/subCommands/startApp.js
@@ -43,6 +43,7 @@ const startApp =
     } else {
       await context.sequelize.assertUpToDate({ skipMigrationCheck });
     }
+    await context.initReportingStores();
 
     await initDeviceId({ context, deviceType: DEVICE_TYPES.FACILITY_SERVER });
     await checkConfig(context);

--- a/packages/facility-server/app/subCommands/startTasks.js
+++ b/packages/facility-server/app/subCommands/startTasks.js
@@ -32,6 +32,7 @@ export async function startTasks({ skipMigrationCheck, taskClasses, syncManager 
   } else {
     await context.sequelize.assertUpToDate({ skipMigrationCheck });
   }
+  await context.initReportingStores();
 
   await initDeviceId({ context, deviceType: DEVICE_TYPES.FACILITY_SERVER });
   await checkConfig(context);


### PR DESCRIPTION
### Changes

Moves the facility reporting connection setup out of `ApplicationContext.init()` into a new `initReportingStores()` method, called **after** `sequelize.migrate('up')` in `startApp`/`startAll`/`startTasks` (and after migrate in the test harness).

Reporting is provisioned/connected after migrations rather than before, so it can rely on migrated state — the `GRANT ... ON ALL TABLES` now covers migrated tables, and it unblocks upcoming reporting work that needs to read settings/secrets which only exist post-migrate. This also matches how central already orders reporting init relative to migrations. No functional change when reporting is disabled (the default).

Note: touches `facility-server/app/ApplicationContext.js`, which TAM-6862 (#10082) also edits — whichever merges second will need a trivial rebase.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->