### PR TITLE
fix(e2e): no-issue: activate encounter tabs reliably via dispatchEvent

### DIFF
--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -278,8 +278,27 @@ export class PatientDetailsPage extends BasePatientPage {
     this.diagnosisName=this.page.getByTestId('diagnosisname-vvn4');
   }
 
+  /**
+   * Select a patient/encounter tab reliably and wait for it to become active before
+   * returning. The encounter tabs are react-beautiful-dnd drag handles whose activation
+   * is a plain `onClick`; rbd's pointer sensor intermittently swallows a normal
+   * `.click()` as a drag-start, so the tab never switches and the pane's controls never
+   * appear — the long-standing source of flakiness in the encounter-tab specs (lab
+   * requests, notes, procedures, …). Dispatching the click event directly fires the
+   * `onClick` without the mousedown/up sequence rbd intercepts; retry until the tab
+   * reports `aria-selected="true"` to also cover the brief post-navigation window before
+   * the handler is wired up. Both tab implementations set `aria-selected` on the testid
+   * element, so this is uniform.
+   */
+  private async selectTab(tab: Locator): Promise<void> {
+    await expect(async () => {
+      await tab.dispatchEvent('click');
+      expect(await tab.getAttribute('aria-selected')).toBe('true');
+    }).toPass({ timeout: 15000, intervals: [100, 250, 500, 1000] });
+  }
+
   async navigateToVaccineTab(): Promise<PatientVaccinePane> {
-    await this.vaccineTab.click();
+    await this.selectTab(this.vaccineTab);
     if (!this.patientVaccinePane) {
       this.patientVaccinePane = new PatientVaccinePane(this.page);
     }
@@ -289,7 +308,7 @@ export class PatientDetailsPage extends BasePatientPage {
   async navigateToProcedureTab(): Promise<ProcedurePane> {
     await this.encountersList.first().waitFor({ state: 'visible' });
     await this.encountersList.first().filter({ hasText: 'Hospital admission' }).click();
-    await this.procedureTab.click();
+    await this.selectTab(this.procedureTab);
     if (!this.patientProcedurePane) {
       this.patientProcedurePane = new ProcedurePane(this.page);
     }
@@ -300,7 +319,7 @@ export class PatientDetailsPage extends BasePatientPage {
     // Navigate to the top encounter
     await this.encountersList.first().waitFor({ state: 'visible' });
     await this.encountersList.first().filter({ hasText: 'Hospital admission' }).click();
-    await this.labsTab.click();
+    await this.selectTab(this.labsTab);
     if (!this.labRequestPane) {
       this.labRequestPane = new LabRequestPane(this.page);
     }
@@ -310,7 +329,7 @@ export class PatientDetailsPage extends BasePatientPage {
     // Navigate to the top encounter
     await this.encountersList.first().waitFor({ state: 'visible' });
     await this.encountersList.first().filter({ hasText: 'Hospital admission' }).click();
-    await this.notesTab.click();
+    await this.selectTab(this.notesTab);
     if (!this.notesPane) {
       this.notesPane = new NotesPane(this.page);
     }
@@ -318,11 +337,11 @@ export class PatientDetailsPage extends BasePatientPage {
   }
 
   async navigateToVitalsTab(): Promise<void> {
-    await this.vitalsTab.click();
+    await this.selectTab(this.vitalsTab);
   }
 
   async navigateToDocumentsTab(): Promise<DocumentsPane> {
-    await this.documentsTab.click();
+    await this.selectTab(this.documentsTab);
     if (!this.documentsPane) {
       this.documentsPane = new DocumentsPane(this.page);
     }
@@ -336,7 +355,7 @@ export class PatientDetailsPage extends BasePatientPage {
   }
 
   async navigateToTasksTab(): Promise<TasksPane> {
-    await this.tasksTab.click();
+    await this.selectTab(this.tasksTab);
     if (!this.tasksPane) {
       this.tasksPane = new TasksPane(this.page);
     }
@@ -344,7 +363,7 @@ export class PatientDetailsPage extends BasePatientPage {
   }
 
   async navigateToChartsTab(): Promise<ChartsPane> {
-    await this.chartsTab.click();
+    await this.selectTab(this.chartsTab);
     if (!this.chartsPane) {
       this.chartsPane = new ChartsPane(this.page);
     }
@@ -352,7 +371,7 @@ export class PatientDetailsPage extends BasePatientPage {
   }
 
   async navigateToReferralsTab(): Promise<ReferralPane> {
-    await this.referralsTab.click();
+    await this.selectTab(this.referralsTab);
     if (!this.referralPane) {
       this.referralPane = new ReferralPane(this.page);
     }
@@ -363,11 +382,11 @@ export class PatientDetailsPage extends BasePatientPage {
   async navigateToImagingRequestTab(): Promise<void> {
     await this.encountersList.first().waitFor({ state: 'visible' });
     await this.encountersList.first().click();
-    await this.imagingTab.click();
+    await this.selectTab(this.imagingTab);
   }
 
   async navigateToPatientDetailsTab(): Promise<PatientDetailsTabPage> {
-    await this.patientDetailsTab.click();
+    await this.selectTab(this.patientDetailsTab);
     if (!this.patientDetailsTabPage) {
       this.patientDetailsTabPage = new PatientDetailsTabPage(this.page);
     }
@@ -382,7 +401,7 @@ export class PatientDetailsPage extends BasePatientPage {
   async navigateToMedicationTab(): Promise<EncounterMedicationPane> {
     await this.encountersList.first().waitFor({ state: 'visible' });
     await this.encountersList.first().click();
-    await this.encounterMedicationTab.click();
+    await this.selectTab(this.encounterMedicationTab);
     if (!this.encounterMedicationPane) {
       this.encounterMedicationPane = new EncounterMedicationPane(this.page);
     }


### PR DESCRIPTION
🤖 Fixes the intermittent merge-queue E2E failures at the root.

**Cause (found via the #10158 server logs + an `aria-selected` wait):** the patient/encounter tabs are react-beautiful-dnd drag handles whose activation is a plain `onClick`. rbd’s pointer sensor intermittently swallows a normal Playwright `.click()` as a drag-start, so the tab never switches — it stays `aria-selected="false"`, its pane is never mounted, and specs time out waiting for pane controls ("New procedure", "New Lab Request", …). The failures resolved to `aria-selected="false"` after each click attempt, on `data-rbd-*` tab elements. The facility server answered every request `200` in 1–70ms throughout, so this was never a backend issue.

**Fix:** a shared `selectTab()` helper that dispatches the click event directly — firing the tab’s `onClick` without the mousedown/up sequence rbd intercepts — and retries until `aria-selected="true"`. Every `navigateTo*Tab` routes through it. Both tab implementations set `aria-selected` on the testid element, so the settle point is uniform.

Test-only change (page objects). An earlier revision of this PR used a plain click + wait; that only *detected* the problem (its own gating runs failed showing `aria-selected="false"`), which is how the rbd cause was pinned down.