### PR TITLE
refactor(settings): TAM-6864: move tasking.upcomingTasksTimeFrame to settings

### DIFF
--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -4,6 +4,7 @@ import { subject } from '@casl/ability';
 import { NotFoundError, InvalidParameterError, InvalidOperationError } from '@tamanu/errors';
 import { getCurrentDateTimeString, getDayBoundaries } from '@tamanu/utils/dateTime';
 import config from 'config';
+import { ReadSettings } from '@tamanu/settings';
 import { toPrimaryDateTimeString } from '@tamanu/shared/utils/primaryDateTime';
 import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
 import {
@@ -813,7 +814,9 @@ encounterRelations.get(
 
     req.checkPermission('list', 'Tasking');
 
-    const upcomingTasksTimeFrame = config.tasking?.upcomingTasksTimeFrame || 8;
+    const upcomingTasksTimeFrame = await new ReadSettings(models).get(
+      'tasking.upcomingTasksTimeFrame',
+    );
     const baseQueryOptions = {
       where: {
         encounterId,

--- a/packages/facility-server/app/routes/apiv1/user.js
+++ b/packages/facility-server/app/routes/apiv1/user.js
@@ -15,7 +15,7 @@ import {
 } from '../../utils/query';
 import { z } from 'zod';
 import { TASK_STATUSES, TASK_TYPES } from '@tamanu/constants';
-import config from 'config';
+import { ReadSettings } from '@tamanu/settings';
 import { toPrimaryDateTimeString } from '@tamanu/shared/utils/primaryDateTime';
 import { add } from 'date-fns';
 import { getOrderClause } from '../../database/utils';
@@ -247,7 +247,9 @@ user.get(
       facilityId,
     } = query;
 
-    const upcomingTasksTimeFrame = config.tasking?.upcomingTasksTimeFrame || 8;
+    const upcomingTasksTimeFrame = await new ReadSettings(models).get(
+      'tasking.upcomingTasksTimeFrame',
+    );
 
     const defaultOrder = [
       ['dueTime', 'ASC'],

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -206,7 +206,7 @@
   "countryTimeZone": "Australia/Melbourne",
   "allowMismatchedTimeZones": false,
   "tasking": {
-    "upcomingTasksTimeFrame": 8, // hours,
+    // upcomingTasksTimeFrame moved to settings (tasking.upcomingTasksTimeFrame)
     "upcomingTasksShouldBeGeneratedTimeFrame": 72, // hours
   },
   "medicationAdministrationRecord": {

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -158,6 +158,17 @@ export const globalSettings = {
         }),
       defaultValue: null,
     },
+    tasking: {
+      description: 'Tasking settings',
+      properties: {
+        upcomingTasksTimeFrame: {
+          description: 'How far ahead to include upcoming (not-yet-due) tasks in task lists',
+          type: yup.number().positive(),
+          unit: 'hours',
+          defaultValue: 8,
+        },
+      },
+    },
     appointments: {
       description: 'Appointment settings',
       exposedToWeb: true,


### PR DESCRIPTION
### Changes

First quick win for **TAM-6864** (move all remaining `config` into settings).

**This PR:** moves `config.tasking.upcomingTasksTimeFrame` (the look-ahead window for task lists) into the global settings schema as `tasking.upcomingTasksTimeFrame` (default `8`, unit hours). The two facility task-list endpoints (`GET /encounter/:id/tasks`, `GET /user/tasks`) now read it via `ReadSettings` instead of `config`. The key is removed from facility `default.json5`. No backwards-compat shim — per the epic plan we cut the config key over directly.

**Migration pattern (for the rest of the epic):**
- Define the value in the appropriate schema under `packages/settings/src/schema/` (`global` / `central` / `facility`) with a `defaultValue`, replacing the old config default.
- Replace `config.x` reads with an async `settings.get('x')`. Only viable where the call site is async and not needed at bootstrap (before the DB/settings reader exists) — infra config (ports, DB, log path) stays in config/env.
- Reader access differs by server:
  - **Central:** `req.settings` is a single `ReadSettings` — use `req.settings.get(...)`.
  - **Facility:** `req.settings` is keyed by facilityId (`req.settings[facilityId]`) with **no `.global`**. For a *global* setting in a facility route, construct `new ReadSettings(req.models)` (same pattern as the existing `browser-support` route); facility-specific settings need a `facilityId` threaded through.
- Delete the migrated key from `config/default.json5`.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->