### PR TITLE
feat(migrations): no-issue: add --dry-run to migrate and upgrade

### DIFF
--- a/packages/central-server/app/subCommands/migrate.js
+++ b/packages/central-server/app/subCommands/migrate.js
@@ -5,9 +5,9 @@ import { initDatabase } from '../database';
 // This is the "just-migrate" command for running database migrations only
 // Note: there's also a 'migrate' alias on the 'upgrade' command for deployment safety, which
 // includes database migrations plus automated upgrade steps
-async function migrate(direction) {
+async function migrate(direction, { dryRun = false } = {}) {
   const store = await initDatabase({ testMode: false });
-  await store.sequelize.migrate(direction);
+  await store.sequelize.migrate(direction, { dryRun });
   process.exit(0);
 }
 

--- a/packages/central-server/app/subCommands/upgrade.js
+++ b/packages/central-server/app/subCommands/upgrade.js
@@ -8,10 +8,20 @@ export const upgradeCommand = new Command('upgrade')
   // or having to version match for the correct migrate command
   .alias('migrate')
   .description('Upgrade Tamanu installation')
-  .action(async () => {
+  .option(
+    '--dry-run',
+    'Run the upgrade in a transaction then roll back, without committing any changes',
+  )
+  .action(async (options) => {
     const { sequelize, models } = await initDatabase({ testMode: false });
     try {
-      await upgrade({ sequelize, models, toVersion: VERSION, serverType: 'central' });
+      await upgrade({
+        sequelize,
+        models,
+        toVersion: VERSION,
+        serverType: 'central',
+        dryRun: Boolean(options.dryRun),
+      });
       process.exit(0);
     } catch (err) {
       console.error(err);

--- a/packages/database/__tests__/services/migrations/dryRun.test.ts
+++ b/packages/database/__tests__/services/migrations/dryRun.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { log } from '@tamanu/shared/services/logging/log';
+import { closeDatabase, createTestDatabase } from '../../utilities';
+import {
+  createMigrationInterface,
+  flushDeferredConstraints,
+  runInRollbackTransaction,
+} from '../../../src/services/migrations/migrations';
+
+// A dry-run migrate runs the real migration code path inside one outer transaction that is
+// always rolled back, so it must commit nothing. These tests avoid reverting real
+// migrations (whose down() functions are not all cleanly re-runnable, which would couple
+// the test to whichever migration happens to be the tip); they prove the rollback
+// guarantee directly instead.
+describe('migrate --dry-run', () => {
+  let sequelize;
+
+  beforeEach(async () => {
+    ({ sequelize } = await createTestDatabase());
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  it('runs the dry-run code path without recording any migrations', async () => {
+    // Smoke test of the real `sequelize.migrate('up', { dryRun })` entry point (rollback
+    // wrapping, summary). The rollback guarantee itself is proven by the
+    // runInRollbackTransaction suite below; here we only assert SequelizeMeta is untouched.
+    const { migrations } = createMigrationInterface(log, sequelize);
+    const executedBefore = (await migrations.executed()).map((migration) => migration.file);
+
+    await sequelize.migrate('up', { dryRun: true });
+
+    const executedAfter = (await migrations.executed()).map((migration) => migration.file);
+    expect(executedAfter).toEqual(executedBefore);
+  });
+
+  it('refuses --dry-run for down migrations', async () => {
+    await expect(sequelize.migrate('down', { dryRun: true })).rejects.toThrow(
+      /only supported for/,
+    );
+  });
+
+  it('refuses a dry run without a parent transaction to nest under', () => {
+    // Guards the footgun where a missing parentTransaction would make each migration's
+    // `sequelize.transaction({ transaction: null })` an independent, committing transaction.
+    expect(() => createMigrationInterface(log, sequelize, { dryRun: true })).toThrow(
+      /requires a parentTransaction/,
+    );
+  });
+});
+
+describe('runInRollbackTransaction', () => {
+  let sequelize;
+
+  beforeEach(async () => {
+    ({ sequelize } = await createTestDatabase());
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  it('rolls back SequelizeMeta writes, so a dry-run migration is never recorded', async () => {
+    const probeName = 'dry-run-probe-migration.js';
+
+    await runInRollbackTransaction(sequelize, async () => {
+      await sequelize.query('INSERT INTO "SequelizeMeta" (name) VALUES ($name)', {
+        bind: { name: probeName },
+      });
+    });
+
+    const [recorded] = await sequelize.query('SELECT name FROM "SequelizeMeta" WHERE name = $name', {
+      bind: { name: probeName },
+    });
+    expect(recorded).toHaveLength(0);
+  });
+
+  it('rolls back DDL', async () => {
+    await runInRollbackTransaction(sequelize, async () => {
+      await sequelize.query('CREATE TABLE dry_run_rollback_probe (id INTEGER)');
+    });
+
+    const [tables] = await sequelize.query(
+      `SELECT to_regclass('public.dry_run_rollback_probe') AS oid`,
+    );
+    expect(tables[0].oid).toBeNull();
+  });
+});
+
+// The dry run runs every migration inside one outer transaction, so DEFERRABLE INITIALLY
+// DEFERRED changelog triggers (which only fire at COMMIT, not at RELEASE SAVEPOINT) would
+// accumulate across migrations and a later DDL migration would trip "pending trigger
+// events" on a table an earlier DML migration wrote to. flushDeferredConstraints fires them
+// at each boundary to mimic the per-migration COMMIT of a real run. This exercises that
+// mechanism directly with a probe table rather than relying on specific migrations.
+describe('flushDeferredConstraints', () => {
+  let sequelize;
+
+  beforeEach(async () => {
+    ({ sequelize } = await createTestDatabase());
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  // Creates a table with a deferred constraint trigger, then a queued INSERT, so that a
+  // following ALTER TABLE would see pending trigger events unless they are flushed first.
+  const setUpProbeTable = async () => {
+    await sequelize.query('CREATE TABLE deferred_flush_probe (id INTEGER)');
+    await sequelize.query(`
+      CREATE FUNCTION pg_temp.deferred_flush_probe_noop() RETURNS trigger
+      AS $$ BEGIN RETURN NULL; END; $$ LANGUAGE plpgsql
+    `);
+    await sequelize.query(`
+      CREATE CONSTRAINT TRIGGER deferred_flush_probe_changelog
+      AFTER INSERT OR UPDATE ON deferred_flush_probe
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW
+      EXECUTE FUNCTION pg_temp.deferred_flush_probe_noop()
+    `);
+    await sequelize.query('INSERT INTO deferred_flush_probe (id) VALUES (1)');
+  };
+
+  it('reproduces the pending trigger events failure when not flushed', async () => {
+    await expect(
+      runInRollbackTransaction(sequelize, async () => {
+        await setUpProbeTable();
+        // DDL on a table with a pending deferred trigger event: PostgreSQL refuses.
+        await sequelize.query('ALTER TABLE deferred_flush_probe ADD COLUMN extra INTEGER');
+      }),
+    ).rejects.toThrow(/pending trigger events/);
+  });
+
+  it('clears pending events so the following DDL succeeds', async () => {
+    await runInRollbackTransaction(sequelize, async () => {
+      await setUpProbeTable();
+      await flushDeferredConstraints(sequelize);
+      // With the deferred events flushed, the same DDL now goes through.
+      await sequelize.query('ALTER TABLE deferred_flush_probe ADD COLUMN extra INTEGER');
+    });
+  });
+});

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -211,8 +211,8 @@ export async function initDatabase(dbOptions) {
   // of calling it to the implementing server (this allows for skipping migrations
   // in favour of calling sequelize.sync() during test mode)
   // eslint-disable-next-line require-atomic-updates
-  sequelize.migrate = async direction => {
-    await migrate(log, sequelize, direction);
+  sequelize.migrate = async (direction, options) => {
+    await migrate(log, sequelize, direction, options);
   };
 
   sequelize.assertUpToDate = async options => assertUpToDate(log, sequelize, options);

--- a/packages/database/src/services/migrations/migrations.js
+++ b/packages/database/src/services/migrations/migrations.js
@@ -7,6 +7,54 @@ import { AUDIT_MIGRATION_CONTEXT_KEY } from '@tamanu/constants';
 import { checkIsMigrationContextAvailable } from '../../utils/audit/checkIsMigrationContextAvailable';
 
 /**
+ * Sentinel thrown to force a managed transaction to roll back at the end of a dry run, while
+ * carrying fn's result back out. Caught by runInRollbackTransaction so it never surfaces as a
+ * real error.
+ */
+class DryRunRollback extends Error {
+  constructor(result) {
+    super();
+    this.result = result;
+  }
+}
+
+/**
+ * Runs `fn` inside a managed transaction that is always rolled back, so a dry run can
+ * exercise the real migration/upgrade code path (including DDL, DML and audit writes)
+ * without committing anything. `fn` receives the outer Transaction object; pass it as
+ * `parentTransaction` so inner `sequelize.transaction()` calls nest as SAVEPOINTs rather
+ * than opening independent connections that would commit for real (Sequelize does not
+ * auto-nest transactions from CLS — only individual queries attach to the current one).
+ */
+export async function runInRollbackTransaction(sequelize, fn) {
+  try {
+    await sequelize.transaction(async (outerTransaction) => {
+      // Throwing rolls the transaction back; the sentinel carries fn's result back out.
+      throw new DryRunRollback(await fn(outerTransaction));
+    });
+  } catch (error) {
+    if (error instanceof DryRunRollback) {
+      return error.result;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Fires any pending DEFERRABLE INITIALLY DEFERRED constraint triggers (e.g. the changelog
+ * audit triggers) immediately, then returns to deferred mode. During a dry run every
+ * migration runs as a SAVEPOINT under one outer transaction; RELEASE SAVEPOINT does not
+ * fire deferred triggers (only the outer COMMIT does), so without this they accumulate and
+ * a later DDL migration trips "cannot ALTER TABLE ... pending trigger events" on a table an
+ * earlier DML migration wrote to. Flushing at each migration boundary mimics the
+ * per-migration COMMIT of a real run; the flushed writes still roll back with the dry run.
+ */
+export async function flushDeferredConstraints(sequelize) {
+  await sequelize.query('SET CONSTRAINTS ALL IMMEDIATE');
+  await sequelize.query('SET CONSTRAINTS ALL DEFERRED');
+}
+
+/**
  * Enhances PostgreSQL "pending trigger events" errors with helpful guidance.
  * This error occurs when a migration mixes DDL and DML on the same table.
  */
@@ -52,8 +100,23 @@ function totalMigrationsDurationMsFromMap(durationMsPerMigration) {
 // migration as the revert boundary instead.
 const LAST_REVERSIBLE_MIGRATION = '1744340076240-fixRaceConditionInSettingUpdateSyncTick.js';
 
-/** @returns {{ migrations: import('umzug'), getDurationStats: () => Record<string, number> }} */
-export function createMigrationInterface(log, sequelize) {
+/**
+ * `options.dryRun`: when true, each migration runs as a SAVEPOINT under
+ * `options.parentTransaction` (the outer dry-run transaction) and deferred audit triggers
+ * are flushed at each boundary so a rolled-back dry run behaves like a real run.
+ *
+ * @returns {{ migrations: import('umzug'), getDurationStats: () => Record<string, number> }}
+ */
+export function createMigrationInterface(log, sequelize, options = {}) {
+  const { dryRun = false, parentTransaction = null } = options;
+
+  // In a dry run each migration nests as a SAVEPOINT under parentTransaction. Without one,
+  // `sequelize.transaction({ transaction: null })` would silently open an independent top-level
+  // transaction that commits for real, defeating the rollback — so fail loudly instead.
+  if (dryRun && !parentTransaction) {
+    throw new Error('createMigrationInterface: a dry run requires a parentTransaction.');
+  }
+
   // ie, database/dist/cjs/migrations
   const migrationsDir = path.join(__dirname, '../..', 'migrations');
 
@@ -78,38 +141,50 @@ export function createMigrationInterface(log, sequelize) {
       path: migrationsDir,
       pattern: /^\d+[\w-]+\.(js|ts)$/,
       params: [sequelize.getQueryInterface()],
-      wrap: (updown) => (...args) => sequelize.transaction(async () => {
-        const isMigrationContextAvailable = await checkIsMigrationContextAvailable(sequelize);
-        if (!isMigrationContextAvailable) {
+      // In a dry run, nest each migration as a SAVEPOINT under the outer dry-run
+      // transaction (Sequelize only nests when the parent is passed explicitly); otherwise
+      // each migration runs in its own top-level transaction as usual.
+      wrap: (updown) => (...args) => {
+        const transactionArgs = dryRun ? [{ transaction: parentTransaction }] : [];
+        return sequelize.transaction(...transactionArgs, async () => {
+          // Flush the previous migration's deferred audit triggers before this one's DDL,
+          // mimicking the per-migration COMMIT that a real run would have done by now.
+          if (dryRun) {
+            await flushDeferredConstraints(sequelize);
+          }
+
+          const isMigrationContextAvailable = await checkIsMigrationContextAvailable(sequelize);
+          if (!isMigrationContextAvailable) {
+            try {
+              return await updown(...args);
+            } catch (error) {
+              throw enhancePendingTriggerError(error, wrapContext.migrationName);
+            }
+          }
+
+          // Create migration context object
+          const migrationContext = {
+            direction: wrapContext.direction,
+            migrationName: wrapContext.migrationName,
+            serverType: global?.serverInfo?.serverType || 'unknown',
+          };
+
+          // Set the migration context as a transaction variable
+          await sequelize.setTransactionVar(AUDIT_MIGRATION_CONTEXT_KEY, JSON.stringify(migrationContext));
+
           try {
             return await updown(...args);
           } catch (error) {
             throw enhancePendingTriggerError(error, wrapContext.migrationName);
+          } finally {
+            try {
+              await sequelize.setTransactionVar(AUDIT_MIGRATION_CONTEXT_KEY, null);
+            } catch {
+              // Transaction already aborted; rollback will clean up.
+            }
           }
-        }
-
-        // Create migration context object
-        const migrationContext = {
-          direction: wrapContext.direction,
-          migrationName: wrapContext.migrationName,
-          serverType: global?.serverInfo?.serverType || 'unknown',
-        };
-
-        // Set the migration context as a transaction variable
-        await sequelize.setTransactionVar(AUDIT_MIGRATION_CONTEXT_KEY, JSON.stringify(migrationContext));
-
-        try {
-          return await updown(...args);
-        } catch (error) {
-          throw enhancePendingTriggerError(error, wrapContext.migrationName);
-        } finally {
-          try {
-            await sequelize.setTransactionVar(AUDIT_MIGRATION_CONTEXT_KEY, null);
-          } catch {
-            // Transaction already aborted; rollback will clean up.
-          }
-        }
-      }),
+        });
+      },
 
       customResolver: async (sqlPath) => {
         const migrationImport = await import(sqlPath);
@@ -182,6 +257,7 @@ export async function migrateUpTo({
   getDurationStats,
   upOpts,
   upgradeRunId,
+  dryRun = false,
 }) {
   const batchStart = Date.now();
 
@@ -200,6 +276,11 @@ export async function migrateUpTo({
 
   log.info('Applied migrations successfully');
 
+  // Flush the last migration's deferred audit triggers before the post-migration DDL.
+  if (dryRun) {
+    await flushDeferredConstraints(sequelize);
+  }
+
   log.info('Running post-migration steps...');
   await runPostMigration(log, sequelize);
   log.info(`Applied post-migration steps successfully.`);
@@ -217,19 +298,29 @@ export async function migrateUpTo({
   });
 }
 
-async function migrateUp(log, sequelize, upOpts = undefined) {
-  const { migrations, getDurationStats } = createMigrationInterface(log, sequelize);
+async function migrateUp(log, sequelize, upOpts = undefined, options = {}) {
+  const { dryRun = false, parentTransaction = null } = options;
+  const { migrations, getDurationStats } = createMigrationInterface(log, sequelize, {
+    dryRun,
+    parentTransaction,
+  });
 
   const pending = await migrations.pending();
   if (pending.length > 0) {
-    await migrateUpTo({ log, sequelize, migrations, getDurationStats, pending, upOpts });
+    await migrateUpTo({ log, sequelize, migrations, getDurationStats, pending, upOpts, dryRun });
   } else {
     log.info('Migrations already up-to-date.');
   }
+
+  return pending.length;
 }
 
-async function migrateDown(log, sequelize, options) {
-  const { migrations, getDurationStats } = createMigrationInterface(log, sequelize);
+async function migrateDown(log, sequelize, options = {}) {
+  const { dryRun = false, parentTransaction = null, to } = options;
+  const { migrations, getDurationStats } = createMigrationInterface(log, sequelize, {
+    dryRun,
+    parentTransaction,
+  });
 
   const batchStart = Date.now();
 
@@ -241,7 +332,7 @@ async function migrateDown(log, sequelize, options) {
 
   const preSnapshot = await tryGatherPreMigrationDbSnapshot(log, sequelize);
 
-  const reverted = await migrations.down(options);
+  const reverted = await migrations.down(to ? { to } : undefined);
   const revertedList = Array.isArray(reverted) ? reverted : [reverted];
   const durationStats = getDurationStats();
   const durationMsPerMigration = migrationDurationsForBatch(durationStats, revertedList);
@@ -255,6 +346,11 @@ async function migrateDown(log, sequelize, options) {
     }
   } else {
     log.info(`Reverted migration ${reverted.file}.`);
+  }
+
+  // Flush the reverted migration's deferred audit triggers before the post-migration DDL.
+  if (dryRun) {
+    await flushDeferredConstraints(sequelize);
   }
 
   log.info('Running post-migration steps...');
@@ -285,21 +381,43 @@ export async function assertUpToDate(log, sequelize, options) {
   }
 }
 
-export async function migrate(log, sequelize, direction) {
-  if (direction === 'up') {
-    return migrateUp(log, sequelize);
+export async function migrate(log, sequelize, direction, options = {}) {
+  const { dryRun = false } = options;
+
+  if (dryRun && direction !== 'up' && direction !== 'redoLatest') {
+    throw new Error(`--dry-run is only supported for 'up' and 'redoLatest', not '${direction}'.`);
   }
-  if (direction === 'down') {
-    return migrateDown(log, sequelize);
+
+  const run = async (parentTransaction = null) => {
+    const opts = { ...options, parentTransaction };
+    if (direction === 'up') {
+      return migrateUp(log, sequelize, undefined, opts);
+    }
+    if (direction === 'down') {
+      return migrateDown(log, sequelize, opts);
+    }
+    if (direction === 'downToLastReversibleMigration') {
+      return migrateDown(log, sequelize, { ...opts, to: LAST_REVERSIBLE_MIGRATION });
+    }
+    if (direction === 'redoLatest') {
+      await migrateDown(log, sequelize, opts);
+      return migrateUp(log, sequelize, undefined, opts);
+    }
+    throw new Error(`Unrecognised migrate direction: ${direction}`);
+  };
+
+  if (dryRun) {
+    log.info(
+      'DRY RUN: applying migrations in a transaction that will be rolled back; no changes will be committed.',
+    );
+    const migrationCount = await runInRollbackTransaction(sequelize, run);
+    log.info(
+      `DRY RUN complete — ${migrationCount ?? 0} migration${migrationCount === 1 ? '' : 's'} would be applied; rolled back, no changes committed.`,
+    );
+    return undefined;
   }
-  if (direction === 'downToLastReversibleMigration') {
-    return migrateDown(log, sequelize, { to: LAST_REVERSIBLE_MIGRATION });
-  }
-  if (direction === 'redoLatest') {
-    await migrateDown(log, sequelize);
-    return migrateUp(log, sequelize);
-  }
-  throw new Error(`Unrecognised migrate direction: ${direction}`);
+
+  return run();
 }
 
 export function createMigrateCommand(Command, migrateCallback, name = 'migrate') {
@@ -308,7 +426,11 @@ export function createMigrateCommand(Command, migrateCallback, name = 'migrate')
   migrateCommand
     .command('up', { isDefault: true })
     .description('Run all unrun migrations until up to date')
-    .action(() => migrateCallback('up'));
+    .option(
+      '--dry-run',
+      'Apply migrations in a transaction then roll back, without committing any changes',
+    )
+    .action((options) => migrateCallback('up', { dryRun: Boolean(options.dryRun) }));
 
   migrateCommand
     .command('down')
@@ -325,7 +447,11 @@ export function createMigrateCommand(Command, migrateCallback, name = 'migrate')
   migrateCommand
     .command('redoLatest')
     .description('Run database migrations down 1 and then up 1')
-    .action(() => migrateCallback('redoLatest'));
+    .option(
+      '--dry-run',
+      'Run the down and up in a transaction then roll back, without committing any changes',
+    )
+    .action((options) => migrateCallback('redoLatest', { dryRun: Boolean(options.dryRun) }));
 
   return migrateCommand;
 }

--- a/packages/facility-server/app/subCommands/migrate.js
+++ b/packages/facility-server/app/subCommands/migrate.js
@@ -5,9 +5,9 @@ import { initDatabase } from '../database';
 // This is the "just-migrate" command for running database migrations only
 // Note: there's also a 'migrate' alias on the 'upgrade' command for deployment safety, which
 // includes database migrations plus automated upgrade steps
-async function migrate(direction) {
+async function migrate(direction, { dryRun = false } = {}) {
   const context = await initDatabase();
-  await context.sequelize.migrate(direction);
+  await context.sequelize.migrate(direction, { dryRun });
   process.exit(0);
 }
 

--- a/packages/facility-server/app/subCommands/upgrade.js
+++ b/packages/facility-server/app/subCommands/upgrade.js
@@ -8,10 +8,20 @@ export const upgradeCommand = new Command('upgrade')
   // or having to version match for the correct migrate command
   .alias('migrate')
   .description('Upgrade Tamanu installation')
-  .action(async () => {
+  .option(
+    '--dry-run',
+    'Run the upgrade in a transaction then roll back, without committing any changes',
+  )
+  .action(async (options) => {
     const { sequelize, models } = await initDatabase();
     try {
-      await upgrade({ sequelize, models, toVersion: VERSION, serverType: 'facility' });
+      await upgrade({
+        sequelize,
+        models,
+        toVersion: VERSION,
+        serverType: 'facility',
+        dryRun: Boolean(options.dryRun),
+      });
       process.exit(0);
     } catch (err) {
       console.error(err);

--- a/packages/upgrade/src/index.ts
+++ b/packages/upgrade/src/index.ts
@@ -1,8 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { log } from '@tamanu/shared/services/logging';
 import { FACT_CURRENT_VERSION } from '@tamanu/constants';
-import { createMigrationInterface, migrateUpTo } from '@tamanu/database/services/migrations';
+import {
+  createMigrationInterface,
+  flushDeferredConstraints,
+  migrateUpTo,
+  runInRollbackTransaction,
+} from '@tamanu/database/services/migrations';
 import type { Models, Sequelize } from '@tamanu/database';
+import type { Transaction } from 'sequelize';
 import { listSteps, MIGRATIONS_END } from './listSteps.js';
 import { END, MIGRATION_PREFIX, migrationFile, onlyMigrations, START } from './step.js';
 import type { MigrationStr, StepArgs } from './step.ts';
@@ -17,11 +23,42 @@ export async function upgrade({
   models,
   toVersion,
   serverType,
+  dryRun = false,
 }: {
   sequelize: Sequelize;
   models: Models;
   toVersion: string;
   serverType: 'central' | 'facility';
+  dryRun?: boolean;
+}) {
+  if (dryRun) {
+    log.info(
+      'DRY RUN: running upgrade in a transaction that will be rolled back; no changes will be committed.',
+    );
+    await runInRollbackTransaction(sequelize, (parentTransaction: Transaction) =>
+      runUpgrade({ sequelize, models, toVersion, serverType, dryRun, parentTransaction }),
+    );
+    log.info('DRY RUN complete — upgrade rolled back, no changes committed.');
+    return;
+  }
+
+  await runUpgrade({ sequelize, models, toVersion, serverType, dryRun });
+}
+
+async function runUpgrade({
+  sequelize,
+  models,
+  toVersion,
+  serverType,
+  dryRun,
+  parentTransaction = null,
+}: {
+  sequelize: Sequelize;
+  models: Models;
+  toVersion: string;
+  serverType: 'central' | 'facility';
+  dryRun: boolean;
+  parentTransaction?: Transaction | null;
 }) {
   const fromVersion =
     (await models.LocalSystemFact.get(FACT_CURRENT_VERSION).catch((err) => {
@@ -33,7 +70,10 @@ export async function upgrade({
   const upgradeRunId = randomUUID();
   log.info('Upgrade run id', { upgradeRunId });
 
-  const { migrations: migrationsUmzug, getDurationStats } = createMigrationInterface(log, sequelize);
+  const { migrations: migrationsUmzug, getDurationStats } = createMigrationInterface(log, sequelize, {
+    dryRun,
+    parentTransaction,
+  });
   const migrations = migrationsUmzug as any;
   let pendingMigrations = await migrations.pending();
   let doneMigrations = await migrations.executed();
@@ -53,6 +93,7 @@ export async function upgrade({
       getDurationStats,
       upOpts: { to: pendingEarliestMigration.file },
       upgradeRunId,
+      dryRun,
     });
     pendingMigrations = await migrations.pending();
     doneMigrations = await migrations.executed();
@@ -84,6 +125,7 @@ export async function upgrade({
         getDurationStats,
         upOpts: {},
         upgradeRunId,
+        dryRun,
       });
       continue;
     }
@@ -106,6 +148,7 @@ export async function upgrade({
           getDurationStats,
           upOpts: { to: target.file },
           upgradeRunId,
+          dryRun,
         });
       }
       continue;
@@ -144,6 +187,11 @@ export async function upgrade({
 
     logger.info('Running step');
     await step.run(args);
+
+    // Flush this step's deferred audit triggers before any later migration or step does DDL.
+    if (dryRun) {
+      await flushDeferredConstraints(sequelize);
+    }
   }
 
   log.info('Tamanu has been upgraded', { toVersion });


### PR DESCRIPTION
### Changes

🤖 Backport of #10144 to release/2.54 — a deployment on this release has an urgent need for the dry-run mode (the feature lands on main via #10144).

Adds a `--dry-run` mode to the `up`/`redoLatest` migrate subcommands and to the `upgrade` command (alias `migrate`), on both central and facility servers. It runs the real migration/upgrade code path inside a single outer transaction that is always rolled back, then exits 0 with a summary — so operators can preview a migration or upgrade on a real database without committing anything.

Adapted to the 2.54 (pre-build-less) code structure: `createMigrationInterface` is synchronous here, `migrate`/`migrateUp` gained an `options` arg, and `sequelize.migrate` now forwards options. The deferred-changelog-trigger flush and the savepoint-nesting approach are unchanged from #10144.

Mechanism notes for reviewers:

- Sequelize 6 does not nest a bare `transaction()` call as a savepoint under CLS (CLS only auto-attaches individual queries to the current transaction). So the outer transaction is threaded down and each migration is nested as an explicit `SAVEPOINT`; the pre/post-migration hooks and upgrade steps attach automatically via CLS. A guard rejects a dry run started without a parent transaction so this cannot silently degrade to a committing top-level transaction.
- Changelog audit triggers are `DEFERRABLE INITIALLY DEFERRED` and only fire at `COMMIT`, not at `RELEASE SAVEPOINT`. Under one outer transaction they would accumulate, and a later DDL migration would trip "pending trigger events" on a table an earlier DML migration wrote to. They are flushed at each migration and step boundary to mimic the per-migration `COMMIT` of a real run.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->