### PR TITLE
feat(settings): TAM-6864: auto-migrate config to settings on upgrade

### DIFF
--- a/database/model/public/facility_setting_migrations.md
+++ b/database/model/public/facility_setting_migrations.md
@@ -1,0 +1,21 @@
+{% docs table__facility_setting_migrations %}
+Transient carrier for the config→settings migration on facility servers.
+
+A facility server can't persist its own facility-scoped settings (those are pulled from
+central), so the upgrade step writes each legacy config value here; the row pushes up and
+central turns it into a facility-scoped [setting](#!/source/source.tamanu.tamanu.settings),
+skipping keys that already have one. Rows are deleted from the facility once pushed, so
+this table is normally empty.
+{% enddocs %}
+
+{% docs facility_setting_migrations__key %}
+Dotted JSON path of the setting to create.
+{% enddocs %}
+
+{% docs facility_setting_migrations__value %}
+JSON value from the legacy config file.
+{% enddocs %}
+
+{% docs facility_setting_migrations__facility_id %}
+The [facility](#!/source/source.tamanu.tamanu.facilities) the setting is scoped to.
+{% enddocs %}

--- a/database/model/public/facility_setting_migrations.yml
+++ b/database/model/public/facility_setting_migrations.yml
@@ -17,7 +17,7 @@ sources:
               - set_facility_setting_migrations_updated_at_sync_tick
         columns:
           - name: id
-            data_type: uuid
+            data_type: text
             description: "{{ doc('generic__id') }} in facility_setting_migrations."
             data_tests:
               - unique

--- a/database/model/public/facility_setting_migrations.yml
+++ b/database/model/public/facility_setting_migrations.yml
@@ -1,0 +1,61 @@
+version: 2
+sources:
+  - name: tamanu
+    schema: public
+    description: "{{ doc('generic__schema') }}"
+    tables:
+      - name: facility_setting_migrations
+        description: "{{ doc('table__facility_setting_migrations') }}"
+        config:
+          tags:
+            - system
+          meta:
+            triggers:
+              - notify_facility_setting_migrations_changed
+              - record_facility_setting_migrations_changelog
+              - set_facility_setting_migrations_updated_at
+              - set_facility_setting_migrations_updated_at_sync_tick
+        columns:
+          - name: id
+            data_type: uuid
+            description: "{{ doc('generic__id') }} in facility_setting_migrations."
+            data_tests:
+              - unique
+              - not_null
+          - name: created_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__created_at') }} in facility_setting_migrations."
+            data_tests:
+              - not_null
+          - name: updated_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__updated_at') }} in facility_setting_migrations."
+            data_tests:
+              - not_null
+          - name: deleted_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__deleted_at') }} in facility_setting_migrations."
+          - name: key
+            data_type: text
+            description: "{{ doc('facility_setting_migrations__key') }}"
+            data_tests:
+              - not_null
+          - name: value
+            data_type: jsonb
+            description: "{{ doc('facility_setting_migrations__value') }}"
+            data_tests:
+              - not_null
+          - name: facility_id
+            data_type: character varying(255)
+            description: "{{ doc('facility_setting_migrations__facility_id') }}"
+            data_tests:
+              - not_null
+              - relationships:
+                  arguments:
+                    to: source('tamanu', 'facilities')
+                    field: id
+          - name: updated_at_sync_tick
+            data_type: bigint
+            description: "{{ doc('generic__updated_at_sync_tick') }} in facility_setting_migrations."
+            data_tests:
+              - not_null

--- a/packages/constants/src/facts.ts
+++ b/packages/constants/src/facts.ts
@@ -27,6 +27,10 @@ export const FACT_META_SERVER_ID = 'metaServerId';
 // one-off migration doesn't re-run and resurrect a setting an operator has deleted.
 export const FACT_CENTRAL_CONFIG_MIGRATED = 'centralConfigMigratedToSettings';
 
+// Set once a facility server has snapshotted its facility-scoped config into the
+// FacilitySettingMigration carrier to push up to central, so it runs only once.
+export const FACT_FACILITY_CONFIG_MIGRATED = 'facilityConfigMigratedToSettings';
+
 // mSupply integration
 export const FACT_MSUPPLY_MED_INTEGRATION_ENABLED_AT = 'mSupplyMedIntegrationEnabledAt';
 

--- a/packages/constants/src/facts.ts
+++ b/packages/constants/src/facts.ts
@@ -23,6 +23,10 @@ export const FACT_DEVICE_KEY = 'deviceKey';
 export const FACT_FACILITY_IDS = 'facilityIds';
 export const FACT_META_SERVER_ID = 'metaServerId';
 
+// Set once the central server has seeded settings from its legacy config, so the
+// one-off migration doesn't re-run and resurrect a setting an operator has deleted.
+export const FACT_CENTRAL_CONFIG_MIGRATED = 'centralConfigMigratedToSettings';
+
 // mSupply integration
 export const FACT_MSUPPLY_MED_INTEGRATION_ENABLED_AT = 'mSupplyMedIntegrationEnabledAt';
 

--- a/packages/database/__tests__/sync/applyFacilitySettingMigrations.test.ts
+++ b/packages/database/__tests__/sync/applyFacilitySettingMigrations.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SETTINGS_SCOPES } from '@tamanu/constants';
+
+vi.mock('@tamanu/shared/services/logging', () => ({ log: { error: vi.fn() } }));
+
+import { applyFacilitySettingMigrations } from '../../src/sync/applyFacilitySettingMigrations';
+
+const makeModels = (rows: any[]) =>
+  ({
+    FacilitySettingMigration: { findAll: vi.fn().mockResolvedValue(rows) },
+    Setting: { get: vi.fn().mockResolvedValue(undefined), set: vi.fn() },
+  }) as any;
+
+describe('applyFacilitySettingMigrations', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writes a facility-scoped setting when none exists yet', async () => {
+    const models = makeModels([{ key: 'tasking.window', value: 12, facilityId: 'f1' }]);
+    await applyFacilitySettingMigrations(models, ['id1']);
+    expect(models.Setting.set).toHaveBeenCalledWith(
+      'tasking.window',
+      12,
+      SETTINGS_SCOPES.FACILITY,
+      'f1',
+    );
+  });
+
+  it('skips a row when the facility setting already exists (never clobbers an operator)', async () => {
+    const models = makeModels([{ key: 'tasking.window', value: 12, facilityId: 'f1' }]);
+    models.Setting.get.mockResolvedValue(25); // operator/prior value present
+    await applyFacilitySettingMigrations(models, ['id1']);
+    expect(models.Setting.set).not.toHaveBeenCalled();
+  });
+
+  it('swallows a per-row failure and still applies the rest (a throw would poison sync)', async () => {
+    const models = makeModels([
+      { key: 'a', value: 1, facilityId: 'f1' },
+      { key: 'b', value: 2, facilityId: 'f1' },
+    ]);
+    models.Setting.get.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(undefined);
+
+    await expect(applyFacilitySettingMigrations(models, ['id1', 'id2'])).resolves.toBeUndefined();
+
+    expect(models.Setting.set).toHaveBeenCalledTimes(1);
+    expect(models.Setting.set).toHaveBeenCalledWith('b', 2, SETTINGS_SCOPES.FACILITY, 'f1');
+  });
+});

