### PR TITLE
feat(web): no-issue: configurable browser/device support gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43303,6 +43303,7 @@
         "@tamanu/constants": "*",
         "@tamanu/errors": "*",
         "@tamanu/utils": "*",
+        "browserslist": "^4.28.0",
         "case": "^1.6.3",
         "chance": "^1.1.8",
         "commander": "^9.0.0",

--- a/packages/central-server/__tests__/browserSupport.test.js
+++ b/packages/central-server/__tests__/browserSupport.test.js
@@ -1,0 +1,82 @@
+import { BROWSER_SUPPORT_POLICIES, PLATFORM_SUPPORT_POLICIES } from '@tamanu/constants';
+import { settingsCache } from '@tamanu/settings';
+import { createTestContext } from './utilities';
+
+const ENDPOINT = '/v1/public/browser-support';
+
+// Extreme version numbers so assertions don't depend on the current major
+// resolved from browserslist at runtime.
+const recentChrome = {
+  browserName: 'Chrome',
+  engineName: 'Blink',
+  browserMajor: 9999,
+  chromiumMajor: 9999,
+  platformType: 'desktop',
+};
+const oldChrome = { ...recentChrome, browserMajor: 1, chromiumMajor: 1 };
+const recentFirefox = {
+  browserName: 'Firefox',
+  engineName: 'Gecko',
+  browserMajor: 9999,
+  chromiumMajor: null,
+  platformType: 'desktop',
+};
+
+describe('Browser support', () => {
+  let ctx;
+  let baseApp;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.store.models;
+  });
+  afterAll(async () => ctx.close());
+
+  afterEach(async () => {
+    await models.Setting.destroy({
+      where: {
+        key: ['browserSupport.policy', 'browserSupport.versionsBack', 'browserSupport.platform'],
+      },
+    });
+    settingsCache.reset();
+  });
+
+  it('is reachable without authentication', async () => {
+    const res = await baseApp.post(ENDPOINT).send(recentChrome);
+    expect(res).toHaveSucceeded();
+    expect(res.body).toEqual({ allowed: true });
+  });
+
+  describe('default settings (blink / 2 versions back / tablets)', () => {
+    it('blocks an out-of-date Chromium browser with reason "browser"', async () => {
+      const res = await baseApp.post(ENDPOINT).send(oldChrome);
+      expect(res.body).toEqual({ allowed: false, reason: 'browser' });
+    });
+
+    it('blocks a non-Blink browser with reason "browser"', async () => {
+      const res = await baseApp.post(ENDPOINT).send(recentFirefox);
+      expect(res.body).toEqual({ allowed: false, reason: 'browser' });
+    });
+
+    it('blocks mobile with reason "platform"', async () => {
+      const res = await baseApp.post(ENDPOINT).send({ ...recentChrome, platformType: 'mobile' });
+      expect(res.body).toEqual({ allowed: false, reason: 'platform' });
+    });
+  });
+
+  it('allows non-Blink browsers when the browser policy is "all"', async () => {
+    await models.Setting.set('browserSupport.policy', BROWSER_SUPPORT_POLICIES.ALL);
+    settingsCache.reset();
+    const res = await baseApp.post(ENDPOINT).send(recentFirefox);
+    expect(res.body).toEqual({ allowed: true });
+  });
+
+  it('allows mobile when the device policy is "all"', async () => {
+    await models.Setting.set('browserSupport.platform', PLATFORM_SUPPORT_POLICIES.ALL);
+    settingsCache.reset();
+    const res = await baseApp.post(ENDPOINT).send({ ...recentChrome, platformType: 'mobile' });
+    expect(res.body).toEqual({ allowed: true });
+  });
+});

--- a/packages/central-server/app/publicRoutes/index.js
+++ b/packages/central-server/app/publicRoutes/index.js
@@ -1,6 +1,9 @@
 import express from 'express';
 import config from 'config';
 import { log } from '@tamanu/shared/services/logging';
+import { ReadSettings } from '@tamanu/settings';
+import { getCurrentBrowserMajors } from '@tamanu/shared/utils/browserSupportVersions';
+import { decideBrowserSupport, parseBrowserDescriptor } from '@tamanu/utils/browserSupport';
 import { keyBy, mapValues } from 'lodash';
 
 import { labResultWidgetRoutes } from './labResultWidget';
@@ -44,6 +47,25 @@ publicRoutes.get('/translation/:language', async (req, res) => {
   });
 
   res.send(mapValues(keyBy(translatedStringRecords, 'stringId'), 'text'));
