### PR TITLE
chore(ai): no-issue: fix on-call sync-session facility/device id field and document sync flags

### DIFF
--- a/llm/docs/initial-overview.md
+++ b/llm/docs/initial-overview.md
@@ -37,10 +37,10 @@ flags, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/s
 | `-2` | `LOOKUP_PENDING_UPDATE` | `sync_lookup` row awaiting its next refresh. |
 | `0` | `OVERWRITE_WITH_CURRENT_TICK` | Re-stamp with the current tick on next write/sync (re-queues the record). Central rows default to this. |
 
-Any positive value is a real sync tick (a monotonic cursor). A row at `-999` on a facility is
-normal (received from central); a row stuck at `0`/`-2` may indicate its `sync_lookup` refresh never completed.
+Any positive value is a real sync tick (a monotonic cursor); a row stuck at `0`/`-2` may mean its
+`sync_lookup` refresh never completed.
 
-The `set_updated_at_sync_tick` trigger enforces this on every insert/update (unless
+The `set_updated_at_sync_tick` trigger enforces these on every insert/update (unless
 `local_system_facts.syncTrigger = 'disabled'`): it rewrites `-1` → `-999` and **any other value →
 the current sync tick**. So you can't set a tick by hand — writing `1` just gets it stamped
 with the latest tick, which is how a record is re-queued for sync.

--- a/llm/docs/initial-overview.md
+++ b/llm/docs/initial-overview.md
@@ -40,14 +40,10 @@ flags, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/s
 Any positive value is a real sync tick (a monotonic cursor). A row at `-999` on a facility is
 normal (received from central); a row stuck at `0`/`-2` may indicate its `sync_lookup` refresh never completed.
 
-These values are enforced by the `set_updated_at_sync_tick` trigger, which fires on every
-insert/update (unless `local_system_facts.syncTrigger = 'disabled'`). It rewrites `-1` to `-999`,
-and **any other value to the current sync tick** (read from `local_system_facts.currentSyncTick`).
-So you can't set an arbitrary tick by hand — writing e.g. `1` or `0` just makes the trigger stamp
-the row with the latest tick, which is exactly how a record gets re-queued for sync. The `0`
-(`OVERWRITE_WITH_CURRENT_TICK`) constant is the app's convention for "give me the current tick",
-but the overwrite applies to any non-`-1` value. This is why `updated_at_sync_tick` must never be
-set manually expecting the value to stick.
+The `set_updated_at_sync_tick` trigger enforces this on every insert/update (unless
+`local_system_facts.syncTrigger = 'disabled'`): it rewrites `-1` → `-999` and **any other value →
+the current sync tick**. So you can't set a tick by hand — writing `0`/`1` just gets it stamped
+with the latest tick, which is how a record is re-queued for sync.
 
 ### FHIR Materialisation
 

--- a/llm/docs/initial-overview.md
+++ b/llm/docs/initial-overview.md
@@ -42,7 +42,7 @@ normal (received from central); a row stuck at `0`/`-2` may indicate its `sync_l
 
 The `set_updated_at_sync_tick` trigger enforces this on every insert/update (unless
 `local_system_facts.syncTrigger = 'disabled'`): it rewrites `-1` → `-999` and **any other value →
-the current sync tick**. So you can't set a tick by hand — writing `0`/`1` just gets it stamped
+the current sync tick**. So you can't set a tick by hand — writing `1` just gets it stamped
 with the latest tick, which is how a record is re-queued for sync.
 
 ### FHIR Materialisation

--- a/llm/docs/initial-overview.md
+++ b/llm/docs/initial-overview.md
@@ -27,18 +27,16 @@ Key sync concepts:
 
 #### Sync tick flags
 
-Negative `updated_at_sync_tick` values (on records, and the same column in `sync_lookup`) are
-flags, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/sync/constants.ts`:
+Some `updated_at_sync_tick` values are flags, not real ticks — from `SYNC_TICK_FLAGS` in
+`packages/database/src/sync/constants.ts`:
 
 | Value | Name | Meaning |
 |-------|------|---------|
 | `-999` | `LAST_UPDATED_ELSEWHERE` | Last written on another server (arrived via sync); this server won't push it back. Facility rows default to this. |
-| `-1` | `INCOMING_FROM_CENTRAL_SERVER` | Row being applied from an in-progress central pull. |
-| `-2` | `LOOKUP_PENDING_UPDATE` | `sync_lookup` row awaiting its next refresh. |
+| `-1` | `INCOMING_FROM_CENTRAL_SERVER` | Marks a row being applied from a central pull; the trigger below stores it as `-999`. |
 | `0` | `OVERWRITE_WITH_CURRENT_TICK` | Re-stamp with the current tick on next write/sync (re-queues the record). Central rows default to this. |
 
-Any positive value is a real sync tick (a monotonic cursor); a row stuck at `0`/`-2` may mean its
-`sync_lookup` refresh never completed.
+Any positive value is a real sync tick (a monotonic cursor).
 
 The `set_updated_at_sync_tick` trigger enforces these on every insert/update (unless
 `local_system_facts.syncTrigger = 'disabled'`): it rewrites `-1` → `-999` and **any other value →

--- a/llm/docs/initial-overview.md
+++ b/llm/docs/initial-overview.md
@@ -25,6 +25,21 @@ Key sync concepts:
 - Sync ticks for cursors, ordering, and conflict resolution
 - Atomic sync sessions with snapshot isolation and strongly enforced concurrency control
 
+#### Sync tick flags
+
+Negative `updated_at_sync_tick` values (on records, and the same column in `sync_lookup`) are
+flags, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/sync/constants.ts`:
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| `-999` | `LAST_UPDATED_ELSEWHERE` | Last written on another server (arrived via sync); this server won't push it back. Facility rows default to this. |
+| `-1` | `INCOMING_FROM_CENTRAL_SERVER` | Row being applied from an in-progress central pull. |
+| `-2` | `LOOKUP_PENDING_UPDATE` | `sync_lookup` row awaiting its next refresh. |
+| `0` | `OVERWRITE_WITH_CURRENT_TICK` | Re-stamp with the current tick on next write/sync (re-queues the record). Central rows default to this. |
+
+Any positive value is a real sync tick (a monotonic cursor). A row at `-999` on a facility is
+normal (received from central); a row stuck at `0`/`-2` may indicate its `sync_lookup` refresh never completed.
+
 ### FHIR Materialisation
 
 Tamanu implements FHIR (Fast Healthcare Interoperability Resources) through a materialisation system:

--- a/llm/docs/initial-overview.md
+++ b/llm/docs/initial-overview.md
@@ -40,6 +40,15 @@ flags, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/s
 Any positive value is a real sync tick (a monotonic cursor). A row at `-999` on a facility is
 normal (received from central); a row stuck at `0`/`-2` may indicate its `sync_lookup` refresh never completed.
 
+These values are enforced by the `set_updated_at_sync_tick` trigger, which fires on every
+insert/update (unless `local_system_facts.syncTrigger = 'disabled'`). It rewrites `-1` to `-999`,
+and **any other value to the current sync tick** (read from `local_system_facts.currentSyncTick`).
+So you can't set an arbitrary tick by hand — writing e.g. `1` or `0` just makes the trigger stamp
+the row with the latest tick, which is exactly how a record gets re-queued for sync. The `0`
+(`OVERWRITE_WITH_CURRENT_TICK`) constant is the app's convention for "give me the current tick",
+but the overwrite applies to any non-`-1` value. This is why `updated_at_sync_tick` must never be
+set manually expecting the value to stick.
+
 ### FHIR Materialisation
 
 Tamanu implements FHIR (Fast Healthcare Interoperability Resources) through a materialisation system:

--- a/llm/docs/on-call-cheatsheet.md
+++ b/llm/docs/on-call-cheatsheet.md
@@ -128,10 +128,10 @@ Get-Content -Path "C:\caddy\logs\server-2024-07-16T15-22-25.879.log" | ForEach-O
 
 These queries were used plenty when we were debugging sync stuff.
 
-### Sync tick sentinel values
+### Sync tick flags
 
 Negative `updated_at_sync_tick` values (on records, and the same column in `sync_lookup`) are
-sentinels, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/sync/constants.ts`:
+flags, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/sync/constants.ts`:
 
 | Value | Name | Meaning |
 |-------|------|---------|

--- a/llm/docs/on-call-cheatsheet.md
+++ b/llm/docs/on-call-cheatsheet.md
@@ -128,21 +128,31 @@ Get-Content -Path "C:\caddy\logs\server-2024-07-16T15-22-25.879.log" | ForEach-O
 
 These queries were used plenty when we were debugging sync stuff.
 
-> Note: the facility/device id and sync parameters live in the `parameters` column
-> (`parameters->>'deviceId'`, `parameters->'facilityIds'`, `parameters->>'useSyncLookup'`).
-> `debug_info` only holds counts (`userId`, `totalToPull`, `totalPushed`). Older queries
-> that filtered on `parameters->>'deviceId'` return null on current versions.
+### Sync tick sentinel values
+
+Negative `updated_at_sync_tick` values (on records, and the same column in `sync_lookup`) are
+sentinels, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/sync/constants.ts`:
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| `-999` | `LAST_UPDATED_ELSEWHERE` | Last written on another server (arrived via sync); this server won't push it back. Facility rows default to this. |
+| `-1` | `INCOMING_FROM_CENTRAL_SERVER` | Row being applied from an in-progress central pull. |
+| `-2` | `LOOKUP_PENDING_UPDATE` | `sync_lookup` row awaiting (re)materialisation. |
+| `0` | `OVERWRITE_WITH_CURRENT_TICK` | Re-stamp with the current tick on next write/sync (re-queues the record). Central rows default to this. |
+
+Any positive value is a real sync tick (a monotonic cursor). So a row at `-999` on a facility is
+normal (received from central); a row stuck at `0`/`-2` may indicate it never finished materialising.
 
 ### Sessions
 
 ```
-SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->>'deviceId' as facility_id FROM sync_sessions ORDER BY updated_at DESC LIMIT 10;
+SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->'facilityIds' as facility_ids FROM sync_sessions ORDER BY updated_at DESC LIMIT 10;
 ```
 
 ### Last 10 errors
 
 ```sql
-SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, parameters->>'deviceId' as facility_id, errors FROM sync_sessions WHERE errors IS NOT NULL ORDER BY updated_at DESC LIMIT 10;
+SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, parameters->'facilityIds' as facility_ids, errors FROM sync_sessions WHERE errors IS NOT NULL ORDER BY updated_at DESC LIMIT 10;
 ```
 
 ### Last error expanded view
@@ -180,13 +190,13 @@ WITH sync_status_aux as (SELECT completed_at - created_at as "duration", errors 
 ### Recent sessions for a facility (replace xxx with facility id)
 
 ```
-SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->>'deviceId' as facility_id FROM sync_sessions WHERE parameters->>'deviceId' = 'xxx' ORDER BY updated_at DESC LIMIT 10;
+SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->'facilityIds' as facility_ids FROM sync_sessions WHERE parameters->'facilityIds' ? 'xxx' ORDER BY updated_at DESC LIMIT 10;
 ```
 
 ### Last successful session for a facility (replace xxx with facility id)
 
 ```
-SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->>'deviceId' as facility_id FROM sync_sessions WHERE parameters->>'deviceId' = 'xxx' AND errors IS NULL AND completed_at IS NOT NULL ORDER BY updated_at DESC LIMIT 10;
+SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->'facilityIds' as facility_ids FROM sync_sessions WHERE parameters->'facilityIds' ? 'xxx' AND errors IS NULL AND completed_at IS NOT NULL ORDER BY updated_at DESC LIMIT 10;
 ```
 
 
@@ -202,10 +212,10 @@ WITH sync_with_status AS (
       WHEN snapshot_started_at IS NOT NULL AND errors IS NOT NULL THEN 'Successful push, unsuccessful pull'
       ELSE 'Unsuccessful'
     END AS sync_status,
-    parameters->>'deviceId' as facility_id,
+    parameters->'facilityIds' as facility_ids,
     ROW_NUMBER() OVER (ORDER BY start_time) as row_num
   FROM sync_sessions
-  WHERE parameters->>'deviceId' = 'xxx'
+  WHERE parameters->'facilityIds' ? 'xxx'
   AND completed_at IS NOT NULL
   ORDER BY completed_at
 ),
@@ -213,7 +223,7 @@ status_change AS (
   SELECT 
     s2.sync_status as status_changed_to,
     s2.completed_at as status_changed_at,
-    s2.facility_id
+    s2.facility_ids
   FROM sync_with_status s1
   JOIN sync_with_status s2 ON s1.row_num + 1 = s2.row_num
   WHERE s1.sync_status != s2.sync_status
@@ -221,7 +231,7 @@ status_change AS (
 SELECT 
   status_changed_to,
   status_changed_at,
-  facility_id
+  facility_ids
 FROM status_change
 WHERE status_changed_at >= 'yyyy-mm-dd'
 ORDER BY status_changed_at DESC;

--- a/llm/docs/on-call-cheatsheet.md
+++ b/llm/docs/on-call-cheatsheet.md
@@ -128,20 +128,8 @@ Get-Content -Path "C:\caddy\logs\server-2024-07-16T15-22-25.879.log" | ForEach-O
 
 These queries were used plenty when we were debugging sync stuff.
 
-### Sync tick flags
-
-Negative `updated_at_sync_tick` values (on records, and the same column in `sync_lookup`) are
-flags, not real ticks — defined in `SYNC_TICK_FLAGS`, `packages/database/src/sync/constants.ts`:
-
-| Value | Name | Meaning |
-|-------|------|---------|
-| `-999` | `LAST_UPDATED_ELSEWHERE` | Last written on another server (arrived via sync); this server won't push it back. Facility rows default to this. |
-| `-1` | `INCOMING_FROM_CENTRAL_SERVER` | Row being applied from an in-progress central pull. |
-| `-2` | `LOOKUP_PENDING_UPDATE` | `sync_lookup` row awaiting (re)materialisation. |
-| `0` | `OVERWRITE_WITH_CURRENT_TICK` | Re-stamp with the current tick on next write/sync (re-queues the record). Central rows default to this. |
-
-Any positive value is a real sync tick (a monotonic cursor). So a row at `-999` on a facility is
-normal (received from central); a row stuck at `0`/`-2` may indicate it never finished materialising.
+> Negative `updated_at_sync_tick` values are flags, not real ticks (e.g. `-999` = last updated
+> on another server). See [Sync tick flags](initial-overview.md#sync-tick-flags) for the full list.
 
 ### Sessions
 

--- a/llm/docs/on-call-cheatsheet.md
+++ b/llm/docs/on-call-cheatsheet.md
@@ -128,16 +128,21 @@ Get-Content -Path "C:\caddy\logs\server-2024-07-16T15-22-25.879.log" | ForEach-O
 
 These queries were used plenty when we were debugging sync stuff.
 
+> Note: the facility/device id and sync parameters live in the `parameters` column
+> (`parameters->>'deviceId'`, `parameters->'facilityIds'`, `parameters->>'useSyncLookup'`).
+> `debug_info` only holds counts (`userId`, `totalToPull`, `totalPushed`). Older queries
+> that filtered on `parameters->>'deviceId'` return null on current versions.
+
 ### Sessions
 
 ```
-SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, debug_info->>'facilityId' as facility_id FROM sync_sessions ORDER BY updated_at DESC LIMIT 10;
+SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->>'deviceId' as facility_id FROM sync_sessions ORDER BY updated_at DESC LIMIT 10;
 ```
 
 ### Last 10 errors
 
 ```sql
-SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, debug_info->>'facilityId' as facility_id, errors FROM sync_sessions WHERE errors IS NOT NULL ORDER BY updated_at DESC LIMIT 10;
+SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, parameters->>'deviceId' as facility_id, errors FROM sync_sessions WHERE errors IS NOT NULL ORDER BY updated_at DESC LIMIT 10;
 ```
 
 ### Last error expanded view
@@ -169,19 +174,19 @@ WITH sync_status_aux as (SELECT completed_at - created_at as "duration", error I
 ### How long sessions using sync_lookup have been taking over the last day
 
 ```
-WITH sync_status_aux as (SELECT completed_at - created_at as "duration", errors IS NOT NULL as "is_error" FROM sync_sessions WHERE debug_info->>'useSyncLookup' = 'true' AND created_at > now() - interval '3 days') SELECT duration_range, COUNT(*) FROM (SELECT CASE WHEN duration >= interval '3 hours' THEN 'a - 3h+' WHEN duration >= interval '2 hours' AND duration < interval '3 hours' THEN 'b - 2-3h' WHEN duration >= interval '1 hour' AND duration < interval '2 hours' THEN 'c - 1-2h' WHEN duration >= interval '30 minutes' AND duration < interval '1 hour' THEN 'd - 30-59m' WHEN duration >= interval '10 minutes' AND duration < interval '1 hour' THEN 'e - 10-30m' WHEN duration >= interval '5 minutes' AND duration < interval '10 minutes' THEN 'f - 5-10m' WHEN duration >= interval '3 minutes' AND duration < interval '5 minutes' THEN 'g - 3-5m' WHEN duration >= interval '2 minutes' AND duration < interval '3 minutes' THEN 'h - 2m' WHEN duration >= interval '1 minute' AND duration < interval '2 minutes' THEN 'i - 1m' WHEN duration < '1 minute' THEN 'j - 1m-' END as "duration_range" FROM sync_status_aux WHERE is_error = FALSE) a GROUP BY a.duration_range;
+WITH sync_status_aux as (SELECT completed_at - created_at as "duration", errors IS NOT NULL as "is_error" FROM sync_sessions WHERE parameters->>'useSyncLookup' = 'true' AND created_at > now() - interval '3 days') SELECT duration_range, COUNT(*) FROM (SELECT CASE WHEN duration >= interval '3 hours' THEN 'a - 3h+' WHEN duration >= interval '2 hours' AND duration < interval '3 hours' THEN 'b - 2-3h' WHEN duration >= interval '1 hour' AND duration < interval '2 hours' THEN 'c - 1-2h' WHEN duration >= interval '30 minutes' AND duration < interval '1 hour' THEN 'd - 30-59m' WHEN duration >= interval '10 minutes' AND duration < interval '1 hour' THEN 'e - 10-30m' WHEN duration >= interval '5 minutes' AND duration < interval '10 minutes' THEN 'f - 5-10m' WHEN duration >= interval '3 minutes' AND duration < interval '5 minutes' THEN 'g - 3-5m' WHEN duration >= interval '2 minutes' AND duration < interval '3 minutes' THEN 'h - 2m' WHEN duration >= interval '1 minute' AND duration < interval '2 minutes' THEN 'i - 1m' WHEN duration < '1 minute' THEN 'j - 1m-' END as "duration_range" FROM sync_status_aux WHERE is_error = FALSE) a GROUP BY a.duration_range;
 ```
 
 ### Recent sessions for a facility (replace xxx with facility id)
 
 ```
-SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, debug_info->>'facilityId' as facility_id FROM sync_sessions WHERE debug_info->>'facilityId' = 'xxx' ORDER BY updated_at DESC LIMIT 10;
+SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->>'deviceId' as facility_id FROM sync_sessions WHERE parameters->>'deviceId' = 'xxx' ORDER BY updated_at DESC LIMIT 10;
 ```
 
 ### Last successful session for a facility (replace xxx with facility id)
 
 ```
-SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, debug_info->>'facilityId' as facility_id FROM sync_sessions WHERE debug_info->>'facilityId' = 'xxx' AND errors IS NULL AND completed_at IS NOT NULL ORDER BY updated_at DESC LIMIT 10;
+SELECT start_time, snapshot_completed_at - start_time as snapshot_duration, completed_at - start_time as full_duration, errors IS NOT NULL as is_error, parameters->>'deviceId' as facility_id FROM sync_sessions WHERE parameters->>'deviceId' = 'xxx' AND errors IS NULL AND completed_at IS NOT NULL ORDER BY updated_at DESC LIMIT 10;
 ```
 
 
@@ -197,10 +202,10 @@ WITH sync_with_status AS (
       WHEN snapshot_started_at IS NOT NULL AND errors IS NOT NULL THEN 'Successful push, unsuccessful pull'
       ELSE 'Unsuccessful'
     END AS sync_status,
-    debug_info->>'facilityId' as facility_id,
+    parameters->>'deviceId' as facility_id,
     ROW_NUMBER() OVER (ORDER BY start_time) as row_num
   FROM sync_sessions
-  WHERE debug_info->>'facilityId' = 'xxx'
+  WHERE parameters->>'deviceId' = 'xxx'
   AND completed_at IS NOT NULL
   ORDER BY completed_at
 ),
@@ -225,7 +230,7 @@ ORDER BY status_changed_at DESC;
 Facility Sync Status
 
 ```
-SELECT created_at, completed_at - created_at as duration, debug_info->>'facilityIds', errors IS NOT NULL as has_errors FROM sync_sessions ORDER BY created_at DESC LIMIT 10;
+SELECT created_at, completed_at - created_at as duration, parameters->'facilityIds', errors IS NOT NULL as has_errors FROM sync_sessions ORDER BY created_at DESC LIMIT 10;
 ```
 
 ### Average sync lookup refresh for the last 2 hours	


### PR DESCRIPTION
### Changes

Fixes the sync-session queries in the on-call cheatsheet: the facility/device id and sync parameters live in `sync_sessions.parameters` (`deviceId`, `facilityIds`, `useSyncLookup`), not `debug_info`. On current versions `debug_info` only carries counts (`userId`, `totalToPull`, `totalPushed`), so the existing `debug_info->>'facilityId'` filters silently return null. Updated the affected queries and added a short note. Hit this first-hand while debugging release-2-57 sync failures.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->