### PR TITLE
fix(auth): no-issue: fall back to cleartext token storage when Web Crypto unavailable (backport 2.59)

### DIFF
--- a/packages/api-client/src/browserTokenStorage.ts
+++ b/packages/api-client/src/browserTokenStorage.ts
@@ -174,6 +174,8 @@ function defaultOrigin(): string {
 
 /**
  * Encrypt and store an API token, or remove the key when `token` is empty.
+ * Falls back to cleartext storage when Web Crypto is unavailable (plain HTTP, non-localhost) — the
+ * session is already transmitted unencrypted in that case, so cleartext localStorage is no worse.
  */
 export async function writePersistedAuthToken(
   storageKey: string,
@@ -185,7 +187,17 @@ export async function writePersistedAuthToken(
 ): Promise<void> {
   const keyMaterial = buildTokenStorageKeyMaterial(deviceId, origin, namespace);
   if (token) {
-    storage.setItem(storageKey, await packPersistedToken(token, keyMaterial));
+    if (!globalThis.crypto?.subtle) {
+      // Web Crypto is only available in secure contexts (HTTPS or localhost).
+      // On plain HTTP (e.g. local-network ITI access), fall back to cleartext rather than
+      // blocking login entirely.
+      console.warn(
+        '[Tamanu] Web Crypto API unavailable; storing auth token as cleartext. Use HTTPS for encrypted token storage.',
+      );
+      storage.setItem(storageKey, token);
+    } else {
+      storage.setItem(storageKey, await packPersistedToken(token, keyMaterial));
+    }
   } else {
     storage.removeItem(storageKey);
   }


### PR DESCRIPTION
### Changes

🤖 Backport of #9942 to `release/2.59`.

On plain HTTP connections (e.g. local-network access to an ITI), `window.crypto.subtle` is unavailable because browsers only expose Web Crypto in secure contexts. `writePersistedAuthToken` was throwing, which caused `setFacilityId` to silently swallow the error and leave `facilityId` unset — making the facility selector appear even with a single facility, then showing the crypto error on submit.

Fix: fall back to storing the token as cleartext when `crypto.subtle` is absent. The session is already transmitted unencrypted over HTTP, so cleartext localStorage is no worse; a `console.warn` makes the condition visible. Encrypted storage continues to work as before on HTTPS.

This is needed for deployments where secure origins are not possible and security is ensured through other means.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->