### PR TITLE
feat(sync): TAM-6863: start sync after first-run setup without a restart

### DIFF
--- a/packages/facility-server/app/setupSyncRuntime.js
+++ b/packages/facility-server/app/setupSyncRuntime.js
@@ -5,7 +5,10 @@ import { performTimeZoneChecks } from '@tamanu/shared/utils/timeZoneCheck';
 
 import { initTimesync } from './services/initTimesync';
 import { CentralServerConnection, FacilitySyncManager } from './sync';
-import { getSyncConfig, isServerConfigured } from './serverConfig';
+import { getSyncConfig, isServerConfigured, initServerConfig } from './serverConfig';
+
+// How often a sync/tasks process re-checks for first-run setup completing.
+const SETUP_POLL_INTERVAL_MS = 30_000;
 
 export const SYNC_NOT_CONFIGURED_WARNING =
   'Facility server has no sync host/facilities configured; sync is disabled until setup ' +
@@ -37,4 +40,23 @@ export async function setupSyncRuntime(context, { syncManager } = {}) {
   });
 
   return true;
+}
+
+// The wizard configures the server in the API process; poll so a separate
+// sync/tasks process re-reads the new config and starts syncing without a restart.
+// Only start this when booted unconfigured.
+export function startSyncRuntimeWhenConfigured(context, { intervalMs = SETUP_POLL_INTERVAL_MS } = {}) {
+  const timer = setInterval(async () => {
+    try {
+      await initServerConfig({ context }); // re-read facts written by the wizard
+      if (!isServerConfigured()) return;
+      clearInterval(timer);
+      log.info('Setup completed; starting sync runtime without a restart');
+      await setupSyncRuntime(context);
+    } catch (error) {
+      log.warn(`startSyncRuntimeWhenConfigured: ${error.message}`);
+    }
+  }, intervalMs);
+  timer.unref();
+  return () => clearInterval(timer);
 }

--- a/packages/facility-server/app/subCommands/startAll.js
+++ b/packages/facility-server/app/subCommands/startAll.js
@@ -9,7 +9,7 @@ import { initDeviceId } from '@tamanu/shared/utils';
 import { performDatabaseIntegrityChecks, prepareDatabaseForStartup } from '../database';
 import { FacilitySyncConnection } from '../sync';
 import { getServerFacilityIds } from '../serverConfig';
-import { setupSyncRuntime } from '../setupSyncRuntime';
+import { setupSyncRuntime, startSyncRuntimeWhenConfigured } from '../setupSyncRuntime';
 import { createApiApp } from '../createApiApp';
 import { startScheduledTasks } from '../tasks';
 
@@ -57,13 +57,15 @@ async function startAll({ skipMigrationCheck }) {
   });
 
   const cancelTasks = startScheduledTasks(context);
-  // SyncTask needs a sync manager, which only exists when the server is configured.
-  const cancelSyncTask = isConfigured ? startScheduledTasks(context, [SyncTask]) : () => {};
+  // SyncTask no-ops until the runtime is ready, so schedule it regardless.
+  const cancelSyncTask = startScheduledTasks(context, [SyncTask]);
+  const cancelConfigPoll = isConfigured ? () => {} : startSyncRuntimeWhenConfigured(context);
 
   process.once('SIGTERM', () => {
     log.info('Received SIGTERM, closing HTTP server');
     cancelTasks();
     cancelSyncTask();
+    cancelConfigPoll();
     server.close();
     syncServer.close();
   });

--- a/packages/facility-server/app/subCommands/startTasks.js
+++ b/packages/facility-server/app/subCommands/startTasks.js
@@ -7,7 +7,7 @@ import { checkConfig } from '../checkConfig';
 import { initDeviceId } from '@tamanu/shared/utils';
 import { performDatabaseIntegrityChecks, prepareDatabaseForStartup } from '../database';
 import { getServerFacilityIds } from '../serverConfig';
-import { setupSyncRuntime } from '../setupSyncRuntime';
+import { setupSyncRuntime, startSyncRuntimeWhenConfigured } from '../setupSyncRuntime';
 import { startScheduledTasks } from '../tasks';
 
 import { version } from '../serverInfo';
@@ -31,12 +31,15 @@ export async function startTasks({ skipMigrationCheck, taskClasses, syncManager 
   await checkConfig(context);
   await performDatabaseIntegrityChecks(context);
 
-  await setupSyncRuntime(context, { syncManager });
+  const isConfigured = await setupSyncRuntime(context, { syncManager });
 
   const cancelTasks = startScheduledTasks(context, taskClasses);
+  // If booted unconfigured, start syncing once first-run setup completes.
+  const cancelConfigPoll = isConfigured ? () => {} : startSyncRuntimeWhenConfigured(context);
   process.once('SIGTERM', () => {
     log.info('Received SIGTERM, stopping scheduled tasks');
     cancelTasks();
+    cancelConfigPoll();
   });
 }
 

--- a/packages/facility-server/app/tasks/SyncTask.js
+++ b/packages/facility-server/app/tasks/SyncTask.js
@@ -18,6 +18,10 @@ export class SyncTask extends ScheduledTask {
   }
 
   async run() {
+    // Not configured yet (first-run setup) — skip until the runtime is wired up.
+    if (!this.context.syncManager) {
+      return;
+    }
     return this.context.syncManager.triggerSync({
       type: 'scheduled',
       urgent: false,


### PR DESCRIPTION
### Changes

Stacked on the sync-host-setup PR (#10124). Addresses the bugbot finding that, after the first-run wizard, no outbound sync happens until a full restart. The wizard runs in the API process, but sync runs in the separate sync/tasks process, which booted unconfigured and skipped its sync runtime. Now: SyncTask tolerates a not-yet-ready sync manager (no-ops instead of throwing) and is scheduled regardless; when a process boots unconfigured it polls (30s) for setup to complete, re-reads the config from the DB, and wires up the sync runtime in-process — so sync starts without a restart. No-op once configured.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->