### PR TITLE
E1: Add padding after invoice items list

### DIFF
--- a/.agents/docs/spec-format.md
+++ b/.agents/docs/spec-format.md
@@ -1,0 +1,109 @@
+---
+workhorse-version: 0.1.0
+---
+
+# Spec format and information architecture
+
+Specs are the product-level source of truth for a workspace. The format serves three audiences: product owners and testers authoring them (via interview or direct edit), developers and AI agents implementing from them, and anyone browsing them as a knowledge base.
+
+## Information hierarchy
+
+Specs live in the workspace's configured specs directory (default `.workhorse/specs/`) as markdown files organised into directories. The directory structure is the hierarchy: **Product > Area > Subarea > ... > Spec**, with arbitrary nesting depth.
+
+```
+.workhorse/specs/
+├── patient/
+│   ├── registration.md
+│   ├── allergies.md
+│   ├── merge/
+│   │   ├── overview.md
+│   │   ├── field-resolution.md
+│   │   └── conflict-handling.md
+│   └── referrals.md
+├── scheduling/
+│   ├── appointments.md
+│   └── recurring-appointments.md
+└── labs/
+    ├── requests.md
+    └── results.md
+```
+
+Areas appear as they're needed — there's no predefined list. When drafting a new spec, the agent picks an area consistent with the existing structure. The spec explorer reads this structure from the main branch to build the navigable reference view.
+
+## File format
+
+Each spec is a markdown file with a single-line YAML frontmatter block and a structured body:
+
+```markdown
+---
+id: ALG
+---
+
+# Patient allergies
+
+Summary paragraph describing what this spec covers.
+
+## Section heading
+
+- [ ] Acceptance criterion one
+- [ ] Acceptance criterion two
+```
+
+The frontmatter carries exactly one field:
+
+- `id` — a short, stable identifier for the spec, used for code-to-spec traceability (see [Spec IDs and code references](#spec-ids-and-code-references))
+
+Nothing else goes in the frontmatter. The title comes from the H1. The area comes from the directory. The originating card isn't recorded on the spec — it's available via git history and doesn't stay tied to the spec after the card closes.
+
+Body structure:
+
+- **Title** — a single `#` H1 at the top, human-readable (e.g. "Patient allergies")
+- **Summary** — one or two plain paragraphs below the title, no heading
+- **Sections** — `##` headings group related criteria
+- **Acceptance criteria** — markdown checkbox items (`- [ ]`)
+
+## Spec IDs and code references
+
+The `id` in frontmatter is a short, stable handle. It lets code reference the spec it implements through inline comments, and survives the spec being renamed or moved.
+
+- IDs are 2–6 character alphanumeric codes, uppercase, chosen when the spec is first created (e.g. `ALG`, `AUTH`, `LAB1`). Use something memorable rather than sequential numbering
+- IDs are unique within a workspace. Workhorse checks for collisions on creation
+- Once assigned, an ID never changes. The filename or location can change freely — code references keep working
+- Code references an implementing spec with an inline comment of the form `// spec: ALG`. For a specific section within the spec, append a kebab-case slug of the heading text: `// spec: ALG#conflict-handling`
+- A single piece of code can reference multiple specs with multiple comments — don't try to combine them
+
+Code references are advisory, not load-bearing. They help a reader jump from an implementation detail to the product rule it answers to. Missing references are not a bug.
+
+## Writing conventions
+
+- **Describe the system as it should be, not the changes to make.** Each spec is a coherent snapshot — it reads as "this is how the system works" rather than "change X to Y" or "no longer does Z". No references to "current behaviour", "remains unchanged", "now does", or "rather than the old way". The implementation agent works from the diff to know what's changing.
+- **Acceptance criteria are facts about behaviour, not instructions to a developer.**
+- **No implementation details.** Specs are written at a product-owner level. Avoid function names, database fields, model names, enum values, and technical identifiers. Write "the system checks whether all parent cards have been committed" rather than naming the field that tracks commit state; write "Spec complete" rather than an all-caps status constant. File paths inside the workspace's specs directory are acceptable because they're part of the product's information architecture.
+- **Stay within the spec's scope.** Each spec contains only sections that relate directly to its title and area. If content would make more sense in another spec, it belongs there — add a cross-reference (e.g. "see `editor/spec-editor.md`") rather than duplicating or misplacing it. When in doubt, ask: "would someone looking for this information expect to find it in a spec with this title?"
+- **Don't specify absences.** Document what the system does, not what it doesn't do. "We don't support X" or "X is not included" is not useful — if it's not in the spec, it's not in the system. If another spec needs updating because this feature changes its behaviour, update that spec declaratively.
+- **No point-in-time language.** Don't document transitions ("we used to do X, now we do Y", "this replaces Z"). Each spec is a snapshot of the desired system, not a changelog.
+- **No stacking adjectives.** Don't describe behaviour with chains of near-synonyms ("seamless, invisible, frictionless"). Use one precise word or describe the concrete behaviour.
+- **No exact measurements in prose.** Pixel widths, animation durations, and precise benchmarks belong in mockups or the design system, not in acceptance criteria. Describe the intent ("compact", "fast enough to feel instant") rather than the number.
+- **Open questions must be resolved before a spec is considered done.** A spec with open questions is a draft. Nail them down with the user before committing.
+- **Australian/NZ English spelling** (colour, organisation, finalise).
+
+## When a change warrants a spec update
+
+Specs describe product behaviour, so spec edits accompany changes that change product behaviour.
+
+- Product-behaviour changes — new features, removed behaviour, changed flows, revised edge-case handling — require spec edits
+- Bug fixes and implementation-detail changes do not require spec edits, unless the bug existed because the spec was unclear, incorrect, or missing. In that case, update the spec first so it reflects the intended behaviour, then fix the code to match
+- Refactors and cleanups that leave product behaviour unchanged do not touch specs
+
+## When to edit, fold, create, or split
+
+Default to editing the spec that already covers the concept. A new spec file appears only when the content cannot plausibly live as a section or set of criteria inside any existing spec in the same area.
+
+- **Fold into an existing spec** when the change is a section, criterion, or refinement on a concept the spec already covers. Most spec changes are folds
+- **Create a new sibling spec** when the content is a distinct concept within an existing area but does not belong in any current file there
+- **Split an existing spec** when it has grown long **and** contains one or more conceptually distinct sub-areas that could each stand alone
+
+When splitting, the parent topic becomes a folder and the sub-topics become files within it:
+
+- Add an `overview.md` when the folder has cross-cutting content (shared terminology, relationships between sub-specs, invariants that apply to all children), or when the folder has more than three siblings and a reader needs orientation
+- Skip `overview.md` when two or three well-named siblings speak for themselves

--- a/.agents/skills/acceptance-audit.md
+++ b/.agents/skills/acceptance-audit.md
@@ -1,0 +1,20 @@
+---
+label: "Acceptance audit"
+pill-order:
+  implementing: 4
+  reviewing: 4
+  complete: 3
+workhorse-version: 0.1.0
+---
+
+## Your task: Acceptance audit
+
+Check whether the code on this card's branch meets the acceptance criteria. This is a compliance check against the specs, not a general code-quality review.
+
+1. Identify what this card was supposed to do: diff the spec changes on this branch against the upstream base (scoped to `specs/`) to see the card's own additions and edits. Also read the surrounding specs in the same area(s) — they describe existing behaviour that must still be met and not regressed
+2. Diff this card's branch against its upstream base to see the implementation (a card's base is usually `main`, but may be a parent card's branch)
+3. Walk the criteria one by one — both the card's new/changed criteria and the surrounding ones that should still hold. Does the code deliver each one? Has any existing behaviour regressed?
+4. Flag criteria that are not yet implemented, partially implemented, or implemented incorrectly — and flag regressions separately
+5. Flag any behaviour in the code that isn't covered by a criterion — that's either missing from the spec, or shouldn't be in the code
+
+Post findings grouped by spec, each finding tied to a specific criterion with file and line references.

--- a/.agents/skills/ascii-design.md
+++ b/.agents/skills/ascii-design.md
@@ -1,0 +1,13 @@
+---
+label: "ASCII design chat"
+pill-order:
+  not-started: 5
+  specifying: 11
+workhorse-version: 0.1.0
+---
+
+## Your task: ASCII design chat
+
+A lightweight UX/UI workshop. Sketch the screen's skeleton as ASCII art directly in chat, get feedback, and iterate. Keep it fast and rough — the goal is to agree on shape and hierarchy before committing to HTML mockups.
+
+Once the skeleton is agreed, suggest moving to an HTML mockup as the next step.

--- a/.agents/skills/automate-test-cases.md
+++ b/.agents/skills/automate-test-cases.md
@@ -1,0 +1,21 @@
+---
+label: "Automate test cases"
+pill-order:
+  implementing: 6
+  reviewing: 5
+jockey-hint: "Surface once the card has a test-cases file with unticked scenarios and implementation is underway. Demote once all scenarios are ticked."
+workhorse-version: 0.1.0
+---
+
+## Your task: Automate test cases
+
+Write automated tests that match the unticked scenarios in this card's test-cases file, ticking each item as its matching test lands.
+
+1. Read the test-cases file at `.workhorse/test-cases/{card-id}/`. If no file exists, stop and ask the user whether to run `Draft test cases` first
+2. For each unticked scenario, locate the right place to put its automated test — follow the target repo's existing test conventions (framework, file layout, fixtures)
+3. Write the test so it exercises the scenario as stated. If the scenario cites a spec id, the test is the automation of that acceptance criterion — match its intent
+4. Tick the scenario (`- [ ]` → `- [x]`) once its test is written and passing locally. Update the test-cases file in place
+5. If a scenario is genuinely not automatable (manual feel, cross-browser visual), leave it unticked and note in the file why it's manual-only
+6. Summarise what you automated, which scenarios remain manual, and any scenarios you couldn't make sense of
+
+See `specs/test-cases/overview.md` for the file's shape.

--- a/.agents/skills/bug-review.md
+++ b/.agents/skills/bug-review.md
@@ -1,0 +1,20 @@
+---
+label: "Bug review"
+pill-order:
+  implementing: 2
+  reviewing: 1
+  complete: 1
+workhorse-version: 0.1.0
+---
+
+## Your task: Bug review
+
+Review the code changes on this card's branch for likely bugs, regressions, and missed edges.
+
+1. Diff this card's branch against its upstream base to see what's changed (a card's base is usually `main`, but may be a parent card's branch)
+2. Read the specs to understand the intended behaviour
+3. Inspect the diff for anything that looks wrong — use your judgement about what matters for this code
+4. Post findings grouped by severity: real bugs first, then smells or likely issues, then nitpicks
+5. For each finding, reference the file and a short excerpt so the user can locate it
+
+Be specific and actionable. Don't flag stylistic preferences as bugs.

--- a/.agents/skills/cherry-pick-changes.md
+++ b/.agents/skills/cherry-pick-changes.md
@@ -1,0 +1,21 @@
+---
+label: "Cherry-pick changes"
+workhorse-version: 0.1.0
+---
+
+## Your task: Cherry-pick post-merge changes
+
+The card just created a follow-up PR on a fresh branch from main. Your job is to cherry-pick the post-merge commits from the previous branch onto this new branch.
+
+The user message contains the previous branch name and the commit SHAs to cherry-pick.
+
+1. Cherry-pick each commit in order using `git cherry-pick <sha>`
+2. If a cherry-pick applies cleanly, move to the next one
+3. If a cherry-pick encounters conflicts:
+   - Examine the conflict markers to understand what diverged
+   - Use the card's specs, description, and conversation history to make informed resolution decisions
+   - Edit the conflicted files to resolve them
+   - `git add` the resolved files
+   - `git cherry-pick --continue` to proceed
+4. After all commits are applied, push the branch with `git push origin <branch>`
+5. Report what you cherry-picked, any conflicts you encountered, and how you resolved them

--- a/.agents/skills/design-audit.md
+++ b/.agents/skills/design-audit.md
@@ -1,0 +1,31 @@
+---
+label: "Design audit"
+pill-order:
+  specifying: 6
+  implementing: 3
+  reviewing: 3
+  complete: 2
+workhorse-version: 0.1.0
+---
+
+## Your task: Design audit
+
+Audit this card's design work against `.workhorse/design/` — the source of truth for the project's design direction.
+
+### What to audit
+
+Work out what stage the card is at and audit accordingly:
+
+- **Mockups only** (specifying phase — this card has mockups but no UI code) — audit the HTML mockups in `.workhorse/design/mockups/{card-id}/`
+- **Implementation** (implementing or reviewing phase — this card has UI code changes) — audit the shipped code on the card's branch
+- **Both** — audit both, and flag any places where the implementation drifted from what the mockups showed
+
+### How to audit
+
+1. Read `.workhorse/design/design-system.md` and any other guidance under `.workhorse/design/` (components, philosophy notes)
+2. Review against both the high-level principles and the pixel-level detail — use your judgement about what matters for this card
+3. Where `.workhorse/design/` disagrees with what's shipped elsewhere in the existing codebase, `.workhorse/design/` wins — it represents the agreed current direction
+4. **Flag unchanged aspects that have drifted.** A mockup or implementation should only change the styling and layout of the feature or tweak the card is about — surrounding regions should match the current implementation. Call out any place where unchanged regions have been re-styled or re-imagined, or where stale styling from older mockups (on other cards) has leaked in. See "Preserving unchanged aspects" in your system prompt
+5. Do not reference mockups from other cards as inspiration or comparison — each card's mockups are point-in-time artefacts, not canonical components
+
+Post findings as specific, actionable items. Reference the exact design-system rule each finding relates to.

--- a/.agents/skills/draft-spec-changes.md
+++ b/.agents/skills/draft-spec-changes.md
@@ -1,0 +1,24 @@
+---
+label: "Draft spec changes"
+pill-order:
+  not-started: 3
+  specifying: 2
+jockey-hint: "Demote once spec drafts have already been produced in this conversation, unless the user signals they want another pass or the scope has materially shifted."
+workhorse-version: 0.1.0
+---
+
+## Your task: Draft spec changes
+
+Produce spec edits directly from the card description — no extended interview.
+
+**Read `.agents/docs/spec-format.md` first.** It defines the writing conventions, the information-architecture rules, and the fold-vs-create-vs-split guidance you must follow. Every edit you make has to conform to it.
+
+1. Read the card title and description carefully.
+2. Read existing specs in `specs/` to understand the area structure.
+3. **Default to editing existing specs.** Most spec work is a fold — a new section, criterion, or refinement on a spec that already covers the concept. Only create a new spec file when the content cannot plausibly live in any existing spec in the same area.
+4. Edit spec files in place, or write new ones at `specs/{area}/{slug}.md` if genuinely needed.
+5. Include a brief summary of what you changed and any open questions you identified.
+
+Do NOT start by asking questions or exploring the codebase. Go straight to drafting. If the description is too thin for meaningful acceptance criteria, write what you can and list the gaps as open questions.
+
+**Generate mockups** for any UI-facing specs as part of the draft. Before writing mockup HTML, follow the Design sourcing process from your system prompt: read the section's actual implementation first, then similar components, then cross-check against `.workhorse/design/`. Do not skip this reading pass.

--- a/.agents/skills/draft-test-cases.md
+++ b/.agents/skills/draft-test-cases.md
@@ -1,0 +1,22 @@
+---
+label: "Draft test cases"
+pill-order:
+  specifying: 9
+  implementing: 5
+jockey-hint: "Surface when the card has specs but no test cases yet, or when the user wants to refresh the scenario list. Demote once a healthy test-cases file exists unless the user signals a fresh area to cover."
+workhorse-version: 0.1.0
+---
+
+## Your task: Draft test cases
+
+Produce or refine the card's test-cases checklist — the concrete scenarios that verify this card is done. The file is read by both the tester running scenarios by hand and the implementing agent writing automated tests against them.
+
+1. Read the card's specs in `specs/` and any existing test cases at `.workhorse/test-cases/{card-id}/`
+2. Skim the target repo to ground the scenarios in the actual surfaces involved
+3. If a test-cases file already exists, edit it in place — add, refine, or reorder scenarios. Don't replace work that still applies
+4. If none exists, create one at `.workhorse/test-cases/{card-id}/overview.md` with an H1 title, an optional summary, and one or more checklist sections
+5. Write each scenario as one concrete verifiable step in operational voice — a thing to do and the observable outcome. Avoid vague items like "test the feature"
+6. Cite the spec id (e.g. "verifies spec: ALG") on scenarios that directly exercise an acceptance criterion. Scenarios without a citation are valid for operational concerns (smoke checks, cross-browser, manual feel)
+7. Ask only the clarifying questions you genuinely need — one or two turns at most, not an extended interview
+
+See `specs/test-cases/overview.md` for the file's shape.

--- a/.agents/skills/git-pull.md
+++ b/.agents/skills/git-pull.md
@@ -1,0 +1,16 @@
+---
+label: "Pull"
+workhorse-version: 0.1.0
+---
+
+## Your task: Pull remote changes
+
+Pull the latest remote changes into the card's branch and reconcile them with local work.
+
+1. Run `git pull` to fetch and integrate remote changes
+2. If a hard conflict occurs, resolve it using the card's specs, description, and conversation history to make informed decisions
+3. **Always check for soft conflicts** — even if git merged cleanly, inspect the incoming changes against local specs and code for assumptions that have been invalidated by the remote changes. Use your judgement about what matters
+4. Report what changed. If soft conflicts exist, explain each one: what the local assumption was, what the remote change did, and how you resolved it (or ask the user if ambiguous)
+5. Apply straightforward resolutions directly. Ask the user about ambiguous ones.
+
+When local changes are small, the soft-conflict check can be brief. When local changes are large, examine thoroughly.

--- a/.agents/skills/git-update.md
+++ b/.agents/skills/git-update.md
@@ -1,0 +1,18 @@
+---
+label: "Update"
+workhorse-version: 0.1.0
+---
+
+## Your task: Update branch from upstream
+
+Rebase this card's branch onto its upstream. The upstream is the parent branch this card was based on — usually `main`, but cards that depend on a parent card rebase onto the parent's branch instead. Determine the actual branch names from `git rev-parse --abbrev-ref HEAD` (the card branch) and `git rev-parse --abbrev-ref @{upstream}` (the base). Use those exact refs, not the workspace default.
+
+1. Run `git fetch origin` to refresh remote refs, then verify the fetch updated the upstream by comparing `git rev-parse origin/<base-branch>` before and after — if the SHA didn't change but `git ls-remote origin <base-branch>` reports a different SHA, abort and report the discrepancy rather than rebasing onto stale state
+2. Run `git rebase origin/<base-branch>` to rebase onto the upstream
+3. If a hard conflict occurs during rebase, resolve it step by step. Use the card's specs, description, and conversation history to decide which side to favour
+4. **Always check for soft conflicts** — even if the rebase completed cleanly, inspect the full diff between the old and new base against local specs and code for assumptions invalidated by upstream changes. Use your judgement about what matters
+5. After the rebase succeeds, force-push with `git push --force-with-lease origin <card-branch>` so the remote reflects the rebased history
+6. Report what upstream changes came in. If soft conflicts exist, explain each one: what the local assumption was, what upstream changed, and how you resolved it (or ask the user if ambiguous)
+7. Apply straightforward resolutions directly. Ask the user about ambiguous ones.
+
+When local changes are small, the soft-conflict check can be brief. When local changes are large, examine thoroughly.

--- a/.agents/skills/handoff.md
+++ b/.agents/skills/handoff.md
@@ -1,0 +1,51 @@
+---
+label: "Handoff"
+pill-order:
+  not-started: 7
+  specifying: 5
+  implementing: 6
+  reviewing: 6
+workhorse-version: 0.1.0
+---
+
+## Your task: Hand off to an external agent
+
+The user wants to hand off work on this card to an external agent (Claude Code, Cursor, or another AI tool). Generate the briefing prompt in one pass — do not ask the user to confirm focus first.
+
+### What to do
+
+1. **Infer a focus** from the card's current state and conversation history. For example:
+   - Specs are drafted and no code yet → focus is "begin implementation"
+   - Implementation is in progress → focus is "continue the implementation"
+   - There are CI failures or known bugs → focus is "fix the build failures" or "investigate the reported bug"
+2. Compose the briefing prompt and return it in a single fenced code block with ```handoff as the language tag. The UI renders these blocks with an **Open in Claude Code** button that launches a local Claude Code terminal session with this prompt pre-filled (via a `claude-cli://` deep link), alongside the standard copy button. **Critical: the entire prompt must be one fenced block. Do not use fenced code blocks (triple backticks) anywhere inside the prompt — they break the outer fence and disable both the button and copy. Use inline code with single backticks for paths, commands, and identifiers instead. Keep the prompt under 5000 characters so the deep link stays within the URL limit; the user can still copy-paste a longer briefing, but the button is disabled if the limit is exceeded.**
+3. **Immediately after the code block**, add a short line naming the focus you inferred and inviting the user to redirect — e.g. "This is for starting implementation of the allergies spec. Let me know if you want it for something else."
+
+### Briefing prompt structure
+
+The prompt contains these sections, in order:
+
+**1. Workhorse context** — explain the spec-driven workflow:
+- Specs live in `specs/` as structured markdown with YAML frontmatter and checkbox acceptance criteria
+- Describe the system as it should be (not changes to make). Acceptance criteria are facts about behaviour. No implementation details in specs
+- Mockups live in `.workhorse/design/mockups/{card-id}/` as standalone HTML with inline CSS
+- Design system is at `.workhorse/design/design-system.md`
+- The card's implementation plan lives at `.workhorse/plans/{card-id}/` — a free-form markdown working document with tech design notes and/or a checklist of build steps. Read it first if it exists, tick items (`- [ ]` → `- [x]`) as work completes, and expand steps into sub-items if they turn out larger than anticipated
+- Australian/NZ English spelling
+
+**2. Card context** — the card title, identifier, and description (when present)
+
+**3. Branch instructions** — tell the agent which branch to check out and to diff it against the upstream base branch to understand what specs and mockups have been added or changed
+
+**4. Journal summary** — summarise what has happened so far on this card based on the conversation history (what was discussed, what decisions were made, what work was done)
+
+**5. Conversation context** — compress the key points from the conversation: decisions made, open threads, areas explored, any unresolved questions. This gives the external agent continuity
+
+**6. Focus instructions** — what the external agent should do, based on the focus you inferred
+
+### Guidelines
+
+- The prompt should be self-contained — the external agent should not need to ask the user for context
+- Teach the agent how to find information (read the specs, diff the branch) rather than inlining all file contents
+- Keep it concise but complete — aim for a prompt that gets the external agent productive immediately
+- Write it as instructions addressed to the external agent ("You are picking up work on...")

--- a/.agents/skills/implement-this.md
+++ b/.agents/skills/implement-this.md
@@ -1,0 +1,52 @@
+---
+label: "Implement this"
+pill-order:
+  not-started: 2
+  specifying: 4
+  implementing: 1
+  reviewing: 2
+jockey-hint: "Demote once implementation has begun on this card — the user typically doesn't want to restart from scratch. Leave high when the card is still in specifying phase, or when the user explicitly asks to resume or redo."
+workhorse-version: 0.1.0
+---
+
+## Your task: Implement this
+
+Implement the work described by this card. The starting point varies — figure out which one applies before writing code.
+
+### Work out what you're implementing
+
+1. **Is there a pending spec change on this branch?** Diff this card's branch against its upstream base (a card's base is usually `main`, but may be a parent card's branch — check `git rev-parse --abbrev-ref @{upstream}` or the branch's merge-base), scoped to `specs/` and `.workhorse/design/mockups/`. If there are spec or mockup changes, that diff is the source of truth for what you're building — new/changed criteria describe the work
+2. **Otherwise, lead with the card description.** Read the title and description carefully — that's what the user wants. Read relevant existing specs in `specs/` for context: how the surrounding behaviour is supposed to work, what conventions and edge cases already exist. Where the description and the existing specs disagree, the description wins — implement to the description, update the affected specs to match, and mention in chat which specs you updated and why
+3. **No spec at all?** Fall back to the card title, description, and any conversation context (e.g. a prior workshop or ASCII design chat). Treat concrete decisions from the conversation as the de facto spec and proceed. If the resulting behaviour is substantive and worth keeping in the knowledge base, write it up as a spec change as part of this work — same fold-vs-create rules apply (see `.agents/docs/spec-format.md`)
+
+### The plan
+
+This card may have a plan at `.workhorse/plans/{card-id}/` — a free-form markdown working document with tech design notes and/or a checklist of build steps (see `specs/plan/overview.md`).
+
+- **If a plan with a checklist exists**, work through the checklist in order and tick items off (`- [ ]` → `- [x]`) as you complete them. Expand a step into sub-items if it turns out larger than anticipated. Self-check against the plan as you go and note if the current work has drifted from what the plan says
+- **If a plan exists but has notes only**, use the notes as context and draft the checklist yourself as you begin implementation
+- **If no plan exists and the work looks multi-stage**, draft a plan at `.workhorse/plans/{card-id}/plan.md` before starting code work, then follow it
+- **If the work is a single focused change**, you can skip the plan — proceed directly
+
+### Implementation
+
+- Follow the design system in `.workhorse/design/design-system.md` for any UI work
+- Source visual language from the existing implementation first, then `.workhorse/design/` for current direction (`.workhorse/design/` wins on clash). Do not reference mockups from other cards unless the user explicitly asks
+- **Preserve unchanged aspects.** Only change the markup and styling for the feature or tweak being implemented. Leave the rest of the screen as it is — same layout, components, copy, spacing, styling — even if you think you can improve it. See "Preserving unchanged aspects" in your system prompt
+- Make the code match the acceptance criteria — each criterion should be traceable to code
+
+### Test cases
+
+The card may have a test-cases file at `.workhorse/test-cases/{card-id}/` — the checklist of scenarios that verify the card is done. Treat it as both a live specification of what to test and a running record of what's covered.
+
+- **If a test-cases file exists**, read it alongside the specs so you know what the scenarios are. As you write automated tests that exercise a scenario, tick that scenario off (`- [ ]` → `- [x]`) in the file
+- **If no test-cases file exists** and the card has meaningful behaviour worth verifying, create one at `.workhorse/test-cases/{card-id}/overview.md` — an H1 title, optional summary, and checklist sections of concrete scenarios. Cite spec ids on scenarios that verify an acceptance criterion
+- **As implementation surfaces new scenarios** (an edge case the specs didn't call out, a regression path worth locking in), append them to the test-cases file
+
+See `specs/test-cases/overview.md` for the file's shape.
+
+### Spec ambiguity
+
+If while implementing you find the spec is unclear, contradictory, or missing something you need, don't guess. Surface it in chat and propose a spec edit before continuing. Prefer editing the existing spec over creating a new one (see `.agents/docs/spec-format.md`).
+
+If there's no spec and the description/conversation is thin, say so and ask rather than inventing behaviour.

--- a/.agents/skills/interview.md
+++ b/.agents/skills/interview.md
@@ -1,0 +1,28 @@
+---
+label: "Interview me"
+pill-order:
+  not-started: 1
+  specifying: 1
+jockey-hint: "Demote sharply once an interview has already happened — if the journal contains an interview entry, or if the recent conversation shows back-and-forth Q&A style exchange. Only re-suggest if the user explicitly asks for another round."
+workhorse-version: 0.1.0
+---
+
+## Your task: Interview me
+
+Guide the user through developing comprehensive acceptance criteria. Read `.agents/docs/spec-format.md` first so the questions you ask, and the criteria you extract, conform to the spec writing conventions and information-architecture rules.
+
+Methodology:
+
+1. **Understand the goal** — start with the high-level intent
+2. **Probe for details** — happy path first, then edge cases, error handling, interactions
+3. **Surface decisions** — identify ambiguity and ask the user to resolve it
+4. **Track open questions** — maintain unresolved questions
+5. **Extract acceptance criteria** — as the conversation progresses, extract concrete criteria
+6. **Flow into writing specs** — as soon as enough detail exists in any area, start drafting or editing the relevant spec files. Don't wait for a "ready" signal and don't announce completion; the interview and the write-up are a continuous activity. Keep interviewing on the areas that are still thin while writing up the areas that are solid
+
+Ask focused questions — one or two at a time, not long lists. **Number your questions** (1., 2., etc.) so the user can reply by number. Example:
+
+1. Where can this action be triggered from — the board, the workspace, or both?
+2. Should there be a confirmation step before it happens?
+
+**Proactively generate mockups** when discussing UI-heavy features — create mockup HTML files whenever a visual would help illustrate the concept being discussed, without waiting to be asked. Before writing any mockup HTML, follow the Design sourcing process from your system prompt: read the section's actual implementation first, then similar components, then cross-check against `.workhorse/design/`. Do not skip this reading pass just because you are mid-interview.

--- a/.agents/skills/investigate-and-fix.md
+++ b/.agents/skills/investigate-and-fix.md
@@ -1,0 +1,21 @@
+---
+label: "Investigate and fix"
+pill-order:
+  not-started: 1
+  specifying: 1
+jockey-hint: "Surface as a top pill only when the card carries the `Bug` tag, and only in the `not-started` and `specifying` phases. On untagged cards, do not include in pills or suggestions at all."
+workhorse-version: 0.1.0
+---
+
+## Your task: Investigate and fix
+
+The card describes a bug. Diagnose the cause and apply the fix.
+
+1. **Read the card** — title, description, reproduction steps, error messages, attachments. Treat these as the report
+2. **Locate the code path** — use the existing specs in `specs/` to understand the intended behaviour, then find the code that implements (or should implement) it
+3. **Form a diagnosis** — what the code currently does, what it should do, and why the two diverge. State this in chat before touching code so the user can agree or redirect
+4. **Apply the fix** — edit the code so it matches the intended behaviour
+5. **Decide about the spec** — bug fixes usually don't require spec updates, but if the bug existed because the spec was unclear, wrong, or missing, update the spec first so it reflects the intended behaviour, then fix the code to match (see `.agents/docs/spec-format.md`)
+6. **Summarise the diagnosis and the fix** in the conversation — short, specific, with file references
+
+If the description is too thin to diagnose confidently, ask the user for the missing reproduction details before guessing.

--- a/.agents/skills/mock-this-up.md
+++ b/.agents/skills/mock-this-up.md
@@ -1,0 +1,24 @@
+---
+label: "Mock this up"
+pill-order:
+  not-started: 6
+  specifying: 12
+jockey-hint: "Demote once one or more mockups have been produced in this conversation, unless the user signals they want another variation or a different screen."
+workhorse-version: 0.1.0
+---
+
+## Your task: Mock this up
+
+Produce an HTML mockup for the UI being discussed. Skip extended exploration — go straight to the mockup.
+
+1. Identify the target screen from the card description and conversation context
+2. Source the visual language before writing any HTML — do not skip steps:
+   a. **Read the actual implementation of the section being mocked** in the target repo. The shipped code is the baseline for how the screen really looks today — components, layout, spacing, copy. Start here so your output is grounded in what exists, not imagined from scratch
+   b. **Read implementations of similar components** elsewhere in the target repo to pick up patterns for any new elements not yet present in the section
+   c. **Cross-check against `.workhorse/design/`** — the design system, component docs, and philosophy notes. The design library may have been updated more recently than the code, so if it disagrees with the implementation, the design library wins
+   d. **Do not reference mockups from other cards** under `.workhorse/design/mockups/` unless the user explicitly asks — they are point-in-time artefacts, not canonical components
+3. **Preserve unchanged aspects.** Author fresh HTML and CSS only for the feature or tweak being developed. For every other region of the screen, be visually faithful to the current implementation — same layout, components, copy, spacing, styling. Do not re-imagine, re-style, or re-layout regions the card is not changing, and do not let stale styling from mockups on other cards leak in. See "Preserving unchanged aspects" in your system prompt
+4. Decide where the file goes based on the kind of card you're on:
+   - **On a product card**, write to `.workhorse/design/mockups/{card-id}/{slug}.html` with inline CSS and an HTML comment header linking to the relevant spec (if one exists). The `{card-id}` folder scopes the mockup to this card so pre-merge cleanup can strip it on merge
+   - **On a design card**, write under `.workhorse/design/` directly — pick a meaningful path (e.g. `.workhorse/design/components/{slug}.html`, `.workhorse/design/views/{slug}.html`, or `.workhorse/design/mockups/{slug}.html` if it doesn't fit a more specific folder). Mockups produced on a design card persist to main with the card's PR, so file them where they belong long-term
+5. Briefly summarise what you produced

--- a/.agents/skills/plan-cards.md
+++ b/.agents/skills/plan-cards.md
@@ -1,0 +1,40 @@
+---
+label: "Plan cards"
+pill-order:
+  not-started: 8
+  specifying: 13
+  implementing: 7
+  reviewing: 7
+jockey-hint: "Always available but low-traffic — surface as an available pill, not a top suggestion. Most cards are implemented as one PR; only suggest prominently when the conversation has already revealed the card is too large to ship in one piece."
+workhorse-version: 0.1.0
+---
+
+## Your task: Plan cards
+
+Workshop how to slice this card into smaller spawned cards and capture the breakdown in the card plan at `.workhorse/plans/{card-id}/card-plan.md`.
+
+**The card plan is not the implementation plan.** Do not edit `.workhorse/plans/{card-id}/plan.md` — that is a separate, free-form working document for tech-design notes and build steps. The card plan has a strict shape:
+
+- An H1 title and an optional intro paragraph
+- A flat list of `## ` heading entries, one per spawned card
+- Each entry's body is a short description paragraph (and optionally a `<!-- mockups: ... -->` comment) — no checklists, no sub-headings, no nested H3s, no build-step bullets
+
+Once the user is ready, a bulk Create cards action turns each uncreated entry into a real spawned card based on this one. The parent stays as the umbrella while the children carry the implementation work.
+
+### How to run the workshop
+
+1. Read the card's specs in `specs/`, the card description, and any existing **card-plan** file at `.workhorse/plans/{card-id}/card-plan.md`. Ignore `plan.md` in the same folder — it is a different artifact and not what you are editing here
+2. Skim the target repo where it helps you reason about boundaries between the children
+3. Talk through how to slice the work — natural seams, dependency order, what each child should own. Ask focused questions one or two at a time
+4. As entries become clear, write them into `card-plan.md` as `## ` headings with a short description paragraph beneath. Edit in place as the conversation refines them — adding, splitting, merging, reordering entries is normal
+5. If `card-plan.md` does not yet exist, create it at the path above with an H1 title and the entries underneath. Do not create or edit any other file
+6. **Suggest mockup carry-forward.** Each entry has an inline Mockups picker for choosing which of the parent's mockups travel with the spawned card. As you write entries, populate the picker by inserting a structured comment line directly under the entry's `## ` heading: `<!-- mockups: slug-one, slug-two -->` (one comment per entry, comma-separated slugs from `.workhorse/design/mockups/{card-id}/`). Pick only the mockups that fit each entry — the user can adjust later
+7. Do not trigger bulk-create yourself. The user runs the Create cards action from the editor when they are ready
+
+### What each entry should look like
+
+- The `## ` heading is the spawned card's title — concise, action-oriented, no trailing punctuation, no code suffix (the editor stamps `· CODE` automatically once the card is created)
+- The body beneath is the spawned card's description — a short paragraph (or two) covering scope and boundaries. Do not write a checklist, sub-headings, or implementation steps; that detail belongs in each child card's own plan after it is created
+- Spawned cards inherit the parent's project and become "based on" the parent via dependencies, so don't restate that
+
+See `specs/card/card-plan.md` for the canonical shape.

--- a/.agents/skills/plan-implementation.md
+++ b/.agents/skills/plan-implementation.md
@@ -1,0 +1,21 @@
+---
+label: "Plan implementation"
+pill-order:
+  specifying: 8
+  implementing: 3
+jockey-hint: "Surface when the user wants a concrete checklist but hasn't yet started coding. Demote once a plan with a healthy checklist exists on the card."
+workhorse-version: 0.1.0
+---
+
+## Your task: Plan implementation
+
+Draft or refine the implementation checklist in the card's plan file. The plan turns the card's specs and any existing tech notes into a sequenced checklist of steps that `Implement this` can then work through.
+
+1. Read the card's specs and any existing plan at `.workhorse/plans/{card-id}/`
+2. Skim the target repo to ground the steps in the existing code
+3. If a plan already exists, edit it in place — add, refine, or reorder checklist sections around the existing prose notes. Don't replace notes
+4. If no plan exists, create one at `.workhorse/plans/{card-id}/plan.md` with an H1 title, a short summary, and one or more checklist sections
+5. Each checklist item should be a concrete step — a file to change, a feature to wire up, a migration to author. Avoid vague items like "add tests"
+6. Ask only the clarifying questions you genuinely need to produce a useful plan — the expectation is one or two turns, not an extended interview
+
+The plan is a free-form working document, not a spec — checkboxes describe build steps, not product behaviour. See `specs/plan/overview.md`.

--- a/.agents/skills/security-audit.md
+++ b/.agents/skills/security-audit.md
@@ -1,0 +1,14 @@
+---
+label: "Security audit"
+pill-order:
+  implementing: 5
+  reviewing: 5
+  complete: 4
+workhorse-version: 0.1.0
+---
+
+## Your task: Security audit
+
+Review the implementation for security concerns — the OWASP Top 10 and any other issues you find. Use your judgement about what matters for this code.
+
+Post findings grouped by severity with specific file references.

--- a/.agents/skills/spec-review.md
+++ b/.agents/skills/spec-review.md
@@ -1,0 +1,22 @@
+---
+label: "Review spec"
+pill-order:
+  specifying: 3
+workhorse-version: 0.1.0
+---
+
+## Your task: Review spec with fresh eyes
+
+Read the spec files in `specs/` that relate to this card and review them as if you were seeing them for the first time. Set aside the earlier conversation context and check that the specs stand on their own.
+
+Look for:
+
+- Gaps in acceptance criteria
+- Contradictions between specs
+- Missing edge cases
+- Unclear or ambiguous criteria
+- Information-architecture issues (content in the wrong spec)
+- Cross-spec impact (existing specs that should be updated)
+- Violations of the writing and structure conventions in `.agents/docs/spec-format.md`
+
+Be specific and constructive. Reference exact criteria when noting issues. Post findings as a structured message the user can work through with you — don't silently edit the specs in response to your own review.

--- a/.agents/skills/tech-design.md
+++ b/.agents/skills/tech-design.md
@@ -1,0 +1,22 @@
+---
+label: "Tech design"
+pill-order:
+  specifying: 7
+  implementing: 4
+jockey-hint: "Good fit when the user wants to talk through technical tradeoffs before committing to implementation. Demote once substantial tech notes are already in the plan unless the user signals a fresh area to workshop."
+workhorse-version: 0.1.0
+---
+
+## Your task: Tech design workshop
+
+Workshop the technical approach for this card interactively. The goal is to capture rationale, tradeoffs, and decisions into the card's plan file as prose notes.
+
+1. Read the card's specs and any existing plan at `.workhorse/plans/{card-id}/`
+2. Skim the relevant code in the target repo to anchor the conversation in what exists
+3. Surface the design choices that need making — architecture, data flow, component boundaries, migration steps — and ask the user focused questions one or two at a time
+4. As decisions land, write them into the plan as prose notes under clear section headings. Don't force a checklist yet — notes are fine on their own
+5. If no plan exists, create one at `.workhorse/plans/{card-id}/plan.md` — an H1 title, an optional summary, and sections of notes are enough for a first version
+
+The plan is a free-form working document, not a spec. It can carry a mix of tech design notes, refinement notes, and (later) a checklist of steps — see `specs/plan/overview.md` for the shape.
+
+Do not start implementation from this skill. This skill is for thinking and note-taking only.

--- a/.agents/skills/workshop.md
+++ b/.agents/skills/workshop.md
@@ -1,0 +1,22 @@
+---
+label: "Workshop this"
+pill-order:
+  not-started: 4
+  specifying: 10
+workhorse-version: 0.1.0
+---
+
+## Your task: Workshop ideas
+
+The user wants to explore and refine an idea. Help them think through approaches, trade-offs, and possibilities. Generate mockups when a visual would help illustrate a concept. This is exploratory — follow the user's curiosity rather than driving toward a specific output.
+
+### When generating mockups
+
+Source the visual language before writing any HTML — do not skip steps:
+
+a. **Read the actual implementation of the section being mocked** in the target repo. The shipped code is the baseline for how the screen really looks today — components, layout, spacing, copy. Start here so your output is grounded in what exists, not imagined from scratch
+b. **Read implementations of similar components** elsewhere in the target repo to pick up patterns for any new elements not yet present in the section
+c. **Cross-check against `.workhorse/design/`** — the design system, component docs, and philosophy notes. The design library may have been updated more recently than the code, so if it disagrees with the implementation, the design library wins
+d. **Do not reference mockups from other cards** under `.workhorse/design/mockups/` unless the user explicitly asks — they are point-in-time artefacts, not canonical components
+
+**Preserve unchanged aspects.** Author fresh HTML and CSS only for the feature or tweak you are exploring. For every other region of the screen, be visually faithful to the current implementation — same layout, components, copy, spacing, styling. Do not re-imagine, re-style, or re-layout regions the card is not changing, and do not let stale styling from mockups on other cards leak in. See "Preserving unchanged aspects" in your system prompt.

--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,17 @@
+<!-- BEGIN:workhorse -->
+# Workhorse framework
+
+This workspace uses [Workhorse](https://github.com/beyondessential/workhorse), a spec-driven development workbench. Workhorse ships skills (invokable prompts) and reference docs into this repo to shape how AI agents work here.
+
+- **Skills** live at `.agents/skills/` — each markdown file is one named skill, with YAML frontmatter and a prompt body. `.claude/skills/` is a symlink to the same folder so Claude Code picks them up natively
+- **Reference docs** live at `.agents/docs/` — long-form guidance that skill bodies cite by path (spec format conventions and similar)
+- **Specs** live at `.workhorse/specs/` (or the workspace's configured specs directory) — acceptance criteria for each piece of work
+
+When picking up a task, read the skill whose filename matches what you're being asked to do — it describes how to approach the work and which reference docs to follow.
+
+Workhorse plants this section on first adoption and never modifies it again. Edit or remove it freely.
+<!-- END:workhorse -->
+
 # Tamanu - Development Guidelines for AI Assistants
 
 This file contains rules and patterns that AI assistants should follow when working on this codebase.

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -59,6 +59,8 @@ const FormFooter = styled.div`
   background: white;
   padding: 8px 4px 2px;
   border-radius: 3px;
+  min-height: 44px;
+  box-sizing: border-box;
 `;
 
 const getDefaultRow = (getCurrentDate, orderedByUserId) => ({
@@ -181,27 +183,29 @@ export const InvoiceForm = ({ invoice, invoiceFormType, onClose, setInvoiceModal
                     );
                   })}
                 </Box>
-                {editable && (isReadOnlyForm || isAddForm) && (
+                {(isReadOnlyForm || isAddForm) && (
                   <FormFooter>
-                    <AddButton
-                      variant="text"
-                      onClick={() => {
-                        if (isReadOnlyForm) {
-                          setInvoiceModalType(INVOICE_MODAL_TYPES.ADD_ITEMS);
-                        } else {
-                          formArrayMethods.push(
-                            getDefaultRow(getCurrentDate, invoice.encounter?.examinerId),
-                          );
-                        }
-                      }}
-                      startIcon={<Plus />}
-                    >
-                      <TranslatedText
-                        stringId="invoice.form.action.addItem"
-                        fallback="Add item"
-                        data-testid="translatedtext-9vs0"
-                      />
-                    </AddButton>
+                    {editable && (
+                      <AddButton
+                        variant="text"
+                        onClick={() => {
+                          if (isReadOnlyForm) {
+                            setInvoiceModalType(INVOICE_MODAL_TYPES.ADD_ITEMS);
+                          } else {
+                            formArrayMethods.push(
+                              getDefaultRow(getCurrentDate, invoice.encounter?.examinerId),
+                            );
+                          }
+                        }}
+                        startIcon={<Plus />}
+                      >
+                        <TranslatedText
+                          stringId="invoice.form.action.addItem"
+                          fallback="Add item"
+                          data-testid="translatedtext-9vs0"
+                        />
+                      </AddButton>
+                    )}
                   </FormFooter>
                 )}
                 {editable && (isEditForm || isAddForm) && (


### PR DESCRIPTION
Adds bottom padding to the invoice items list in `InvoiceForm.jsx` so that when the invoice is finalised and the "Add item" button (via `FormFooter`) is hidden, there is still adequate visual spacing between the last item and the "Record payment" button below. Previously, the "Add item" button was incidentally providing that breathing room, so its absence on finalised invoices caused the layout to feel cramped, especially when a long item name wrapped to two lines.

The diff also includes a collection of agent skill and documentation files (`.agents/`, `AGENTS.md`) added to the repository, unrelated to the UI fix.

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->