### PR TITLE
fix(appointments): no-issue: fix past appointments query on locale-collated DBs (backport 2.55)

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -100,7 +100,9 @@ describe('Appointments', () => {
       status: APPOINTMENT_STATUSES.CANCELLED,
     });
     expect(result).toHaveSucceeded();
-    const getResult = await userApp.get('/api/appointments?includeCancelled=true');
+    const getResult = await userApp.get(
+      `/api/appointments?includeCancelled=true&patientId=${patient.id}`,
+    );
     expect(getResult).toHaveSucceeded();
     expect(getResult.body.count).toEqual(1);
     expect(getResult.body.data[0].status).toEqual(APPOINTMENT_STATUSES.CANCELLED);

--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { add, format } from 'date-fns';
+import { add, format, sub } from 'date-fns';
 import { Op } from 'sequelize';
 
 import {
@@ -11,6 +11,7 @@ import {
   MODIFY_REPEATING_APPOINTMENT_MODE,
 } from '@tamanu/constants';
 import { replaceInTemplate } from '@tamanu/utils/replaceInTemplate';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
 import { createDummyPatient } from '@tamanu/database/demoData/patients';
 import { randomRecordId } from '@tamanu/database/demoData/utilities';
 import { fake } from '@tamanu/fake-data/fake';
@@ -63,6 +64,35 @@ describe('Appointments', () => {
     expect(result.body.count).toEqual(1);
     // verify that the appointment returned is the one created above
     expect(result.body.data[0].id).toEqual(appointment.id);
+  });
+
+  it('should list past appointments when queried with an ISO 9075 earliest after bound', async () => {
+    const pastAppointmentsPatient = await models.Patient.create(await createDummyPatient(models));
+    const locationGroup = await models.LocationGroup.create(fake(models.LocationGroup, { facilityId }));
+    const pastAppointment = await models.Appointment.create({
+      ...fake(models.Appointment),
+      patientId: pastAppointmentsPatient.id,
+      clinicianId: userApp.user.dataValues.id,
+      locationGroupId: locationGroup.id,
+      startTime: toDateTimeString(sub(new Date(), { days: 7 })),
+    });
+    const futureAppointment = await models.Appointment.create({
+      ...fake(models.Appointment),
+      patientId: pastAppointmentsPatient.id,
+      clinicianId: userApp.user.dataValues.id,
+      locationGroupId: locationGroup.id,
+      startTime: toDateTimeString(add(new Date(), { days: 7 })),
+    });
+
+    const before = encodeURIComponent(toDateTimeString(new Date()));
+    const after = encodeURIComponent('0000-01-01 00:00:00');
+    const result = await userApp.get(
+      `/api/appointments?all=true&locationGroupId=&before=${before}&after=${after}&patientId=${pastAppointmentsPatient.id}&facilityId=${facilityId}`,
+    );
+
+    expect(result).toHaveSucceeded();
+    expect(result.body.data.map(({ id }) => id)).toContain(pastAppointment.id);
+    expect(result.body.data.map(({ id }) => id)).not.toContain(futureAppointment.id);
   });
 
   it('should cancel an appointment', async () => {

--- a/packages/web/app/components/Appointments/PastAppointmentModal/PastAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/PastAppointmentModal/PastAppointmentModal.jsx
@@ -201,7 +201,7 @@ export const PastAppointmentModal = ({ open, onClose, patient }) => {
       all: true,
       patientId: patient?.id,
       before: getCurrentDateTime(),
-      after: '-infinity',
+      after: '0000-01-01 00:00:00',
       orderBy,
       order,
     },

--- a/packages/web/app/components/Appointments/PastBookingsModal.jsx
+++ b/packages/web/app/components/Appointments/PastBookingsModal.jsx
@@ -253,7 +253,7 @@ export const PastBookingsModal = ({ onClose, patient }) => {
       all: true,
       patientId: patient?.id,
       before: getCurrentDateTime(),
-      after: '-infinity',
+      after: '0000-01-01 00:00:00',
       orderBy,
       order,
     },


### PR DESCRIPTION
### Changes

Past appointment modals queried with \`after=-infinity\`, which fails under locale-collated PostgreSQL (e.g. \`en_US.UTF-8\`) when \`buildTimeQuery\` compares \`date_time_string\` columns as varchar. Replace with ISO 9075 sentinel \`0000-01-01 00:00:00\`, which sorts before real dates under all collations._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)