### PR TITLE
ci: no-issue: speed up Android CI builds (single-ABI test builds + ccache)

### DIFF
--- a/.github/workflows/cd-package-android.yml
+++ b/.github/workflows/cd-package-android.yml
@@ -117,12 +117,24 @@ jobs:
       - name: Build mobile dependencies
         run: npm run build -- --filter=@tamanu/mobile^...
 
+      # The New Architecture compiles each native module's C++ via CMake, which
+      # dominates build time. ccache persists the compiled objects across runs so
+      # only changed sources recompile. CMake reads the *_COMPILER_LAUNCHER vars
+      # from the environment at configure time.
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: android-${{ inputs.branding }}
+          max-size: 2G
+
       - name: Build release
         working-directory: packages/mobile/android
         env:
           ANDROID_SIGNING_KEY_ALIAS: ${{ vars.ANDROID_SIGNING_KEY_ALIAS }}
           ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
           ANDROID_SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          CMAKE_C_COMPILER_LAUNCHER: ccache
         run: |
           ARCH_ARGS=""
           if [ -n "${{ inputs.architectures }}" ]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -366,6 +366,10 @@ jobs:
       server: central.${{ matrix.name }}.cd.tamanu.app
       ref: ${{ needs.config.outputs.ref }}
       branding: ${{ fromJson(matrix.options).branding }}
+      # Test builds are for QA on physical (arm64) devices, so only compile that
+      # ABI. Avoids the New Architecture C++/CMake compile running once per ABI;
+      # release builds (below) still produce all ABIs.
+      architectures: arm64-v8a
     secrets:
       ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
       ANDROID_SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}


### PR DESCRIPTION
### Changes

🤖 The react-native 0.85 upgrade turned on the New Architecture, so every third-party native module (worklets, reanimated, screens, quick-sqlite, …) now compiles its C++ via CMake. That pushed Android CI builds from ~8-10 min to ~25-30 min. Two changes to claw that back:

- **Single-ABI test builds.** The PR "Package test Android" job compiled all four ABIs (`armeabi-v7a, arm64-v8a, x86, x86_64`) — same as a release. Test builds are for QA on physical (arm64) devices, so it now passes `architectures: arm64-v8a`, cutting the native compile roughly 4x. Release builds (tag-triggered) still produce all ABIs.
- **ccache for the native C++.** `org.gradle.caching` only covers Gradle task outputs, not the CMake/NDK object compilation that dominates here. Added `hendrikmuhs/ccache-action` and pointed CMake at it via `CMAKE_C(XX)_COMPILER_LAUNCHER=ccache`, so warm builds reuse compiled objects instead of rebuilding from scratch.

Now takes 10-15 minutes.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [x] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
