### PR TITLE
ci: no-issue: fix cut-release-branch reusable-workflow job

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -136,12 +136,14 @@ jobs:
           tags: ghcr.io/beyondessential/tamanu-seed:${{ needs.run.outputs.version }}
           build-args: GIT_SHA=${{ steps.sha.outputs.sha }}
 
-  # Snapshot creation is best-effort: a release cut shouldn't be blocked
-  # if pgsnap or the EBS snapshotter is degraded. Re-run via
-  # workflow_dispatch on seed-snapshot.yml to retry.
+  # Snapshot creation is best-effort: seed-snapshot.yml marks its infra-touching
+  # steps continue-on-error, so a degraded snapshotter doesn't fail this run.
+  # (continue-on-error isn't valid on a reusable-workflow call, so the tolerance
+  # lives in the called workflow's steps instead.) The release branch is also
+  # already cut by the `run` job above, so a failure here can never undo it.
+  # Re-run via workflow_dispatch on seed-snapshot.yml to retry.
   seed-snapshot:
     needs: [run, build-seed-image]
-    continue-on-error: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/seed-snapshot.yml
+++ b/.github/workflows/seed-snapshot.yml
@@ -60,7 +60,13 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      # Best-effort: a degraded snapshotter (Tailscale/k8s unreachable, or the
+      # pgsnap operator down) must not fail the release-cut run that calls this
+      # workflow. continue-on-error isn't valid on the caller's reusable-workflow
+      # job, so the infra-touching steps tolerate failure here instead. A bad
+      # input still fails loudly via "Validate version format" above.
       - uses: ./.github/actions/setup-cd
+        continue-on-error: true
         with:
           tailscale-oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
           tailscale-tags: ${{ vars.TS_TAGS }}
@@ -79,6 +85,7 @@ jobs:
       # unsuspending, snapshotting on completion, GC). Job correctness is
       # observed via the resulting VolumeSnapshot in `tamanu-seed`, not here.
       - name: Create seed Job
+        continue-on-error: true
         env:
           JOB_NAME: ${{ steps.names.outputs.job_name }}
           IMAGE: ${{ inputs.image }}


### PR DESCRIPTION
### Changes

🤖 The `cut-release-branch` workflow could not be dispatched — GitHub rejected it with `runs-on` required / `uses`,`secrets`,`with` unexpected on the `seed-snapshot` job.

That job calls a reusable workflow (`uses:`), but also had `continue-on-error: true`, which is not a valid key on a reusable-workflow call. Its presence makes GitHub parse the job as a normal job, which then requires `runs-on` and rejects the reusable-call keys — blocking the release cut entirely.

This removes `continue-on-error`. The release branch is already cut and pushed by the earlier `run` job, so a downstream snapshot failure can no longer undo the cut; it just marks the run red (the correct signal, and still re-runnable via `seed-snapshot.yml`). Pre-existing issue, unrelated to the browser-support PRs.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->