### PR TITLE
fix(notes): no-issue: deterministic note change log ordering

### DIFF
--- a/packages/facility-server/app/routeHandlers/notes/noteChangelogsHandler.js
+++ b/packages/facility-server/app/routeHandlers/notes/noteChangelogsHandler.js
@@ -28,7 +28,14 @@ export const noteChangelogsHandler = recordType =>
         [Op.or]: [{ revisedById: rootNoteId }, { id: rootNoteId }],
         visibilityStatus: VISIBILITY_STATUSES.CURRENT,
       },
-      order: [['date', 'DESC']],
+      // `date` is a second-precision datetime string, so a note created and then
+      // edited within the same second ties. Break the tie by `createdAt` (the revised
+      // row is inserted at edit time, so it has the later value) to keep the newest
+      // version first deterministically — otherwise the change log order flaps.
+      order: [
+        ['date', 'DESC'],
+        ['createdAt', 'DESC'],
+      ],
     });
 
     res.send({ data: notes, count: notes.length });


### PR DESCRIPTION
### Changes

🤖 The `…/changelogs` endpoint (`noteChangelogsHandler`) ordered note versions by `date DESC` only. Note `date` is a second-precision ISO-9075 string, so when a note is created and then edited within the same second (common in E2E, possible in real use), the original and revised rows tie and Postgres returns them in arbitrary order — the change log intermittently shows the older version first.

This surfaced as a flaky E2E (`patients/note` → "validate the change log"): `changelogTextContents.first()` expected "Updated treatment plan" but sometimes got "Original treatment plan", which fails the merge queue.

Editing a note POSTs a new revision row (with `revisedById` → root) at edit time, so the newest version always has the later `createdAt`. Adding `createdAt DESC` as a tiebreaker makes the ordering deterministic (newest first) regardless of same-second ties.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