+});
+
+publicRoutes.post('/browser-support', async (req, res) => {
+  // Pre-login gate for the admin panel; the client posts its parsed navigator info.
+  const settings = new ReadSettings(req.models);
+  const [policy, versionsBack, platformPolicy] = await Promise.all([
+    settings.get('browserSupport.policy'),
+    settings.get('browserSupport.versionsBack'),
+    settings.get('browserSupport.platform'),
+  ]);
+  res.send(
+    decideBrowserSupport({
+      policy,
+      versionsBack,
+      platformPolicy,
+      currentMajors: getCurrentBrowserMajors(),
+      descriptor: parseBrowserDescriptor(req.body),
+    }),
+  );
 });
 
 publicRoutes.use('/labResultWidget', labResultWidgetRoutes);

--- a/packages/constants/src/settings.ts
+++ b/packages/constants/src/settings.ts
@@ -35,3 +35,29 @@ export const SETTING_EDITORS = {
 } as const;
 
 export type SettingEditor = (typeof SETTING_EDITORS)[keyof typeof SETTING_EDITORS];
+
+// Which browser families may load the web app, in increasing permissiveness.
+export const BROWSER_SUPPORT_POLICIES = {
+  // Identifies as Chrome, Chromium or Edge only.
+  CHROMIUM: 'chromium',
+  // Any Blink-engine browser (also Opera, Vivaldi, Brave, Yandex, Arc, ...).
+  BLINK: 'blink',
+  // Any browser, including Firefox and Safari (experimental, caveat emptor).
+  ALL: 'all',
+} as const;
+
+export type BrowserSupportPolicy =
+  (typeof BROWSER_SUPPORT_POLICIES)[keyof typeof BROWSER_SUPPORT_POLICIES];
+
+// Which device types may load the web app, in increasing permissiveness.
+export const PLATFORM_SUPPORT_POLICIES = {
+  // Desktops and laptops only.
+  DESKTOP: 'desktop',
+  // Desktops, laptops and tablets.
+  TABLET: 'tablet',
+  // Any device, including mobile phones.
+  ALL: 'all',
+} as const;
+
+export type PlatformSupportPolicy =
+  (typeof PLATFORM_SUPPORT_POLICIES)[keyof typeof PLATFORM_SUPPORT_POLICIES];

--- a/packages/facility-server/__tests__/apiv1/BrowserSupport.test.js
+++ b/packages/facility-server/__tests__/apiv1/BrowserSupport.test.js
@@ -1,0 +1,82 @@
+import { BROWSER_SUPPORT_POLICIES, PLATFORM_SUPPORT_POLICIES } from '@tamanu/constants';
+import { settingsCache } from '@tamanu/settings';
+import { createTestContext } from '../utilities';
+
+const ENDPOINT = '/v1/public/browser-support';
+
+// Use extreme version numbers so the assertions don't depend on the actual
+// current major resolved from browserslist at runtime.
+const recentChrome = {
+  browserName: 'Chrome',
+  engineName: 'Blink',
+  browserMajor: 9999,
+  chromiumMajor: 9999,
+  platformType: 'desktop',
+};
+const oldChrome = { ...recentChrome, browserMajor: 1, chromiumMajor: 1 };
+const recentFirefox = {
+  browserName: 'Firefox',
+  engineName: 'Gecko',
+  browserMajor: 9999,
+  chromiumMajor: null,
+  platformType: 'desktop',
+};
+
+describe('Browser support', () => {
+  let ctx;
+  let baseApp;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.models;
+  });
+  afterAll(() => ctx.close());
+
+  afterEach(async () => {
+    await models.Setting.destroy({ where: { key: ['browserSupport.policy', 'browserSupport.platform'] } });
+    settingsCache.reset();
+  });
+
+  it('is reachable without authentication', async () => {
+    const res = await baseApp.post(ENDPOINT).send(recentChrome);
+    expect(res).toHaveSucceeded();
+  });
+
+  describe('default settings (blink / 2 versions back / tablets)', () => {
+    it('allows a recent Chromium browser on desktop', async () => {
+      const res = await baseApp.post(ENDPOINT).send(recentChrome);
+      expect(res.body).toEqual({ allowed: true });
+    });
+
+    it('blocks an out-of-date Chromium browser with reason "browser"', async () => {
+      const res = await baseApp.post(ENDPOINT).send(oldChrome);
+      expect(res.body).toEqual({ allowed: false, reason: 'browser' });
+    });
+
+    it('blocks a non-Blink browser with reason "browser"', async () => {
+      const res = await baseApp.post(ENDPOINT).send(recentFirefox);
+      expect(res.body).toEqual({ allowed: false, reason: 'browser' });
+    });
+
+    it('blocks mobile with reason "platform" (checked before browser)', async () => {
+      const res = await baseApp.post(ENDPOINT).send({ ...recentChrome, platformType: 'mobile' });
+      expect(res.body).toEqual({ allowed: false, reason: 'platform' });
+    });
+  });
+
+  it('allows non-Blink browsers when the browser policy is "all"', async () => {
+    await models.Setting.set('browserSupport.policy', BROWSER_SUPPORT_POLICIES.ALL);
+    settingsCache.reset();
+    const res = await baseApp.post(ENDPOINT).send(recentFirefox);
+    expect(res.body).toEqual({ allowed: true });
+  });
+
+  it('allows mobile when the device policy is "all"', async () => {
+    await models.Setting.set('browserSupport.platform', PLATFORM_SUPPORT_POLICIES.ALL);
+    settingsCache.reset();
+    const res = await baseApp.post(ENDPOINT).send({ ...recentChrome, platformType: 'mobile' });
+    expect(res.body).toEqual({ allowed: true });
+  });
+});

