### PR TITLE
fix(sync): avoid stack overflow in `runFunctionInBatches` on large batches

### DIFF
--- a/packages/utils/src/runFunctionInBatches.ts
+++ b/packages/utils/src/runFunctionInBatches.ts
@@ -13,7 +13,9 @@ export async function runFunctionInBatches<T, R>(
   for (let i = 0; i < arrayToBeBatched.length; i += batchSize) {
     const batch = arrayToBeBatched.slice(i, i + batchSize);
     const chunkedResult = await functionToRun(batch);
-    results.push(...chunkedResult);
+    for (const item of chunkedResult) {
+      results.push(item);
+    }
   }
   return results;
 }


### PR DESCRIPTION
## Summary
Backport of #10017 to `release/2.56`.

`runFunctionInBatches` appended each batch's results with `results.push(...chunkedResult)`. Spreading passes every element as a separate function argument, which overflows V8's call-stack limit on large batches — surfacing as `RangeError: Maximum call stack size exceeded`.

Fix: append with a `for...of` loop instead of a spread.

## Test plan
- [ ] Cherry-pick applies cleanly (single file: `packages/utils/src/runFunctionInBatches.ts`)

Made with [Cursor](https://cursor.com)