### PR TITLE
chore: no-issue: build-less migration (2/3) — generated codemod output

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -3,31 +3,16 @@
   "version": "2.59.0",
   "private": true,
   "description": "API client for Tamanu Facility Server",
-  "main": "dist/cjs/index.js",
-  "module": "dist/mjs/index.js",
+  "main": "./src/index",
   "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./*": {
-      "source": "./src/*.ts",
-      "import": "./dist/mjs/*.js",
-      "require": "./dist/cjs/*.js"
-    }
+    ".": "./src",
+    "./*": "./src/*"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "npm run build:src && npm run build:cjs && npm run build:types && dual-pkg dist/mjs dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:src": "swc --delete-dir-on-start --out-dir dist/mjs --copy-files --source-maps true src",
-    "build:cjs": "npm run build:src -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/mjs --rootDir src && move-dts --copy dist/mjs dist/cjs",
-    "build-watch": "npm run build && concurrently \"npm run build:src -- --watch\" \"npm run build:cjs -- --watch\"",
     "clean": "rimraf -- dist .tsbuild",
     "clean:deps": "rimraf -- node_modules"
   },
@@ -43,5 +28,6 @@
     "jose": "^5.1.1",
     "lodash": "^4.17.21",
     "qs": "^6.10.2"
-  }
+  },
+  "type": "module"
 }

