### PR TITLE
fix(reporting): TAM-6862: degrade when reporting init fails

### DIFF
--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -91,7 +91,18 @@ export class ApplicationContext {
 
     this.emailService = new EmailService();
 
-    this.reportSchemaStores = await initReporting(this.store);
+    try {
+      this.reportSchemaStores = await initReporting(this.store);
+    } catch (error) {
+      // Reporting requires the app db role to manage the reporting roles (see
+      // ensureReportingRole). On an under-provisioned database that fails; the
+      // rest of the server works without reporting, so degrade instead of
+      // crash-looping the whole deployment.
+      log.error(
+        'initReporting failed; reporting schemas unavailable until the db grants are fixed',
+        { error },
+      );
+    }
 
     if (appType === CENTRAL_SERVER_APP_TYPES.API) {
       this.aiService = await AIService.init({

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -2,7 +2,7 @@ import config from 'config';
 import { omit } from 'es-toolkit/compat';
 
 import { initReporting } from '@tamanu/database/services/reporting';
-import { initBugsnag } from '@tamanu/shared/services/logging';
+import { initBugsnag, log } from '@tamanu/shared/services/logging';
 import { ReadSettings } from '@tamanu/settings/reader';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { initFhirSettingsFromDb } from '@tamanu/shared/utils/fhir/fhirSettings';
@@ -75,7 +75,18 @@ export class ApplicationContext {
 
   // Call after migrations: reporting reads its per-server secret from local_system_facts.
   async initReportingStores() {
-    this.reportSchemaStores = await initReporting(this.store);
+    try {
+      this.reportSchemaStores = await initReporting(this.store);
+    } catch (error) {
+      // Reporting requires the app db role to manage the reporting roles (see
+      // ensureReportingRole). On an under-provisioned database that fails; the
+      // rest of the server works without reporting, so degrade instead of
+      // crash-looping the whole deployment.
+      log.error(
+        'initReporting failed; reporting schemas unavailable until the db grants are fixed',
+        { error },
+      );
+    }
   }
 
   onClose(hook) {


### PR DESCRIPTION
### Changes

TAM-6862's always-on reporting-role bootstrap hard-fails server boot when the `app` db role can't manage the reporting roles — on Postgres 16+ altering an *existing* role needs ADMIN on it, not just CREATEROLE, and under-provisioned databases (e.g. PR-deploy clusters before ops#235's grants) lack that. The result is the whole central/facility deployment crash-looping on `Failed to set password for reporting role "tamanu_reporting": permission denied to alter role`.

Running without reporting schemas was a supported configuration before the roles became self-managed, so `initReporting` failure now logs a prominent error and the server continues with reporting unavailable, instead of taking the deployment down.

Observed on the tam-6864 PR-deploy: facility pods crash-looping with exactly this error ([deploy run](https://github.com/beyondessential/tamanu/actions/runs/28563280205)).

### Notes
- **Tests** — behaviour change is a try/catch degrade; existing reporting tests (provisioned DBs) unaffected.
- **Manual upgrade / deployment** — none; strictly more tolerant.