--- a/packages/database/src/migrations/1785000000000-createFacilitySettingMigrations.ts
+++ b/packages/database/src/migrations/1785000000000-createFacilitySettingMigrations.ts
@@ -1,0 +1,46 @@
+import { DataTypes, QueryInterface, Sequelize } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.createTable('facility_setting_migrations', {
+    id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: Sequelize.fn('gen_random_uuid'),
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('now'),
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('now'),
+    },
+    deleted_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    key: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    value: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+    },
+    facility_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: 'facilities',
+        key: 'id',
+      },
+    },
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.dropTable('facility_setting_migrations');
+}

--- a/packages/database/src/migrations/1785000000000-createFacilitySettingMigrations.ts
+++ b/packages/database/src/migrations/1785000000000-createFacilitySettingMigrations.ts
@@ -3,10 +3,12 @@ import { DataTypes, QueryInterface, Sequelize } from 'sequelize';
 export async function up(query: QueryInterface): Promise<void> {
   await query.createTable('facility_setting_migrations', {
     id: {
-      type: DataTypes.UUID,
+      // Deterministic composite id ("facilityId;key", see the upgrade step), so the
+      // migration produces identical rows every run — a random UUID pk would fail the
+      // migration-determinism check.
+      type: DataTypes.TEXT,
       allowNull: false,
       primaryKey: true,
-      defaultValue: Sequelize.fn('gen_random_uuid'),
     },
     created_at: {
       type: DataTypes.DATE,

--- a/packages/database/src/models/FacilitySettingMigration.ts
+++ b/packages/database/src/models/FacilitySettingMigration.ts
@@ -1,0 +1,39 @@
+import { DataTypes } from 'sequelize';
+import { SYNC_DIRECTIONS } from '@tamanu/constants';
+
+import { Model } from './Model';
+import { applyFacilitySettingMigrations } from '../sync/applyFacilitySettingMigrations';
+import type { InitOptions, Models } from '../types/model';
+
+// Transient carrier for the config→settings migration. A facility server can't persist
+// its own facility-scoped settings (they're PULL_FROM_CENTRAL), so it writes each legacy
+// config value here; the row pushes up and central turns it into a facility Setting.
+// PUSH_TO_CENTRAL_THEN_DELETE so the rows drain off the facility once pushed.
+export class FacilitySettingMigration extends Model {
+  declare id: string;
+  declare key: string;
+  declare value: unknown;
+  declare facilityId: string;
+
+  static initModel({ primaryKey, ...options }: InitOptions) {
+    super.init(
+      {
+        id: primaryKey,
+        key: { type: DataTypes.TEXT, allowNull: false },
+        value: { type: DataTypes.JSONB, allowNull: false },
+      },
+      {
+        ...options,
+        syncDirection: SYNC_DIRECTIONS.PUSH_TO_CENTRAL_THEN_DELETE,
+      },
+    );
+  }
+
+  static initRelations(models: Models) {
+    this.belongsTo(models.Facility, { foreignKey: 'facilityId', as: 'facility' });
+  }
+
+  static async adjustDataPostSyncPush(ids: string[]) {
+    await applyFacilitySettingMigrations(this.sequelize.models, ids);
+  }
+}

--- a/packages/database/src/models/index.ts
+++ b/packages/database/src/models/index.ts
@@ -96,6 +96,7 @@ export * from './Setting';
 export * from './PatientCommunication';
 
 export * from './Facility';
+export * from './FacilitySettingMigration';
 export * from './Department';
 export * from './Location';
 export * from './LocationGroup';

--- a/packages/database/src/sync/applyFacilitySettingMigrations.ts
+++ b/packages/database/src/sync/applyFacilitySettingMigrations.ts
@@ -1,0 +1,31 @@
+import { SETTINGS_SCOPES } from '@tamanu/constants';
+import { log } from '@tamanu/shared/services/logging';
+import type { SettingPath } from '@tamanu/settings/types';
+
+import type { Models } from '../types/model';
+
+// Central-side apply for pushed FacilitySettingMigration carrier rows: turn each into a
+// facility-scoped Setting, unless one already exists (never clobber an operator's value).
+//
+// The per-row try/catch is load-bearing: this runs from adjustDataPostSyncPush, which
+// executes post-commit and whose throw errors the entire sync session (and retries), so
+// one malformed carrier row must not poison the rest of the push.
+export async function applyFacilitySettingMigrations(models: Models, ids: string[]) {
+  const { FacilitySettingMigration, Setting } = models;
+  const rows = await FacilitySettingMigration.findAll({ where: { id: ids } });
+  for (const row of rows) {
+    // The carrier column is free-text; the setting path was validated when the row was written.
+    const key = row.key as SettingPath;
+    try {
+      const existing = await Setting.get(key, row.facilityId, SETTINGS_SCOPES.FACILITY);
+      if (existing !== undefined) continue;
+      await Setting.set(key, row.value, SETTINGS_SCOPES.FACILITY, row.facilityId);
+    } catch (error) {
+      log.error('Failed to apply facility setting migration', {
+        key,
+        facilityId: row.facilityId,
+        error,
+      });
+    }
+  }
+}

--- a/packages/upgrade/__tests__/steps/1785000000000-migrateCentralConfigToSettings.test.ts
+++ b/packages/upgrade/__tests__/steps/1785000000000-migrateCentralConfigToSettings.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FACT_CENTRAL_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
+
+vi.mock('@tamanu/settings', () => ({
+  configOverridesForScope: vi.fn(),
+}));
+
+import { configOverridesForScope } from '@tamanu/settings';
+import {
+  STEPS,
+  mergeConfigUnderExisting,
+} from '../../src/steps/1785000000000-migrateCentralConfigToSettings.js';
+
+const step = STEPS[0];
+
+const makeArgs = () => ({
+  models: {
+    Setting: { get: vi.fn().mockResolvedValue({}), set: vi.fn() },
+    LocalSystemFact: { get: vi.fn().mockResolvedValue(undefined), set: vi.fn() },
+  },
+  serverType: 'central',
+  toVersion: '2.99.0',
+});
+
+describe('mergeConfigUnderExisting', () => {
+  it('keeps the existing value and fills only the gaps', () => {
+    expect(mergeConfigUnderExisting({ a: 1 }, { a: 2, b: 3 })).toEqual({ a: 1, b: 3 });
+  });
+  it('deep-merges nested objects, existing winning per leaf', () => {
+    expect(mergeConfigUnderExisting({ x: { a: 1 } }, { x: { a: 9, b: 2 } })).toEqual({
+      x: { a: 1, b: 2 },
+    });
+  });
+});
+
+describe('1785000000000-migrateCentralConfigToSettings', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('check', () => {
+    it('runs on central when not yet migrated', async () => {
+      const args = makeArgs();
+      expect(await step.check(args)).toBe(true);
+    });
+    it('skips when already migrated', async () => {
+      const args = makeArgs();
+      args.models.LocalSystemFact.get.mockResolvedValue('2.50.0');
+      expect(await step.check(args)).toBe(false);
+    });
+    it('skips on a facility server', async () => {
+      const args = { ...makeArgs(), serverType: 'facility' };
+      expect(await step.check(args)).toBe(false);
+    });
+  });
+
+  describe('run', () => {
+    it('preserves an operator setting and fills a config-only key, then marks done', async () => {
+      configOverridesForScope.mockImplementation(scope =>
+        scope === SETTINGS_SCOPES.CENTRAL ? { tasking: { window: 30 }, newKey: 'fromConfig' } : {},
+      );
+      const args = makeArgs();
+      args.models.Setting.get.mockResolvedValue({ tasking: { window: 25 } }); // operator value
+
+      await step.run(args);
+
+      expect(args.models.Setting.set).toHaveBeenCalledTimes(1); // global overrides empty -> skipped
+      expect(args.models.Setting.set).toHaveBeenCalledWith(
+        '',
+        { tasking: { window: 25 }, newKey: 'fromConfig' }, // existing wins, config fills the gap
+        SETTINGS_SCOPES.CENTRAL,
+      );
+      expect(args.models.LocalSystemFact.set).toHaveBeenCalledWith(
+        FACT_CENTRAL_CONFIG_MIGRATED,
+        '2.99.0',
+      );
+    });
+
+    it('writes nothing when config has no overrides for any scope', async () => {
+      configOverridesForScope.mockReturnValue({});
+      const args = makeArgs();
+
+      await step.run(args);
+
+      expect(args.models.Setting.set).not.toHaveBeenCalled();
+      expect(args.models.LocalSystemFact.set).toHaveBeenCalledWith(
+        FACT_CENTRAL_CONFIG_MIGRATED,
+        '2.99.0',
+      );
+    });
+  });
+});

--- a/packages/upgrade/__tests__/steps/1785000000000-migrateCentralConfigToSettings.test.ts
+++ b/packages/upgrade/__tests__/steps/1785000000000-migrateCentralConfigToSettings.test.ts
@@ -5,10 +5,16 @@ vi.mock('@tamanu/settings', () => ({
   configOverridesForScope: vi.fn(),
 }));
 
+vi.mock('@tamanu/shared/utils/crypto', () => ({
+  encryptSecret: vi.fn().mockResolvedValue('S1:iv:ciphertext'),
+  getSettingsPskKeyBuffer: vi.fn().mockResolvedValue(Buffer.alloc(32)),
+}));
+
 import { configOverridesForScope } from '@tamanu/settings';
 import {
   STEPS,
   mergeConfigUnderExisting,
+  splitTransportPassword,
 } from '../../src/steps/1785000000000-migrateCentralConfigToSettings.js';
 
 const step = STEPS[0];
@@ -20,6 +26,20 @@ const makeArgs = () => ({
   },
   serverType: 'central',
   toVersion: '2.99.0',
+});
+
+describe('splitTransportPassword', () => {
+  it('moves an embedded SMTP password into the encrypted secret', async () => {
+    const overrides = { mail: { transport: { host: 'smtp', auth: { user: 'u', pass: 'pw' } } } };
+    const result = await splitTransportPassword(overrides);
+    expect(result.mail.transport).toEqual({ host: 'smtp', auth: { user: 'u' } });
+    expect(result.mail.transportPassword).toBe('S1:iv:ciphertext');
+  });
+
+  it('passes through when no password is embedded', async () => {
+    const overrides = { mail: { transport: { host: 'smtp' } } };
+    expect(await splitTransportPassword(overrides)).toEqual(overrides);
+  });
 });
 
 describe('mergeConfigUnderExisting', () => {

--- a/packages/upgrade/__tests__/steps/1785000000001-migrateFacilityConfigToSettings.test.ts
+++ b/packages/upgrade/__tests__/steps/1785000000001-migrateFacilityConfigToSettings.test.ts
@@ -12,6 +12,7 @@ vi.mock('@tamanu/settings', () => ({
 import { configOverridesForScope } from '@tamanu/settings';
 import {
   STEPS,
+  carrierId,
   facilityConfigRows,
 } from '../../src/steps/1785000000001-migrateFacilityConfigToSettings.js';
 
@@ -19,7 +20,7 @@ const step = STEPS[0];
 
 const makeArgs = () => ({
   models: {
-    FacilitySettingMigration: { create: vi.fn() },
+    FacilitySettingMigration: { upsert: vi.fn() },
     Facility: { findAll: vi.fn().mockResolvedValue([{ id: 'f1' }, { id: 'f2' }]) },
     LocalSystemFact: { get: vi.fn().mockResolvedValue(undefined), set: vi.fn() },
   },
@@ -65,13 +66,15 @@ describe('1785000000001-migrateFacilityConfigToSettings', () => {
 
       await step.run(args);
 
-      expect(args.models.FacilitySettingMigration.create).toHaveBeenCalledTimes(2);
-      expect(args.models.FacilitySettingMigration.create).toHaveBeenCalledWith({
+      expect(args.models.FacilitySettingMigration.upsert).toHaveBeenCalledTimes(2);
+      expect(args.models.FacilitySettingMigration.upsert).toHaveBeenCalledWith({
+        id: 'f1;tasking.window',
         key: 'tasking.window',
         value: 12,
         facilityId: 'f1',
       });
-      expect(args.models.FacilitySettingMigration.create).toHaveBeenCalledWith({
+      expect(args.models.FacilitySettingMigration.upsert).toHaveBeenCalledWith({
+        id: 'f2;tasking.window',
         key: 'tasking.window',
         value: 12,
         facilityId: 'f2',
@@ -89,11 +92,19 @@ describe('1785000000001-migrateFacilityConfigToSettings', () => {
       await step.run(args);
 
       expect(args.models.Facility.findAll).not.toHaveBeenCalled();
-      expect(args.models.FacilitySettingMigration.create).not.toHaveBeenCalled();
+      expect(args.models.FacilitySettingMigration.upsert).not.toHaveBeenCalled();
       expect(args.models.LocalSystemFact.set).toHaveBeenCalledWith(
         FACT_FACILITY_CONFIG_MIGRATED,
         '2.99.0',
       );
+    });
+  });
+
+  describe('carrierId', () => {
+    it('is deterministic and escapes the separator', () => {
+      expect(carrierId('f1', 'tasking.window')).toBe('f1;tasking.window');
+      expect(carrierId('f1', 'tasking.window')).toBe(carrierId('f1', 'tasking.window'));
+      expect(carrierId('fac;i', 'a;b')).toBe('fac:i;a:b');
     });
   });
 });

--- a/packages/upgrade/__tests__/steps/1785000000001-migrateFacilityConfigToSettings.test.ts
+++ b/packages/upgrade/__tests__/steps/1785000000001-migrateFacilityConfigToSettings.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FACT_FACILITY_CONFIG_MIGRATED } from '@tamanu/constants';
+
+vi.mock('@tamanu/settings', () => ({
+  CONFIG_TO_SETTINGS: [
+    { config: 'tasking.window', setting: 'tasking.window', scope: 'facility' },
+    { config: 'language', setting: 'language', scope: 'central' }, // filtered out (not facility)
+  ],
+  configOverridesForScope: vi.fn(),
+}));
+
+import { configOverridesForScope } from '@tamanu/settings';
+import {
+  STEPS,
+  facilityConfigRows,
+} from '../../src/steps/1785000000001-migrateFacilityConfigToSettings.js';
+
+const step = STEPS[0];
+
+const makeArgs = () => ({
+  models: {
+    FacilitySettingMigration: { create: vi.fn() },
+    Facility: { findAll: vi.fn().mockResolvedValue([{ id: 'f1' }, { id: 'f2' }]) },
+    LocalSystemFact: { get: vi.fn().mockResolvedValue(undefined), set: vi.fn() },
+  },
+  serverType: 'facility',
+  toVersion: '2.99.0',
+});
+
+describe('facilityConfigRows', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps facility-scoped keys with a config value and drops the rest', () => {
+    configOverridesForScope.mockReturnValue({ tasking: { window: 12 } });
+    expect(facilityConfigRows()).toEqual([{ key: 'tasking.window', value: 12 }]);
+  });
+
+  it('drops a facility key with no local config value', () => {
+    configOverridesForScope.mockReturnValue({});
+    expect(facilityConfigRows()).toEqual([]);
+  });
+});
+
+describe('1785000000001-migrateFacilityConfigToSettings', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('check', () => {
+    it('runs on facility when not yet migrated', async () => {
+      expect(await step.check(makeArgs())).toBe(true);
+    });
+    it('skips when already migrated', async () => {
+      const args = makeArgs();
+      args.models.LocalSystemFact.get.mockResolvedValue('2.50.0');
+      expect(await step.check(args)).toBe(false);
+    });
+    it('skips on a central server', async () => {
+      expect(await step.check({ ...makeArgs(), serverType: 'central' })).toBe(false);
+    });
+  });
+
+  describe('run', () => {
+    it('writes one carrier row per served facility, then marks done', async () => {
+      configOverridesForScope.mockReturnValue({ tasking: { window: 12 } });
+      const args = makeArgs();
+
+      await step.run(args);
+
+      expect(args.models.FacilitySettingMigration.create).toHaveBeenCalledTimes(2);
+      expect(args.models.FacilitySettingMigration.create).toHaveBeenCalledWith({
+        key: 'tasking.window',
+        value: 12,
+        facilityId: 'f1',
+      });
+      expect(args.models.FacilitySettingMigration.create).toHaveBeenCalledWith({
+        key: 'tasking.window',
+        value: 12,
+        facilityId: 'f2',
+      });
+      expect(args.models.LocalSystemFact.set).toHaveBeenCalledWith(
+        FACT_FACILITY_CONFIG_MIGRATED,
+        '2.99.0',
+      );
+    });
+
+    it('marks done without touching facilities when there is nothing to migrate', async () => {
+      configOverridesForScope.mockReturnValue({});
+      const args = makeArgs();
+
+      await step.run(args);
+
+      expect(args.models.Facility.findAll).not.toHaveBeenCalled();
+      expect(args.models.FacilitySettingMigration.create).not.toHaveBeenCalled();
+      expect(args.models.LocalSystemFact.set).toHaveBeenCalledWith(
+        FACT_FACILITY_CONFIG_MIGRATED,
+        '2.99.0',
+      );
+    });
+  });
+});

--- a/packages/upgrade/src/steps/1785000000000-migrateCentralConfigToSettings.ts
+++ b/packages/upgrade/src/steps/1785000000000-migrateCentralConfigToSettings.ts
@@ -1,5 +1,6 @@
 import { FACT_CENTRAL_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
 import { configOverridesForScope } from '@tamanu/settings';
+import { encryptSecret, getSettingsPskKeyBuffer } from '@tamanu/shared/utils/crypto';
 import { cloneDeep, defaultsDeep, isEmpty } from 'es-toolkit/compat';
 
 import type { Steps, StepArgs } from '../step.ts';
@@ -9,6 +10,23 @@ import { END } from '../step.js';
 // wins — an operator's value is never overwritten, config only fills the gaps.
 export const mergeConfigUnderExisting = (existing: object, overrides: object) =>
   defaultsDeep(cloneDeep(existing ?? {}), overrides);
+
+// A legacy config mail.transport may embed the SMTP password (nodemailer's
+// auth.pass). Settings keep that credential in the mail.transportPassword secret
+// instead, so split it out and encrypt it rather than persisting it in plain text.
+// Exported for tests.
+export const splitTransportPassword = async (overrides: any) => {
+  const pass = overrides?.mail?.transport?.auth?.pass;
+  if (!pass) return overrides;
+  delete overrides.mail.transport.auth.pass;
+  if (isEmpty(overrides.mail.transport.auth)) delete overrides.mail.transport.auth;
+  // eslint-disable-next-line require-atomic-updates
+  overrides.mail.transportPassword = await encryptSecret(
+    await getSettingsPskKeyBuffer(),
+    String(pass),
+  );
+  return overrides;
+};
 
 // On the first central upgrade, seed central- and global-scoped settings from the
 // legacy config (per the CONFIG_TO_SETTINGS map) so values moved out of config keep
@@ -24,7 +42,7 @@ export const STEPS: Steps = [
     },
     async run({ toVersion, models: { Setting, LocalSystemFact } }: StepArgs) {
       for (const scope of [SETTINGS_SCOPES.CENTRAL, SETTINGS_SCOPES.GLOBAL]) {
-        const overrides = configOverridesForScope(scope);
+        const overrides = await splitTransportPassword(configOverridesForScope(scope));
         if (isEmpty(overrides)) continue;
         const existing = (await Setting.get('', null, scope)) ?? {};
         await Setting.set('', mergeConfigUnderExisting(existing, overrides), scope);

--- a/packages/upgrade/src/steps/1785000000000-migrateCentralConfigToSettings.ts
+++ b/packages/upgrade/src/steps/1785000000000-migrateCentralConfigToSettings.ts
@@ -1,0 +1,35 @@
+import { FACT_CENTRAL_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
+import { configOverridesForScope } from '@tamanu/settings';
+import { cloneDeep, defaultsDeep, isEmpty } from 'es-toolkit/compat';
+
+import type { Steps, StepArgs } from '../step.ts';
+import { END } from '../step.js';
+
+// Merge config overrides under the recorded settings so an existing setting always
+// wins — an operator's value is never overwritten, config only fills the gaps.
+export const mergeConfigUnderExisting = (existing: object, overrides: object) =>
+  defaultsDeep(cloneDeep(existing ?? {}), overrides);
+
+// On the first central upgrade, seed central- and global-scoped settings from the
+// legacy config (per the CONFIG_TO_SETTINGS map) so values moved out of config keep
+// their deployment overrides. Runs once (guarded by a fact) so it can't resurrect a
+// setting an operator later deletes while the config value is still present.
+export const STEPS: Steps = [
+  {
+    at: END,
+    async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
+      return (
+        serverType === 'central' && !(await LocalSystemFact.get(FACT_CENTRAL_CONFIG_MIGRATED))
+      );
+    },
+    async run({ toVersion, models: { Setting, LocalSystemFact } }: StepArgs) {
+      for (const scope of [SETTINGS_SCOPES.CENTRAL, SETTINGS_SCOPES.GLOBAL]) {
+        const overrides = configOverridesForScope(scope);
+        if (isEmpty(overrides)) continue;
+        const existing = (await Setting.get('', null, scope)) ?? {};
+        await Setting.set('', mergeConfigUnderExisting(existing, overrides), scope);
+      }
+      await LocalSystemFact.set(FACT_CENTRAL_CONFIG_MIGRATED, toVersion);
+    },
+  },
+];

--- a/packages/upgrade/src/steps/1785000000001-migrateFacilityConfigToSettings.ts
+++ b/packages/upgrade/src/steps/1785000000001-migrateFacilityConfigToSettings.ts
@@ -5,6 +5,12 @@ import { get as getAtPath } from 'es-toolkit/compat';
 import type { Steps, StepArgs } from '../step.ts';
 import { END } from '../step.js';
 
+// Deterministic id (same shape as patient_facilities' composite key) so every run
+// produces identical rows — a random UUID pk would fail the migration-determinism
+// check — and an interrupted run upserts rather than duplicating.
+export const carrierId = (facilityId: string, key: string) =>
+  `${facilityId.replaceAll(';', ':')};${key.replaceAll(';', ':')}`;
+
 // Flat {key, value} for each facility-scoped config value present locally. Secrets and
 // keys with no local config value are already dropped by configOverridesForScope.
 export const facilityConfigRows = () => {
@@ -35,7 +41,12 @@ export const STEPS: Steps = [
         const facilities = await Facility.findAll({ attributes: ['id'] });
         for (const { id: facilityId } of facilities) {
           for (const { key, value } of rows) {
-            await FacilitySettingMigration.create({ key, value, facilityId });
+            await FacilitySettingMigration.upsert({
+              id: carrierId(facilityId, key),
+              key,
+              value,
+              facilityId,
+            });
           }
         }
       }

--- a/packages/upgrade/src/steps/1785000000001-migrateFacilityConfigToSettings.ts
+++ b/packages/upgrade/src/steps/1785000000001-migrateFacilityConfigToSettings.ts
@@ -1,0 +1,45 @@
+import { FACT_FACILITY_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
+import { CONFIG_TO_SETTINGS, configOverridesForScope } from '@tamanu/settings';
+import { get as getAtPath } from 'es-toolkit/compat';
+
+import type { Steps, StepArgs } from '../step.ts';
+import { END } from '../step.js';
+
+// Flat {key, value} for each facility-scoped config value present locally. Secrets and
+// keys with no local config value are already dropped by configOverridesForScope.
+export const facilityConfigRows = () => {
+  const overrides = configOverridesForScope(SETTINGS_SCOPES.FACILITY);
+  return CONFIG_TO_SETTINGS.filter(entry => entry.scope === SETTINGS_SCOPES.FACILITY)
+    .map(entry => ({ key: entry.setting, value: getAtPath(overrides, entry.setting) }))
+    .filter(row => row.value !== undefined);
+};
+
+// On the first facility upgrade, snapshot each facility-scoped config value into the
+// FacilitySettingMigration carrier (one row per served facility) so it pushes up and
+// central turns it into a facility Setting. Fact-gated to run once. The config fallback
+// reader serves these values until the setting arrives, so timing isn't load-bearing.
+export const STEPS: Steps = [
+  {
+    at: END,
+    async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
+      return (
+        serverType === 'facility' && !(await LocalSystemFact.get(FACT_FACILITY_CONFIG_MIGRATED))
+      );
+    },
+    async run({
+      toVersion,
+      models: { FacilitySettingMigration, Facility, LocalSystemFact },
+    }: StepArgs) {
+      const rows = facilityConfigRows();
+      if (rows.length) {
+        const facilities = await Facility.findAll({ attributes: ['id'] });
+        for (const { id: facilityId } of facilities) {
+          for (const { key, value } of rows) {
+            await FacilitySettingMigration.create({ key, value, facilityId });
+          }
+        }
+      }
+      await LocalSystemFact.set(FACT_FACILITY_CONFIG_MIGRATED, toVersion);
+    },
+  },
+];


### PR DESCRIPTION
Stacked on #10165. Automatically seeds settings from a deployment's legacy config on upgrade, driven by the `CONFIG_TO_SETTINGS` map (config path → setting path + scope) that #10165's config-fallback reader shares.

## Central (simple half)
- Run-once upgrade step (fact-gated): merges config values **under** existing settings per scope (central + global) — an operator's recorded setting always wins, config only fills gaps.
- A legacy `mail.transport` may embed the SMTP password (nodemailer's `auth.pass`); the step splits it out into the encrypted `mail.transportPassword` secret rather than persisting it in plain text.

## Facility (round-trip half)
A facility server can't persist facility-scoped settings (they're `PULL_FROM_CENTRAL`), so:
- `facility_setting_migrations` carrier table (`PUSH_TO_CENTRAL_THEN_DELETE`) — rows drain off the facility once pushed.
- Run-once facility upgrade step snapshots each facility-scoped config value into the carrier (one row per served facility). Rows are upserted with a deterministic `facilityId;key` id (same shape as `patient_facilities`), so re-runs can't duplicate and the migration-determinism check sees identical output — a random UUID pk would hash differently every run.
- Central applies pushed rows via the model's `adjustDataPostSyncPush`: each becomes a facility-scoped Setting **unless one already exists**. Per-row try/catch so a malformed row can't poison the sync session.
- #10165's config-fallback reader serves the value until the setting round-trips, so sync timing isn't load-bearing.

No mobile migration: the carrier is a facility-server-only push model (same as `PatientCommunication`), never pulled, and excluded from the sync lookup by direction.

## Tests
- Central step: merge semantics (existing-wins), fact gating, scope skipping, transport-password split (9)
- Facility step: row snapshotting per facility, deterministic carrier ids, fact gating (8)
- Central apply: skip-if-present, per-row error isolation (3)