--- a/packages/api-client/src/InterceptorManager.ts
+++ b/packages/api-client/src/InterceptorManager.ts
@@ -1,4 +1,4 @@
-import { forEach as _forEach } from 'lodash';
+import { forEach as _forEach } from 'es-toolkit/compat';
 
 export interface Interceptor<T, U> {
   fulfilled: (value: T) => T | Promise<T>;

--- a/packages/build-tooling/move-dts.mjs
+++ b/packages/build-tooling/move-dts.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { glob } from 'glob';
-import _ from 'lodash';
+import _ from 'es-toolkit/compat';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { parseArgs, styleText } from 'node:util';

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -2,7 +2,7 @@
   "name": "@tamanu/build-tooling",
   "version": "2.59.0",
   "description": "Build tooling for Tamanu packages",
-  "main": "index.mjs",
+  "main": "./src/index",
   "type": "module",
   "scripts": {
     "clean:deps": "rimraf -- node_modules"

--- a/packages/central-server/__tests__/admin/importSchemas.test.js
+++ b/packages/central-server/__tests__/admin/importSchemas.test.js
@@ -1,4 +1,4 @@
-import { SSCPatientIssue } from '../../dist/admin/importSchemas';
+import { SSCPatientIssue } from '../../app/admin/importSchemas';
 
 describe('admin import schemas', () => {
   it('allows PatientIssue config required by survey submission', async () => {

--- a/packages/central-server/__tests__/admin/patientMerge/PatientProgramRegistrationConditionsMerge.test.js
+++ b/packages/central-server/__tests__/admin/patientMerge/PatientProgramRegistrationConditionsMerge.test.js
@@ -1,7 +1,7 @@
 import { capitalize } from 'es-toolkit/compat';
 import { fake } from '@tamanu/fake-data/fake';
 
-import { mergePatient } from '../../../dist/admin/patientMerge/mergePatient';
+import { mergePatient } from '../../../app/admin/patientMerge/mergePatient';
 import { createTestContext } from '../../utilities';
 import { makeTwoPatients } from './makeTwoPatients';
 import { setupProgramRegistry } from './setupProgramRegistry';

--- a/packages/central-server/__tests__/admin/patientMerge/PatientProgramRegistrationConditionsMerge.test.js
+++ b/packages/central-server/__tests__/admin/patientMerge/PatientProgramRegistrationConditionsMerge.test.js
@@ -1,4 +1,4 @@
-import { capitalize } from 'lodash';
+import { capitalize } from 'es-toolkit/compat';
 import { fake } from '@tamanu/fake-data/fake';
 
 import { mergePatient } from '../../../dist/admin/patientMerge/mergePatient';

--- a/packages/central-server/__tests__/admin/patientMerge/PatientProgramRegistrationsMerge.test.js
+++ b/packages/central-server/__tests__/admin/patientMerge/PatientProgramRegistrationsMerge.test.js
@@ -1,7 +1,7 @@
 import { REGISTRATION_STATUSES } from '@tamanu/constants';
 import { fake } from '@tamanu/fake-data/fake';
 
-import { mergePatient } from '../../../dist/admin/patientMerge/mergePatient';
+import { mergePatient } from '../../../app/admin/patientMerge/mergePatient';
 import { createTestContext } from '../../utilities';
 import { makeTwoPatients } from './makeTwoPatients';
 import { setupProgramRegistry } from './setupProgramRegistry';

--- a/packages/central-server/__tests__/admin/patientMerge/patientMerge.test.js
+++ b/packages/central-server/__tests__/admin/patientMerge/patientMerge.test.js
@@ -2,13 +2,13 @@ import { fake, fakeUser } from '@tamanu/fake-data/fake';
 import {
   getTablesWithNoMergeCoverage,
   mergePatient,
-} from '../../../dist/admin/patientMerge/mergePatient';
+} from '../../../app/admin/patientMerge/mergePatient';
 import { createTestContext } from '../../utilities';
 import { InvalidParameterError } from '@tamanu/errors';
 import { NOTE_TYPES } from '@tamanu/constants/notes';
 import { Op } from 'sequelize';
 import { PATIENT_FIELD_DEFINITION_TYPES } from '@tamanu/constants/patientFields';
-import { PatientMergeMaintainer } from '../../../dist/tasks/PatientMergeMaintainer';
+import { PatientMergeMaintainer } from '../../../app/tasks/PatientMergeMaintainer';
 import { PORTAL_USER_STATUSES, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { FACT_CURRENT_SYNC_TICK } from '@tamanu/constants/facts';
 

--- a/packages/central-server/__tests__/admin/programDefinition.test.js
+++ b/packages/central-server/__tests__/admin/programDefinition.test.js
@@ -2,7 +2,7 @@ import {
   normalizeQuestionConfigForImport,
   programDefinitionSchema,
   sanitizeProgramDefinitionPreview,
-} from '../../dist/admin/programImporter/programDefinition';
+} from '../../app/admin/programImporter/programDefinition';
 
 describe('programDefinition', () => {
   it('normalizes generated PatientIssue issue types to Tamanu values', () => {

--- a/packages/central-server/__tests__/admin/programExporter/exportProgram.test.js
+++ b/packages/central-server/__tests__/admin/programExporter/exportProgram.test.js
@@ -1,4 +1,4 @@
-import { exportProgram } from '../../../dist/admin/programExporter';
+import { exportProgram } from '../../../app/admin/programExporter';
 import { createTestContext } from '../../utilities';
 import { fake } from '@tamanu/fake-data/fake';
 import { Program, Survey, ProgramDataElement, SurveyScreenComponent } from '@tamanu/database';

--- a/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
+++ b/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
@@ -1,6 +1,6 @@
 import { REPORT_DB_CONNECTIONS, REPORT_VERSION_EXPORT_FORMATS } from '@tamanu/constants/reports';
 import { createTestContext, withDateUnsafelyFaked } from '../../utilities';
-import { readJSON, sanitizeFilename, verifyQuery } from '../../../dist/admin/reports/utils';
+import { readJSON, sanitizeFilename, verifyQuery } from '../../../app/admin/reports/utils';
 import { User } from '@tamanu/database';
 import path from 'path';
 

--- a/packages/central-server/__tests__/attachment.test.js
+++ b/packages/central-server/__tests__/attachment.test.js
@@ -1,4 +1,4 @@
-import { canUploadAttachment } from '../dist/utils/getFreeDiskSpace';
+import { canUploadAttachment } from '../app/utils/getFreeDiskSpace';
 import { createTestContext } from './utilities';
 
 // Mock image to be created with fs module. Expected size of 1002 bytes.

--- a/packages/central-server/__tests__/auth/jwt-validation.test.js
+++ b/packages/central-server/__tests__/auth/jwt-validation.test.js
@@ -20,7 +20,7 @@ describe('JWT Token Validation', () => {
 
   describe('JWT Token Structure', () => {
     it('Should create JWT tokens with correct payload structure', async () => {
-      const { buildToken } = require('../../dist/auth/utils');
+      const { buildToken } = require('../../app/auth/utils');
       const { User } = models;
 
       // Create a test user
@@ -58,7 +58,7 @@ describe('JWT Token Validation', () => {
     });
 
     it('Should create JWT tokens with optional deviceId and facilityId', async () => {
-      const { buildToken } = require('../../dist/auth/utils');
+      const { buildToken } = require('../../app/auth/utils');
       const { User, Device, Facility } = models;
 
       const user = await User.create({
@@ -107,7 +107,7 @@ describe('JWT Token Validation', () => {
 
   describe('JWT Token Verification', () => {
     it('Should correctly verify JWT tokens using User.loginFromToken', async () => {
-      const { buildToken } = require('../../dist/auth/utils');
+      const { buildToken } = require('../../app/auth/utils');
       const { User } = models;
 
       const user = await User.create({
@@ -143,7 +143,7 @@ describe('JWT Token Validation', () => {
     });
 
     it('Should handle JWT tokens with deviceId correctly', async () => {
-      const { buildToken } = require('../../dist/auth/utils');
+      const { buildToken } = require('../../app/auth/utils');
       const { User, Device } = models;
 
       const user = await User.create({
@@ -195,7 +195,7 @@ describe('JWT Token Validation', () => {
     });
 
     it('Should reject JWT tokens with non-existent userId', async () => {
-      const { buildToken } = require('../../dist/auth/utils');
+      const { buildToken } = require('../../app/auth/utils');
       const { User } = models;
 
       const fakeUserId = '99999999-9999-9999-9999-999999999999';

--- a/packages/central-server/__tests__/configureEnvironment.js
+++ b/packages/central-server/__tests__/configureEnvironment.js
@@ -14,7 +14,7 @@ const { TextDecoder } = require('util');
 global.TextDecoder = TextDecoder;
 
 jest.setTimeout(45 * 1000); // more generous than the default 5s but not crazy
-jest.mock('../dist/utils/getFreeDiskSpace');
+jest.mock('../app/utils/getFreeDiskSpace');
 
 const formatError = response => {
   if (!response.body) {

--- a/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
+++ b/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
@@ -30,13 +30,13 @@ import {
   REFERENCE_TYPES,
 } from '@tamanu/constants';
 import { createTestContext } from '../utilities';
-import { exporter } from '../../dist/admin/exporter';
+import { exporter } from '../../app/admin/exporter';
 import { parseDate } from '@tamanu/utils/dateTime';
-import { writeExcelFile } from '../../dist/utils/excelUtils';
+import { writeExcelFile } from '../../app/utils/excelUtils';
 import { makeRoleWithPermissions } from '../permissions';
 
-jest.mock('../../dist/utils/excelUtils', () => {
-  const originalModule = jest.requireActual('../../dist/utils/excelUtils');
+jest.mock('../../app/utils/excelUtils', () => {
+  const originalModule = jest.requireActual('../../app/utils/excelUtils');
 
   return {
     __esModule: true,

--- a/packages/central-server/__tests__/hl7fhir/administeredVaccine.test.js
+++ b/packages/central-server/__tests__/hl7fhir/administeredVaccine.test.js
@@ -2,7 +2,7 @@ import { fake, fakeReferenceData, fakeUser } from '@tamanu/fake-data/fake';
 import {
   administeredVaccineToHL7Immunization,
   getAdministeredVaccineInclude,
-} from '../../dist/hl7fhir/administeredVaccine';
+} from '../../app/hl7fhir/administeredVaccine';
 import { createTestContext } from '../utilities';
 
 import { validate } from './hl7utilities';

--- a/packages/central-server/__tests__/hl7fhir/labTest.test.js
+++ b/packages/central-server/__tests__/hl7fhir/labTest.test.js
@@ -11,7 +11,7 @@ import {
   labTestToHL7Device,
   labTestToHL7DiagnosticReport,
   labTestToHL7Observation,
-} from '../../dist/hl7fhir/labTest';
+} from '../../app/hl7fhir/labTest';
 
 async function prepopulate(models) {
   // test category

--- a/packages/central-server/__tests__/hl7fhir/loinc.test.js
+++ b/packages/central-server/__tests__/hl7fhir/loinc.test.js
@@ -1,5 +1,5 @@
 import { chance } from '@tamanu/fake-data/fake';
-import { labTestTypeToLOINCCode } from '../../dist/hl7fhir/loinc';
+import { labTestTypeToLOINCCode } from '../../app/hl7fhir/loinc';
 
 describe('HL7 LOINC', () => {
   it('returns "Immunoassay" for a swab', () => {

--- a/packages/central-server/__tests__/hl7fhir/materialised/Patient.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Patient.test.js
@@ -5,10 +5,10 @@ import { getCurrentDateString } from '@tamanu/utils/dateTime';
 import { fakeUUID } from '@tamanu/utils/generateId';
 import { formatFhirDate } from '@tamanu/shared/utils/fhir/datetime';
 import { FHIR_DATETIME_PRECISION } from '@tamanu/constants/fhir';
-import { mergePatient } from '../../../dist/admin/patientMerge/mergePatient';
+import { mergePatient } from '../../../app/admin/patientMerge/mergePatient';
 
 import { createTestContext } from '../../utilities';
-import { IDENTIFIER_NAMESPACE } from '../../../dist/hl7fhir/utils';
+import { IDENTIFIER_NAMESPACE } from '../../../app/hl7fhir/utils';
 import { ALL_FHIR_PERMISSIONS } from '../../fake/fhir';
 
 const INTEGRATION_ROUTE = 'fhir/mat';

--- a/packages/central-server/__tests__/hl7fhir/materialised/databaseTriggers.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/databaseTriggers.test.js
@@ -6,7 +6,7 @@ a migration that registers a trigger for database tables.
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { createTestContext } from '../../utilities';
-import { setFhirRefreshTriggers } from '../../../dist/database/setFhirRefreshTriggers';
+import { setFhirRefreshTriggers } from '../../../app/database/setFhirRefreshTriggers';
 
 expect.extend({
   async toHaveARegisteredTrigger(tableName, triggerType, triggers) {

--- a/packages/central-server/__tests__/hl7fhir/materialised/resolver.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/resolver.test.js
@@ -5,7 +5,7 @@ import { createTestContext } from '../../utilities';
 import { ALL_FHIR_PERMISSIONS, fakeResourcesOfFhirServiceRequest } from '../../fake/fhir';
 import { sleepAsync } from '../../../../utils/dist/cjs/sleepAsync';
 
-import { mergePatient } from '../../../dist/admin/patientMerge/mergePatient';
+import { mergePatient } from '../../../app/admin/patientMerge/mergePatient';
 
 const INTEGRATION_ROUTE = 'fhir/mat';
 

--- a/packages/central-server/__tests__/hl7fhir/patient.test.js
+++ b/packages/central-server/__tests__/hl7fhir/patient.test.js
@@ -10,7 +10,7 @@ import {
   getPatientWhereClause,
   patientToHL7Patient,
   patientToHL7PatientList,
-} from '../../dist/hl7fhir/patient';
+} from '../../app/hl7fhir/patient';
 
 import { validate } from './hl7utilities';
 

--- a/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testPatientHandler.js
+++ b/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testPatientHandler.js
@@ -4,7 +4,7 @@ import { fake } from '@tamanu/fake-data/fake';
 import { getCurrentDateString } from '@tamanu/utils/dateTime';
 
 import { createTestContext } from '../../utilities';
-import { IDENTIFIER_NAMESPACE } from '../../../dist/hl7fhir/utils';
+import { IDENTIFIER_NAMESPACE } from '../../../app/hl7fhir/utils';
 
 export function testPatientHandler(integrationName, requestHeaders = {}) {
   describe(`${integrationName} integration - Patient`, () => {

--- a/packages/central-server/__tests__/hl7fhir/utils.test.js
+++ b/packages/central-server/__tests__/hl7fhir/utils.test.js
@@ -4,8 +4,8 @@ import { BaseError, InvalidParameterError } from '@tamanu/errors';
 import { formatFhirDate } from '@tamanu/shared/utils/fhir/datetime';
 import { createTestContext } from '../utilities';
 
-import { hl7SortToTamanu } from '../../dist/hl7fhir/utils';
-import { sortableHL7PatientFields } from '../../dist/hl7fhir/hl7PatientFields';
+import { hl7SortToTamanu } from '../../app/hl7fhir/utils';
+import { sortableHL7PatientFields } from '../../app/hl7fhir/hl7PatientFields';
 
 describe('HL7FHIR module utils', () => {
   let models;

--- a/packages/central-server/__tests__/importers/labTestPanel/labTestPanelImporter.test.js
+++ b/packages/central-server/__tests__/importers/labTestPanel/labTestPanelImporter.test.js
@@ -1,7 +1,7 @@
 import { REFERENCE_TYPES } from '@tamanu/constants';
 
-import { importerTransaction } from '../../../dist/admin/importer/importerEndpoint';
-import { referenceDataImporter } from '../../../dist/admin/referenceDataImporter';
+import { importerTransaction } from '../../../app/admin/importer/importerEndpoint';
+import { referenceDataImporter } from '../../../app/admin/referenceDataImporter';
 import { createTestContext } from '../../utilities';
 import '../matchers';
 

--- a/packages/central-server/__tests__/importers/matchers.js
+++ b/packages/central-server/__tests__/importers/matchers.js
@@ -1,4 +1,4 @@
-import { ForeignkeyResolutionError, ValidationError } from '../../dist/admin/errors';
+import { ForeignkeyResolutionError, ValidationError } from '../../app/admin/errors';
 
 function toContainError(errors, { ofType = null, inSheet, atRow, withMessage }) {
   const suffix = `on ${inSheet} at row ${atRow}`;

--- a/packages/central-server/__tests__/importers/normaliser.test.js
+++ b/packages/central-server/__tests__/importers/normaliser.test.js
@@ -1,4 +1,4 @@
-import { normaliseSheetName } from '../../dist/admin/importer/importerEndpoint';
+import { normaliseSheetName } from '../../app/admin/importer/importerEndpoint';
 
 describe('Sheet name normaliser', () => {
   it('should normalise single words', () => {

--- a/packages/central-server/__tests__/importers/patient/patientImporter.test.js
+++ b/packages/central-server/__tests__/importers/patient/patientImporter.test.js
@@ -1,5 +1,5 @@
-import { importerTransaction } from '../../../dist/admin/importer/importerEndpoint';
-import { referenceDataImporter } from '../../../dist/admin/referenceDataImporter';
+import { importerTransaction } from '../../../app/admin/importer/importerEndpoint';
+import { referenceDataImporter } from '../../../app/admin/referenceDataImporter';
 import { createTestContext } from '../../utilities';
 import '../matchers';
 

--- a/packages/central-server/__tests__/importers/programsImporter.charting.test.js
+++ b/packages/central-server/__tests__/importers/programsImporter.charting.test.js
@@ -1,8 +1,8 @@
 import { fake } from '@tamanu/fake-data/fake';
 import { SURVEY_TYPES } from '@tamanu/constants';
 
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { programImporter } from '../../dist/admin/programImporter';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { programImporter } from '../../app/admin/programImporter';
 import { createTestContext } from '../utilities';
 import './matchers';
 

--- a/packages/central-server/__tests__/importers/programsImporter.questionValidation.test.js
+++ b/packages/central-server/__tests__/importers/programsImporter.questionValidation.test.js
@@ -1,5 +1,5 @@
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { programImporter } from '../../dist/admin/programImporter';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { programImporter } from '../../app/admin/programImporter';
 import { createTestContext } from '../utilities';
 import './matchers';
 

--- a/packages/central-server/__tests__/importers/programsImporter.registry.test.js
+++ b/packages/central-server/__tests__/importers/programsImporter.registry.test.js
@@ -1,9 +1,9 @@
 import { PROGRAM_REGISTRY_CONDITION_CATEGORIES } from '@tamanu/constants';
 import { fake } from '@tamanu/fake-data/fake';
 import { findOneOrCreate } from '@tamanu/fake-data/test-helpers';
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { programImporter } from '../../dist/admin/programImporter';
-import { autoFillConditionCategoryImport } from '../../dist/admin/programImporter/autoFillConditionCategoryImport';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { programImporter } from '../../app/admin/programImporter';
+import { autoFillConditionCategoryImport } from '../../app/admin/programImporter/autoFillConditionCategoryImport';
 import { createTestContext } from '../utilities';
 import './matchers';
 

--- a/packages/central-server/__tests__/importers/programsImporter.test.js
+++ b/packages/central-server/__tests__/importers/programsImporter.test.js
@@ -1,5 +1,5 @@
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { programImporter } from '../../dist/admin/programImporter';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { programImporter } from '../../app/admin/programImporter';
 import { createTestContext } from '../utilities';
 import './matchers';
 

--- a/packages/central-server/__tests__/importers/programsImporter.translation.test.js
+++ b/packages/central-server/__tests__/importers/programsImporter.translation.test.js
@@ -2,8 +2,8 @@ import { Op } from 'sequelize';
 import { REFERENCE_DATA_TRANSLATION_PREFIX } from '@tamanu/constants';
 import { getReferenceDataOptionStringId } from '@tamanu/shared/utils/translation';
 
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { programImporter } from '../../dist/admin/programImporter';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { programImporter } from '../../app/admin/programImporter';
 import { createTestContext } from '../utilities';
 import './matchers';
 import {

--- a/packages/central-server/__tests__/importers/programsImporter.vitals.test.js
+++ b/packages/central-server/__tests__/importers/programsImporter.vitals.test.js
@@ -1,8 +1,8 @@
 import { fake } from '@tamanu/fake-data/fake';
 import { SURVEY_TYPES } from '@tamanu/constants';
 
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { programImporter } from '../../dist/admin/programImporter';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { programImporter } from '../../app/admin/programImporter';
 import { createTestContext } from '../utilities';
 import './matchers';
 

--- a/packages/central-server/__tests__/importers/referenceDataImporter.test.js
+++ b/packages/central-server/__tests__/importers/referenceDataImporter.test.js
@@ -12,11 +12,11 @@ import { createDummyPatient } from '@tamanu/database/demoData/patients';
 import { getReferenceDataOptionStringId } from '@tamanu/shared/utils/translation';
 import { REFERENCE_TYPES, REFERENCE_DATA_TRANSLATION_PREFIX } from '@tamanu/constants';
 
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { referenceDataImporter } from '../../dist/admin/referenceDataImporter';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { referenceDataImporter } from '../../app/admin/referenceDataImporter';
 import { createTestContext } from '../utilities';
 import './matchers';
-import { exporter } from '../../dist/admin/exporter/exporter';
+import { exporter } from '../../app/admin/exporter/exporter';
 import { createAllergy, createDiagnosis } from '../exporters/referenceDataUtils';
 import { camelCase } from 'es-toolkit/compat';
 import { makeRoleWithPermissions } from '../permissions';

--- a/packages/central-server/__tests__/importers/referenceDataImporter.test.js
+++ b/packages/central-server/__tests__/importers/referenceDataImporter.test.js
@@ -18,7 +18,7 @@ import { createTestContext } from '../utilities';
 import './matchers';
 import { exporter } from '../../dist/admin/exporter/exporter';
 import { createAllergy, createDiagnosis } from '../exporters/referenceDataUtils';
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 import { makeRoleWithPermissions } from '../permissions';
 import { normaliseOptions } from '../../app/admin/importer/translationHandler';
 

--- a/packages/central-server/__tests__/importers/stats.test.js
+++ b/packages/central-server/__tests__/importers/stats.test.js
@@ -1,4 +1,4 @@
-import { coalesceStats } from "../../dist/admin/stats";
+import { coalesceStats } from "../../app/admin/stats";
 
 describe('Importer statistics utility functions', () => {
 

--- a/packages/central-server/__tests__/importers/user/userImporter.test.js
+++ b/packages/central-server/__tests__/importers/user/userImporter.test.js
@@ -1,8 +1,8 @@
 import { VISIBILITY_STATUSES } from '@tamanu/constants';
 import { fake } from '@tamanu/fake-data/fake';
 
-import { importerTransaction } from '../../../dist/admin/importer/importerEndpoint';
-import { referenceDataImporter } from '../../../dist/admin/referenceDataImporter';
+import { importerTransaction } from '../../../app/admin/importer/importerEndpoint';
+import { referenceDataImporter } from '../../../app/admin/referenceDataImporter';
 import { createTestContext } from '../../utilities';
 import '../matchers';
 

--- a/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -15,7 +15,7 @@ import { log } from '@tamanu/shared/services/logging';
 
 import { createTestContext } from '../../utilities';
 import { ALL_FHIR_PERMISSIONS } from '../../fake/fhir';
-import { allFromUpstream } from '../../../dist/tasks/fhir/refresh/allFromUpstream';
+import { allFromUpstream } from '../../../app/tasks/fhir/refresh/allFromUpstream';
 
 jest.setTimeout(50000);
 

--- a/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'es-toolkit/compat';
 import { utcToZonedTime } from 'date-fns-tz';
 import {
   REFERENCE_TYPES,

--- a/packages/central-server/__tests__/middleware/versionCompatibility.test.js
+++ b/packages/central-server/__tests__/middleware/versionCompatibility.test.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { promises as fs } from 'fs';
 import { SERVER_TYPES, VERSION_COMPATIBILITY_ERRORS } from '@tamanu/constants';
 import { createTestContext } from '../utilities';
-import { VERSION_CONTROLLED_CLIENTS } from '../../dist/middleware/versionCompatibility';
+import { VERSION_CONTROLLED_CLIENTS } from '../../app/middleware/versionCompatibility';
 
 const MIN_MOBILE_VERSION = VERSION_CONTROLLED_CLIENTS[SERVER_TYPES.MOBILE].min;
 const MIN_FACILITY_VERSION = VERSION_CONTROLLED_CLIENTS[SERVER_TYPES.FACILITY].min;

--- a/packages/central-server/__tests__/patientCertificate.test.js
+++ b/packages/central-server/__tests__/patientCertificate.test.js
@@ -7,7 +7,7 @@ import { randomLabRequest } from '@tamanu/database/demoData/labRequests';
 import { chance, fake } from '@tamanu/fake-data/fake';
 import { CertificateTypes } from '@tamanu/shared/utils';
 import { LAB_REQUEST_STATUSES, REFERENCE_TYPES } from '@tamanu/constants';
-import { makeCovidCertificate, makeVaccineCertificate } from '../dist/utils/makePatientCertificate';
+import { makeCovidCertificate, makeVaccineCertificate } from '../app/utils/makePatientCertificate';
 
 import { createTestContext } from './utilities';
 import { getCurrentDateString } from '@tamanu/utils/dateTime';

--- a/packages/central-server/__tests__/subCommands/apiKeys.test.js
+++ b/packages/central-server/__tests__/subCommands/apiKeys.test.js
@@ -1,7 +1,7 @@
 import { fake } from '@tamanu/fake-data/fake';
 import config from 'config';
-import { verifyToken } from '../../dist/auth/utils';
-import { genToken } from '../../dist/subCommands/apiKeys/issue';
+import { verifyToken } from '../../app/auth/utils';
+import { genToken } from '../../app/subCommands/apiKeys/issue';
 import { createTestContext } from '../utilities';
 
 describe('apiKeys issue', () => {

--- a/packages/central-server/__tests__/subCommands/fhir.test.js
+++ b/packages/central-server/__tests__/subCommands/fhir.test.js
@@ -5,8 +5,8 @@ import {
   LAB_REQUEST_STATUSES,
 } from '@tamanu/constants';
 import { createTestContext } from '../utilities';
-import { fhir } from '../../dist/subCommands/fhir';
-import { ApplicationContext } from '../../dist/ApplicationContext';
+import { fhir } from '../../app/subCommands/fhir';
+import { ApplicationContext } from '../../app/ApplicationContext';
 import {
   fakeResourcesOfFhirServiceRequest,
   fakeResourcesOfFhirServiceRequestWithImagingRequest,

--- a/packages/central-server/__tests__/subCommands/generate.test.js
+++ b/packages/central-server/__tests__/subCommands/generate.test.js
@@ -1,4 +1,4 @@
-import { generateFiji } from '../../dist/subCommands/generate/fiji';
+import { generateFiji } from '../../app/subCommands/generate/fiji';
 import { createTestContext } from '../utilities';
 
 describe('`generate fiji` subcommand', () => {

--- a/packages/central-server/__tests__/subCommands/importReport/actions.test.js
+++ b/packages/central-server/__tests__/subCommands/importReport/actions.test.js
@@ -2,7 +2,7 @@ import Table from 'cli-table3';
 import { log } from '@tamanu/shared/services/logging';
 import { spyOnModule } from '@tamanu/shared/test-helpers/spyOn';
 import { VISIBILITY_STATUSES } from '@tamanu/constants';
-import { initDatabase } from '../../../dist/database';
+import { initDatabase } from '../../../app/database';
 import {
   ACTIVE_TEXT,
   createVersion,
@@ -11,7 +11,7 @@ import {
   getVersionError,
   listVersions,
   OVERWRITING_TEXT,
-} from '../../../dist/subCommands/importReport/actions';
+} from '../../../app/subCommands/importReport/actions';
 
 spyOnModule(jest, '../../../dist/subCommands/importReport/actions');
 
@@ -56,7 +56,7 @@ const mockVersions = [
   { versionNumber: 1, status: 'draft', updatedAt: mockUpdatedAt },
 ];
 
-jest.mock('../../../dist/database', () => ({
+jest.mock('../../../app/database', () => ({
   initDatabase: jest.fn().mockResolvedValue({
     models: {
       User: {

--- a/packages/central-server/__tests__/subCommands/importReport/utils.test.js
+++ b/packages/central-server/__tests__/subCommands/importReport/utils.test.js
@@ -2,7 +2,7 @@ import { REPORT_STATUSES } from '@tamanu/constants';
 import {
   findOrCreateDefinition,
   getLatestVersion,
-} from '../../../dist/subCommands/importReport/utils';
+} from '../../../app/subCommands/importReport/utils';
 
 const mockDefinition = {
   name: 'test-definition-name',

--- a/packages/central-server/__tests__/subCommands/migrateAppointmentsToLocationGroups.test.js
+++ b/packages/central-server/__tests__/subCommands/migrateAppointmentsToLocationGroups.test.js
@@ -1,7 +1,7 @@
 import { fake } from '@tamanu/fake-data/fake';
 import { IMAGING_TYPES } from '@tamanu/constants';
 import { createTestContext } from '../utilities';
-import { migrateImagingRequests } from '../../dist/subCommands';
+import { migrateImagingRequests } from '../../app/subCommands';
 
 async function prepopulate(models) {
   const { Facility, User, Location, LocationGroup, ImagingRequest } = models;

--- a/packages/central-server/__tests__/subCommands/migrateVitals.test.js
+++ b/packages/central-server/__tests__/subCommands/migrateVitals.test.js
@@ -1,7 +1,7 @@
-import { COLUMNS_TO_DATA_ELEMENT_ID, migrateVitals } from '../../dist/subCommands/migrateVitals';
-import { initDatabase } from '../../dist/database';
+import { COLUMNS_TO_DATA_ELEMENT_ID, migrateVitals } from '../../app/subCommands/migrateVitals';
+import { initDatabase } from '../../app/database';
 
-jest.mock('../../dist/database', () => ({
+jest.mock('../../app/database', () => ({
   initDatabase: jest.fn().mockResolvedValue({
     models: {
       Vitals: {

--- a/packages/central-server/__tests__/subCommands/provision.test.js
+++ b/packages/central-server/__tests__/subCommands/provision.test.js
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { chance, fake } from '@tamanu/fake-data/fake';
 
 import { createTestContext } from '../utilities';
-import { provision } from '../../dist/subCommands/provision';
+import { provision } from '../../app/subCommands/provision';
 
 const ADMIN_EMAIL = 'admin@tamanu.io';
 

--- a/packages/central-server/__tests__/subCommands/removeDuplicatedDischarges.test.js
+++ b/packages/central-server/__tests__/subCommands/removeDuplicatedDischarges.test.js
@@ -6,7 +6,7 @@ import { getCurrentDateTimeString, toDateTimeString } from '@tamanu/utils/dateTi
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { createTestContext } from '../utilities';
-import { removeDuplicatedDischarges } from '../../dist/subCommands';
+import { removeDuplicatedDischarges } from '../../app/subCommands';
 
 describe('removeDuplicatedDischarges', () => {
   let ctx;

--- a/packages/central-server/__tests__/subCommands/user.test.js
+++ b/packages/central-server/__tests__/subCommands/user.test.js
@@ -3,7 +3,7 @@ import bcrypt from 'bcrypt';
 import { chance, fake } from '@tamanu/fake-data/fake';
 
 import { createTestContext } from '../utilities';
-import { changePassword } from '../../dist/subCommands/user';
+import { changePassword } from '../../app/subCommands/user';
 
 // mock 'read' and provide implementation
 jest.mock('read');

--- a/packages/central-server/__tests__/sync/CentralSyncManager.edgeCases.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.edgeCases.test.js
@@ -19,7 +19,7 @@ import {
   waitForPushCompleted,
   initializeCentralSyncManagerWithContext,
 } from '../utilities';
-import { OutpatientDischarger } from '../../dist/tasks/OutpatientDischarger';
+import { OutpatientDischarger } from '../../app/tasks/OutpatientDischarger';
 
 describe('CentralSyncManager Edge Cases', () => {
   let ctx;

--- a/packages/central-server/__tests__/sync/CentralSyncManager.setupSnapshotForPull.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.setupSnapshotForPull.test.js
@@ -25,8 +25,8 @@ import {
   waitForPushCompleted,
   initializeCentralSyncManagerWithContext,
 } from '../utilities';
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { referenceDataImporter } from '../../dist/admin/referenceDataImporter';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { referenceDataImporter } from '../../app/admin/referenceDataImporter';
 
 const doImport = (options, models) => {
   const { file, ...opts } = options;

--- a/packages/central-server/__tests__/sync/CentralSyncManager.startSession.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.startSession.test.js
@@ -7,7 +7,7 @@ import {
   waitForSession,
   initializeCentralSyncManagerWithContext,
 } from '../utilities';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'es-toolkit/compat';
 
 describe('CentralSyncManager.startSession', () => {
   let ctx;

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -21,11 +21,11 @@ import {
   SYNC_SESSION_DIRECTION,
 } from '@tamanu/database/sync';
 
-import { CentralSyncManager } from '../../dist/sync/CentralSyncManager';
+import { CentralSyncManager } from '../../app/sync/CentralSyncManager';
 import { createTestContext } from '../utilities';
-import { getPatientLinkedModels } from '../../dist/sync/getPatientLinkedModels';
-import { createMarkedForSyncPatientsTable } from '../../dist/sync/createMarkedForSyncPatientsTable';
-import { snapshotOutgoingChanges } from '../../dist/sync/snapshotOutgoingChanges';
+import { getPatientLinkedModels } from '../../app/sync/getPatientLinkedModels';
+import { createMarkedForSyncPatientsTable } from '../../app/sync/createMarkedForSyncPatientsTable';
+import { snapshotOutgoingChanges } from '../../app/sync/snapshotOutgoingChanges';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 describe('Sync Lookup data', () => {
@@ -1494,7 +1494,7 @@ describe('Sync Lookup data', () => {
       });
 
       const actualConfig = jest.requireActual('config');
-      const { CentralSyncManager } = require('../../dist/sync/CentralSyncManager');
+      const { CentralSyncManager } = require('../../app/sync/CentralSyncManager');
       const config = {
         ...actualConfig,
         sync: {

--- a/packages/central-server/__tests__/sync/CentralSyncManager.updateLookupTable.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.updateLookupTable.test.js
@@ -16,8 +16,8 @@ import {
   waitForSession,
   initializeCentralSyncManagerWithContext,
 } from '../utilities';
-import { importerTransaction } from '../../dist/admin/importer/importerEndpoint';
-import { referenceDataImporter } from '../../dist/admin/referenceDataImporter';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { referenceDataImporter } from '../../app/admin/referenceDataImporter';
 
 const doImport = (options, models) => {
   const { file, ...opts } = options;

--- a/packages/central-server/__tests__/sync/PatientMergeSync.test.js
+++ b/packages/central-server/__tests__/sync/PatientMergeSync.test.js
@@ -10,7 +10,7 @@ import { fake, fakeUser } from '@tamanu/fake-data/fake';
 import { makeTwoPatients } from '../admin/patientMerge/makeTwoPatients';
 import { mergePatient } from '../../app/admin/patientMerge/mergePatient';
 import { createTestContext } from '../utilities';
-import { CentralSyncManager } from '../../dist/sync/CentralSyncManager';
+import { CentralSyncManager } from '../../app/sync/CentralSyncManager';
 
 jest.mock('config', () => ({
   ...jest.requireActual('config'),

--- a/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
+++ b/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
@@ -80,7 +80,7 @@ const MAX_CONCURRENT_SESSIONS = 1;
         ),
       );
 
-      const { CentralSyncManager } = require('../../dist/sync/CentralSyncManager');
+      const { CentralSyncManager } = require('../../app/sync/CentralSyncManager');
       CentralSyncManager.overrideConfig({
         sync: {
           awaitPreparation: true,

--- a/packages/central-server/__tests__/sync/getPatientLinkedModels.test.js
+++ b/packages/central-server/__tests__/sync/getPatientLinkedModels.test.js
@@ -1,7 +1,7 @@
 import { Sequelize } from 'sequelize';
 
 import { createTestContext } from '../utilities';
-import { getPatientLinkedModels } from '../../dist/sync/getPatientLinkedModels';
+import { getPatientLinkedModels } from '../../app/sync/getPatientLinkedModels';
 
 describe('getPatientLinkedModels', () => {
   let ctx;

--- a/packages/central-server/__tests__/sync/integration/notes.test.js
+++ b/packages/central-server/__tests__/sync/integration/notes.test.js
@@ -9,7 +9,7 @@ import {
 } from '@tamanu/constants';
 
 import { createTestContext, waitForSession } from '../../utilities';
-import { CentralSyncManager } from '../../../dist/sync/CentralSyncManager';
+import { CentralSyncManager } from '../../../app/sync/CentralSyncManager';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 describe('CentralSyncManager', () => {

--- a/packages/central-server/__tests__/sync/sanitizeBuffer.test.js
+++ b/packages/central-server/__tests__/sync/sanitizeBuffer.test.js
@@ -10,7 +10,7 @@ import {
 } from '@tamanu/database/sync';
 
 import { createTestContext } from '../utilities';
-import { snapshotOutgoingChanges } from '../../dist/sync/snapshotOutgoingChanges';
+import { snapshotOutgoingChanges } from '../../app/sync/snapshotOutgoingChanges';
 import { FACT_CURRENT_SYNC_TICK } from '@tamanu/constants/facts';
 
 describe('sanitize binary data', () => {

--- a/packages/central-server/__tests__/sync/snapshotOutgoingChanges.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/snapshotOutgoingChanges.syncLookup.test.js
@@ -11,8 +11,8 @@ import { fakeUUID } from '@tamanu/utils/generateId';
 import { createDummyPatient } from '@tamanu/database/demoData/patients';
 
 import { createTestContext } from '../utilities';
-import { createMarkedForSyncPatientsTable } from '../../dist/sync/createMarkedForSyncPatientsTable';
-import { snapshotOutgoingChanges } from '../../dist/sync/snapshotOutgoingChanges';
+import { createMarkedForSyncPatientsTable } from '../../app/sync/createMarkedForSyncPatientsTable';
+import { snapshotOutgoingChanges } from '../../app/sync/snapshotOutgoingChanges';
 import { FACT_CURRENT_SYNC_TICK } from '@tamanu/constants/facts';
 
 describe('snapshotOutgoingChanges', () => {

--- a/packages/central-server/__tests__/sync/snapshotOutgoingChanges.test.js
+++ b/packages/central-server/__tests__/sync/snapshotOutgoingChanges.test.js
@@ -17,8 +17,8 @@ import { sleepAsync } from '@tamanu/utils/sleepAsync';
 import { fakeUUID } from '@tamanu/utils/generateId';
 
 import { createTestContext } from '../utilities';
-import { snapshotOutgoingChanges } from '../../dist/sync/snapshotOutgoingChanges';
-import { createMarkedForSyncPatientsTable } from '../../dist/sync/createMarkedForSyncPatientsTable';
+import { snapshotOutgoingChanges } from '../../app/sync/snapshotOutgoingChanges';
+import { createMarkedForSyncPatientsTable } from '../../app/sync/createMarkedForSyncPatientsTable';
 
 describe('snapshotOutgoingChanges', () => {
   let ctx;

--- a/packages/central-server/__tests__/tasks/DHIS2IntegrationProcessor.test.js
+++ b/packages/central-server/__tests__/tasks/DHIS2IntegrationProcessor.test.js
@@ -8,7 +8,7 @@ import {
   ERROR_LOGS,
   LOG_FIELDS,
   AUDIT_STATUSES,
-} from '../../dist/tasks/DHIS2IntegrationProcessor';
+} from '../../app/tasks/DHIS2IntegrationProcessor';
 import { REPORT_DB_CONNECTIONS, REPORT_STATUSES, SETTINGS_SCOPES } from '@tamanu/constants';
 import { fake } from '../../../fake-data/dist/mjs/fake/fake';
 import { log } from '@tamanu/shared/services/logging';

--- a/packages/central-server/__tests__/tasks/DHIS2IntegrationProcessor.test.js
+++ b/packages/central-server/__tests__/tasks/DHIS2IntegrationProcessor.test.js
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 
 import { createTestContext } from '../utilities';
 import {

--- a/packages/central-server/__tests__/tasks/FhirMissingResources.test.js
+++ b/packages/central-server/__tests__/tasks/FhirMissingResources.test.js
@@ -6,7 +6,7 @@ import {
   fakeResourcesOfFhirServiceRequestWithImagingRequest,
   fakeResourcesOfFhirSpecimen,
 } from '../fake/fhir';
-import { FhirMissingResources } from '../../dist/tasks/FhirMissingResources';
+import { FhirMissingResources } from '../../app/tasks/FhirMissingResources';
 import { JOB_PRIORITIES, SYSTEM_USER_UUID } from '@tamanu/constants';
 
 describe('FhirMissingResources task', () => {

--- a/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
+++ b/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
@@ -9,8 +9,8 @@ import {
   fakeResourcesOfFhirServiceRequest,
   fakeResourcesOfFhirServiceRequestWithImagingRequest,
 } from '../fake/fhir';
-import { allFromUpstream } from '../../dist/tasks/fhir/refresh/allFromUpstream';
-import { entireResource } from '../../dist/tasks/fhir/refresh/entireResource';
+import { allFromUpstream } from '../../app/tasks/fhir/refresh/allFromUpstream';
+import { entireResource } from '../../app/tasks/fhir/refresh/entireResource';
 
 describe('FHIR refresh handler', () => {
   let ctx;

--- a/packages/central-server/__tests__/tasks/MedicationDiscontinuer.test.js
+++ b/packages/central-server/__tests__/tasks/MedicationDiscontinuer.test.js
@@ -3,7 +3,7 @@ import { toDateTimeString } from '@tamanu/utils/dateTime';
 import { SYSTEM_USER_UUID } from '@tamanu/constants';
 import { sub } from 'date-fns';
 
-import { MedicationDiscontinuer } from '../../dist/tasks/MedicationDiscontinuer';
+import { MedicationDiscontinuer } from '../../app/tasks/MedicationDiscontinuer';
 import { createTestContext } from '../utilities';
 
 describe('Medication Discontinuer', () => {

--- a/packages/central-server/__tests__/tasks/ProgramRegistryPltfuFlagger.js.test.js
+++ b/packages/central-server/__tests__/tasks/ProgramRegistryPltfuFlagger.js.test.js
@@ -8,7 +8,7 @@ import {
   VISIBILITY_STATUSES,
 } from '@tamanu/constants';
 
-import { ProgramRegistryPltfuFlagger } from '../../dist/tasks/ProgramRegistryPltfuFlagger';
+import { ProgramRegistryPltfuFlagger } from '../../app/tasks/ProgramRegistryPltfuFlagger';
 import { createTestContext } from '../utilities';
 
 jest.setTimeout(60000);

--- a/packages/central-server/__tests__/tasks/SnapshotTableCleaner.test.js
+++ b/packages/central-server/__tests__/tasks/SnapshotTableCleaner.test.js
@@ -3,7 +3,7 @@ import { sub } from 'date-fns';
 import { fakeUUID } from '@tamanu/utils/generateId';
 import { createSnapshotTable, dropSnapshotTable } from '@tamanu/database/sync';
 
-import { SnapshotTableCleaner } from '../../dist/tasks/SnapshotTableCleaner';
+import { SnapshotTableCleaner } from '../../app/tasks/SnapshotTableCleaner';
 import { createTestContext } from '../utilities';
 
 describe('SnapshotTableCleaner', () => {

--- a/packages/central-server/__tests__/tasks/automaticLabTestPublisher.test.js
+++ b/packages/central-server/__tests__/tasks/automaticLabTestPublisher.test.js
@@ -3,7 +3,7 @@ import { ENCOUNTER_TYPES, LAB_REQUEST_STATUSES } from '@tamanu/constants';
 import { chance, fake, fakeUser } from '@tamanu/fake-data/fake';
 
 import { createTestContext } from '../utilities';
-import { AutomaticLabTestResultPublisher } from '../../dist/tasks/AutomaticLabTestResultPublisher';
+import { AutomaticLabTestResultPublisher } from '../../app/tasks/AutomaticLabTestResultPublisher';
 
 const testConfig = {
   enabled: true,

--- a/packages/central-server/__tests__/tasks/fhir/resolver.test.js
+++ b/packages/central-server/__tests__/tasks/fhir/resolver.test.js
@@ -1,5 +1,5 @@
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
-import { sortResourcesInDependencyOrder } from '../../../dist/tasks/fhir/resolver';
+import { sortResourcesInDependencyOrder } from '../../../app/tasks/fhir/resolver';
 import { createTestContext } from '../../utilities';
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
 

--- a/packages/central-server/__tests__/tasks/outpatientDischarger.test.js
+++ b/packages/central-server/__tests__/tasks/outpatientDischarger.test.js
@@ -3,7 +3,7 @@ import { ENCOUNTER_TYPES } from '@tamanu/constants/encounters';
 import { fake, fakeUser } from '@tamanu/fake-data/fake';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
 
-import { OutpatientDischarger } from '../../dist/tasks/OutpatientDischarger';
+import { OutpatientDischarger } from '../../app/tasks/OutpatientDischarger';
 import { createTestContext } from '../utilities';
 
 describe('Outpatient discharger', () => {

--- a/packages/central-server/__tests__/teardown.js
+++ b/packages/central-server/__tests__/teardown.js
@@ -1,4 +1,4 @@
-import { closeDatabase } from '../dist/database';
+import { closeDatabase } from '../app/database';
 
 export default async function() {
   await closeDatabase();

--- a/packages/central-server/__tests__/translation.test.js
+++ b/packages/central-server/__tests__/translation.test.js
@@ -1,4 +1,4 @@
-import { sortBy } from 'lodash';
+import { sortBy } from 'es-toolkit/compat';
 import { fake } from '@tamanu/fake-data/fake';
 import { createTestContext } from './utilities';
 

--- a/packages/central-server/__tests__/utilities.js
+++ b/packages/central-server/__tests__/utilities.js
@@ -9,10 +9,10 @@ import { asNewRole } from '@tamanu/fake-data/test-helpers';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 import { initReporting } from '@tamanu/database/services/reporting';
 
-import { buildToken } from '../dist/auth/utils';
-import { createApp } from '../dist/createApp';
-import { closeDatabase, initDatabase } from '../dist/database';
-import { initIntegrations } from '../dist/integrations';
+import { buildToken } from '../app/auth/utils';
+import { createApp } from '../app/createApp';
+import { closeDatabase, initDatabase } from '../app/database';
+import { initIntegrations } from '../app/integrations';
 
 class MockApplicationContext {
   closeHooks = [];
@@ -154,7 +154,7 @@ const DEFAULT_CONFIG = {
 
 export const initializeCentralSyncManagerWithContext = (ctx, config) => {
   // Have to load test function within test scope so that we can mock dependencies per test case
-  const { CentralSyncManager: TestCentralSyncManager } = require('../dist/sync/CentralSyncManager');
+  const { CentralSyncManager: TestCentralSyncManager } = require('../app/sync/CentralSyncManager');
 
   TestCentralSyncManager.overrideConfig(config || DEFAULT_CONFIG);
 

--- a/packages/central-server/__tests__/utils/prepareQuery.test.js
+++ b/packages/central-server/__tests__/utils/prepareQuery.test.js
@@ -1,4 +1,4 @@
-import { prepareQuery } from '../../dist/utils/prepareQuery';
+import { prepareQuery } from '../../app/utils/prepareQuery';
 import { createTestContext } from '../utilities';
 
 describe('prepareQuery()', () => {

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { Timesimp } from 'timesimp';
 
 import { ReadSettings } from '@tamanu/settings';

--- a/packages/central-server/app/admin/adminRoutes.js
+++ b/packages/central-server/app/admin/adminRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { unset, get as getAtPath, set as setAtPath } from 'lodash';
+import { unset, get as getAtPath, set as setAtPath } from 'es-toolkit/compat';
 
 import { ensurePermissionCheck } from '@tamanu/shared/permissions/middleware';
 import { InvalidParameterError, NotFoundError } from '@tamanu/errors';

--- a/packages/central-server/app/admin/designations.get.js
+++ b/packages/central-server/app/admin/designations.get.js
@@ -1,5 +1,5 @@
 import asyncHandler from 'express-async-handler';
-import { escapeRegExp } from 'lodash';
+import { escapeRegExp } from 'es-toolkit/compat';
 import { Op } from 'sequelize';
 
 import { REFERENCE_TYPES } from '@tamanu/constants';

--- a/packages/central-server/app/admin/exporter/exporterRouter.js
+++ b/packages/central-server/app/admin/exporter/exporterRouter.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'es-toolkit/compat';
 import { REFERENCE_TYPE_VALUES } from '@tamanu/constants';
 
 import { exporter } from './exporter';

--- a/packages/central-server/app/admin/exporter/modelExporters/ModelExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/ModelExporter.js
@@ -1,4 +1,4 @@
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 import { Model } from 'sequelize';
 
 const METADATA_COLUMNS = [

--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -1,4 +1,4 @@
-import { camelCase, lowerCase, lowerFirst, startCase, upperFirst } from 'lodash';
+import { camelCase, lowerCase, lowerFirst, startCase, upperFirst } from 'es-toolkit/compat';
 import { AggregateError, DataTypes, Op } from 'sequelize';
 import { ValidationError as YupValidationError } from 'yup';
 import config from 'config';

--- a/packages/central-server/app/admin/importer/importerEndpoint.js
+++ b/packages/central-server/app/admin/importer/importerEndpoint.js
@@ -2,7 +2,7 @@ import config from 'config';
 import asyncHandler from 'express-async-handler';
 import { promises as fs } from 'fs';
 import { singularize } from 'inflection';
-import { camelCase, lowerCase } from 'lodash';
+import { camelCase, lowerCase } from 'es-toolkit/compat';
 import { Sequelize } from 'sequelize';
 
 import { OTHER_REFERENCE_TYPES, PROGRAM_REFERENCE_TYPES } from '@tamanu/constants';

--- a/packages/central-server/app/admin/importer/importerEndpoint.js
+++ b/packages/central-server/app/admin/importer/importerEndpoint.js
@@ -1,7 +1,8 @@
 import config from 'config';
 import asyncHandler from 'express-async-handler';
 import { promises as fs } from 'fs';
-import { singularize } from 'inflection';
+import __cjs_inflection from 'inflection';
+const { singularize } = __cjs_inflection;
 import { camelCase, lowerCase } from 'es-toolkit/compat';
 import { Sequelize } from 'sequelize';
 

--- a/packages/central-server/app/admin/importer/translationHandler.js
+++ b/packages/central-server/app/admin/importer/translationHandler.js
@@ -1,4 +1,4 @@
-import { camelCase, isArray, isObject, isString } from 'lodash';
+import { camelCase, isArray, isObject, isString } from 'es-toolkit/compat';
 import { Op } from 'sequelize';
 import {
   TRANSLATABLE_REFERENCE_TYPES,

--- a/packages/central-server/app/admin/invoice/insurerPaymentImporter.js
+++ b/packages/central-server/app/admin/invoice/insurerPaymentImporter.js
@@ -1,5 +1,5 @@
 import * as xlsx from 'xlsx';
-import { chain } from 'lodash';
+import { chain } from 'es-toolkit/compat';
 import { z } from 'zod';
 import { customAlphabet } from 'nanoid';
 import {

--- a/packages/central-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/central-server/app/admin/patientMerge/mergePatient.js
@@ -1,6 +1,6 @@
 import { Op } from 'sequelize';
 import config from 'config';
-import { chunk, omit, omitBy } from 'lodash';
+import { chunk, omit, omitBy } from 'es-toolkit/compat';
 import { PORTAL_USER_STATUSES, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { NOTE_RECORD_TYPES } from '@tamanu/constants/notes';
 import { InvalidParameterError } from '@tamanu/errors';

--- a/packages/central-server/app/admin/programExporter/exportProgram.js
+++ b/packages/central-server/app/admin/programExporter/exportProgram.js
@@ -10,7 +10,7 @@
  * }} Program
  */
 
-import { groupBy } from 'lodash';
+import { groupBy } from 'es-toolkit/compat';
 import { QueryTypes } from 'sequelize';
 
 import { NotFoundError } from '@tamanu/errors';

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -14,7 +14,8 @@ import {
   INVOICE_ITEMS_CATEGORIES_MODELS,
   GENERIC_SURVEY_EXPORT_REPORT_ID,
 } from '@tamanu/constants';
-import { pluralize } from 'inflection';
+import __cjs_inflection from 'inflection';
+const { pluralize } = __cjs_inflection;
 import { isEmpty, isNil } from 'es-toolkit/compat';
 import { REPORT_DEFINITIONS } from '@tamanu/shared/reports';
 

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -15,7 +15,7 @@ import {
   GENERIC_SURVEY_EXPORT_REPORT_ID,
 } from '@tamanu/constants';
 import { pluralize } from 'inflection';
-import { isEmpty, isNil } from 'lodash';
+import { isEmpty, isNil } from 'es-toolkit/compat';
 import { REPORT_DEFINITIONS } from '@tamanu/shared/reports';
 
 function stripNotes(fields) {

--- a/packages/central-server/app/admin/referenceDataImporter/referenceDataImporter.js
+++ b/packages/central-server/app/admin/referenceDataImporter/referenceDataImporter.js
@@ -1,4 +1,4 @@
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'es-toolkit/compat';
 import { read, readFile } from 'xlsx';
 
 import { log } from '@tamanu/shared/services/logging';

--- a/packages/central-server/app/admin/referenceDataManageUtils.js
+++ b/packages/central-server/app/admin/referenceDataManageUtils.js
@@ -1,4 +1,4 @@
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'es-toolkit/compat';
 import {
   REFERENCE_TYPE_VALUES,
   MANAGEABLE_REFERENCE_DATA_TYPES,

--- a/packages/central-server/app/admin/reports/reportRoutes.js
+++ b/packages/central-server/app/admin/reports/reportRoutes.js
@@ -5,7 +5,7 @@ import asyncHandler from 'express-async-handler';
 import { QueryTypes, Sequelize } from 'sequelize';
 import { getUploadedData } from '@tamanu/shared/utils/getUploadedData';
 import { InvalidOperationError, NotFoundError } from '@tamanu/errors';
-import { capitalize } from 'lodash';
+import { capitalize } from 'es-toolkit/compat';
 import {
   REPORT_DB_CONNECTIONS,
   REPORT_STATUSES,

--- a/packages/central-server/app/admin/roles.get.js
+++ b/packages/central-server/app/admin/roles.get.js
@@ -1,5 +1,5 @@
 import asyncHandler from 'express-async-handler';
-import { escapeRegExp } from 'lodash';
+import { escapeRegExp } from 'es-toolkit/compat';
 import { Op } from 'sequelize';
 
 import { NotFoundError } from '@tamanu/errors';

--- a/packages/central-server/app/admin/translation.js
+++ b/packages/central-server/app/admin/translation.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import { Op } from 'sequelize';
 import { queryTranslatedStringsByLanguage } from '@tamanu/shared/utils/translation/queryTranslatedStringsByLanguage';
 import { LANGUAGE_NAME_STRING_ID, DEFAULT_LANGUAGE_CODE } from '@tamanu/constants';

--- a/packages/central-server/app/admin/users.js
+++ b/packages/central-server/app/admin/users.js
@@ -2,7 +2,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { Op } from 'sequelize';
 import { dateCustomValidation, getCurrentDateString } from '@tamanu/utils/dateTime';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 import * as yup from 'yup';
 import {
   REFERENCE_TYPES,

--- a/packages/central-server/app/health.js
+++ b/packages/central-server/app/health.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import config from 'config';
-import { isObject } from 'lodash';
+import { isObject } from 'es-toolkit/compat';
 
 import { log } from '@tamanu/shared/services/logging';
 import { createMigrationInterface } from '@tamanu/database/services/migrations';

--- a/packages/central-server/app/hl7fhir/index.js
+++ b/packages/central-server/app/hl7fhir/index.js
@@ -1,4 +1,5 @@
-import { Router } from 'express';
+import __cjs_express from 'express';
+const { Router } = __cjs_express;
 import { Problem } from '@tamanu/errors';
 
 import {

--- a/packages/central-server/app/hl7fhir/materialised/handlers.js
+++ b/packages/central-server/app/hl7fhir/materialised/handlers.js
@@ -1,5 +1,5 @@
-import { Router } from 'express';
-
+import __cjs_express from 'express';
+const { Router } = __cjs_express;
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
 import { OperationOutcome } from '@tamanu/shared/utils/fhir';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';

--- a/packages/central-server/app/hl7fhir/materialised/search/query.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/query.js
@@ -1,4 +1,4 @@
-import { last } from 'lodash';
+import { last } from 'es-toolkit/compat';
 
 import { FHIR_COUNT_CONFIG_DEFAULT } from '@tamanu/shared/utils/fhir/parameters';
 

--- a/packages/central-server/app/hl7fhir/materialised/search/where.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/where.js
@@ -1,4 +1,4 @@
-import { escapeRegExp } from 'lodash';
+import { escapeRegExp } from 'es-toolkit/compat';
 import { Op, Sequelize } from 'sequelize';
 import * as yup from 'yup';
 

--- a/packages/central-server/app/hl7fhir/patient.js
+++ b/packages/central-server/app/hl7fhir/patient.js
@@ -1,7 +1,7 @@
 import config from 'config';
 import { format } from 'date-fns';
 import { Op } from 'sequelize';
-import { groupBy, keyBy } from 'lodash';
+import { groupBy, keyBy } from 'es-toolkit/compat';
 import { FHIR_PATIENT_LINK_TYPES, VISIBILITY_STATUSES } from '@tamanu/constants';
 
 import {

--- a/packages/central-server/app/hl7fhir/schema.js
+++ b/packages/central-server/app/hl7fhir/schema.js
@@ -1,5 +1,5 @@
 import * as yup from 'yup';
-import { isArray } from 'lodash';
+import { isArray } from 'es-toolkit/compat';
 
 import { getSortParameterName, isValidIdentifier } from './utils';
 import { hl7PatientFields, sortableHL7PatientFields } from './hl7PatientFields';

--- a/packages/central-server/app/hl7fhir/utils/getHL7Link.js
+++ b/packages/central-server/app/hl7fhir/utils/getHL7Link.js
@@ -1,4 +1,4 @@
-import { isArray } from 'lodash';
+import { isArray } from 'es-toolkit/compat';
 
 export function getHL7Link(baseUrl, params = {}) {
   const query = Object.entries(params)

--- a/packages/central-server/app/hl7fhir/utils/search.js
+++ b/packages/central-server/app/hl7fhir/utils/search.js
@@ -13,7 +13,8 @@ import {
   startOfYear,
   isMatch,
 } from 'date-fns';
-import { zonedTimeToUtc } from 'date-fns-tz';
+import __cjs_date_fns_tz from 'date-fns-tz';
+const { zonedTimeToUtc } = __cjs_date_fns_tz;
 
 export function toSearchId({ after, ...params }) {
   const result = { ...params };

--- a/packages/central-server/app/integrations/fiji-vrs/routes.js
+++ b/packages/central-server/app/integrations/fiji-vrs/routes.js
@@ -1,7 +1,7 @@
 import config from 'config';
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { set } from 'lodash';
+import { set } from 'es-toolkit/compat';
 
 import { buildErrorHandler } from '../../middleware/errorHandler';
 import { requireClientHeaders } from '../../middleware/requireClientHeaders';

--- a/packages/central-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/central-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -4,8 +4,8 @@ import asyncHandler from 'express-async-handler';
 import config from 'config';
 import { mapKeys, camelCase, upperFirst } from 'es-toolkit/compat';
 import { parseISO } from 'date-fns';
-import { formatInTimeZone } from 'date-fns-tz';
-
+import __cjs_date_fns_tz from 'date-fns-tz';
+const { formatInTimeZone } = __cjs_date_fns_tz;
 import { FHIR_DATETIME_PRECISION } from '@tamanu/constants/fhir';
 import { parseDateTime, formatFhirDate } from '@tamanu/shared/utils/fhir/datetime';
 

--- a/packages/central-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/central-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -2,7 +2,7 @@ import { QueryTypes } from 'sequelize';
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import config from 'config';
-import { mapKeys, camelCase, upperFirst } from 'lodash';
+import { mapKeys, camelCase, upperFirst } from 'es-toolkit/compat';
 import { parseISO } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 

--- a/packages/central-server/app/localisation.js
+++ b/packages/central-server/app/localisation.js
@@ -1,6 +1,6 @@
 import config from 'config';
 import * as yup from 'yup';
-import { defaultsDeep } from 'lodash';
+import { defaultsDeep } from 'es-toolkit/compat';
 import { log } from '@tamanu/shared/services/logging';
 import { IMAGING_TYPES } from '@tamanu/constants';
 

--- a/packages/central-server/app/publicRoutes/index.js
+++ b/packages/central-server/app/publicRoutes/index.js
@@ -4,7 +4,7 @@ import { log } from '@tamanu/shared/services/logging';
 import { ReadSettings } from '@tamanu/settings';
 import { getCurrentBrowserMajors } from '@tamanu/shared/utils/browserSupportVersions';
 import { decideBrowserSupport, parseBrowserDescriptor } from '@tamanu/utils/browserSupport';
-import { keyBy, mapValues } from 'lodash';
+import { keyBy, mapValues } from 'es-toolkit/compat';
 
 import { labResultWidgetRoutes } from './labResultWidget';
 import { publicIntegrationRoutes } from '../integrations';

--- a/packages/central-server/app/subCommands/generate/fiji/index.js
+++ b/packages/central-server/app/subCommands/generate/fiji/index.js
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { pick, uniq } from 'lodash';
+import { pick, uniq } from 'es-toolkit/compat';
 import { UniqueConstraintError } from 'sequelize';
 
 import { closeDatabase, initDatabase } from '../../../database';

--- a/packages/central-server/app/subCommands/provision.js
+++ b/packages/central-server/app/subCommands/provision.js
@@ -1,6 +1,6 @@
 import { resolve, join, parse } from 'node:path';
 import { Command } from 'commander';
-import { defaultsDeep, get as getAtPath, keyBy, set as setAtPath, unset } from 'lodash';
+import { defaultsDeep, get as getAtPath, keyBy, set as setAtPath, unset } from 'es-toolkit/compat';
 import { Op } from 'sequelize';
 import { utils } from 'xlsx';
 import fs from 'node:fs';

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -1,7 +1,7 @@
 import { trace } from '@opentelemetry/api';
 import { Op, QueryTypes } from 'sequelize';
 import _config from 'config';
-import { isNil } from 'lodash';
+import { isNil } from 'es-toolkit/compat';
 
 import { DEBUG_LOG_TYPES, SETTINGS_SCOPES, SYNC_DIRECTIONS } from '@tamanu/constants';
 import { FACT_CURRENT_SYNC_TICK, FACT_LOOKUP_UP_TO_TICK } from '@tamanu/constants/facts';

--- a/packages/central-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/central-server/app/sync/snapshotOutgoingChanges.js
@@ -1,4 +1,5 @@
-import { snake } from 'case';
+import __cjs_case from 'case';
+const { snake } = __cjs_case;
 import {
   COLUMNS_EXCLUDED_FROM_SYNC,
   getSnapshotTableName,

--- a/packages/central-server/app/tasks/DHIS2IntegrationProcessor.js
+++ b/packages/central-server/app/tasks/DHIS2IntegrationProcessor.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 import { fetch } from 'undici';
 import { utils } from 'xlsx';
 

--- a/packages/central-server/app/translation.js
+++ b/packages/central-server/app/translation.js
@@ -1,4 +1,5 @@
-import { Router } from 'express';
+import __cjs_express from 'express';
+const { Router } = __cjs_express;
 
 export const translationRoutes = Router();
 

--- a/packages/central-server/app/utils/makePatientCertificate.jsx
+++ b/packages/central-server/app/utils/makePatientCertificate.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import config from 'config';
 import path from 'path';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 import ReactPDF from '@react-pdf/renderer';
 
 import { ASSET_FALLBACK_NAMES, ASSET_NAMES } from '@tamanu/constants';

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -7,7 +7,7 @@
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later AND BUSL-1.1",
-  "main": "dist/index.js",
+  "main": "./src/index",
   "bin": "dist/index.js",
   "pkg": {
     "assets": [
@@ -16,9 +16,6 @@
     ]
   },
   "scripts": {
-    "build": "swc --out-dir dist --copy-files --source-maps true app",
-    "clean-build": "npm run clean && npm run build",
-    "build-watch": "npm run build -- --watch",
     "clean": "rimraf -- dist __disttests__",
     "clean:deps": "rimraf -- node_modules",
     "setup-dev": "node dist setup",
@@ -114,5 +111,6 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yup": "^0.32.9",
     "zod": "^4.0.17"
-  }
+  },
+  "type": "module"
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -3,35 +3,16 @@
   "version": "2.59.0",
   "private": true,
   "description": "Shared constants",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index",
   "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/esm/index.d.ts"
-    },
-    "./*": {
-      "source": "./src/*.ts",
-      "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/esm/*.d.ts"
-    }
+    ".": "./src",
+    "./*": "./src/*"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "concurrently -n esm,cjs -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" && move-dts --copy dist/esm dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:cjs": "swc --copy-files --source-maps true --out-dir dist/cjs src",
-    "build:esm": "tsc",
-    "build:types:cjs": "tsc --emitDeclarationOnly --outDir dist/cjs",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules"
   },
@@ -41,5 +22,6 @@
     "date-fns": "^2.25.0",
     "concurrently": "^9.2.1",
     "rimraf": "^6.1.3"
-  }
+  },
+  "type": "module"
 }

--- a/packages/database/__tests__/models/sortInDependencyOrder.test.ts
+++ b/packages/database/__tests__/models/sortInDependencyOrder.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign,no-return-assign */
 
 import * as fc from 'fast-check';
-import { uniq } from 'lodash';
+import { uniq } from 'es-toolkit/compat';
 
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -3,84 +3,26 @@
   "version": "2.59.0",
   "private": true,
   "description": "BES - Database",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index",
   "exports": {
-    ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "types": "./dist/esm/index.d.ts"
-    },
-    "./*": {
-      "require": "./dist/cjs/*.js",
-      "import": "./dist/esm/*.js",
-      "types": "./dist/esm/*.d.ts"
-    },
-    "./demoData": {
-      "require": "./dist/cjs/demoData/index.js",
-      "import": "./dist/esm/demoData/index.js",
-      "types": "./dist/esm/demoData/index.d.ts"
-    },
-    "./demoData/*": {
-      "require": "./dist/cjs/demoData/*.js",
-      "import": "./dist/esm/demoData/*.js",
-      "types": "./dist/esm/demoData/*.d.ts"
-    },
-    "./dataMigrations": {
-      "require": "./dist/cjs/dataMigrations/index.js",
-      "import": "./dist/esm/dataMigrations/index.js",
-      "types": "./dist/esm/dataMigrations/index.d.ts"
-    },
-    "./dataMigrations/*": {
-      "require": "./dist/cjs/dataMigrations/*.js",
-      "import": "./dist/esm/dataMigrations/*.js",
-      "types": "./dist/esm/dataMigrations/*.d.ts"
-    },
-    "./services/migrations": {
-      "require": "./dist/cjs/services/migrations/index.js",
-      "import": "./dist/esm/services/migrations/index.js",
-      "types": "./dist/esm/services/migrations/index.d.ts"
-    },
-    "./services/migrations/*": {
-      "require": "./dist/cjs/services/migrations/*.js",
-      "import": "./dist/esm/services/migrations/*.js",
-      "types": "./dist/esm/services/migrations/*.d.ts"
-    },
-    "./services/database": {
-      "require": "./dist/cjs/services/database.js",
-      "import": "./dist/esm/services/database.js",
-      "types": "./dist/esm/services/database.d.ts"
-    },
-    "./sync": {
-      "require": "./dist/cjs/sync/index.js",
-      "import": "./dist/esm/sync/index.js",
-      "types": "./dist/esm/sync/index.d.ts"
-    },
-    "./utils/fhir": {
-      "require": "./dist/cjs/utils/fhir/index.js",
-      "import": "./dist/esm/utils/fhir/index.js",
-      "types": "./dist/esm/utils/fhir/index.d.ts"
-    },
-    "./utils/audit": {
-      "require": "./dist/cjs/utils/audit/index.js",
-      "import": "./dist/esm/utils/audit/index.js",
-      "types": "./dist/esm/utils/audit/index.d.ts"
-    }
+    ".": "./src",
+    "./*": "./src/*",
+    "./demoData": "./src/demoData",
+    "./demoData/*": "./src/demoData/*",
+    "./dataMigrations": "./src/dataMigrations",
+    "./dataMigrations/*": "./src/dataMigrations/*",
+    "./services/migrations": "./src/services/migrations",
+    "./services/migrations/*": "./src/services/migrations/*",
+    "./services/database": "./src/services/database",
+    "./sync": "./src/sync",
+    "./utils/fhir": "./src/utils/fhir",
+    "./utils/audit": "./src/utils/audit"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later AND BUSL-1.1",
   "scripts": {
-    "build": "concurrently -n esm,cjs,types -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" \"npm run build:types\"",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:esm -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:esm": "swc --out-dir dist/esm --copy-files --source-maps true src",
-    "build:cjs": "npm run build:esm -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "npm run build:types:esm && move-dts --copy dist/esm dist/cjs",
-    "build:types:esm": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/esm",
-    "build:types:cjs": "npm run build:types:esm -- --outDir dist/cjs",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules",
     "test": "vitest run --no-file-parallelism",
@@ -126,5 +68,6 @@
     "umzug": "^2.3.0",
     "yup": "^0.32.11",
     "zod": "^4.4.3"
-  }
+  },
+  "type": "module"
 }

--- a/packages/database/src/demoData/settings.js
+++ b/packages/database/src/demoData/settings.js
@@ -1,7 +1,7 @@
 import config from 'config';
 import { SETTINGS_SCOPES } from '@tamanu/constants';
 import { facilityTestSettings, centralTestSettings, globalTestSettings } from '@tamanu/settings';
-import { defaultsDeep } from 'lodash';
+import { defaultsDeep } from 'es-toolkit/compat';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 
 const seedForScope = async (models, settings, serverFacilityIds, scopeOverride) => {

--- a/packages/database/src/models/Appointment.ts
+++ b/packages/database/src/models/Appointment.ts
@@ -1,5 +1,5 @@
 import { DataTypes, Op, type BelongsToGetAssociationMixin } from 'sequelize';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 
 import { APPOINTMENT_STATUSES, SYNC_DIRECTIONS } from '@tamanu/constants';
 import type { ReadSettings } from '@tamanu/settings';

--- a/packages/database/src/models/AppointmentSchedule.ts
+++ b/packages/database/src/models/AppointmentSchedule.ts
@@ -1,4 +1,4 @@
-import { isMatch, isNumber, omit } from 'lodash';
+import { isMatch, isNumber, omit } from 'es-toolkit/compat';
 import { DataTypes, Op, type HasManyGetAssociationsMixin } from 'sequelize';
 import { parseISO, add, set, isAfter, endOfDay } from 'date-fns';
 

--- a/packages/database/src/models/Device.ts
+++ b/packages/database/src/models/Device.ts
@@ -1,4 +1,4 @@
-import { difference } from 'lodash';
+import { difference } from 'es-toolkit/compat';
 import { DataTypes, Op, Sequelize, Transaction } from 'sequelize';
 import {
   DEVICE_SCOPES,

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -1,5 +1,5 @@
 import { Op, DataTypes } from 'sequelize';
-import { capitalize, isEqual } from 'lodash';
+import { capitalize, isEqual } from 'es-toolkit/compat';
 
 import {
   ENCOUNTER_TYPE_VALUES,

--- a/packages/database/src/models/Setting.ts
+++ b/packages/database/src/models/Setting.ts
@@ -1,5 +1,5 @@
 import { DataTypes, Op, Sequelize } from 'sequelize';
-import { isPlainObject, get as getAtPath, set as setAtPath, isEqual, keyBy } from 'lodash';
+import { isPlainObject, get as getAtPath, set as setAtPath, isEqual, keyBy } from 'es-toolkit/compat';
 import { settingsCache } from '@tamanu/settings/cache';
 import { SYNC_DIRECTIONS, SETTINGS_SCOPES } from '@tamanu/constants';
 import { extractDefaults, getScopedSchema } from '@tamanu/settings/schema';

--- a/packages/database/src/models/SurveyResponseAnswer.ts
+++ b/packages/database/src/models/SurveyResponseAnswer.ts
@@ -1,4 +1,4 @@
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'es-toolkit/compat';
 import { DataTypes, Op } from 'sequelize';
 import { AUDIT_REASON_KEY, SURVEY_TYPES, SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';

--- a/packages/database/src/models/TranslatedString.ts
+++ b/packages/database/src/models/TranslatedString.ts
@@ -5,7 +5,7 @@ import {
 } from '@tamanu/constants';
 import { DataTypes, Op } from 'sequelize';
 import { Model } from './Model';
-import { keyBy, mapValues } from 'lodash';
+import { keyBy, mapValues } from 'es-toolkit/compat';
 import { translationFactory } from '@tamanu/shared/utils/translation/translationFactory';
 import type { InitOptions } from '../types/model';
 import { getEnumPrefix } from '@tamanu/shared/utils/enumRegistry';

--- a/packages/database/src/models/User.ts
+++ b/packages/database/src/models/User.ts
@@ -1,7 +1,7 @@
 import { createSecretKey, randomBytes } from 'node:crypto';
 import { compare, hash } from 'bcrypt';
 import * as jose from 'jose';
-import { unionBy } from 'lodash';
+import { unionBy } from 'es-toolkit/compat';
 import { DataTypes, Sequelize } from 'sequelize';
 import type { Logger } from 'winston';
 import * as z from 'zod';

--- a/packages/database/src/models/User.ts
+++ b/packages/database/src/models/User.ts
@@ -1,5 +1,6 @@
 import { createSecretKey, randomBytes } from 'node:crypto';
-import { compare, hash } from 'bcrypt';
+import __cjs_bcrypt from 'bcrypt';
+const { compare, hash } = __cjs_bcrypt;
 import * as jose from 'jose';
 import { unionBy } from 'es-toolkit/compat';
 import { DataTypes, Sequelize } from 'sequelize';

--- a/packages/database/src/models/fhir/Resource.ts
+++ b/packages/database/src/models/fhir/Resource.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { snakeCase } from 'lodash';
+import { snakeCase } from 'es-toolkit/compat';
 import { DataTypes, Sequelize, Utils, type InitOptions, type ModelAttributes } from 'sequelize';
 import { subMinutes } from 'date-fns';
 

--- a/packages/database/src/sync/buildEncounterLinkedSyncFilter.ts
+++ b/packages/database/src/sync/buildEncounterLinkedSyncFilter.ts
@@ -1,5 +1,5 @@
 import { Utils } from 'sequelize';
-import { isObject, isString } from 'lodash';
+import { isObject, isString } from 'es-toolkit/compat';
 import { Model } from '../models/Model';
 
 export type JoinConfig =

--- a/packages/database/src/sync/buildNoteLinkedSyncFilter.ts
+++ b/packages/database/src/sync/buildNoteLinkedSyncFilter.ts
@@ -1,4 +1,5 @@
-import { snake } from 'case';
+import __cjs_case from 'case';
+const { snake } = __cjs_case;
 import { Utils } from 'sequelize';
 import { NOTE_RECORD_TYPE_VALUES, NOTE_RECORD_TYPES } from '@tamanu/constants';
 import type { SessionConfig } from '../types/sync';

--- a/packages/database/src/sync/buildSyncLookupSelect.ts
+++ b/packages/database/src/sync/buildSyncLookupSelect.ts
@@ -1,4 +1,5 @@
-import { snake } from 'case';
+import __cjs_case from 'case';
+const { snake } = __cjs_case;
 import { COLUMNS_EXCLUDED_FROM_SYNC } from './constants';
 import type { Model } from '../models/Model';
 

--- a/packages/database/src/sync/bumpSyncTickForRepull.ts
+++ b/packages/database/src/sync/bumpSyncTickForRepull.ts
@@ -1,4 +1,4 @@
-import { groupBy } from 'lodash';
+import { groupBy } from 'es-toolkit/compat';
 import { Sequelize } from 'sequelize';
 
 import { SYNC_SESSION_DIRECTION } from './constants';

--- a/packages/database/src/sync/findSyncSnapshotRecords.ts
+++ b/packages/database/src/sync/findSyncSnapshotRecords.ts
@@ -1,4 +1,5 @@
-import { camel } from 'case';
+import __cjs_case from 'case';
+const { camel } = __cjs_case;
 import { QueryTypes, Sequelize } from 'sequelize';
 
 import { getSnapshotTableName } from './manageSnapshotTable';

--- a/packages/database/src/sync/manageSnapshotTable.ts
+++ b/packages/database/src/sync/manageSnapshotTable.ts
@@ -1,4 +1,5 @@
-import { snake } from 'case';
+import __cjs_case from 'case';
+const { snake } = __cjs_case;
 import { Sequelize } from 'sequelize';
 
 const SCHEMA = 'sync_snapshots';

--- a/packages/database/src/sync/mergeRecord.ts
+++ b/packages/database/src/sync/mergeRecord.ts
@@ -1,4 +1,5 @@
-import { snake } from 'case';
+import __cjs_case from 'case';
+const { snake } = __cjs_case;
 
 // utility that can pick the latest whole record, or single field, depending on what is passed in
 const pickLatest = (

--- a/packages/database/src/sync/resolveAppointmentSchedules.ts
+++ b/packages/database/src/sync/resolveAppointmentSchedules.ts
@@ -1,5 +1,5 @@
 import { QueryTypes } from 'sequelize';
-import { keyBy, mapValues } from 'lodash';
+import { keyBy, mapValues } from 'es-toolkit/compat';
 
 import { APPOINTMENT_STATUSES } from '@tamanu/constants';
 

--- a/packages/database/src/types/express.ts
+++ b/packages/database/src/types/express.ts
@@ -1,4 +1,5 @@
-import type { Request } from 'express';
+import __cjs_express from 'express';
+const { Request } = __cjs_express;
 import type { AccessLog, User } from '../models';
 import type { ModelProperties, Models } from './model';
 import type { ReadSettings } from '@tamanu/settings';

--- a/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
+++ b/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
@@ -1,5 +1,6 @@
 import type { ExpressRequest } from 'types/express';
-import type { NextFunction } from 'express';
+import __cjs_express from 'express';
+const { NextFunction } = __cjs_express;
 import { AsyncLocalStorage } from 'async_hooks';
 
 const auditUserIdAsyncLocalStorage = new AsyncLocalStorage();

--- a/packages/database/src/utils/fhir/MedicationRequest/getValues.ts
+++ b/packages/database/src/utils/fhir/MedicationRequest/getValues.ts
@@ -1,5 +1,5 @@
 import config from 'config';
-import { isNaN } from 'lodash';
+import { isNaN } from 'es-toolkit/compat';
 
 import {
   FhirReference,

--- a/packages/database/src/utils/fhir/utils.ts
+++ b/packages/database/src/utils/fhir/utils.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from 'es-toolkit/compat';
 
 import { VISIBILITY_STATUSES } from '@tamanu/constants';
 

--- a/packages/database/src/utils/pgComposite/pgType.js
+++ b/packages/database/src/utils/pgComposite/pgType.js
@@ -1,4 +1,4 @@
-import { snakeCase } from 'lodash';
+import { snakeCase } from 'es-toolkit/compat';
 import { DataTypes, ValidationError } from 'sequelize';
 import { compositeToSql } from './stringifier';
 import { Composite } from './sequelizeType';

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -3,21 +3,12 @@
   "version": "2.59.0",
   "private": true,
   "description": "API errors",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "concurrently -n esm,cjs -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" && move-dts --copy dist/esm dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:cjs": "swc --copy-files --source-maps true --out-dir dist/cjs src",
-    "build:esm": "tsc",
-    "build:types:cjs": "tsc --emitDeclarationOnly --outDir dist/cjs",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules"
   },
@@ -32,5 +23,6 @@
     "@types/node": "^18.14.6",
     "concurrently": "^9.2.1",
     "rimraf": "^6.1.3"
-  }
+  },
+  "type": "module"
 }

--- a/packages/errors/src/Problem.ts
+++ b/packages/errors/src/Problem.ts
@@ -1,4 +1,4 @@
-import { escapeRegExp, kebabCase } from 'lodash';
+import { escapeRegExp, kebabCase } from 'es-toolkit/compat';
 import { ValidationError as YupValidationError } from 'yup';
 import { $ZodError } from 'zod/v4/core';
 

--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -18,7 +18,7 @@ import { getCurrentDateTimeString, toDateTimeString } from '@tamanu/utils/dateTi
 import { disableHardcodedPermissionsForSuite } from '@tamanu/shared/test-helpers';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 
-import { uploadAttachment } from '../../dist/utils/uploadAttachment';
+import { uploadAttachment } from '../../app/utils/uploadAttachment';
 import { createTestContext } from '../utilities';
 import { setupSurvey } from '../setupSurvey';
 

--- a/packages/facility-server/__tests__/apiv1/EncounterLabs.test.js
+++ b/packages/facility-server/__tests__/apiv1/EncounterLabs.test.js
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit/compat';
 import { createDummyEncounter, createDummyPatient } from '@tamanu/database/demoData/patients';
 import { randomLabRequest, randomSensitiveLabRequest } from '@tamanu/database/demoData';
 import { LAB_REQUEST_STATUSES, NOTE_TYPES } from '@tamanu/constants';

--- a/packages/facility-server/__tests__/apiv1/EncounterSummary.test.js
+++ b/packages/facility-server/__tests__/apiv1/EncounterSummary.test.js
@@ -1,7 +1,7 @@
 import { createDummyEncounter, createDummyPatient } from '@tamanu/database/demoData/patients';
 import { disableHardcodedPermissionsForSuite } from '@tamanu/shared/test-helpers';
 
-import { CentralServerConnection } from '../../dist/sync/CentralServerConnection';
+import { CentralServerConnection } from '../../app/sync/CentralServerConnection';
 import { createTestContext } from '../utilities';
 
 const SUMMARY_URL = encounterId => `/api/ai/encounter/summary/${encounterId}`;

--- a/packages/facility-server/__tests__/apiv1/PatientDocumentMetadata.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientDocumentMetadata.test.js
@@ -1,7 +1,7 @@
 import { createDummyEncounter, createDummyPatient } from '@tamanu/database/demoData/patients';
 import { DOCUMENT_SOURCES } from '@tamanu/constants';
 import { createTestContext } from '../utilities';
-import { uploadAttachment } from '../../dist/utils/uploadAttachment';
+import { uploadAttachment } from '../../app/utils/uploadAttachment';
 
 describe('PatientDocumentMetadata', () => {
   let baseApp;

--- a/packages/facility-server/__tests__/apiv1/PatientSummary.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientSummary.test.js
@@ -1,7 +1,7 @@
 import { createDummyPatient } from '@tamanu/database/demoData/patients';
 import { disableHardcodedPermissionsForSuite } from '@tamanu/shared/test-helpers';
 
-import { CentralServerConnection } from '../../dist/sync/CentralServerConnection';
+import { CentralServerConnection } from '../../app/sync/CentralServerConnection';
 import { createTestContext } from '../utilities';
 
 const SUMMARY_URL = patientId => `/api/ai/patient/summary/${patientId}`;

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -21,7 +21,7 @@ import { findOneOrCreate } from '@tamanu/fake-data/test-helpers';
 import { fake, chance } from '@tamanu/fake-data/fake';
 import { createTestContext } from '../utilities';
 import { testDiagnoses } from '../seed';
-import { sortBy } from 'lodash';
+import { sortBy } from 'es-toolkit/compat';
 
 describe('Suggestions', () => {
   let userApp = null;

--- a/packages/facility-server/__tests__/apiv1/TranslatedString.test.js
+++ b/packages/facility-server/__tests__/apiv1/TranslatedString.test.js
@@ -1,5 +1,5 @@
 import { fake } from '@tamanu/fake-data/fake';
-import { sortBy } from 'lodash';
+import { sortBy } from 'es-toolkit/compat';
 import Chance from 'chance';
 import { createTestContext } from '../utilities';
 

--- a/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
+++ b/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
@@ -7,7 +7,7 @@ import { toDateString } from '@tamanu/utils/dateTime';
 import { VACCINE_STATUS, REFERENCE_TYPES, VACCINE_CATEGORIES } from '@tamanu/constants';
 import { fake } from '@tamanu/fake-data/fake';
 
-import { RefreshUpcomingVaccinations } from '../../dist/tasks/RefreshMaterializedView';
+import { RefreshUpcomingVaccinations } from '../../app/tasks/RefreshMaterializedView';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 
 jest.mock('@tamanu/utils/dateTime', () => ({

--- a/packages/facility-server/__tests__/apiv1/User.test.js
+++ b/packages/facility-server/__tests__/apiv1/User.test.js
@@ -7,8 +7,8 @@ import { fake, chance } from '@tamanu/fake-data/fake';
 import { addHours } from 'date-fns';
 import { createDummyEncounter } from '@tamanu/database/demoData/patients';
 
-import { centralServerLogin, buildToken, comparePassword } from '../../dist/middleware/auth';
-import { CentralServerConnection } from '../../dist/sync/CentralServerConnection';
+import { centralServerLogin, buildToken, comparePassword } from '../../app/middleware/auth';
+import { CentralServerConnection } from '../../app/sync/CentralServerConnection';
 import { createTestContext } from '../utilities';
 
 const createUser = overrides => ({

--- a/packages/facility-server/__tests__/apiv1/User.test.js
+++ b/packages/facility-server/__tests__/apiv1/User.test.js
@@ -1,5 +1,5 @@
 import { CAN_ACCESS_ALL_FACILITIES, VISIBILITY_STATUSES } from '@tamanu/constants';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 import { ERROR_TYPE, Problem } from '@tamanu/errors';
 import { disableHardcodedPermissionsForSuite } from '@tamanu/shared/test-helpers';
 import { fake, chance } from '@tamanu/fake-data/fake';

--- a/packages/facility-server/__tests__/arithmetic.test.js
+++ b/packages/facility-server/__tests__/arithmetic.test.js
@@ -1,4 +1,4 @@
-import { runArithmetic } from '../dist/utils/arithmetic';
+import { runArithmetic } from '../app/utils/arithmetic';
 
 describe('Arithmetic', () => {
   describe('basics', () => {

--- a/packages/facility-server/__tests__/integrations/imaging/MerlinProvider.test.js
+++ b/packages/facility-server/__tests__/integrations/imaging/MerlinProvider.test.js
@@ -1,5 +1,5 @@
 import { fake } from '@tamanu/fake-data/fake';
-import { MerlinProvider } from '../../../dist/integrations/imaging/MerlinProvider';
+import { MerlinProvider } from '../../../app/integrations/imaging/MerlinProvider';
 import { createTestContext } from '../../utilities';
 import { SYSTEM_USER_UUID } from '@tamanu/constants';
 

--- a/packages/facility-server/__tests__/migrateAppointmentsToLocationGroups.test.js
+++ b/packages/facility-server/__tests__/migrateAppointmentsToLocationGroups.test.js
@@ -1,7 +1,7 @@
 import { fake } from '@tamanu/fake-data/fake';
 import { createDummyPatient } from '@tamanu/database/demoData/patients';
 import { createTestContext } from './utilities';
-import { migrateAppointments } from '../dist/subCommands';
+import { migrateAppointments } from '../app/subCommands';
 
 async function prepopulate(models) {
   const { Facility, User, Patient, Location, LocationGroup, Appointment } = models;

--- a/packages/facility-server/__tests__/sync/CentralServerConnection.test.js
+++ b/packages/facility-server/__tests__/sync/CentralServerConnection.test.js
@@ -16,7 +16,7 @@ import {
 } from '@tamanu/errors';
 import * as jose from 'jose';
 
-const { CentralServerConnection } = jest.requireActual('../../dist/sync/CentralServerConnection');
+const { CentralServerConnection } = jest.requireActual('../../app/sync/CentralServerConnection');
 
 const fakeResponse = (response, body, headers = {}) => {
   const validBody = JSON.parse(JSON.stringify(body));

--- a/packages/facility-server/__tests__/sync/FacilitySyncManager-edgecases.test.js
+++ b/packages/facility-server/__tests__/sync/FacilitySyncManager-edgecases.test.js
@@ -45,7 +45,7 @@ describe('FacilitySyncManager edge cases', () => {
 
     const {
       FacilitySyncManager: TestFacilitySyncManager,
-    } = require('../../dist/sync/FacilitySyncManager');
+    } = require('../../app/sync/FacilitySyncManager');
     const syncManager = new TestFacilitySyncManager({
       models,
       sequelize,
@@ -151,7 +151,7 @@ describe('FacilitySyncManager edge cases', () => {
       });
       const {
         FacilitySyncManager: TestFacilitySyncManager,
-      } = require('../../dist/sync/FacilitySyncManager');
+      } = require('../../app/sync/FacilitySyncManager');
       if (configToOverride) {
         TestFacilitySyncManager.overrideConfig(configToOverride);
       }
@@ -204,8 +204,8 @@ describe('FacilitySyncManager edge cases', () => {
       const pushOutgoingChangesPromise = new Promise(resolve => {
         resolvePushOutgoingChangesPromise = async () => resolve(true);
       });
-      jest.doMock('../../dist/sync/pushOutgoingChanges', () => ({
-        ...jest.requireActual('../../dist/sync/pushOutgoingChanges'),
+      jest.doMock('../../app/sync/pushOutgoingChanges', () => ({
+        ...jest.requireActual('../../app/sync/pushOutgoingChanges'),
         pushOutgoingChanges: jest.fn().mockImplementation(() => {
           return pushOutgoingChangesPromise;
         }),
@@ -233,8 +233,8 @@ describe('FacilitySyncManager edge cases', () => {
       const pushOutgoingChangesPromise = new Promise(resolve => {
         resolvePushOutgoingChangesPromise = async () => resolve(true);
       });
-      jest.doMock('../../dist/sync/pushOutgoingChanges', () => ({
-        ...jest.requireActual('../../dist/sync/pushOutgoingChanges'),
+      jest.doMock('../../app/sync/pushOutgoingChanges', () => ({
+        ...jest.requireActual('../../app/sync/pushOutgoingChanges'),
         pushOutgoingChanges: jest.fn().mockImplementation(() => {
           return pushOutgoingChangesPromise;
         }),
@@ -268,8 +268,8 @@ describe('FacilitySyncManager edge cases', () => {
       const pushOutgoingChangesPromise = new Promise(resolve => {
         resolvePushOutgoingChangesPromise = async () => resolve(true);
       });
-      jest.doMock('../../dist/sync/pushOutgoingChanges', () => ({
-        ...jest.requireActual('../../dist/sync/pushOutgoingChanges'),
+      jest.doMock('../../app/sync/pushOutgoingChanges', () => ({
+        ...jest.requireActual('../../app/sync/pushOutgoingChanges'),
         pushOutgoingChanges: jest.fn().mockImplementation(() => {
           return pushOutgoingChangesPromise;
         }),
@@ -306,7 +306,7 @@ describe('FacilitySyncManager edge cases', () => {
 
       const {
         FacilitySyncManager: TestFacilitySyncManager,
-      } = require('../../dist/sync/FacilitySyncManager');
+      } = require('../../app/sync/FacilitySyncManager');
 
       const markSessionErrored = jest.fn();
 
@@ -353,10 +353,10 @@ describe('FacilitySyncManager edge cases', () => {
 
       const {
         FacilitySyncManager: TestFacilitySyncManager,
-      } = require('../../dist/sync/FacilitySyncManager');
+      } = require('../../app/sync/FacilitySyncManager');
 
       const { CentralServerConnection: TestCentralServerConnection } = jest.requireActual(
-        '../../dist/sync/CentralServerConnection',
+        '../../app/sync/CentralServerConnection',
       );
 
       const markSessionErrored = jest.fn();

--- a/packages/facility-server/__tests__/sync/FacilitySyncManager-integration.test.js
+++ b/packages/facility-server/__tests__/sync/FacilitySyncManager-integration.test.js
@@ -1,5 +1,5 @@
 import { createTestContext } from '../utilities';
-import { FacilitySyncManager } from '../../dist/sync/FacilitySyncManager';
+import { FacilitySyncManager } from '../../app/sync/FacilitySyncManager';
 import {
   FACT_CURRENT_SYNC_TICK,
   FACT_LAST_SUCCESSFUL_SYNC_PULL

--- a/packages/facility-server/__tests__/sync/FacilitySyncManager.test.js
+++ b/packages/facility-server/__tests__/sync/FacilitySyncManager.test.js
@@ -5,7 +5,7 @@ import {
 } from '@tamanu/constants/facts';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
-import { FacilitySyncManager } from '../../dist/sync/FacilitySyncManager';
+import { FacilitySyncManager } from '../../app/sync/FacilitySyncManager';
 import { createTestContext } from '../utilities';
 
 describe('FacilitySyncManager', () => {
@@ -115,15 +115,15 @@ describe('FacilitySyncManager', () => {
     it("snapshots outgoing changes with the current 'lastSuccessfulSyncPush'", async () => {
       await ctx.models.LocalSystemFact.set(FACT_LAST_SUCCESSFUL_SYNC_PUSH, '10');
 
-      jest.doMock('../../dist/sync/snapshotOutgoingChanges', () => ({
+      jest.doMock('../../app/sync/snapshotOutgoingChanges', () => ({
         snapshotOutgoingChanges: jest.fn().mockImplementation(() => []),
       }));
 
       // Have to load test function within test scope so that we can mock dependencies per test case
       const {
         FacilitySyncManager: TestFacilitySyncManager,
-      } = require('../../dist/sync/FacilitySyncManager');
-      const { snapshotOutgoingChanges } = require('../../dist/sync/snapshotOutgoingChanges');
+      } = require('../../app/sync/FacilitySyncManager');
+      const { snapshotOutgoingChanges } = require('../../app/sync/snapshotOutgoingChanges');
 
       const syncManager = new TestFacilitySyncManager({
         models,
@@ -146,12 +146,12 @@ describe('FacilitySyncManager', () => {
       const outgoingChanges = [{ test: 'test' }];
       await ctx.models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, '10');
 
-      jest.doMock('../../dist/sync/snapshotOutgoingChanges', () => ({
-        ...jest.requireActual('../../dist/sync/snapshotOutgoingChanges'),
+      jest.doMock('../../app/sync/snapshotOutgoingChanges', () => ({
+        ...jest.requireActual('../../app/sync/snapshotOutgoingChanges'),
         snapshotOutgoingChanges: jest.fn().mockImplementation(() => outgoingChanges),
       }));
-      jest.doMock('../../dist/sync/pushOutgoingChanges', () => ({
-        ...jest.requireActual('../../dist/sync/pushOutgoingChanges'),
+      jest.doMock('../../app/sync/pushOutgoingChanges', () => ({
+        ...jest.requireActual('../../app/sync/pushOutgoingChanges'),
         pushOutgoingChanges: jest.fn().mockImplementation(() => true),
       }));
       jest.doMock('@tamanu/database/utils/audit', () => ({
@@ -162,8 +162,8 @@ describe('FacilitySyncManager', () => {
       // Have to load test function within test scope so that we can mock dependencies per test case
       const {
         FacilitySyncManager: TestFacilitySyncManager,
-      } = require('../../dist/sync/FacilitySyncManager');
-      const { pushOutgoingChanges } = require('../../dist/sync/pushOutgoingChanges');
+      } = require('../../app/sync/FacilitySyncManager');
+      const { pushOutgoingChanges } = require('../../app/sync/pushOutgoingChanges');
       const { attachChangelogToSnapshotRecords } = require('@tamanu/database/utils/audit');
 
       const syncManager = new TestFacilitySyncManager({
@@ -210,19 +210,19 @@ describe('FacilitySyncManager', () => {
         ...jest.requireActual('@tamanu/database/sync'),
         createSnapshotTable: jest.fn(),
       }));
-      jest.doMock('../../dist/sync/pullIncomingChanges', () => ({
-        ...jest.requireActual('../../dist/sync/pullIncomingChanges'),
+      jest.doMock('../../app/sync/pullIncomingChanges', () => ({
+        ...jest.requireActual('../../app/sync/pullIncomingChanges'),
         pullIncomingChanges: jest.fn().mockImplementation(() => []),
       }));
-      jest.doMock('../../dist/sync/assertIfPulledRecordsUpdatedAfterPushSnapshot', () => ({
-        ...jest.requireActual('../../dist/sync/assertIfPulledRecordsUpdatedAfterPushSnapshot'),
+      jest.doMock('../../app/sync/assertIfPulledRecordsUpdatedAfterPushSnapshot', () => ({
+        ...jest.requireActual('../../app/sync/assertIfPulledRecordsUpdatedAfterPushSnapshot'),
         assertIfPulledRecordsUpdatedAfterPushSnapshot: jest.fn(),
       }));
 
       // Have to load test function within test scope so that we can mock dependencies per test case
       const {
         FacilitySyncManager: TestFacilitySyncManager,
-      } = require('../../dist/sync/FacilitySyncManager');
+      } = require('../../app/sync/FacilitySyncManager');
       const { createSnapshotTable } = require('@tamanu/database/sync');
 
       const syncManager = new TestFacilitySyncManager({
@@ -250,19 +250,19 @@ describe('FacilitySyncManager', () => {
         createSnapshotTable: jest.fn(),
         saveIncomingChanges: jest.fn(),
       }));
-      jest.doMock('../../dist/sync/pullIncomingChanges', () => ({
-        ...jest.requireActual('../../dist/sync/pullIncomingChanges'),
+      jest.doMock('../../app/sync/pullIncomingChanges', () => ({
+        ...jest.requireActual('../../app/sync/pullIncomingChanges'),
         pullIncomingChanges: jest.fn().mockImplementation(() => ({ totalPulled: 3, tick: 1 })),
       }));
-      jest.doMock('../../dist/sync/assertIfPulledRecordsUpdatedAfterPushSnapshot', () => ({
-        ...jest.requireActual('../../dist/sync/assertIfPulledRecordsUpdatedAfterPushSnapshot'),
+      jest.doMock('../../app/sync/assertIfPulledRecordsUpdatedAfterPushSnapshot', () => ({
+        ...jest.requireActual('../../app/sync/assertIfPulledRecordsUpdatedAfterPushSnapshot'),
         assertIfPulledRecordsUpdatedAfterPushSnapshot: jest.fn(),
       }));
 
       // Have to load test function within test scope so that we can mock dependencies per test case
       const {
         FacilitySyncManager: TestFacilitySyncManager,
-      } = require('../../dist/sync/FacilitySyncManager');
+      } = require('../../app/sync/FacilitySyncManager');
       const { saveIncomingChanges } = require('@tamanu/database/sync');
 
       const syncManager = new TestFacilitySyncManager({

--- a/packages/facility-server/__tests__/sync/calculatePageLimit.test.js
+++ b/packages/facility-server/__tests__/sync/calculatePageLimit.test.js
@@ -1,6 +1,6 @@
 import * as fc from 'fast-check';
 
-import { calculatePageLimit } from '../../dist/sync/calculatePageLimit';
+import { calculatePageLimit } from '../../app/sync/calculatePageLimit';
 
 const defaultConfig = {
   initialLimit: 10,

--- a/packages/facility-server/__tests__/sync/deleteRedundantLocalCopies.test.js
+++ b/packages/facility-server/__tests__/sync/deleteRedundantLocalCopies.test.js
@@ -1,6 +1,6 @@
 import { Op } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
-import { deleteRedundantLocalCopies } from '../../dist/sync/deleteRedundantLocalCopies';
+import { deleteRedundantLocalCopies } from '../../app/sync/deleteRedundantLocalCopies';
 
 describe('deleteRedundantLocalCopies', () => {
   it('should delete records for models marked as PUSH_TO_CENTRAL_THEN_DELETE', async () => {

--- a/packages/facility-server/__tests__/sync/pushOutgoingChanges.test.js
+++ b/packages/facility-server/__tests__/sync/pushOutgoingChanges.test.js
@@ -25,7 +25,7 @@ describe('pushOutgoingChanges', () => {
               jest.doMock('config', () => makeLimitConfig(config));
               // Have to load test function within test scope so that we can mock config per test case
               // https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options
-              const { pushOutgoingChanges } = require('../../dist/sync/pushOutgoingChanges');
+              const { pushOutgoingChanges } = require('../../app/sync/pushOutgoingChanges');
               const centralServer = {
                 push: jest.fn().mockImplementation(async () => {}),
                 completePush: jest.fn().mockImplementation(async () => true),
@@ -54,7 +54,7 @@ describe('pushOutgoingChanges', () => {
               jest.doMock('config', () => makeLimitConfig(config));
               // Have to load test function within test scope so that we can mock config per test case
               // https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options
-              const { pushOutgoingChanges } = require('../../dist/sync/pushOutgoingChanges');
+              const { pushOutgoingChanges } = require('../../app/sync/pushOutgoingChanges');
               const centralServer = {
                 push: jest.fn().mockImplementation(async () => {}),
                 completePush: jest.fn().mockImplementation(async () => true),
@@ -82,7 +82,7 @@ describe('pushOutgoingChanges', () => {
               jest.doMock('config', () => makeLimitConfig(config));
               // Have to load test function within test scope so that we can mock config per test case
               // https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options
-              const { pushOutgoingChanges } = require('../../dist/sync/pushOutgoingChanges');
+              const { pushOutgoingChanges } = require('../../app/sync/pushOutgoingChanges');
               const centralServer = {
                 push: jest.fn().mockImplementation(async () => {}),
                 completePush: jest.fn().mockImplementation(async () => true),

--- a/packages/facility-server/__tests__/sync/snapshotOutgoingChanges.test.js
+++ b/packages/facility-server/__tests__/sync/snapshotOutgoingChanges.test.js
@@ -8,7 +8,7 @@ import { FACT_CURRENT_SYNC_TICK } from '@tamanu/constants/facts';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { createTestContext } from '../utilities';
-import { snapshotOutgoingChanges } from '../../dist/sync/snapshotOutgoingChanges';
+import { snapshotOutgoingChanges } from '../../app/sync/snapshotOutgoingChanges';
 
 describe('snapshotOutgoingChanges', () => {
   let ctx;

--- a/packages/facility-server/__tests__/tasks/MSupplyStockOnHandProcessor.test.js
+++ b/packages/facility-server/__tests__/tasks/MSupplyStockOnHandProcessor.test.js
@@ -1,6 +1,6 @@
 import config from 'config';
 import { createTestContext } from '../utilities';
-import { MSupplyStockOnHandProcessor } from '../../dist/tasks/MSupplyStockOnHandProcessor';
+import { MSupplyStockOnHandProcessor } from '../../app/tasks/MSupplyStockOnHandProcessor';
 import { fetchWithRetryBackoff } from '@tamanu/api-client/fetchWithRetryBackoff';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { REFERENCE_TYPES, DRUG_STOCK_STATUSES, SETTINGS_SCOPES } from '@tamanu/constants';

--- a/packages/facility-server/__tests__/tasks/RefreshMaterializedView.test.js
+++ b/packages/facility-server/__tests__/tasks/RefreshMaterializedView.test.js
@@ -1,6 +1,6 @@
 import config from 'config';
 import { createTestContext } from '../utilities';
-import { RefreshUpcomingVaccinations } from '../../dist/tasks/RefreshMaterializedView';
+import { RefreshUpcomingVaccinations } from '../../app/tasks/RefreshMaterializedView';
 import { fake } from '@tamanu/fake-data/fake';
 import { toDateString } from '@tamanu/utils/dateTime';
 import { QueryTypes } from 'sequelize';

--- a/packages/facility-server/__tests__/tasks/mSupplyMedIntegrationProcessor.test.js
+++ b/packages/facility-server/__tests__/tasks/mSupplyMedIntegrationProcessor.test.js
@@ -1,6 +1,6 @@
 import config from 'config';
 import { createTestContext } from '../utilities';
-import { mSupplyMedIntegrationProcessor } from '../../dist/tasks/mSupplyMedIntegrationProcessor';
+import { mSupplyMedIntegrationProcessor } from '../../app/tasks/mSupplyMedIntegrationProcessor';
 import { fetchWithRetryBackoff } from '@tamanu/api-client/fetchWithRetryBackoff';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';

--- a/packages/facility-server/__tests__/uploadAttachment.test.js
+++ b/packages/facility-server/__tests__/uploadAttachment.test.js
@@ -3,9 +3,9 @@ import { promises as fs } from 'fs';
 import { InvalidParameterError, RemoteCallError } from '@tamanu/errors';
 import { getUploadedData } from '@tamanu/shared/utils/getUploadedData';
 
-import { CentralServerConnection } from '../dist/sync/CentralServerConnection';
+import { CentralServerConnection } from '../app/sync/CentralServerConnection';
 // Get the unmocked function to be able to test it
-const { uploadAttachment } = jest.requireActual('../dist/utils/uploadAttachment');
+const { uploadAttachment } = jest.requireActual('../app/utils/uploadAttachment');
 
 // Mock image to be created with fs module. Expected size of 1002 bytes.
 const FILEDATA =

--- a/packages/facility-server/__tests__/utilities.js
+++ b/packages/facility-server/__tests__/utilities.js
@@ -19,21 +19,21 @@ import { showError } from '@tamanu/shared/test-helpers';
 import { asNewRole } from '@tamanu/fake-data/test-helpers';
 import { initReporting } from '@tamanu/database/services/reporting';
 
-import { createApiApp } from '../dist/createApiApp';
-import { buildToken } from '../dist/middleware/auth';
+import { createApiApp } from '../app/createApiApp';
+import { buildToken } from '../app/middleware/auth';
 
 import { toMatchTabularReport } from './toMatchTabularReport';
 import { allSeeds } from './seed';
 import { deleteAllTestIds } from './setupUtilities';
 
-import { FacilitySyncManager } from '../dist/sync/FacilitySyncManager';
-import { CentralServerConnection } from '../dist/sync/CentralServerConnection';
-import { ApplicationContext } from '../dist/ApplicationContext';
-import { FacilitySyncConnection } from '../dist/sync/FacilitySyncConnection';
+import { FacilitySyncManager } from '../app/sync/FacilitySyncManager';
+import { CentralServerConnection } from '../app/sync/CentralServerConnection';
+import { ApplicationContext } from '../app/ApplicationContext';
+import { FacilitySyncConnection } from '../app/sync/FacilitySyncConnection';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 
-jest.mock('../dist/sync/CentralServerConnection');
-jest.mock('../dist/utils/uploadAttachment');
+jest.mock('../app/sync/CentralServerConnection');
+jest.mock('../app/utils/uploadAttachment');
 
 const formatError = response => `
 

--- a/packages/facility-server/__tests__/versionCompatibility.test.js
+++ b/packages/facility-server/__tests__/versionCompatibility.test.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { lte as semverLte } from 'semver';
-import { MAX_CLIENT_VERSION, MIN_CLIENT_VERSION } from '../dist/middleware/versionCompatibility';
+import { MAX_CLIENT_VERSION, MIN_CLIENT_VERSION } from '../app/middleware/versionCompatibility';
 
 async function readVersion(pkg) {
   const normalisedPath = path.resolve(__dirname, '..', '..', '..', 'packages', pkg, 'package.json');

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 
 import { initReporting } from '@tamanu/database/services/reporting';
 import { initBugsnag } from '@tamanu/shared/services/logging';

--- a/packages/facility-server/app/middleware/auth.js
+++ b/packages/facility-server/app/middleware/auth.js
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
-import { compare } from 'bcrypt';
+import __cjs_bcrypt from 'bcrypt';
+const { compare } = __cjs_bcrypt;
 import config from 'config';
 import * as jose from 'jose';
 import ms from 'ms';

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -2,7 +2,7 @@ import { format, isSameDay } from 'date-fns';
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { Op, QueryTypes, Sequelize, literal } from 'sequelize';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { z } from 'zod';
 
 import {

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -34,7 +34,7 @@ import {
   fetchGraphData,
   fetchChartInstances,
 } from '../../routeHandlers/charts';
-import { keyBy } from 'lodash';
+import { keyBy } from 'es-toolkit/compat';
 import { createEncounterSchema } from '@tamanu/shared/schemas/facility/requests/createEncounter.schema';
 import { uploadAttachment } from '../../utils/uploadAttachment';
 import { noteChangelogsHandler, noteListHandler } from '../../routeHandlers';

--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -19,7 +19,7 @@ import * as z from 'zod';
 import { ForbiddenError } from '@tamanu/errors';
 import { log } from '@tamanu/shared/services/logging';
 import { getPermissionsForRoles } from '@tamanu/shared/permissions/rolesToPermissions';
-import { keyBy, mapValues } from 'lodash';
+import { keyBy, mapValues } from 'es-toolkit/compat';
 
 import { allergy } from './allergy';
 import { appointments } from './appointments';

--- a/packages/facility-server/app/routes/apiv1/invoice/invoiceForResponse.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoiceForResponse.js
@@ -1,4 +1,4 @@
-import { keyBy } from 'lodash';
+import { keyBy } from 'es-toolkit/compat';
 
 // Map invoice items with insurance plans and product codes & convert the Sequelize object to a plain object
 export const invoiceForResponse = invoiceRecord => {

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { keyBy, round } from 'lodash';
+import { keyBy, round } from 'es-toolkit/compat';
 import { ValidationError, NotFoundError, InvalidOperationError } from '@tamanu/errors';
 import {
   INVOICE_ITEMS_DISCOUNT_TYPES,

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -13,7 +13,7 @@ import {
   NOTE_TYPES,
   VISIBILITY_STATUSES,
 } from '@tamanu/constants';
-import { keyBy } from 'lodash';
+import { keyBy } from 'es-toolkit/compat';
 import { renameObjectKeys } from '@tamanu/utils/renameObjectKeys';
 import {
   permissionCheckingRouter,

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { literal, QueryTypes, Op } from 'sequelize';
-import { snakeCase } from 'lodash';
+import { snakeCase } from 'es-toolkit/compat';
 import { isBefore } from 'date-fns';
 
 import {

--- a/packages/facility-server/app/routes/apiv1/patient/patientSecondaryId.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientSecondaryId.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 import { NotFoundError } from '@tamanu/errors';
 
 export const patientSecondaryIdRoutes = express.Router();

--- a/packages/facility-server/app/routes/apiv1/patient/utils/patientBirth.js
+++ b/packages/facility-server/app/routes/apiv1/patient/utils/patientBirth.js
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 
 export const pickPatientBirthData = (patientBirthDataModel, data) =>
   pick(data, patientBirthDataModel.nonMetadataColumns);

--- a/packages/facility-server/app/routes/apiv1/referenceData.js
+++ b/packages/facility-server/app/routes/apiv1/referenceData.js
@@ -3,7 +3,7 @@ import { simpleGet, simplePost, simplePut } from '@tamanu/shared/utils/crudHelpe
 import asyncHandler from 'express-async-handler';
 import { REFERENCE_DATA_RELATION_TYPES, DEFAULT_HIERARCHY_TYPE, REFERENCE_TYPES } from '@tamanu/constants';
 import { NotFoundError } from '@tamanu/errors';
-import { keyBy, mapValues } from 'lodash';
+import { keyBy, mapValues } from 'es-toolkit/compat';
 
 export const referenceData = express.Router();
 

--- a/packages/facility-server/app/routes/apiv1/surveyResponse/changes.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse/changes.js
@@ -19,7 +19,7 @@
  * @typedef {Revision[]} RevisionHistory
  */
 import asyncHandler from 'express-async-handler';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { QueryTypes } from 'sequelize';
 
 import { PROGRAM_DATA_ELEMENT_TYPES, SURVEY_TYPES } from '@tamanu/constants';

--- a/packages/facility-server/app/routes/apiv1/surveyResponse/surveyResponse.patch.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse/surveyResponse.patch.js
@@ -1,5 +1,5 @@
 import asyncHandler from 'express-async-handler';
-import { isEqual, isPlainObject } from 'lodash';
+import { isEqual, isPlainObject } from 'es-toolkit/compat';
 
 import { PROGRAM_DATA_ELEMENT_TYPES, SURVEY_TYPES } from '@tamanu/constants';
 import { InvalidOperationError, InvalidParameterError, NotFoundError } from '@tamanu/errors';

--- a/packages/facility-server/app/sync/pullIncomingChanges.js
+++ b/packages/facility-server/app/sync/pullIncomingChanges.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { chunk } from 'lodash';
+import { chunk } from 'es-toolkit/compat';
 import { log } from '@tamanu/shared/services/logging';
 import { SYNC_STREAM_MESSAGE_KIND } from '@tamanu/constants';
 import {

--- a/packages/facility-server/app/tasks/RefreshMaterializedView.js
+++ b/packages/facility-server/app/tasks/RefreshMaterializedView.js
@@ -1,6 +1,6 @@
 import config from 'config';
-import { pascal, snake } from 'case';
-
+import __cjs_case from 'case';
+const { pascal, snake } = __cjs_case;
 import { ScheduledTask } from '@tamanu/shared/tasks';
 import {
   MATERIALIZED_VIEWS,

--- a/packages/facility-server/app/utils/makePatientLetter.jsx
+++ b/packages/facility-server/app/utils/makePatientLetter.jsx
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 import path from 'path';
 import ReactPDF from '@react-pdf/renderer';
 import config from 'config';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 import { Op } from 'sequelize';
 
 import { ASSET_NAMES, SETTING_KEYS } from '@tamanu/constants';

--- a/packages/facility-server/app/utils/medication.js
+++ b/packages/facility-server/app/utils/medication.js
@@ -1,4 +1,4 @@
-import { keyBy } from 'lodash';
+import { keyBy } from 'es-toolkit/compat';
 
 /**
  * Returns when each ongoing prescription was last sent to pharmacy.

--- a/packages/facility-server/app/utils/patientFilters.js
+++ b/packages/facility-server/app/utils/patientFilters.js
@@ -1,5 +1,5 @@
 import { sub } from 'date-fns';
-import { snakeCase } from 'lodash';
+import { snakeCase } from 'es-toolkit/compat';
 import { toDateString } from '@tamanu/utils/dateTime';
 import {
   ENCOUNTER_TYPES,

--- a/packages/facility-server/package.json
+++ b/packages/facility-server/package.json
@@ -7,7 +7,7 @@
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
-  "main": "dist/index.js",
+  "main": "./src/index",
   "bin": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
@@ -15,9 +15,6 @@
     "./schemas/encounter.schema": "./dist/routes/apiv1/encounter.schema.js"
   },
   "scripts": {
-    "build": "swc --out-dir dist --copy-files --source-maps true app",
-    "clean-build": "npm run clean && npm run build",
-    "build-watch": "npm run build -- --watch",
     "clean": "rimraf -- dist __disttests__",
     "clean:deps": "rimraf -- node_modules",
     "setup-dev": "node dist setup",
@@ -86,5 +83,6 @@
     "undici": "^7.5.0",
     "yup": "^0.32.9",
     "zod": "^4.0.17"
-  }
+  },
+  "type": "module"
 }

--- a/packages/fake-data/package.json
+++ b/packages/fake-data/package.json
@@ -3,53 +3,22 @@
   "version": "2.59.0",
   "private": true,
   "description": "TODO",
-  "main": "dist/cjs/index.js",
-  "module": "dist/mjs/index.js",
+  "main": "./src/index",
   "exports": {
-    ".": {
-      "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./populateDb": {
-      "import": "./dist/mjs/populateDb/index.js",
-      "require": "./dist/cjs/populateDb/index.js"
-    },
-    "./fake": {
-      "import": "./dist/mjs/fake/index.js",
-      "require": "./dist/cjs/fake/index.js"
-    },
-    "./fake/*": {
-      "import": "./dist/mjs/fake/*.js",
-      "require": "./dist/cjs/fake/*.js"
-    },
-    "./test-helpers": {
-      "import": "./dist/mjs/test-helpers/index.js",
-      "require": "./dist/cjs/test-helpers/index.js"
-    },
-    "./test-helpers/*": {
-      "import": "./dist/mjs/test-helpers/*.js",
-      "require": "./dist/cjs/test-helpers/*.js"
-    },
-    "./services/*": {
-      "import": "./dist/mjs/services/*.js",
-      "require": "./dist/cjs/services/*.js"
-    },
-    "./utils/*": {
-      "import": "./dist/mjs/utils/*.js",
-      "require": "./dist/cjs/utils/*.js"
-    }
+    ".": "./src",
+    "./populateDb": "./src/populateDb",
+    "./fake": "./src/fake",
+    "./fake/*": "./src/fake/*",
+    "./test-helpers": "./src/test-helpers",
+    "./test-helpers/*": "./src/test-helpers/*",
+    "./services/*": "./src/services/*",
+    "./utils/*": "./src/utils/*"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "npm run build:src && npm run build:cjs && npm run build:types && dual-pkg dist/mjs dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:src": "swc --delete-dir-on-start --out-dir dist/mjs --copy-files --source-maps true src",
-    "build:cjs": "npm run build:src -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/mjs --rootDir src && move-dts --copy dist/mjs dist/cjs",
-    "build-watch": "npm run build && concurrently \"npm run build:src -- --watch\" \"npm run build:cjs -- --watch\"",
     "clean": "rimraf -- dist .tsbuild",
     "clean:deps": "rimraf -- node_modules"
   },
@@ -76,5 +45,6 @@
     "sequelize": "^6.37.8",
     "zocker": "^2.2.2",
     "zod": "^4.0.17"
-  }
+  },
+  "type": "module"
 }

--- a/packages/fake-data/src/fake/fake.ts
+++ b/packages/fake-data/src/fake/fake.ts
@@ -1,5 +1,5 @@
 import { randomInt } from 'crypto';
-import { isFunction, snakeCase } from 'lodash';
+import { isFunction, snakeCase } from 'es-toolkit/compat';
 import Chance from 'chance';
 import Sequelize from 'sequelize';
 import { inspect } from 'util';

--- a/packages/fake-data/src/populateDb/helpers/appointment.ts
+++ b/packages/fake-data/src/populateDb/helpers/appointment.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from 'es-toolkit/compat';
 
 import { REPEAT_FREQUENCY } from '@tamanu/constants';
 import { randomRecordId } from '../randomRecord.js';

--- a/packages/fake-data/src/populateDb/helpers/encounter.ts
+++ b/packages/fake-data/src/populateDb/helpers/encounter.ts
@@ -2,7 +2,7 @@ import { NOTE_RECORD_TYPES } from '@tamanu/constants';
 import type { Encounter } from '@tamanu/database';
 import { randomRecordId } from '../randomRecord.js';
 
-import { times } from 'lodash';
+import { times } from 'es-toolkit/compat';
 import { fake, chance } from '../../fake/index.js';
 import type { CommonParams } from './common.js';
 

--- a/packages/fake-data/src/populateDb/helpers/invoice.ts
+++ b/packages/fake-data/src/populateDb/helpers/invoice.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from 'es-toolkit/compat';
 
 import { randomRecordId } from '../randomRecord.js';
 

--- a/packages/fake-data/src/populateDb/helpers/labRequest.ts
+++ b/packages/fake-data/src/populateDb/helpers/labRequest.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from 'es-toolkit/compat';
 import { randomRecordId } from '../randomRecord.js';
 import { fake, chance } from '../../fake/index.js';
 import type { CommonParams } from './common.js';

--- a/packages/fake-data/src/populateDb/helpers/patient.ts
+++ b/packages/fake-data/src/populateDb/helpers/patient.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from 'es-toolkit/compat';
 
 import { REFERENCE_TYPES } from '@tamanu/constants';
 import type { Patient } from '@tamanu/database';

--- a/packages/fake-data/src/populateDb/helpers/programRegistry.ts
+++ b/packages/fake-data/src/populateDb/helpers/programRegistry.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from 'es-toolkit/compat';
 import { randomRecordId } from '../randomRecord.js';
 import { fake, chance } from '../../fake/index.js';
 import type { CommonParams } from './common.js';

--- a/packages/fake-data/src/populateDb/parseTally/populateFromLogTally.ts
+++ b/packages/fake-data/src/populateDb/parseTally/populateFromLogTally.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs';
-import { times } from 'lodash';
+import { times } from 'es-toolkit/compat';
 
 import { Models } from '@tamanu/database';
 

--- a/packages/mobile/App/dummyData/patients.ts
+++ b/packages/mobile/App/dummyData/patients.ts
@@ -1,5 +1,5 @@
 import { Chance } from 'chance';
-import { sample } from 'lodash';
+import { sample } from 'es-toolkit/compat';
 import { GenderOptions } from '/helpers/constants';
 import { bloodOptions } from '/helpers/additionalData';
 import { IPatient } from '~/types';

--- a/packages/mobile/App/migrations/1668987530000-addFieldUpdateTicksToPAD.ts
+++ b/packages/mobile/App/migrations/1668987530000-addFieldUpdateTicksToPAD.ts
@@ -1,5 +1,5 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
-import { snakeCase } from 'lodash';
+import { snakeCase } from 'es-toolkit/compat';
 import { getTable } from './utils/queryRunner';
 
 const METADATA_FIELDS = [

--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, Index, OneToMany, In } from 'typeorm';
 import { getUniqueId } from 'react-native-device-info';
 import { addHours, parseISO, startOfDay, subYears } from 'date-fns';
-import { groupBy } from 'lodash';
+import { groupBy } from 'es-toolkit/compat';
 import { readConfig } from '~/services/config';
 import { BaseModel, IdRelation } from './BaseModel';
 import { Encounter } from './Encounter';

--- a/packages/mobile/App/models/PatientAdditionalData.ts
+++ b/packages/mobile/App/models/PatientAdditionalData.ts
@@ -7,7 +7,7 @@ import {
   PrimaryColumn,
   RelationId,
 } from 'typeorm';
-import { isEmpty, snakeCase } from 'lodash';
+import { isEmpty, snakeCase } from 'es-toolkit/compat';
 import { BaseModel, IdRelation } from './BaseModel';
 import { IPatientAdditionalData } from '~/types';
 import { ReferenceData, ReferenceDataRelation } from './ReferenceData';

--- a/packages/mobile/App/models/Setting.ts
+++ b/packages/mobile/App/models/Setting.ts
@@ -1,5 +1,5 @@
 import { Brackets, Column, RelationId, Entity, ManyToOne } from 'typeorm';
-import { get as getAtPath, merge, set as setAtPath } from 'lodash';
+import { get as getAtPath, merge, set as setAtPath } from 'es-toolkit/compat';
 
 import { BaseModel } from './BaseModel';
 import { Facility } from './Facility';

--- a/packages/mobile/App/models/User.ts
+++ b/packages/mobile/App/models/User.ts
@@ -10,7 +10,7 @@ import { SYNC_DIRECTIONS } from './types';
 import { VisibilityStatus } from '../visibilityStatuses';
 import { CAN_ACCESS_ALL_FACILITIES, SYSTEM_USER_UUID } from '~/constants';
 import { type PureAbility } from '@casl/ability';
-import { union } from 'lodash';
+import { union } from 'es-toolkit/compat';
 import { MODELS_MAP } from './modelsMap';
 @Entity('users')
 export class User extends BaseModel implements IUser {

--- a/packages/mobile/App/services/localisation.ts
+++ b/packages/mobile/App/services/localisation.ts
@@ -1,5 +1,5 @@
 import mitt from 'mitt';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 
 import { LocalDataService } from './localData';
 

--- a/packages/mobile/App/services/settings.ts
+++ b/packages/mobile/App/services/settings.ts
@@ -1,5 +1,5 @@
 import mitt from 'mitt';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 
 import { LocalDataService } from './localData';
 

--- a/packages/mobile/App/services/sync/utils/buildFromSyncRecord.ts
+++ b/packages/mobile/App/services/sync/utils/buildFromSyncRecord.ts
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 
 import { DataToPersist, SyncRecord } from '../types';
 import { BaseModel } from '../../../models/BaseModel';

--- a/packages/mobile/App/services/sync/utils/executePreparedQuery.ts
+++ b/packages/mobile/App/services/sync/utils/executePreparedQuery.ts
@@ -1,5 +1,5 @@
 import { Repository } from 'typeorm';
-import { chunk } from 'lodash';
+import { chunk } from 'es-toolkit/compat';
 import { DataToPersist } from '../types';
 import { getEffectiveBatchSize } from '../../../infra/db/limits';
 

--- a/packages/mobile/App/services/sync/utils/extractIncludedColumns.ts
+++ b/packages/mobile/App/services/sync/utils/extractIncludedColumns.ts
@@ -1,4 +1,4 @@
-import { without } from 'lodash';
+import { without } from 'es-toolkit/compat';
 
 import { BaseModel } from '../../../models/BaseModel';
 

--- a/packages/mobile/App/services/sync/utils/manageSnapshotTable.ts
+++ b/packages/mobile/App/services/sync/utils/manageSnapshotTable.ts
@@ -1,5 +1,5 @@
 import { Database } from '~/infra/db';
-import { chunk } from 'lodash';
+import { chunk } from 'es-toolkit/compat';
 import { SyncRecord } from '../types';
 
 export const insertSnapshotRecords = async (

--- a/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
@@ -1,5 +1,5 @@
 import { In } from 'typeorm';
-import { chunk, groupBy, partition } from 'lodash';
+import { chunk, groupBy, partition } from 'es-toolkit/compat';
 
 import { SyncRecord } from '../types';
 import { getSnapshotBatchIds, getSnapshotBatchesByIds } from './manageSnapshotTable';

--- a/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
@@ -1,5 +1,5 @@
 import { MoreThan } from 'typeorm';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 
 import { BaseModel } from '../../../models/BaseModel';
 import { SyncRecord, SyncRecordData } from '../types';

--- a/packages/mobile/App/ui/components/FieldRowDisplay.tsx
+++ b/packages/mobile/App/ui/components/FieldRowDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { chunk, keyBy } from 'lodash';
+import { chunk, keyBy } from 'es-toolkit/compat';
 import { isTablet } from 'react-native-device-info';
 
 import { RowView, StyledView } from '../styled/common';

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -14,7 +14,7 @@ import { yupAttemptTransformToNumber } from '~/ui/helpers/numeralTranslation';
 import { CustomPatientFieldValues } from '~/ui/hooks/usePatientAdditionalData';
 import { PatientAdditionalData } from '~/models/PatientAdditionalData';
 import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
-import { isObject } from 'lodash';
+import { isObject } from 'es-toolkit/compat';
 
 // All PatientAdditionalData plain fields sorted alphabetically
 export const plainFields = [

--- a/packages/mobile/App/ui/components/FrequencySearchField/FrequencySearchField.tsx
+++ b/packages/mobile/App/ui/components/FrequencySearchField/FrequencySearchField.tsx
@@ -3,7 +3,7 @@ import { useNavigation } from '@react-navigation/native';
 import { StyledText, StyledView } from '~/ui/styled/common';
 import { theme } from '../../styled/theme';
 import { ADMINISTRATION_FREQUENCY_SYNONYMS } from '~/constants/medications';
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 import { FrequencySuggester, FrequencySuggestion } from '../../helpers/frequencySuggester';
 import { useTranslation } from '../../contexts/TranslationContext';
 import { TranslatedText } from '../Translations/TranslatedText';

--- a/packages/mobile/App/ui/components/HierarchyFields.tsx
+++ b/packages/mobile/App/ui/components/HierarchyFields.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { HierarchyFieldItem } from './HierarchyFieldItem';
 import { useFormikContext } from 'formik';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import { REFERENCE_TYPES } from '@tamanu/constants';
 

--- a/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
+++ b/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useNetInfo } from '@react-native-community/netinfo';
-import { keyBy, mapValues, uniq } from 'lodash';
+import { keyBy, mapValues, uniq } from 'es-toolkit/compat';
 
 import { Dropdown, SelectOption } from '../Dropdown';
 import { StyledText, StyledView } from '../../styled/common';

--- a/packages/mobile/App/ui/components/VaccinesTable/index.tsx
+++ b/packages/mobile/App/ui/components/VaccinesTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useMemo, useRef } from 'react';
 import { NativeScrollEvent, NativeSyntheticEvent, ScrollView } from 'react-native';
-import { uniqBy } from 'lodash';
+import { uniqBy } from 'es-toolkit/compat';
 import { useIsFocused } from '@react-navigation/native';
 import { useBackendEffect } from '~/ui/hooks';
 import { Table } from '../Table';

--- a/packages/mobile/App/ui/components/VitalsTable/VitalsTableCell.tsx
+++ b/packages/mobile/App/ui/components/VitalsTable/VitalsTableCell.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isNumber } from 'lodash';
+import { isNumber } from 'es-toolkit/compat';
 import { StyleSheet, Text, View } from 'react-native';
 import { theme } from '/styled/theme';
 import { Orientation, screenPercentageToDP } from '/helpers/screen';

--- a/packages/mobile/App/ui/contexts/TranslationContext.tsx
+++ b/packages/mobile/App/ui/contexts/TranslationContext.tsx
@@ -11,7 +11,7 @@ import React, {
 import { DEFAULT_LANGUAGE_CODE, ENGLISH_LANGUAGE_CODE } from '@tamanu/constants';
 import { DevSettings } from 'react-native';
 import { useBackend } from '../hooks';
-import { isEmpty, upperFirst } from 'lodash';
+import { isEmpty, upperFirst } from 'es-toolkit/compat';
 import { registerYup } from '../helpers/yupMethods';
 import { readConfig, writeConfig } from '~/services/config';
 import { LanguageOption } from '~/models/TranslatedString';

--- a/packages/mobile/App/ui/helpers/calculations.ts
+++ b/packages/mobile/App/ui/helpers/calculations.ts
@@ -1,5 +1,5 @@
 import { all as allMath, create } from 'mathjs';
-import { isNumber } from 'lodash';
+import { isNumber } from 'es-toolkit/compat';
 import { ISurveyScreenComponent } from '~/types/ISurvey';
 
 // set up math context

--- a/packages/mobile/App/ui/helpers/fields.ts
+++ b/packages/mobile/App/ui/helpers/fields.ts
@@ -1,5 +1,5 @@
 import { format, formatISO9075 } from 'date-fns';
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 
 import { PATIENT_DATA_FIELD_LOCATIONS, SEX_LABELS } from '@tamanu/constants';
 import { checkJSONCriteria, parseSurveyTimeToHHmmss } from '@tamanu/utils';

--- a/packages/mobile/App/ui/helpers/getVaccineStatus.ts
+++ b/packages/mobile/App/ui/helpers/getVaccineStatus.ts
@@ -1,6 +1,6 @@
 import { VaccineStatus } from './patient';
 import { differenceInDays, parseISO } from 'date-fns';
-import { toNumber } from 'lodash';
+import { toNumber } from 'es-toolkit/compat';
 import { IAdministeredVaccine, IPatient, IScheduledVaccine } from '~/types';
 
 type Threshold<T> = { threshold: T; status: VaccineStatus };

--- a/packages/mobile/App/ui/helpers/numeralTranslation.ts
+++ b/packages/mobile/App/ui/helpers/numeralTranslation.ts
@@ -1,5 +1,5 @@
 import { limon } from 'khmer-unicode-converter';
-import { isNaN } from 'lodash';
+import { isNaN } from 'es-toolkit/compat';
 
 function isNumeric(value) {
   return !isNaN(parseFloat(value));

--- a/packages/mobile/App/ui/hooks/usePatientAdditionalData.ts
+++ b/packages/mobile/App/ui/hooks/usePatientAdditionalData.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
-import { groupBy } from 'lodash';
+import { groupBy } from 'es-toolkit/compat';
 import { useBackend } from '.';
 import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
 import { PatientFieldValue } from '~/models/PatientFieldValue';

--- a/packages/mobile/App/ui/navigation/screens/historyvitals/tabs/VaccinesScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/historyvitals/tabs/VaccinesScreen.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { compose } from 'redux';
-import { groupBy } from 'lodash';
+import { groupBy } from 'es-toolkit/compat';
 import { ErrorScreen } from '~/ui/components/ErrorScreen';
 import { PatientVaccineHistoryAccordion } from '~/ui/components/PatientVaccineHistoryAccordion';
 import { withPatient } from '~/ui/containers/Patient';

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -8,7 +8,7 @@ import {
   CustomPatientFieldValues,
   usePatientAdditionalData,
 } from '~/ui/hooks/usePatientAdditionalData';
-import { mapValues } from 'lodash';
+import { mapValues } from 'es-toolkit/compat';
 import { PatientAdditionalData } from '~/models/PatientAdditionalData';
 import { Patient } from '~/models/Patient';
 import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/ArrowButton.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/ArrowButton.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { StyledTouchableOpacity } from '/styled/common';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'es-toolkit/compat';
 import { Orientation, screenPercentageToDP } from '/helpers/screen';
 import { ArrowDownIcon, ArrowUpIcon } from '/components/Icons';
 import { theme } from '/styled/theme';

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/PatientProgramRegistrationDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/PatientProgramRegistrationDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { sortBy, groupBy } from 'lodash';
+import { sortBy, groupBy } from 'es-toolkit/compat';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { PROGRAM_REGISTRY_CONDITION_CATEGORIES } from '~/constants/programRegistries';
 import {

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit/compat';
 import React, { ReactElement, ReactNode, useCallback, useEffect, useRef } from 'react';
 import {
   AppState,

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "android": "npx react-native start --reset-cache",
-    "build:android": "cd android && ./gradlew clean && ./gradlew app:assembleRelease && cd ..",
     "clean:deps": "rimraf -- node_modules",
     "start": "rnstl --silent && react-native start",
     "test": "jest",
@@ -133,5 +132,6 @@
     "source-map": "^0.5.7",
     "sqlite3": "^6.0.1",
     "ts-jest": "^29.1.2"
-  }
+  },
+  "type": "module"
 }

--- a/packages/mobile/tests/helpers/fake.ts
+++ b/packages/mobile/tests/helpers/fake.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { random, sample } from 'lodash';
+import { random, sample } from 'es-toolkit/compat';
 import { formatISO9075 } from 'date-fns';
 
 import {

--- a/packages/patient-portal/package.json
+++ b/packages/patient-portal/package.json
@@ -11,9 +11,7 @@
   "type": "module",
   "scripts": {
     "start-dev": "vite",
-    "build": "tsc && vite build",
     "clean": "rimraf -- dist *.tsbuildinfo",
-    "clean-build": "npm run clean && npm run build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/packages/patient-portal/src/contexts/SettingsContext.tsx
+++ b/packages/patient-portal/src/contexts/SettingsContext.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 import { styled } from '@mui/material';
 import { Alert } from '@material-ui/lab';
 import { useQuery } from '@tanstack/react-query';

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -3,8 +3,6 @@
   "version": "2.59.0",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "swc --out-dir dist --copy-files --source-maps true src",
-    "clean-build": "npm run clean && npm run build",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules",
     "test": "npm run build && tape 'tests/**/*.test.*js'",
@@ -25,5 +23,6 @@
     "@types/node": "^20.9.0",
     "rimraf": "^6.1.3",
     "tape": "^5.7.5"
-  }
+  },
+  "type": "module"
 }

--- a/packages/scripts/src/dbt/generateModel.js
+++ b/packages/scripts/src/dbt/generateModel.js
@@ -3,7 +3,7 @@
 const fs = require('node:fs/promises');
 const path = require('node:path');
 const YAML = require('yaml');
-const { compact, differenceBy, intersectionBy, remove } = require('lodash');
+const { compact, differenceBy, intersectionBy, remove } = require('es-toolkit/compat');
 const { spawnSync } = require('child_process');
 
 const KNOWN_TABLE_MASKING_KINDS = ['truncate'];

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -3,56 +3,21 @@
   "version": "2.59.0",
   "private": true,
   "description": "BES - Settings",
-  "main": "dist/cjs/index.js",
-  "module": "dist/mjs/index.js",
+  "main": "./src/index",
   "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./cache": {
-      "source": "./src/cache/index.ts",
-      "import": "./dist/mjs/cache/index.js",
-      "require": "./dist/cjs/cache/index.js"
-    },
-    "./schema": {
-      "source": "./src/schema/index.ts",
-      "import": "./dist/mjs/schema/index.js",
-      "require": "./dist/cjs/schema/index.js"
-    },
-    "./types": {
-      "source": "./src/types/index.ts",
-      "import": "./dist/mjs/types/index.js",
-      "require": "./dist/cjs/types/index.js"
-    },
-    "./test": {
-      "source": "./src/test/index.ts",
-      "import": "./dist/mjs/test/index.js",
-      "require": "./dist/cjs/test/index.js"
-    },
-    "./reader": {
-      "source": "./src/reader/index.ts",
-      "import": "./dist/mjs/reader/index.js",
-      "require": "./dist/cjs/reader/index.js"
-    },
-    "./middleware": {
-      "source": "./src/middleware/index.ts",
-      "import": "./dist/mjs/middleware/index.js",
-      "require": "./dist/cjs/middleware/index.js"
-    }
+    ".": "./src",
+    "./cache": "./src/cache",
+    "./schema": "./src/schema",
+    "./types": "./src/types",
+    "./test": "./src/test",
+    "./reader": "./src/reader",
+    "./middleware": "./src/middleware"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "npm run build:src && npm run build:cjs && npm run build:types && dual-pkg dist/mjs dist/cjs",
-    "clean-build": "npm run clean && npm run build",
-    "build:src": "swc --delete-dir-on-start --out-dir dist/mjs --copy-files --source-maps true src",
-    "build:cjs": "npm run build:src -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/mjs --rootDir src && move-dts --copy dist/mjs dist/cjs",
-    "build-watch": "npm run build && concurrently \"npm run build:src  -- --delete-dir-on-start=false --watch\" \"npm run build:cjs -- --delete-dir-on-start=false --watch\"",
     "clean": "rimraf -- dist .tsbuild",
     "clean:deps": "rimraf -- node_modules",
     "test": "NODE_ENV=test jest --passWithNoTests",
@@ -80,5 +45,6 @@
     "@types/lodash": "^4.14.197",
     "lodash": "^4.17.21",
     "yup": "^1.4.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/settings/src/cache/dbNotifier.ts
+++ b/packages/settings/src/cache/dbNotifier.ts
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit/compat';
 import { settingsCache as defaultSettingsCache, SettingsCache } from './settingsCache';
 
 const SETTINGS_TABLE = 'settings';

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -1,4 +1,4 @@
-import { get as lodashGet, pick } from 'lodash';
+import { get as lodashGet, pick } from 'es-toolkit/compat';
 import { ExposedFlag, SettingPath, SettingsSchema } from '../types';
 import { buildSettings } from '..';
 import { settingsCache } from '../cache';

--- a/packages/settings/src/reader/buildSettings.ts
+++ b/packages/settings/src/reader/buildSettings.ts
@@ -1,5 +1,5 @@
 import { SETTINGS_SCOPES } from '@tamanu/constants';
-import { isArray, mergeWith } from 'lodash';
+import { isArray, mergeWith } from 'es-toolkit/compat';
 
 import { centralDefaults, facilityDefaults, globalDefaults } from '../schema';
 import { Models, SettingsDBReader } from './readers/SettingsDBReader';

--- a/packages/settings/src/schema/utils.ts
+++ b/packages/settings/src/schema/utils.ts
@@ -6,7 +6,7 @@ import {
   get as getAtPath,
   set as setAtPath,
   cloneDeep,
-} from 'lodash';
+} from 'es-toolkit/compat';
 import { Setting, SettingsSchema } from '../types';
 
 export const isSetting = (value: Setting | SettingsSchema): value is Setting => {

--- a/packages/settings/src/schema/validation.ts
+++ b/packages/settings/src/schema/validation.ts
@@ -3,7 +3,7 @@ import { globalSettings } from './global';
 import { centralSettings } from './central';
 import { facilitySettings } from './facility';
 import * as yup from 'yup';
-import _, { cloneDeep, isArray, mergeWith } from 'lodash';
+import _, { cloneDeep, isArray, mergeWith } from 'es-toolkit/compat';
 import { SettingsSchema } from '../types';
 import { extractDefaults, isSetting } from './utils';
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,138 +2,41 @@
   "name": "@tamanu/shared",
   "version": "2.59.0",
   "description": "Common code across Tamanu packages",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index",
   "exports": {
-    ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js"
-    },
-    "./permissions/*": {
-      "require": "./dist/cjs/permissions/*.js",
-      "import": "./dist/esm/permissions/*.js"
-    },
-    "./reports/utilities/*": {
-      "require": "./dist/cjs/reports/utilities/*.js",
-      "import": "./dist/esm/reports/utilities/*.js"
-    },
-    "./services/fhirTypes/*": {
-      "require": "./dist/cjs/services/fhirTypes/*.js",
-      "import": "./dist/esm/services/fhirTypes/*.js"
-    },
-    "./services/logging/*": {
-      "require": "./dist/cjs/services/logging/*.js",
-      "import": "./dist/esm/services/logging/*.js"
-    },
-    "./services/suggestions/*": {
-      "require": "./dist/cjs/services/suggestions/*.js",
-      "import": "./dist/esm/services/suggestions/*.js"
-    },
-    "./schemas/types": {
-      "require": "./dist/cjs/schemas/types.js",
-      "import": "./dist/esm/schemas/types.js"
-    },
-    "./schemas/facility/requests/*": {
-      "require": "./dist/cjs/schemas/facility/requests/*.js",
-      "import": "./dist/esm/schemas/facility/requests/*.js"
-    },
-    "./subCommands/*": {
-      "require": "./dist/cjs/subCommands/*.js",
-      "import": "./dist/esm/subCommands/*.js"
-    },
-    "./sync/*": {
-      "require": "./dist/cjs/sync/*.js",
-      "import": "./dist/esm/sync/*.js"
-    },
-    "./tasks/*": {
-      "require": "./dist/cjs/tasks/*.js",
-      "import": "./dist/esm/tasks/*.js"
-    },
-    "./test-helpers/*": {
-      "require": "./dist/cjs/test-helpers/*.js",
-      "import": "./dist/esm/test-helpers/*.js"
-    },
-    "./utils/fhir": {
-      "require": "./dist/cjs/utils/fhir/index.js",
-      "import": "./dist/esm/utils/fhir/index.js"
-    },
-    "./utils/handoverNotes": {
-      "require": "./dist/cjs/utils/handoverNotes/index.js",
-      "import": "./dist/esm/utils/handoverNotes/index.js"
-    },
-    "./utils/patientCertificates": {
-      "require": "./dist/cjs/utils/patientCertificates/index.js",
-      "import": "./dist/esm/utils/patientCertificates/index.js"
-    },
-    "./utils/signature": {
-      "require": "./dist/cjs/utils/signature/index.js",
-      "import": "./dist/esm/utils/signature/index.js"
-    },
-    "./utils/uvci": {
-      "require": "./dist/cjs/utils/uvci/index.js",
-      "import": "./dist/esm/utils/uvci/index.js"
-    },
-    "./utils/translation": {
-      "require": "./dist/cjs/utils/translation/index.js",
-      "import": "./dist/esm/utils/translation/index.js"
-    },
-    "./utils/*": {
-      "require": "./dist/cjs/utils/*.js",
-      "import": "./dist/esm/utils/*.js"
-    },
-    "./audit/*": {
-      "require": "./dist/cjs/audit/*.js",
-      "import": "./dist/esm/audit/*.js"
-    },
-    "./schemas/*": {
-      "require": "./dist/cjs/schemas/*.js",
-      "import": "./dist/esm/schemas/*.js",
-      "types": "./dist/esm/schemas/*.d.ts"
-    },
-    "./schemas/patientPortal": {
-      "require": "./dist/cjs/schemas/patientPortal/index.js",
-      "import": "./dist/esm/schemas/patientPortal/index.js",
-      "types": "./dist/esm/schemas/patientPortal/index.d.ts"
-    },
-    "./schemas/patientPortal/*": {
-      "require": "./dist/cjs/schemas/patientPortal/*.js",
-      "import": "./dist/esm/schemas/patientPortal/*.js",
-      "types": "./dist/esm/schemas/patientPortal/*.d.ts"
-    },
-    "./schemas/patientPortal/responses/*": {
-      "require": "./dist/cjs/schemas/patientPortal/responses/*.js",
-      "import": "./dist/esm/schemas/patientPortal/responses/*.js",
-      "types": "./dist/esm/schemas/patientPortal/responses/*.d.ts"
-    },
-    "./schemas/patientPortal/requests/*": {
-      "require": "./dist/cjs/schemas/patientPortal/requests/*.js",
-      "import": "./dist/esm/schemas/patientPortal/requests/*.js",
-      "types": "./dist/esm/schemas/patientPortal/requests/*.d.ts"
-    },
-    "./schemas/facility/responses/*": {
-      "require": "./dist/cjs/schemas/facility/responses/*.js",
-      "import": "./dist/esm/schemas/facility/responses/*.js",
-      "types": "./dist/esm/schemas/facility/responses/*.d.ts"
-    },
-    "./*": {
-      "import": "./dist/esm/*/index.js",
-      "require": "./dist/cjs/*/index.js"
-    }
+    ".": "./src",
+    "./permissions/*": "./src/permissions/*",
+    "./reports/utilities/*": "./src/reports/utilities/*",
+    "./services/fhirTypes/*": "./src/services/fhirTypes/*",
+    "./services/logging/*": "./src/services/logging/*",
+    "./services/suggestions/*": "./src/services/suggestions/*",
+    "./schemas/types": "./src/schemas/types",
+    "./schemas/facility/requests/*": "./src/schemas/facility/requests/*",
+    "./subCommands/*": "./src/subCommands/*",
+    "./sync/*": "./src/sync/*",
+    "./tasks/*": "./src/tasks/*",
+    "./test-helpers/*": "./src/test-helpers/*",
+    "./utils/fhir": "./src/utils/fhir",
+    "./utils/handoverNotes": "./src/utils/handoverNotes",
+    "./utils/patientCertificates": "./src/utils/patientCertificates",
+    "./utils/signature": "./src/utils/signature",
+    "./utils/uvci": "./src/utils/uvci",
+    "./utils/translation": "./src/utils/translation",
+    "./utils/*": "./src/utils/*",
+    "./audit/*": "./src/audit/*",
+    "./schemas/*": "./src/schemas/*",
+    "./schemas/patientPortal": "./src/schemas/patientPortal",
+    "./schemas/patientPortal/*": "./src/schemas/patientPortal/*",
+    "./schemas/patientPortal/responses/*": "./src/schemas/patientPortal/responses/*",
+    "./schemas/patientPortal/requests/*": "./src/schemas/patientPortal/requests/*",
+    "./schemas/facility/responses/*": "./src/schemas/facility/responses/*",
+    "./*": "./src/*"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later AND BUSL-1.1",
   "scripts": {
-    "build": "concurrently -n esm,cjs,types -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" \"npm run build:types\"",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev": "npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\"",
-    "build:esm": "swc --out-dir dist/esm --copy-files --source-maps true src",
-    "build:cjs": "npm run build:esm -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "tsc --emitDeclarationOnly --outDir dist/esm --rootDir src",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist .tsbuild",
     "clean:deps": "rimraf -- node_modules",
     "test": "NODE_ENV=test jest"
@@ -189,5 +92,6 @@
     "winston": "^3.14.2",
     "yup": "^0.32.9",
     "zod": "^4.0.17"
-  }
+  },
+  "type": "module"
 }

--- a/packages/shared/src/reports/generic-survey-export-line-list.js
+++ b/packages/shared/src/reports/generic-survey-export-line-list.js
@@ -1,5 +1,5 @@
 import { endOfDay, parseISO, startOfDay, subDays } from 'date-fns';
-import { keyBy } from 'lodash';
+import { keyBy } from 'es-toolkit/compat';
 
 import {
   NON_ANSWERABLE_DATA_ELEMENT_TYPES,

--- a/packages/shared/src/reports/utilities/transformAnswers.js
+++ b/packages/shared/src/reports/utilities/transformAnswers.js
@@ -1,4 +1,4 @@
-import { keyBy } from 'lodash';
+import { keyBy } from 'es-toolkit/compat';
 
 import { PATIENT_DATA_FIELD_LOCATIONS, PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
 import { convertBinaryToYesNo } from '@tamanu/utils/criteria';

--- a/packages/shared/src/services/fhirTypes/address.js
+++ b/packages/shared/src/services/fhirTypes/address.js
@@ -1,5 +1,5 @@
 import { Chance } from 'chance';
-import { sample } from 'lodash';
+import { sample } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FhirBaseType } from './baseType';

--- a/packages/shared/src/services/fhirTypes/codeableConcept.js
+++ b/packages/shared/src/services/fhirTypes/codeableConcept.js
@@ -1,4 +1,4 @@
-import { random } from 'lodash';
+import { random } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FhirBaseType } from './baseType';

--- a/packages/shared/src/services/fhirTypes/coding.js
+++ b/packages/shared/src/services/fhirTypes/coding.js
@@ -1,4 +1,4 @@
-import { random, sample } from 'lodash';
+import { random, sample } from 'es-toolkit/compat';
 import crypto from 'crypto';
 import * as yup from 'yup';
 

--- a/packages/shared/src/services/fhirTypes/contactPoint.js
+++ b/packages/shared/src/services/fhirTypes/contactPoint.js
@@ -1,4 +1,4 @@
-import { random, sample } from 'lodash';
+import { random, sample } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FhirBaseType } from './baseType';

--- a/packages/shared/src/services/fhirTypes/encounterLocation.js
+++ b/packages/shared/src/services/fhirTypes/encounterLocation.js
@@ -1,4 +1,4 @@
-import { sample } from 'lodash';
+import { sample } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FHIR_ENCOUNTER_LOCATION_STATUS } from '@tamanu/constants';

--- a/packages/shared/src/services/fhirTypes/humanName.js
+++ b/packages/shared/src/services/fhirTypes/humanName.js
@@ -1,5 +1,5 @@
 import { Chance } from 'chance';
-import { sample } from 'lodash';
+import { sample } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FhirBaseType } from './baseType';

--- a/packages/shared/src/services/fhirTypes/identifier.js
+++ b/packages/shared/src/services/fhirTypes/identifier.js
@@ -1,4 +1,4 @@
-import { sample } from 'lodash';
+import { sample } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FhirBaseType } from './baseType';

--- a/packages/shared/src/services/fhirTypes/immunizationProtocolApplied.js
+++ b/packages/shared/src/services/fhirTypes/immunizationProtocolApplied.js
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 import { Chance } from 'chance';
-import { random } from 'lodash';
+import { random } from 'es-toolkit/compat';
 
 import { FhirCodeableConcept } from './codeableConcept';
 import { FhirReference } from './reference';

--- a/packages/shared/src/services/fhirTypes/patientLink.js
+++ b/packages/shared/src/services/fhirTypes/patientLink.js
@@ -1,4 +1,4 @@
-import { sample } from 'lodash';
+import { sample } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FhirBaseType } from './baseType';

--- a/packages/shared/src/services/fhirTypes/period.js
+++ b/packages/shared/src/services/fhirTypes/period.js
@@ -1,4 +1,4 @@
-import { random } from 'lodash';
+import { random } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { formatFhirDate } from '../../utils/fhir';

--- a/packages/shared/src/services/fhirTypes/quantity.js
+++ b/packages/shared/src/services/fhirTypes/quantity.js
@@ -1,4 +1,4 @@
-import { random } from 'lodash';
+import { random } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FhirBaseType } from './baseType';

--- a/packages/shared/src/services/fhirTypes/reference.js
+++ b/packages/shared/src/services/fhirTypes/reference.js
@@ -1,5 +1,5 @@
 import * as yup from 'yup';
-import { lowerCase, snakeCase } from 'lodash';
+import { lowerCase, snakeCase } from 'es-toolkit/compat';
 
 import { FhirBaseType } from './baseType';
 import { FhirIdentifier } from './identifier';

--- a/packages/shared/src/services/fhirTypes/timing.js
+++ b/packages/shared/src/services/fhirTypes/timing.js
@@ -1,4 +1,4 @@
-import { random } from 'lodash';
+import { random } from 'es-toolkit/compat';
 import * as yup from 'yup';
 
 import { FhirBaseType } from './baseType';

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -1,4 +1,5 @@
-import { pascal } from 'case';
+import __cjs_case from 'case';
+const { pascal } = __cjs_case;
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { literal, Op, Sequelize } from 'sequelize';

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -3,7 +3,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { literal, Op, Sequelize } from 'sequelize';
 import { NotFoundError, ValidationError } from '@tamanu/errors';
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 import {
   DEFAULT_HIERARCHY_TYPE,
   REFERENCE_DATA_TRANSLATION_PREFIX,

--- a/packages/shared/src/utils/crudHelpers.js
+++ b/packages/shared/src/utils/crudHelpers.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 import { QueryTypes } from 'sequelize';
 import { z } from 'zod';
 

--- a/packages/shared/src/utils/crypto.js
+++ b/packages/shared/src/utils/crypto.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { get as lodashGet } from 'lodash';
+import { get as lodashGet } from 'es-toolkit/compat';
 import { promises as fs } from 'fs';
 import { promisify } from 'util';
 import readSync from 'read';

--- a/packages/shared/src/utils/fhir/OperationOutcome.js
+++ b/packages/shared/src/utils/fhir/OperationOutcome.js
@@ -1,4 +1,4 @@
-import { last } from 'lodash';
+import { last } from 'es-toolkit/compat';
 import crypto from 'crypto';
 
 import { FHIR_ISSUE_SEVERITY } from '@tamanu/constants';

--- a/packages/shared/src/utils/fhir/datetime.js
+++ b/packages/shared/src/utils/fhir/datetime.js
@@ -11,7 +11,8 @@ import {
   isValid,
   parse,
 } from 'date-fns';
-import { getTimezoneOffset, zonedTimeToUtc } from 'date-fns-tz';
+import __cjs_date_fns_tz from 'date-fns-tz';
+const { getTimezoneOffset, zonedTimeToUtc } = __cjs_date_fns_tz;
 import { pick } from 'es-toolkit/compat';
 import { number, object, string, date as yupDate } from 'yup';
 

--- a/packages/shared/src/utils/fhir/datetime.js
+++ b/packages/shared/src/utils/fhir/datetime.js
@@ -12,7 +12,7 @@ import {
   parse,
 } from 'date-fns';
 import { getTimezoneOffset, zonedTimeToUtc } from 'date-fns-tz';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 import { number, object, string, date as yupDate } from 'yup';
 
 import { FHIR_DATETIME_PRECISION } from '@tamanu/constants';

--- a/packages/shared/src/utils/fhir/errors.js
+++ b/packages/shared/src/utils/fhir/errors.js
@@ -1,4 +1,4 @@
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 import { FHIR_ISSUE_SEVERITY, FHIR_ISSUE_TYPE } from '@tamanu/constants';
 import { BaseError } from '@tamanu/errors';
 

--- a/packages/shared/src/utils/medication.js
+++ b/packages/shared/src/utils/medication.js
@@ -1,6 +1,6 @@
 import { addDays, format, isSameDay, set } from 'date-fns';
 import { DRUG_UNIT_SHORT_LABELS, MEDICATION_ADMINISTRATION_TIME_SLOTS } from '@tamanu/constants';
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 
 export const findAdministrationTimeSlotFromIdealTime = idealTime => {
   const index = MEDICATION_ADMINISTRATION_TIME_SLOTS.findIndex(slot => {

--- a/packages/shared/src/utils/numeralTranslation.js
+++ b/packages/shared/src/utils/numeralTranslation.js
@@ -1,5 +1,5 @@
 import { limon } from 'khmer-unicode-converter';
-import { isNaN } from 'lodash';
+import { isNaN } from 'es-toolkit/compat';
 
 function isNumeric(value) {
   return !isNaN(parseFloat(value));

--- a/packages/shared/src/utils/patientAccessors.js
+++ b/packages/shared/src/utils/patientAccessors.js
@@ -1,4 +1,4 @@
-import { capitalize } from 'lodash';
+import { capitalize } from 'es-toolkit/compat';
 import { ageInYears } from '@tamanu/utils/dateTime';
 import { getDisplayAge } from '@tamanu/utils/date';
 

--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Document, StyleSheet, View } from '@react-pdf/renderer';
-import { get, startCase } from 'lodash';
+import { get, startCase } from 'es-toolkit/compat';
 
 import {
   ENCOUNTER_TYPE_LABELS,

--- a/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Document, StyleSheet, View } from '@react-pdf/renderer';
-import { capitalize } from 'lodash';
+import { capitalize } from 'es-toolkit/compat';
 
 import { INVOICE_INSURER_PAYMENT_STATUSES } from '@tamanu/constants';
 

--- a/packages/shared/src/utils/patientCertificates/MultipleImagingRequestsPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/MultipleImagingRequestsPrintout.jsx
@@ -11,7 +11,7 @@ import { EncounterDetails } from './printComponents/EncounterDetails';
 import { HorizontalRule } from './printComponents/HorizontalRule';
 import { MultiPageHeader } from './printComponents/MultiPageHeader';
 import { PatientDetailsWithBarcode } from './printComponents/PatientDetailsWithBarcode';
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 import { DoubleHorizontalRule } from './printComponents/DoubleHorizontalRule';
 import { withLanguageContext } from '../pdf/languageContext';
 import { withDateTimeContext, useDateTime } from '../pdf/withDateTimeContext';

--- a/packages/shared/src/utils/patientCertificates/VaccineCertificate.jsx
+++ b/packages/shared/src/utils/patientCertificates/VaccineCertificate.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Document, StyleSheet, View } from '@react-pdf/renderer';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 
 import {
   Box,

--- a/packages/shared/src/utils/pdf/languageContext.jsx
+++ b/packages/shared/src/utils/pdf/languageContext.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import React, { createContext, useContext, useMemo } from 'react';
-import { cloneDeep, get } from 'lodash';
+import { cloneDeep, get } from 'es-toolkit/compat';
 import { translationFactory } from '../translation/translationFactory';
 import { getEnumPrefix } from '@tamanu/shared/utils/enumRegistry';
 import { registerFonts } from './registerFonts';

--- a/packages/shared/src/utils/pdf/withDateTimeContext.jsx
+++ b/packages/shared/src/utils/pdf/withDateTimeContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useMemo } from 'react';
-import { get, mapValues } from 'lodash';
+import { get, mapValues } from 'es-toolkit/compat';
 import * as dateTimeFormatters from '@tamanu/utils/dateFormatters';
 import {
   getCurrentDateStringInTimezone,

--- a/packages/shared/src/utils/primaryDateTime.js
+++ b/packages/shared/src/utils/primaryDateTime.js
@@ -2,7 +2,8 @@
 //! Servers require a specific reference to timeZone since most of our servers are in UTC
 
 import { formatISO9075 } from 'date-fns';
-import { formatInTimeZone } from 'date-fns-tz';
+import __cjs_date_fns_tz from 'date-fns-tz';
+const { formatInTimeZone } = __cjs_date_fns_tz;
 import config from 'config';
 import {
   ISO9075_DATE_FORMAT,

--- a/packages/shared/src/utils/refreshChildRecordsForSync.js
+++ b/packages/shared/src/utils/refreshChildRecordsForSync.js
@@ -1,4 +1,4 @@
-import { snakeCase } from 'lodash';
+import { snakeCase } from 'es-toolkit/compat';
 
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 

--- a/packages/shared/src/utils/translation/getReferenceDataCategoryFromRowConfig.js
+++ b/packages/shared/src/utils/translation/getReferenceDataCategoryFromRowConfig.js
@@ -1,4 +1,4 @@
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 
 export const getReferenceDataCategoryFromRowConfig = configString => {
   try {

--- a/packages/shared/src/utils/translation/translationFactory.js
+++ b/packages/shared/src/utils/translation/translationFactory.js
@@ -1,4 +1,4 @@
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'es-toolkit/compat';
 
 const applyCasing = (text, casing) => {
   if (!casing) return text;

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -7,15 +7,11 @@
   "author": "Beyond Essential Systems Pty. Ltd. <tamanu@bes.au>",
   "license": "GPL-3.0-or-later",
   "type": "module",
-  "main": "src/index.js",
-  "module": "src/index.js",
+  "main": "./src/index",
   "exports": {
     ".": "./src/index.js"
   },
-  "scripts": {
-    "build": "echo 'builds with client frontend'",
-    "clean-build": "echo 'builds with client frontend'"
-  },
+  "scripts": {},
   "dependencies": {
     "@tamanu/shared": "*",
     "@tamanu/utils": "*"

--- a/packages/ui-components/src/components/Field/AutocompleteField.jsx
+++ b/packages/ui-components/src/components/Field/AutocompleteField.jsx
@@ -2,7 +2,7 @@ import React, { Component, useId } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import Autosuggest from 'react-autosuggest';
-import { debounce, groupBy, map } from 'lodash';
+import { debounce, groupBy, map } from 'es-toolkit/compat';
 import { IconButton, MenuItem, Paper, Popper, Typography } from '@material-ui/core';
 import { StyledTextField } from './TextField';
 import { TAMANU_COLORS } from '../../constants';

--- a/packages/ui-components/src/components/Form/Form.jsx
+++ b/packages/ui-components/src/components/Form/Form.jsx
@@ -1,7 +1,7 @@
 import { Typography } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import { Formik, useFormikContext } from 'formik';
-import { isObject } from 'lodash';
+import { isObject } from 'es-toolkit/compat';
 import React, { isValidElement, useEffect } from 'react';
 import styled from 'styled-components';
 import { ValidationError } from 'yup';

--- a/packages/ui-components/src/components/Form/flattenObject.js
+++ b/packages/ui-components/src/components/Form/flattenObject.js
@@ -1,4 +1,4 @@
-import { isArray, isObject } from 'lodash';
+import { isArray, isObject } from 'es-toolkit/compat';
 import { isValidElement } from 'react';
 
 /** 

--- a/packages/ui-components/src/contexts/DateTimeContext.tsx
+++ b/packages/ui-components/src/contexts/DateTimeContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useMemo } from 'react';
-import { mapValues } from 'lodash';
+import { mapValues } from 'es-toolkit/compat';
 
 import {
   locale as runtimeLocale,

--- a/packages/ui-components/src/hooks/usePatientDataDisplayValue.js
+++ b/packages/ui-components/src/hooks/usePatientDataDisplayValue.js
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 import { PATIENT_DATA_FIELD_LOCATIONS, SEX_LABELS } from '@tamanu/constants';
 import { getPatientNameAsString } from '../components';
 import { useApi, useTranslation, useDateTime } from '../contexts';

--- a/packages/ui-components/src/utils/notify.jsx
+++ b/packages/ui-components/src/utils/notify.jsx
@@ -1,5 +1,5 @@
 import React, { isValidElement } from 'react';
-import { isArray, toString } from 'lodash';
+import { isArray, toString } from 'es-toolkit/compat';
 import { toast } from 'react-toastify';
 
 export const prepareToastMessage = msg => {

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -3,29 +3,15 @@
   "version": "2.59.0",
   "private": true,
   "description": "Tamanu upgrade files",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index",
   "exports": {
-    ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "types": "./dist/esm/index.d.ts"
-    }
+    ".": "./src"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "concurrently -n esm,cjs,types -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs && npm run package-default-translations\" \"npm run build:types\"",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:esm -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:esm": "swc --out-dir dist/esm --copy-files --source-maps true src",
-    "build:cjs": "npm run build:esm -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "npm run build:types:esm && move-dts --copy dist/esm dist/cjs",
-    "build:types:esm": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/esm",
-    "build:types:cjs": "npm run build:types:esm -- --outDir dist/cjs",
-    "build-watch": "npm run build:dev:watch",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules",
     "test": "vitest run --no-file-parallelism",
@@ -50,5 +36,6 @@
     "sequelize": "^6.37.8",
     "toposort": "^2.0.2",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
-  }
+  },
+  "type": "module"
 }

--- a/packages/upgrade/src/steps/1752105049000-importDefaultTranslations.ts
+++ b/packages/upgrade/src/steps/1752105049000-importDefaultTranslations.ts
@@ -1,5 +1,5 @@
 import { QueryTypes } from 'sequelize';
-import { uniqBy } from 'lodash';
+import { uniqBy } from 'es-toolkit/compat';
 import * as xlsx from 'xlsx';
 import path from 'path';
 import fs from 'fs';

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,44 +3,19 @@
   "version": "2.59.0",
   "private": true,
   "description": "Common code across Tamanu packages",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./src/index",
   "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/esm/index.d.ts"
-    },
-    "./invoice": {
-      "source": "./src/invoice/index.ts",
-      "import": "./dist/esm/invoice/index.js",
-      "require": "./dist/cjs/invoice/index.js",
-      "types": "./dist/esm/invoice/index.d.ts"
-    },
-    "./*": {
-      "source": "./src/*.ts",
-      "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/esm/*.d.ts"
-    }
+    ".": "./src",
+    "./invoice": "./src/invoice",
+    "./*": "./src/*"
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "concurrently -n esm,cjs,types -c auto --kill-others-on-fail \"npm run build:esm\" \"npm run build:cjs\" \"npm run build:types\"",
-    "clean-build": "npm run clean && npm run build",
-    "build:dev:watch": "npm run clean && concurrently \"npm run build:esm -- --watch\" \"npm run build:cjs -- --watch\" \"npm run build:types:esm -- --watch\" \"npm run build:types:cjs -- --watch\"",
-    "build:esm": "swc --out-dir dist/esm --copy-files --source-maps true src",
-    "build:cjs": "npm run build:esm -- --out-dir dist/cjs --config module.type=commonjs",
-    "build:types": "npm run build:types:esm && move-dts --copy dist/esm dist/cjs",
-    "build:types:esm": "tsc --declaration --declarationMap --emitDeclarationOnly --noEmit false --outDir dist/esm",
-    "build:types:cjs": "npm run build:types:esm -- --outDir dist/cjs",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules",
-    "build-watch": "npm run build:dev:watch",
     "test": "vitest run",
     "test:watch": "vitest --watch"
   },
@@ -61,5 +36,6 @@
     "nanoid": "^3.3.8",
     "temporal-polyfill": "^0.3.0",
     "zod": "^4.0.17"
-  }
+  },
+  "type": "module"
 }

--- a/packages/utils/src/criteria.ts
+++ b/packages/utils/src/criteria.ts
@@ -1,4 +1,4 @@
-import { inRange } from 'lodash';
+import { inRange } from 'es-toolkit/compat';
 import { PROGRAM_DATA_ELEMENT_TYPES, type DataElementType } from '@tamanu/constants';
 
 const RESERVED_KEYS = ['_conjunction', 'hidden'];

--- a/packages/utils/src/labTests.ts
+++ b/packages/utils/src/labTests.ts
@@ -1,5 +1,5 @@
 import { SEX_VALUES } from '@tamanu/constants';
-import { isNil } from 'lodash';
+import { isNil } from 'es-toolkit/compat';
 
 // These types are structurally compatible with the Database models but defined here
 // to avoid circular dependencies between utils and database packages.

--- a/packages/utils/src/renameObjectKeys.ts
+++ b/packages/utils/src/renameObjectKeys.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from 'es-toolkit/compat';
 
 export const camelify = (str: string) => {
   const [initial, ...subsequent] = str.split('_');

--- a/packages/web/app/api/queries/useAutoUpdatingQuery.js
+++ b/packages/web/app/api/queries/useAutoUpdatingQuery.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit/compat';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSocket } from '../../utils/useSocket';
 import { useApi } from '../useApi';

--- a/packages/web/app/api/queries/useSurveyResponseQuery.js
+++ b/packages/web/app/api/queries/useSurveyResponseQuery.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'es-toolkit/compat';
 import { safeJsonParse } from '@tamanu/utils/safeJsonParse';
 import { PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
 import { usePatientDataDisplayValue } from '@tamanu/ui-components';

--- a/packages/web/app/api/queries/useTranslationLanguagesQuery.js
+++ b/packages/web/app/api/queries/useTranslationLanguagesQuery.js
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../useApi';
-import { keyBy, mapValues, uniq } from 'lodash';
+import { keyBy, mapValues, uniq } from 'es-toolkit/compat';
 import { DEFAULT_LANGUAGE_CODE, ENGLISH_LANGUAGE_CODE } from '@tamanu/constants';
 
 const applyDefaultsToTranslations = ({

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentStatusSelector.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentStatusSelector.jsx
@@ -1,6 +1,6 @@
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { styled } from '@mui/material/styles';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit/compat';
 import React from 'react';
 import { toast } from 'react-toastify';
 import { useTranslation, TranslatedText } from '@tamanu/ui-components';

--- a/packages/web/app/components/Appointments/DailySchedule.jsx
+++ b/packages/web/app/components/Appointments/DailySchedule.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { groupBy } from 'lodash';
+import { groupBy } from 'es-toolkit/compat';
 import { APPOINTMENT_STATUSES } from '@tamanu/constants';
 import { Colors } from '../../constants';
 import { Appointment } from './Appointment';

--- a/packages/web/app/components/Appointments/LocationAssignmentForm/AssignUserDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationAssignmentForm/AssignUserDrawer.jsx
@@ -47,7 +47,7 @@ import {
   FORM_TYPES,
   SUBMIT_ATTEMPTED_STATUS,
 } from '@tamanu/constants';
-import { isNumber } from 'lodash';
+import { isNumber } from 'es-toolkit/compat';
 import { toast } from 'react-toastify';
 import { useAuth } from '../../../contexts/Auth';
 import { useSettings } from '../../../contexts/Settings';

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -2,7 +2,7 @@ import FormHelperText, { formHelperTextClasses } from '@mui/material/FormHelperT
 import ToggleButtonGroup, { toggleButtonGroupClasses } from '@mui/material/ToggleButtonGroup';
 import { areIntervalsOverlapping, isSameDay, max, min, parseISO } from 'date-fns';
 import { useFormikContext } from 'formik';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit/compat';
 import { PropTypes } from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/utils.js
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/utils.js
@@ -1,5 +1,5 @@
 import { isValid, parseISO } from 'date-fns';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit/compat';
 
 export const appointmentToInterval = (appointment) => {
   const { startTime, endTime } = appointment;

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import HighPriorityIcon from '@mui/icons-material/PriorityHigh';
-import { isNumber, omit, set } from 'lodash';
+import { isNumber, omit, set } from 'es-toolkit/compat';
 import { isAfter, parseISO, add, set as dateFnsSet } from 'date-fns';
 import styled from 'styled-components';
 import * as yup from 'yup';

--- a/packages/web/app/components/Appointments/RepeatingFields.jsx
+++ b/packages/web/app/components/Appointments/RepeatingFields.jsx
@@ -10,7 +10,7 @@ import FormLabel from '@mui/material/FormLabel';
 import { add, parseISO } from 'date-fns';
 import { toDateString } from '@tamanu/utils/dateTime';
 import { useDateTime } from '@tamanu/ui-components';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 
 import {
   REPEAT_FREQUENCY,

--- a/packages/web/app/components/Charts/components/DateTimeSelector.jsx
+++ b/packages/web/app/components/Charts/components/DateTimeSelector.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit/compat';
 import { addDays, parseISO, startOfDay } from 'date-fns';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
 import {

--- a/packages/web/app/components/Field/HierarchyFields.jsx
+++ b/packages/web/app/components/Field/HierarchyFields.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useHierarchyTypesQuery } from '../../api/queries';
 import { HierarchyFieldItem } from './HierarchyFieldItem';
 import { useFormikContext } from 'formik';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 import { FormGrid } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';
 

--- a/packages/web/app/components/Field/MultiAutocompleteField.jsx
+++ b/packages/web/app/components/Field/MultiAutocompleteField.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import FormControl from '@material-ui/core/FormControl';
 import { OuterLabelFieldWrapper } from './OuterLabelFieldWrapper';
 import { Colors } from '../../constants';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit/compat';
 import { useTranslation } from '../../contexts/Translation';
 import FormHelperText from '@mui/material/FormHelperText';
 import { SelectDropdownIndicator, SelectMultiValueRemove, Select } from '../Select';

--- a/packages/web/app/components/Field/PaginatedForm.jsx
+++ b/packages/web/app/components/Field/PaginatedForm.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Alert from '@material-ui/lab/Alert';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { Box, Typography } from '@material-ui/core';
 import {
   Form,

--- a/packages/web/app/components/FormattedTableCell.jsx
+++ b/packages/web/app/components/FormattedTableCell.jsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@mui/material';
-import { isNumber } from 'lodash';
+import { isNumber } from 'es-toolkit/compat';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 

--- a/packages/web/app/components/Medication/FrequencySearchInput.jsx
+++ b/packages/web/app/components/Medication/FrequencySearchInput.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ADMINISTRATION_FREQUENCY_SYNONYMS } from '@tamanu/constants';
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 import { AutocompleteInput } from '../Field';
 import { FrequencySuggester } from './frequencySuggester';
 import { TranslatedText } from '../Translation/TranslatedText';

--- a/packages/web/app/components/NoteChangeLogs.jsx
+++ b/packages/web/app/components/NoteChangeLogs.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Box from '@material-ui/core/Box';
 import styled from 'styled-components';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import { useQuery } from '@tanstack/react-query';
 
 import { Colors } from '../constants';

--- a/packages/web/app/components/Notification/NotificationDrawer.jsx
+++ b/packages/web/app/components/Notification/NotificationDrawer.jsx
@@ -5,7 +5,7 @@ import IconButton from '@mui/material/IconButton';
 import { Drawer } from '@material-ui/core';
 import { NOTIFICATION_TYPES, NOTIFICATION_STATUSES, LAB_REQUEST_STATUSES } from '@tamanu/constants';
 import { DateDisplay, TimeDisplay } from '@tamanu/ui-components';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'es-toolkit/compat';
 import { useNavigate } from 'react-router';
 import { useDispatch } from 'react-redux';
 import { Box } from '@mui/material';

--- a/packages/web/app/components/PatientInfoPane/InfoPaneList.jsx
+++ b/packages/web/app/components/PatientInfoPane/InfoPaneList.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { Button, Collapse, Typography } from '@material-ui/core';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'es-toolkit/compat';
 import { PATIENT_ISSUE_TYPES } from '@tamanu/constants';
 import { Colors } from '../../constants';
 import { FormModal } from '../FormModal';

--- a/packages/web/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 import { Box, Divider } from '@material-ui/core';
-import { intersectionBy } from 'lodash';
+import { intersectionBy } from 'es-toolkit/compat';
 import {
   OuterLabelFieldWrapper,
   TextField,

--- a/packages/web/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 
 import { MultilineDatetimeDisplay } from '../../DateDisplay';
 import { getImagingRequestType } from '../../../utils/getImagingRequestType';

--- a/packages/web/app/components/SearchBar/AdditionalSearchField.jsx
+++ b/packages/web/app/components/SearchBar/AdditionalSearchField.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 import { PAD_REFERENCE_DATA_FIELDS } from '@tamanu/constants';
 import { AutocompleteField, LocalisedField, SearchField } from '../Field';
 import { useSuggester } from '../../api';

--- a/packages/web/app/components/Table/DataFetchingTable.jsx
+++ b/packages/web/app/components/Table/DataFetchingTable.jsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit/compat';
 import { useDateTime } from '@tamanu/ui-components';
 import { useApi } from '../../api';
 

--- a/packages/web/app/components/Table/Table.jsx
+++ b/packages/web/app/components/Table/Table.jsx
@@ -20,7 +20,7 @@ import { ThemedTooltip } from '../Tooltip';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { Paginator } from './Paginator';
 import { TranslatedText } from '../Translation/TranslatedText';
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 import { useTranslation } from '../../contexts/Translation.jsx';
 
 const preventInputCallback = e => {

--- a/packages/web/app/components/Table/useTableSorting.js
+++ b/packages/web/app/components/Table/useTableSorting.js
@@ -1,4 +1,4 @@
-import { isNil } from 'lodash';
+import { isNil } from 'es-toolkit/compat';
 import { useState } from 'react';
 
 export const useTableSorting = ({ initialSortKey, initialSortDirection }) => {

--- a/packages/web/app/components/Tasks/DashboardTaskPane.jsx
+++ b/packages/web/app/components/Tasks/DashboardTaskPane.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 
 import { Colors } from '../../constants';

--- a/packages/web/app/contexts/Localisation.jsx
+++ b/packages/web/app/contexts/Localisation.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { get, merge } from 'lodash';
+import { get, merge } from 'es-toolkit/compat';
 
 const overrides = {}; // add keys to this object to help with development
 

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get } from 'es-toolkit/compat';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 

--- a/packages/web/app/contexts/SettingsRefresher.jsx
+++ b/packages/web/app/contexts/SettingsRefresher.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit/compat';
 import { WS_EVENTS } from '@tamanu/constants';
 
 import { useSocket } from '../utils/useSocket';

--- a/packages/web/app/features/Invoice/InsurerPaymentsTable.jsx
+++ b/packages/web/app/features/Invoice/InsurerPaymentsTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { capitalize } from 'lodash';
+import { capitalize } from 'es-toolkit/compat';
 import { Box } from '@material-ui/core';
 import { INVOICE_INSURER_PAYMENT_STATUSES } from '@tamanu/constants';
 import { formatDisplayPrice, getInvoiceSummary } from '@tamanu/utils/invoice';

--- a/packages/web/app/forms/ImagingRequestForm.jsx
+++ b/packages/web/app/forms/ImagingRequestForm.jsx
@@ -1,4 +1,4 @@
-import { camelCase } from 'lodash';
+import { camelCase } from 'es-toolkit/compat';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useDispatch } from 'react-redux';

--- a/packages/web/app/forms/LabRequestForm/LabRequestFormScreen2.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestFormScreen2.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { LAB_REQUEST_FORM_TYPES } from '@tamanu/constants/labs';
-import { uniqBy } from 'lodash';
+import { uniqBy } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import { Field, TextField } from '../../components';
 import { TestSelectorField } from '../../views/labRequest/TestSelector';

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -60,7 +60,7 @@ import { useAuth } from '../contexts/Auth';
 import { useSettings } from '../contexts/Settings';
 import { ChevronIcon } from '../components/Icons/ChevronIcon';
 import { ConditionalTooltip } from '../components/Tooltip';
-import { capitalize } from 'lodash';
+import { capitalize } from 'es-toolkit/compat';
 import {
   preventInvalidNumber,
   preventInvalidRepeatsInput,

--- a/packages/web/app/forms/PatientDetailsForm/PatientDetailsForm.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/PatientDetailsForm.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import { useQuery } from '@tanstack/react-query';
 
 import { PATIENT_REGISTRY_TYPES, PLACE_OF_BIRTH_TYPES } from '@tamanu/constants';

--- a/packages/web/app/forms/PatientDetailsForm/PatientFields.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/PatientFields.jsx
@@ -3,7 +3,7 @@ import { Field, NumberField, TranslatedReferenceData, TranslatedText } from '../
 import { TextField, FormGrid } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';
 import { PATIENT_FIELD_DEFINITION_TYPES } from '@tamanu/constants';
-import { groupBy } from 'lodash';
+import { groupBy } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import { TranslatedOptionSelectField } from '../../components/Translation/TranslatedOptions';
 

--- a/packages/web/app/forms/PatientDetailsForm/useFilterPatientFields.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/useFilterPatientFields.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { isBoolean } from 'lodash';
+import { isBoolean } from 'es-toolkit/compat';
 import { useSettings } from '../../contexts/Settings';
 
 export const useFilterPatientFields = ({ fields, filterByMandatory }) => {

--- a/packages/web/app/hooks/useSuggesterOptions.js
+++ b/packages/web/app/hooks/useSuggesterOptions.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useApi } from '../api';
 import { useAuth } from '../contexts/Auth';
 import { getCurrentLanguageCode } from '../utils/translation';
-import { unionBy } from 'lodash';
+import { unionBy } from 'es-toolkit/compat';
 
 export const useSuggesterOptions = ({
   field,

--- a/packages/web/app/utils/flattenObject.js
+++ b/packages/web/app/utils/flattenObject.js
@@ -1,4 +1,4 @@
-import { isArray, isObject } from 'lodash';
+import { isArray, isObject } from 'es-toolkit/compat';
 import { isValidElement } from 'react';
 
 /*

--- a/packages/web/app/utils/groupRootNoteItems.js
+++ b/packages/web/app/utils/groupRootNoteItems.js
@@ -1,4 +1,4 @@
-import { groupBy } from 'lodash';
+import { groupBy } from 'es-toolkit/compat';
 import { isAfter } from 'date-fns';
 
 /**

--- a/packages/web/app/utils/invoice.jsx
+++ b/packages/web/app/utils/invoice.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isBoolean } from 'lodash';
+import { isBoolean } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import { TableCellTag, TranslatedText } from '@tamanu/ui-components';
 import { Colors } from '../constants';

--- a/packages/web/app/utils/pdf/pdfRenderPlans.js
+++ b/packages/web/app/utils/pdf/pdfRenderPlans.js
@@ -1,4 +1,4 @@
-import { chunk } from 'lodash';
+import { chunk } from 'es-toolkit/compat';
 
 // Notes are rendered in slices of this size. Each slice becomes its own bounded render so the
 // per-render react-pdf layout tree never grows large enough to exhaust worker memory. Kept well

--- a/packages/web/app/utils/utils.jsx
+++ b/packages/web/app/utils/utils.jsx
@@ -1,7 +1,7 @@
 import React, { isValidElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { flushSync } from 'react-dom';
-import { each, isArray, toString } from 'lodash';
+import { each, isArray, toString } from 'es-toolkit/compat';
 import { toast } from 'react-toastify';
 import deepEqual from 'deep-equal';
 import shortid from 'shortid';

--- a/packages/web/app/utils/validation.js
+++ b/packages/web/app/utils/validation.js
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 import { numeralTranslation } from '@tamanu/shared/utils/numeralTranslation';
-import { isNaN } from 'lodash';
+import { isNaN } from 'es-toolkit/compat';
 
 // Foreign keys used to be more complicated nested objects requiring custom
 // validation, but they're just strings now. We could remove these validators entirely,

--- a/packages/web/app/validations/patientDetailValidations.jsx
+++ b/packages/web/app/validations/patientDetailValidations.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as yup from 'yup';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit/compat';
 
 import {
   BIRTH_DELIVERY_TYPES,

--- a/packages/web/app/views/administration/components/ExporterView.jsx
+++ b/packages/web/app/views/administration/components/ExporterView.jsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 import * as yup from 'yup';
 import styled from 'styled-components';
 import { pluralize } from 'inflection';

--- a/packages/web/app/views/administration/components/ImporterView.jsx
+++ b/packages/web/app/views/administration/components/ImporterView.jsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { startCase, sum } from 'lodash';
+import { startCase, sum } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import * as yup from 'yup';
 import { useFormikContext } from 'formik';

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/AddReferenceDataModal.jsx
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/AddReferenceDataModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 import { VISIBILITY_STATUSES } from '@tamanu/constants';
 import { FormModal } from '../../../../components/FormModal';
 import { TranslatedText } from '../../../../components/Translation/TranslatedText';

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/EditReferenceDataModal.jsx
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/EditReferenceDataModal.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 import { FormModal } from '../../../../components/FormModal';
 import { TranslatedText } from '../../../../components/Translation/TranslatedText';
 import { ReferenceDataForm } from './ReferenceDataForm';

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/FormField.jsx
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/FormField.jsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import styled from 'styled-components';
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 import { TextField } from '@tamanu/ui-components';
 import { NONPATIENT_VISIBILITY_STATUS_VALUES } from '@tamanu/constants/importable';
 import {

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/constants.js
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/constants.js
@@ -1,5 +1,5 @@
 import { MANAGEABLE_REFERENCE_DATA_TYPES } from '@tamanu/constants';
-import { startCase } from 'lodash';
+import { startCase } from 'es-toolkit/compat';
 
 export const ENDPOINT = 'admin/referenceData/manage';
 export const COLUMNS_ENDPOINT = 'admin/referenceData/manage/columns';

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useMemo, useState } from 'react';
-import { capitalize, cloneDeep, get, omitBy, pickBy, set, startCase } from 'lodash';
+import { capitalize, cloneDeep, get, omitBy, pickBy, set, startCase } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import { Box, Divider } from '@material-ui/core';
 

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -10,7 +10,7 @@ import { JSONEditor } from './components/JSONEditor';
 import { DefaultSettingsModal } from './components/DefaultSettingsModal';
 import { notifyError } from '../../../utils';
 import { TranslatedText } from '../../../components/Translation';
-import { isNull } from 'lodash';
+import { isNull } from 'es-toolkit/compat';
 
 const SettingsWrapper = styled.div`
   background-color: ${Colors.white};

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { get, isEqual, isString, isUndefined, startCase } from 'lodash';
+import { get, isEqual, isString, isUndefined, startCase } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import { Switch, IconButton, InputAdornment } from '@material-ui/core';
 import VisibilityIcon from '@mui/icons-material/Visibility';

--- a/packages/web/app/views/administration/translation/TranslationForm.jsx
+++ b/packages/web/app/views/administration/translation/TranslationForm.jsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import * as yup from 'yup';
-import { omit, sortBy } from 'lodash';
+import { omit, sortBy } from 'es-toolkit/compat';
 import React, { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { Box, Tooltip } from '@material-ui/core';

--- a/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
+++ b/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import Timeline from '@material-ui/lab/Timeline';
 import TimelineItem from '@material-ui/lab/TimelineItem';

--- a/packages/web/app/views/patients/EncounterView.jsx
+++ b/packages/web/app/views/patients/EncounterView.jsx
@@ -34,7 +34,7 @@ import { useSettings } from '../../contexts/Settings';
 import { EncounterPaneWithPermissionCheck } from './panes/EncounterPaneWithPermissionCheck';
 import { TabDisplayDraggable } from '../../components/TabDisplayDraggable';
 import { useUserPreferencesQuery } from '../../api/queries/useUserPreferencesQuery';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit/compat';
 import { ChartDataProvider } from '../../contexts/ChartData';
 import { PlannedMoveActions } from './components/PlannedMoveActions';
 

--- a/packages/web/app/views/patients/components/LabTestResultsModal.jsx
+++ b/packages/web/app/views/patients/components/LabTestResultsModal.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { Box } from '@material-ui/core';
 import styled from 'styled-components';
-import { keyBy, pick } from 'lodash';
+import { keyBy, pick } from 'es-toolkit/compat';
 import { Alert, AlertTitle, Skeleton } from '@material-ui/lab';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import * as yup from 'yup';
 import { useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 import styled from 'styled-components';
 
 import {

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { ButtonGroup } from '@material-ui/core';
 import { useQueryClient } from '@tanstack/react-query';
-import { keyBy } from 'lodash';
+import { keyBy } from 'es-toolkit/compat';
 import { Plus } from 'lucide-react';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';

--- a/packages/web/app/views/patients/panes/TasksPane.jsx
+++ b/packages/web/app/views/patients/panes/TasksPane.jsx
@@ -2,7 +2,7 @@ import { Button, TranslatedText } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
 import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { Box } from '@material-ui/core';
 import { TASK_STATUSES } from '@tamanu/constants';
 

--- a/packages/web/app/views/programRegistry/ConditionSection.jsx
+++ b/packages/web/app/views/programRegistry/ConditionSection.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { sortBy } from 'lodash';
+import { sortBy } from 'es-toolkit/compat';
 import { Divider, ButtonBase } from '@material-ui/core';
 import { TranslatedText } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';

--- a/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { ButtonGroup } from '@material-ui/core';
 import { useQueryClient } from '@tanstack/react-query';
-import { keyBy } from 'lodash';
+import { keyBy } from 'es-toolkit/compat';
 import { Plus } from 'lucide-react';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';

--- a/packages/web/app/views/reports/FacilityField.jsx
+++ b/packages/web/app/views/reports/FacilityField.jsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useSuggester } from '../../api';
 import { AutocompleteField, Field } from '../../components';
 import { useFormikContext } from 'formik';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { FIELD_TYPES_SUPPORTING_FILTER_BY_SELECTED_FACILITY } from './ParameterField';
 
 export const FacilityField = ({

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { keyBy, orderBy } from 'lodash';
+import { keyBy, orderBy } from 'es-toolkit/compat';
 import { format } from 'date-fns';
 import { Box, Typography } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';

--- a/packages/web/app/views/reports/VaccineField.jsx
+++ b/packages/web/app/views/reports/VaccineField.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { uniqBy } from 'lodash';
+import { uniqBy } from 'es-toolkit/compat';
 import {
   SelectField,
   TranslatedReferenceData,

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsDailyCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsDailyCalendar.jsx
@@ -18,7 +18,7 @@ import React, { useEffect, useMemo, useState, useRef, useCallback, forwardRef } 
 import styled from 'styled-components';
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'es-toolkit/compat';
 import { useDrop, useDrag } from 'react-dnd';
 
 import { toDateTimeString, toDateString } from '@tamanu/utils/dateTime';

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsFilter.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsFilter.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { debounce, omit } from 'lodash';
+import { debounce, omit } from 'es-toolkit/compat';
 import { useFormikContext } from 'formik';
 import styled from '@mui/system/styled';
 

--- a/packages/web/app/views/scheduling/outpatientBookings/GroupAppointmentToggle.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/GroupAppointmentToggle.jsx
@@ -9,7 +9,7 @@ import { TranslatedText } from '../../../components';
 import { useOutpatientAppointmentsContext } from '../../../contexts/OutpatientAppointments';
 import { useUserPreferencesMutation } from '../../../api/mutations';
 import { useAuth } from '../../../contexts/Auth';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit/compat';
 import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 
 const Wrapper = styled(Box)`

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsFilter.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsFilter.jsx
@@ -1,5 +1,5 @@
 import { useFormikContext } from 'formik';
-import { debounce, omit } from 'lodash';
+import { debounce, omit } from 'es-toolkit/compat';
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
@@ -1,7 +1,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import Box from '@mui/material/Box';
 import { parseISO } from 'date-fns';
-import { omit, pick } from 'lodash';
+import { omit, pick } from 'es-toolkit/compat';
 import queryString from 'query-string';
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';

--- a/packages/web/app/views/scheduling/outpatientBookings/useOutpatientAppointmentsCalendarData.js
+++ b/packages/web/app/views/scheduling/outpatientBookings/useOutpatientAppointmentsCalendarData.js
@@ -1,4 +1,4 @@
-import { groupBy as lodashGroupBy } from 'lodash';
+import { groupBy as lodashGroupBy } from 'es-toolkit/compat';
 import { useMemo } from 'react';
 
 import { toDateString } from '@tamanu/utils/dateTime';

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,8 +10,6 @@
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {
-    "build": "vite build",
-    "clean-build": "npm run clean && npm run build",
     "clean": "rimraf -- dist",
     "clean:deps": "rimraf -- node_modules",
     "preview": "vite preview",


### PR DESCRIPTION
### Changes

🤖 Second of three stacked PRs making Tamanu run build-less (see [the prep PR](https://github.com/beyondessential/tamanu/pull/10097) for the overall context).

This PR is **purely mechanical**: every commit is exactly the output of running one codemod from the prep PR against a clean tree, and nothing else. Re-running the four commands on the prep branch reproduces this PR byte-for-byte — so it can be reviewed by auditing the four scripts and what they do, rather than reading all the files they touch.

Each commit ↔ one command ↔ one script:

1. **Rename lodash imports to `es-toolkit/compat`** — `node scripts/codemod-lodash-named-imports.mjs packages`
   lodash is CommonJS with no statically-analysable named exports, so `import { x } from 'lodash'` fails under native ESM (the old swc→CJS build hid this). `es-toolkit/compat` is a lodash-compatible ESM build with real named exports, so the imports resolve unchanged. Pure specifier rename. The few sites the rename can't handle (`chain`, whole-namespace/`require` imports) are corrected by hand in [the fixes PR](https://github.com/beyondessential/tamanu/pull/10099). → [`codemod-lodash-named-imports.mjs`](https://github.com/beyondessential/tamanu/blob/buildless-1-prep/scripts/codemod-lodash-named-imports.mjs)

2. **Default-import CJS deps and destructure named bindings** — `node scripts/codemod-cjs-named-imports.mjs --pkgs bcrypt case date-fns-tz express inflection config -- <packages>`
   For a handful of CommonJS packages, rewrites `import { a, b } from 'pkg'` to `import pkg from 'pkg'` + a destructure, which is how named bindings must be consumed from CJS under native ESM. → [`codemod-cjs-named-imports.mjs`](https://github.com/beyondessential/tamanu/blob/buildless-1-prep/scripts/codemod-cjs-named-imports.mjs)

3. **Point package `main`/`exports` at `./src`** — `node scripts/source-exports.mjs <packages>`
   Repoints each workspace package's `main` and `exports` map from `./dist` to `./src` (extension-less directory exports) and drops the now-unused `build`/`build-watch` scripts, so consumers resolve to TypeScript source. → [`source-exports.mjs`](https://github.com/beyondessential/tamanu/blob/buildless-1-prep/scripts/source-exports.mjs)

4. **Rewrite server test imports `../dist` → `../app`** — `node scripts/codemod-test-dist-to-app.mjs <server __tests__>`
   Server tests imported the built `../dist` output; with no build step they import the real `../app` source instead. → [`codemod-test-dist-to-app.mjs`](https://github.com/beyondessential/tamanu/blob/buildless-1-prep/scripts/codemod-test-dist-to-app.mjs)

These commits don't stand alone at runtime — the hand-written fixes that make the result actually boot and pass tests are in [the fixes PR](https://github.com/beyondessential/tamanu/pull/10099).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