--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -1,9 +1,11 @@
 import express from 'express';
 
 import { constructPermission } from '@tamanu/shared/permissions/middleware';
-import { settingsCache } from '@tamanu/settings';
+import { ReadSettings, settingsCache } from '@tamanu/settings';
 import { attachAuditUserToDbSession } from '@tamanu/database/utils/audit';
 import { suggestions } from '@tamanu/shared/services/suggestions';
+import { getCurrentBrowserMajors } from '@tamanu/shared/utils/browserSupportVersions';
+import { decideBrowserSupport, parseBrowserDescriptor } from '@tamanu/utils/browserSupport';
 
 import {
   authMiddleware,
@@ -129,7 +131,30 @@ export function createApiv1({ authLimiter } = {}) {
       res.send(mapValues(keyBy(translatedStringRecords, 'stringId'), 'text'));
     }),
   );
-  
+
+  apiv1.post(
+    '/public/browser-support',
+    asyncHandler(async (req, res) => {
+      // Pre-login gate for the web app; the client posts its parsed navigator info.
+      req.flagPermissionChecked();
+      const settings = new ReadSettings(req.models);
+      const [policy, versionsBack, platformPolicy] = await Promise.all([
+        settings.get('browserSupport.policy'),
+        settings.get('browserSupport.versionsBack'),
+        settings.get('browserSupport.platform'),
+      ]);
+      res.send(
+        decideBrowserSupport({
+          policy,
+          versionsBack,
+          platformPolicy,
+          currentMajors: getCurrentBrowserMajors(),
+          descriptor: parseBrowserDescriptor(req.body),
+        }),
+      );
+    }),
+  );
+
   apiv1.use(authMiddleware);
   
   apiv1.use(constructPermission);

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -27,7 +27,9 @@ import {
 } from './global-settings-properties/layouts';
 import {
   ADMINISTRATION_FREQUENCIES,
+  BROWSER_SUPPORT_POLICIES,
   isValidAdditionalSearchField,
+  PLATFORM_SUPPORT_POLICIES,
   SETTING_EDITORS,
 } from '@tamanu/constants';
 import {
@@ -92,6 +94,42 @@ export const globalSettings = {
       exposedToWeb: true,
       type: ageDisplayFormatSchema,
       defaultValue: ageDisplayFormatDefault,
+    },
+    browserSupport: {
+      name: 'Browser support',
+      description: 'Controls which browsers and devices may load the web application',
+      properties: {
+        policy: {
+          name: 'Browser policy',
+          description:
+            'Which browser families may load the app: Chrome/Chromium/Edge only, any Chromium-based browser, or any browser (experimental)',
+          type: yup.string().oneOf(Object.values(BROWSER_SUPPORT_POLICIES)),
+          defaultValue: BROWSER_SUPPORT_POLICIES.BLINK,
+          options: [
+            { value: BROWSER_SUPPORT_POLICIES.CHROMIUM, label: 'Chrome, Chromium and Edge only' },
+            { value: BROWSER_SUPPORT_POLICIES.BLINK, label: 'Any Chromium-based browser' },
+            { value: BROWSER_SUPPORT_POLICIES.ALL, label: 'Any browser (experimental)' },
+          ],
+        },
+        versionsBack: {
+          name: 'Versions back',
+          description:
+            'How many major browser versions behind the current release are allowed (0 = current only)',
+          type: yup.number().integer().min(0),
+          defaultValue: 2,
+        },
+        platform: {
+          name: 'Device policy',
+          description: 'Which device types may load the app',
+          type: yup.string().oneOf(Object.values(PLATFORM_SUPPORT_POLICIES)),
+          defaultValue: PLATFORM_SUPPORT_POLICIES.TABLET,
+          options: [
+            { value: PLATFORM_SUPPORT_POLICIES.DESKTOP, label: 'Desktops and laptops only' },
+            { value: PLATFORM_SUPPORT_POLICIES.TABLET, label: 'Allow tablets' },
+            { value: PLATFORM_SUPPORT_POLICIES.ALL, label: 'Allow all devices (incl. mobile)' },
+          ],
+        },
+      },
     },
     dateTimeLocale: {
       description:

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -158,6 +158,7 @@
     "@tamanu/constants": "*",
     "@tamanu/errors": "*",
     "@tamanu/utils": "*",
+    "browserslist": "^4.28.0",
     "case": "^1.6.3",
     "chance": "^1.1.8",
     "commander": "^9.0.0",

--- a/packages/shared/src/utils/browserSupportVersions.js
+++ b/packages/shared/src/utils/browserSupportVersions.js
@@ -1,0 +1,27 @@
+import browserslist from 'browserslist';
+
+const majorFrom = (query) =>
+  Math.max(...browserslist(query).map((entry) => parseInt(entry.split(' ')[1], 10)));
+
+let cached;
+
+// Latest stable major version per engine, from browserslist's bundled
+// caniuse-lite data. Used by the public browser-support endpoint to floor the
+// "N versions back" check. Resolved once per process — the data is static for a
+// given deploy. Freshness tracks the installed caniuse-lite, the same way the
+// web build's MIN_CHROME_VERSION does (see packages/web/vite.config.js); stale
+// data only ever lowers the floor, it never wrongly blocks a current browser.
+//
+// Server-only: this imports browserslist (Node) and must never be pulled into
+// the web bundle.
+export const getCurrentBrowserMajors = () => {
+  if (!cached) {
+    cached = {
+      chromium: majorFrom('last 1 chrome version'),
+      firefox: majorFrom('last 1 firefox version'),
+      // Safari majors can be decimal (e.g. "safari 18.2"); parseInt → 18.
+      safari: majorFrom('last 1 safari version'),
+    };
+  }
+  return cached;
+};

--- a/packages/utils/__test__/browserSupport.test.ts
+++ b/packages/utils/__test__/browserSupport.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { BROWSER_SUPPORT_POLICIES, PLATFORM_SUPPORT_POLICIES } from '@tamanu/constants';
+import { decideBrowserSupport, type BrowserDescriptor } from '../src/browserSupport';
+
+const CURRENT = { chromium: 146, firefox: 134, safari: 18 };
+
+const desc = (overrides: Partial<BrowserDescriptor> = {}): BrowserDescriptor => ({
+  browserName: 'Chrome',
+  engineName: 'Blink',
+  browserMajor: 146,
+  chromiumMajor: 146,
+  platformType: 'desktop',
+  ...overrides,
+});
+
+const decide = (
+  descriptor: BrowserDescriptor,
+  {
+    policy = BROWSER_SUPPORT_POLICIES.BLINK,
+    versionsBack = 2,
+    platformPolicy = PLATFORM_SUPPORT_POLICIES.TABLET,
+  } = {},
+) => decideBrowserSupport({ policy, versionsBack, platformPolicy, currentMajors: CURRENT, descriptor });
+
+describe('decideBrowserSupport', () => {
+  describe('platform policy (checked before browser)', () => {
+    it.each([
+      [PLATFORM_SUPPORT_POLICIES.DESKTOP, 'desktop', true],
+      [PLATFORM_SUPPORT_POLICIES.DESKTOP, 'tablet', false],
+      [PLATFORM_SUPPORT_POLICIES.DESKTOP, 'mobile', false],
+      [PLATFORM_SUPPORT_POLICIES.TABLET, 'tablet', true],
+      [PLATFORM_SUPPORT_POLICIES.TABLET, 'mobile', false],
+      [PLATFORM_SUPPORT_POLICIES.ALL, 'mobile', true],
+      [PLATFORM_SUPPORT_POLICIES.ALL, 'tv', true],
+    ])('policy %s on %s device → allowed=%s', (platformPolicy, platformType, allowed) => {
+      expect(decide(desc({ platformType }), { platformPolicy }).allowed).toBe(allowed);
+    });
+
+    it('reports reason "platform" when the device is blocked (even on a supported browser)', () => {
+      expect(decide(desc({ platformType: 'mobile' }))).toEqual({
+        allowed: false,
+        reason: 'platform',
+      });
+    });
+  });
+
+  describe('chromium policy', () => {
+    it('allows recent Chrome/Chromium/Edge', () => {
+      for (const browserName of ['Chrome', 'Chromium', 'Microsoft Edge']) {
+        expect(decide(desc({ browserName }), { policy: BROWSER_SUPPORT_POLICIES.CHROMIUM }).allowed).toBe(true);
+      }
+    });
+
+    it('rejects branded Chromium browsers (Opera/Vivaldi) even when recent', () => {
+      const opera = desc({ browserName: 'Opera', chromiumMajor: 146, browserMajor: 120 });
+      expect(decide(opera, { policy: BROWSER_SUPPORT_POLICIES.CHROMIUM })).toEqual({
+        allowed: false,
+        reason: 'browser',
+      });
+    });
+  });
+
+  describe('blink policy', () => {
+    it('allows any recent Blink browser regardless of brand', () => {
+      const vivaldi = desc({ browserName: 'Vivaldi', chromiumMajor: 145, browserMajor: 6 });
+      expect(decide(vivaldi, { policy: BROWSER_SUPPORT_POLICIES.BLINK }).allowed).toBe(true);
+    });
+
+    it('rejects non-Blink browsers', () => {
+      const firefox = desc({ browserName: 'Firefox', engineName: 'Gecko', chromiumMajor: null, browserMajor: 134 });
+      expect(decide(firefox, { policy: BROWSER_SUPPORT_POLICIES.BLINK })).toEqual({
+        allowed: false,
+        reason: 'browser',
+      });
+    });
+  });
+
+  describe('version floor (current - versionsBack), enforced per engine', () => {
+    it('allows exactly versionsBack behind and blocks one older', () => {
+      expect(decide(desc({ chromiumMajor: 144 })).allowed).toBe(true); // 146 - 2
+      expect(decide(desc({ chromiumMajor: 143 })).allowed).toBe(false);
+    });
+
+    it('versionsBack 0 allows only the current major', () => {
+      expect(decide(desc({ chromiumMajor: 146 }), { versionsBack: 0 }).allowed).toBe(true);
+      expect(decide(desc({ chromiumMajor: 145 }), { versionsBack: 0 }).allowed).toBe(false);
+    });
+
+    it('floors Firefox and Safari under the "all" tier', () => {
+      const opts = { policy: BROWSER_SUPPORT_POLICIES.ALL };
+      const ff = (browserMajor: number) =>
+        desc({ browserName: 'Firefox', engineName: 'Gecko', chromiumMajor: null, browserMajor });
+      const safari = (browserMajor: number) =>
+        desc({ browserName: 'Safari', engineName: 'WebKit', chromiumMajor: null, browserMajor });
+      expect(decide(ff(132), opts).allowed).toBe(true); // 134 - 2
+      expect(decide(ff(131), opts).allowed).toBe(false);
+      expect(decide(safari(16), opts).allowed).toBe(true); // 18 - 2
+      expect(decide(safari(15), opts).allowed).toBe(false);
+    });
+  });
+
+  describe('all (experimental) tier', () => {
+    it('allows an unknown engine regardless of version (no data to floor)', () => {
+      const unknown = desc({ browserName: 'Mystery', engineName: 'Goanna', chromiumMajor: null, browserMajor: 3 });
+      expect(decide(unknown, { policy: BROWSER_SUPPORT_POLICIES.ALL }).allowed).toBe(true);
+    });
+  });
+});

--- a/packages/utils/src/browserSupport.ts
+++ b/packages/utils/src/browserSupport.ts
@@ -1,0 +1,124 @@
+import {
+  BROWSER_SUPPORT_POLICIES,
+  PLATFORM_SUPPORT_POLICIES,
+  type BrowserSupportPolicy,
+  type PlatformSupportPolicy,
+} from '@tamanu/constants';
+
+// A parsed summary of the client's navigator, as produced by bowser on the web
+// client. This is a UX gate, not a security boundary — the fields are trivially
+// spoofable, so they're treated as advisory.
+export interface BrowserDescriptor {
+  browserName: string;
+  engineName: string;
+  // The browser's own product major (e.g. Firefox 130, Safari 17, Opera 120).
+  browserMajor: number | null;
+  // The underlying Chromium major from the Chrome/Chromium/HeadlessChrome UA
+  // token, present for all Blink browsers regardless of their product version.
+  chromiumMajor: number | null;
+  // bowser's platform type: 'desktop' | 'tablet' | 'mobile' | 'tv' | ...
+  platformType: string;
+}
+
+// Current latest major version per engine, resolved server-side from browserslist.
+export interface CurrentBrowserMajors {
+  chromium: number;
+  firefox: number;
+  safari: number;
+}
+
+export interface BrowserSupportDecision {
+  allowed: boolean;
+  // Why a browser was rejected, so the client can show the matching page.
+  reason?: 'platform' | 'browser';
+}
+
+// bowser reports these names for the strict Chrome-family tier.
+const CHROMIUM_BROWSER_NAMES = ['Chrome', 'Chromium', 'Microsoft Edge'];
+
+const isPlatformAllowed = (platformPolicy: PlatformSupportPolicy, platformType: string): boolean => {
+  switch (platformPolicy) {
+    case PLATFORM_SUPPORT_POLICIES.DESKTOP:
+      return platformType === 'desktop';
+    case PLATFORM_SUPPORT_POLICIES.TABLET:
+      return platformType === 'desktop' || platformType === 'tablet';
+    case PLATFORM_SUPPORT_POLICIES.ALL:
+      return true;
+    default:
+      return false;
+  }
+};
+
+const isRecentEnough = (major: number | null, current: number, versionsBack: number): boolean =>
+  typeof major === 'number' && Number.isFinite(major) && major >= current - versionsBack;
+
+const isBrowserAllowed = (
+  policy: BrowserSupportPolicy,
+  versionsBack: number,
+  currentMajors: CurrentBrowserMajors,
+  descriptor: BrowserDescriptor,
+): boolean => {
+  const { engineName, browserName, browserMajor, chromiumMajor } = descriptor;
+  const isBlink = engineName === 'Blink';
+
+  switch (policy) {
+    case BROWSER_SUPPORT_POLICIES.CHROMIUM:
+      return (
+        isBlink &&
+        CHROMIUM_BROWSER_NAMES.includes(browserName) &&
+        isRecentEnough(chromiumMajor, currentMajors.chromium, versionsBack)
+      );
+    case BROWSER_SUPPORT_POLICIES.BLINK:
+      return isBlink && isRecentEnough(chromiumMajor, currentMajors.chromium, versionsBack);
+    case BROWSER_SUPPORT_POLICIES.ALL:
+      if (isBlink) return isRecentEnough(chromiumMajor, currentMajors.chromium, versionsBack);
+      if (engineName === 'Gecko')
+        return isRecentEnough(browserMajor, currentMajors.firefox, versionsBack);
+      if (engineName === 'WebKit')
+        return isRecentEnough(browserMajor, currentMajors.safari, versionsBack);
+      // Unknown engine under the experimental tier: no version data to floor
+      // against, so allow it (caveat emptor).
+      return true;
+    default:
+      return false;
+  }
+};
+
+const toMajor = (value: unknown): number | null => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : null;
+};
+
+// Normalise the untrusted request body sent by the web client into a descriptor.
+export const parseBrowserDescriptor = (input: Record<string, unknown> = {}): BrowserDescriptor => ({
+  browserName: String(input.browserName ?? ''),
+  engineName: String(input.engineName ?? ''),
+  browserMajor: toMajor(input.browserMajor),
+  chromiumMajor: toMajor(input.chromiumMajor),
+  platformType: String(input.platformType ?? ''),
+});
+
+// Pure, Node-free decision shared by both servers' public endpoints. Platform is
+// checked before browser so a blocked mobile device gets the device message
+// rather than a browser one.
+export const decideBrowserSupport = ({
+  policy,
+  versionsBack,
+  platformPolicy,
+  currentMajors,
+  descriptor,
+}: {
+  policy: BrowserSupportPolicy;
+  versionsBack: number;
+  platformPolicy: PlatformSupportPolicy;
+  currentMajors: CurrentBrowserMajors;
+  descriptor: BrowserDescriptor;
+}): BrowserSupportDecision => {
+  if (!isPlatformAllowed(platformPolicy, descriptor.platformType)) {
+    return { allowed: false, reason: 'platform' };
+  }
+  if (!isBrowserAllowed(policy, versionsBack, currentMajors, descriptor)) {
+    return { allowed: false, reason: 'browser' };
+  }
+  return { allowed: true };
+};

--- a/packages/web/app/App.jsx
+++ b/packages/web/app/App.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-import Bowser from 'bowser';
 import 'typeface-roboto';
 import { checkIsLoggedIn, checkIsFacilitySelected, getServerType } from './store/auth';
 import { useLocation } from 'react-router';
@@ -19,8 +18,8 @@ import {
   SingleTabStatusPage,
 } from './components/StatusPage';
 import { useCheckServerAliveQuery } from './api/queries/useCheckServerAliveQuery';
+import { useBrowserSupport } from './api/queries/useBrowserSupport';
 import { useSingleTab } from './utils/singleTab';
-import { MIN_CHROME_VERSION } from './utils/env';
 import { SERVER_TYPES } from '@tamanu/constants';
 
 const AppContainer = styled.div`
@@ -44,32 +43,26 @@ export function App({ sidebar, children }) {
   const disableSingleTab =
     localStorage.getItem('DISABLE_SINGLE_TAB') || process.env.DISABLE_SINGLE_TAB === 'true';
 
-  const browser = Bowser.getParser(window.navigator.userAgent);
-  // Accept any sufficiently recent Chromium-based browser (Chrome, Edge, Brave,
-  // Opera, Vivaldi, Yandex, ...) by checking the real Blink engine version. We
-  // can't use bowser's per-browser version: branded Chromium browsers report
-  // their own product version (e.g. "Opera 120"), not the Chromium major — but
-  // they all carry the true Chromium major in a Chrome/Chromium/HeadlessChrome UA
-  // token (some Linux and headless builds expose Chromium/ or HeadlessChrome/
-  // rather than Chrome/). MIN_CHROME_VERSION is resolved at build time (see
-  // vite.config.js) so the gate rolls forward with each release branch.
-  // Safari/Firefox aren't Blink and lack the token, so they remain unsupported.
-  const chromiumVersionMatch = /(?:HeadlessChrome|Chromium|Chrome)\/(\d+)/.exec(
-    window.navigator.userAgent,
-  );
-  const chromiumMajor = chromiumVersionMatch ? Number(chromiumVersionMatch[1]) : null;
-  const isChromish =
-    browser.getEngineName() === 'Blink' &&
-    chromiumMajor !== null &&
-    chromiumMajor >= MIN_CHROME_VERSION;
-  const platformType = browser.getPlatformType();
-  const isMobile = platformType === 'mobile';
+  // Browser/device support is decided server-side against configurable settings
+  // (see the /public/browser-support endpoint), so it can be loosened/tightened
+  // per deployment. Falls back to the static build-time check on error/timeout.
+  // DEBUG_PROD bypasses the gate entirely.
   const isDebugMode = localStorage.getItem('DEBUG_PROD');
+  const {
+    status: browserSupportStatus,
+    reason: unsupportedReason,
+    descriptor,
+  } = useBrowserSupport({ enabled: !isDebugMode });
 
   if (!isDebugMode) {
-    // Skip browser/platform check in debug mode
-    if (isMobile) return <MobileStatusPage platformType={platformType} />;
-    if (!isChromish) return <UnsupportedBrowserStatusPage />;
+    if (browserSupportStatus === 'loading') return <LoadingStatusPage />;
+    if (browserSupportStatus === 'unsupported') {
+      return unsupportedReason === 'platform' ? (
+        <MobileStatusPage platformType={descriptor.platformType} />
+      ) : (
+        <UnsupportedBrowserStatusPage />
+      );
+    }
   }
   if (!isPrimaryTab && !disableSingleTab) return <SingleTabStatusPage />;
   if (isLoading) return <LoadingStatusPage />;

--- a/packages/web/app/api/queries/useBrowserSupport.js
+++ b/packages/web/app/api/queries/useBrowserSupport.js
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import { useApi } from '../useApi';
+import {
+  getBrowserDescriptor,
+  readCachedDecision,
+  staticDecision,
+  writeCachedDecision,
+} from '../../utils/browserSupport';
+
+// Resolves the dynamic browser/device support gate against the public endpoint,
+// falling back to the static build-time check on any error or timeout. Returns
+// 'loading' until decided; a cached "allowed" decision (seeded as initialData)
+// resolves immediately with no loading flash.
+export const useBrowserSupport = ({ enabled = true } = {}) => {
+  const api = useApi();
+  const descriptor = getBrowserDescriptor();
+
+  const { data, isLoading } = useQuery(
+    ['browserSupport'],
+    async () => {
+      const cached = readCachedDecision();
+      if (cached) return cached;
+      try {
+        const decision = await api.post('public/browser-support', descriptor, {
+          useAuthToken: false,
+          waitForAuth: false,
+          showUnknownErrorToast: false,
+          timeout: 2000,
+        });
+        writeCachedDecision(decision);
+        return decision;
+      } catch {
+        return staticDecision(descriptor);
+      }
+    },
+    {
+      enabled,
+      staleTime: Infinity,
+      initialData: () => readCachedDecision() ?? undefined,
+    },
+  );
+
+  if (!enabled) return { status: 'allowed', descriptor };
+  if (isLoading || !data) return { status: 'loading', descriptor };
+  return {
+    status: data.allowed ? 'allowed' : 'unsupported',
+    reason: data.reason,
+    descriptor,
+  };
+};

--- a/packages/web/app/components/StatusPage.jsx
+++ b/packages/web/app/components/StatusPage.jsx
@@ -182,8 +182,8 @@ export const UnsupportedBrowserStatusPage = () => {
       }
       description={
         <TranslatedText
-          stringId="splash.browser.description"
-          fallback="Please contact your system administrator for further information on how to access :brandName using a Chrome or Edge browser."
+          stringId="splash.browser.supportedBrowserDescription"
+          fallback="Please contact your system administrator for further information on how to access :brandName using a supported, up-to-date browser."
           replacements={{ brandName }}
           data-testid="translatedtext-v9m5"
         />
@@ -214,12 +214,23 @@ export const MobileStatusPage = ({ platformType }) => {
     <MobileContainer $platformType={platformType} data-testid="mobilecontainer-qsvl">
       <Logo onClick={handleRefreshPage} size="140px" data-testid="logo-7r7o" />
       <ErrorDescription color="textTertiary" data-testid="errordescription-asrb">
-        <TranslatedText
-          stringId="splash.mobile.description"
-          fallback=":brandName is not currently supported on mobile devices. Please access via a desktop computer, laptop, or tablet."
-          replacements={{ brandName }}
-          data-testid="translatedtext-9p7e"
-        />
+        {platformType === 'mobile' ? (
+          <TranslatedText
+            stringId="splash.mobile.description"
+            fallback=":brandName is not currently supported on mobile devices. Please access via a desktop computer, laptop, or tablet."
+            replacements={{ brandName }}
+            data-testid="translatedtext-9p7e"
+          />
+        ) : (
+          // Other device types (e.g. tablets blocked by a stricter device policy)
+          // mustn't see mobile-specific copy that suggests using a tablet.
+          <TranslatedText
+            stringId="splash.device.unsupportedDescription"
+            fallback=":brandName is not supported on this device. Please access via a supported device or contact your system administrator for further information."
+            replacements={{ brandName }}
+            data-testid="translatedtext-device-unsupported"
+          />
+        )}
       </ErrorDescription>
     </MobileContainer>
   );

--- a/packages/web/app/utils/browserSupport.js
+++ b/packages/web/app/utils/browserSupport.js
@@ -1,0 +1,85 @@
+import Bowser from 'bowser';
+import { MIN_CHROME_VERSION } from './env';
+
+const CACHE_KEY = 'browserSupport';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+// Branded Chromium browsers report their own product version, but all carry the
+// real Chromium major in a Chrome/Chromium/HeadlessChrome UA token (matches the
+// static gate this falls back to — see App.jsx history).
+const parseChromiumMajor = userAgent => {
+  const match = /(?:HeadlessChrome|Chromium|Chrome)\/(\d+)/.exec(userAgent);
+  return match ? Number(match[1]) : null;
+};
+
+const parseMajor = version => {
+  const major = parseInt(version, 10);
+  return Number.isFinite(major) ? major : null;
+};
+
+// The parsed navigator summary posted to the server for a support decision.
+export const getBrowserDescriptor = () => {
+  const userAgent = window.navigator.userAgent;
+  const browser = Bowser.getParser(userAgent);
+  return {
+    browserName: browser.getBrowserName(),
+    engineName: browser.getEngineName(),
+    browserMajor: parseMajor(browser.getBrowserVersion()),
+    chromiumMajor: parseChromiumMajor(userAgent),
+    platformType: browser.getPlatformType(),
+  };
+};
+
+// Fallback when the server can't be reached. Mirrors the default settings
+// (platform `tablet` = desktop/laptop/tablet only, plus a recent Blink engine)
+// so a network failure degrades to the same gate an unconfigured server applies,
+// rather than letting through device types the default would block.
+export const staticDecision = descriptor => {
+  if (descriptor.platformType !== 'desktop' && descriptor.platformType !== 'tablet') {
+    return { allowed: false, reason: 'platform' };
+  }
+  const isChromish =
+    descriptor.engineName === 'Blink' &&
+    descriptor.chromiumMajor !== null &&
+    descriptor.chromiumMajor >= MIN_CHROME_VERSION;
+  return isChromish ? { allowed: true } : { allowed: false, reason: 'browser' };
+};
+
+// djb2 — a tiny non-cryptographic hash, enough to key the cache by user agent so
+// that a browser update re-queries the server.
+const hashUserAgent = userAgent => {
+  let hash = 5381;
+  for (let i = 0; i < userAgent.length; i++) {
+    hash = (((hash << 5) + hash) + userAgent.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+};
+
+export const readCachedDecision = () => {
+  try {
+    const cached = JSON.parse(localStorage.getItem(CACHE_KEY));
+    if (!cached || cached.uaHash !== hashUserAgent(window.navigator.userAgent)) return null;
+    if (Date.now() - cached.checkedAt >= CACHE_TTL_MS) return null;
+    return { allowed: true };
+  } catch {
+    return null;
+  }
+};
+
+export const writeCachedDecision = decision => {
+  // Only persist allowed decisions: a blocked browser should re-query on every
+  // load so a policy change that now permits it is picked up immediately.
+  if (!decision.allowed) return;
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        uaHash: hashUserAgent(window.navigator.userAgent),
+        allowed: true,
+        checkedAt: Date.now(),
+      }),
+    );
+  } catch {
+    // ignore storage failures (private mode, quota) — we'll just re-query.
+  }
+};


### PR DESCRIPTION
### Changes

🤖 Stacked on #10090 (review/merge that first).

Makes the web browser/device support gate dynamic and configurable per deployment, rather than fixed at build time.

A new public endpoint `POST /api/public/browser-support` (on both facility and central servers) decides support from two new global settings:
- `browserSupport.policy` — `chromium` (Chrome/Chromium/Edge only), `blink` (any Chromium-based browser), or `all` (any browser, experimental).
- `browserSupport.versionsBack` — how many major versions behind current are allowed; the per-engine floor uses browserslist's current Chromium/Firefox/Safari majors.
- `browserSupport.platform` — `desktop`, `tablet`, or `all`, replacing the previous hard mobile block (default `tablet` = today's behaviour).

The web client posts its parsed navigator info, caches an *allowed* decision in localStorage keyed by a UA hash (24h TTL; blocked browsers re-query each load so loosening the policy is picked up immediately), and falls back to the previous static build-time check on any timeout/error — so a network failure can never lock out a working browser. The decision logic is a pure, unit-tested function in `@tamanu/utils`; the browserslist version resolver is server-only (never bundled into the web app).

The unsupported-browser page copy is now browser-agnostic ("a supported, up-to-date browser") instead of naming Chrome/Edge.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [x] **Run E2E tests** <!-- #e2e -->
- [x] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
