### PR TITLE
chore(agents): no-issue: Pull latest workhorse stuff

### DIFF
--- a/.agents/docs/card-context.md
+++ b/.agents/docs/card-context.md
@@ -1,0 +1,28 @@
+---
+workhorse-version: 0.1.0
+---
+
+# Establishing card context outside Workhorse
+
+Skills are discovered natively by Claude Code, so they can be invoked in an external tool with no Workhorse session around them. Inside Workhorse the system prompt injects the card's context — its title, identifier, and description. Outside it, that context is absent, and a skill that needs to know which card it is working on has to establish that context before doing its work.
+
+Follow this process whenever a skill directs you here.
+
+## When this applies
+
+- Apply it only when you do **not** already have the card's context — no title, identifier, or description available to you. This is the case when you are running outside Workhorse
+- Inside Workhorse the card's context is always present, so this process never runs there
+- If you already established the card's context earlier in this conversation, reuse it — do not ask again
+
+## Establishing context
+
+When you have no card context, ask the user to establish it before you start the skill's work. Offer two paths:
+
+1. **Linear card** — the user gives you a Linear card code and connects the Linear MCP, so you can read the card directly. Read whatever detail helps the task at hand — at minimum the card's title and description. If the Linear MCP is not connected, walk the user through connecting it
+2. **Paste** — the user pastes the card's title and description directly into the chat
+
+Also ask the user for the card's **identifier**. It is used for the file paths of mockups (`.workhorse/design/mockups/{card-id}/`), plans (`.workhorse/plans/{card-id}/`), and test cases (`.workhorse/test-cases/{card-id}/`). Every card has one — a Linear card code supplies it directly. If no Linear or Workhorse ticket backs the work, ask the user to create one so the work is tracked; you can offer to create it for them through the Linear MCP.
+
+## When context is incomplete
+
+If the user cannot or will not supply full context, do the best you can with what is available — ask them for whatever detail they can provide to work from, and proceed on that. Don't block on missing context you can reasonably work around.

--- a/.agents/docs/spec-format.md
+++ b/.agents/docs/spec-format.md
@@ -8,7 +8,7 @@ Specs are the product-level source of truth for a workspace. The format serves t
 
 ## Information hierarchy
 
-Specs live in the workspace's configured specs directory (default `specs/`) as markdown files organised into directories. The directory structure is the hierarchy: **Product > Area > Subarea > ... > Spec**, with arbitrary nesting depth.
+Specs live in `specs/` as markdown files organised into directories. The directory structure is the hierarchy: **Product > Area > Subarea > ... > Spec**, with arbitrary nesting depth.
 
 ```
 specs/
@@ -78,7 +78,7 @@ Code references are advisory, not load-bearing. They help a reader jump from an 
 
 - **Describe the system as it should be, not the changes to make.** Each spec is a coherent snapshot — it reads as "this is how the system works" rather than "change X to Y" or "no longer does Z". No references to "current behaviour", "remains unchanged", "now does", or "rather than the old way". The implementation agent works from the diff to know what's changing.
 - **Acceptance criteria are facts about behaviour, not instructions to a developer.**
-- **No implementation details.** Specs are written at a product-owner level. Avoid function names, database fields, model names, enum values, and technical identifiers. Write "the system checks whether all parent cards have been committed" rather than naming the field that tracks commit state; write "Spec complete" rather than an all-caps status constant. File paths inside the workspace's specs directory are acceptable because they're part of the product's information architecture.
+- **No implementation details.** Specs are written at a product-owner level. Avoid function names, database fields, model names, enum values, and technical identifiers. Write "the system checks whether all parent cards have been committed" rather than naming the field that tracks commit state; write "Spec complete" rather than an all-caps status constant. File paths inside `specs/` are acceptable because they're part of the product's information architecture.
 - **Stay within the spec's scope.** Each spec contains only sections that relate directly to its title and area. If content would make more sense in another spec, it belongs there — add a cross-reference (e.g. "see `editor/spec-editor.md`") rather than duplicating or misplacing it. When in doubt, ask: "would someone looking for this information expect to find it in a spec with this title?"
 - **Don't specify absences.** Document what the system does, not what it doesn't do. "We don't support X" or "X is not included" is not useful — if it's not in the spec, it's not in the system. If another spec needs updating because this feature changes its behaviour, update that spec declaratively.
 - **No point-in-time language.** Don't document transitions ("we used to do X, now we do Y", "this replaces Z"). Each spec is a snapshot of the desired system, not a changelog.

--- a/.agents/skills/ascii-design/SKILL.md
+++ b/.agents/skills/ascii-design/SKILL.md
@@ -10,6 +10,8 @@ workhorse-version: 0.1.0
 
 ## Your task: ASCII design chat
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 A lightweight UX/UI workshop. Sketch the screen's skeleton as ASCII art directly in chat, get feedback, and iterate. Keep it fast and rough — the goal is to agree on shape and hierarchy before committing to HTML mockups.
 
 Once the skeleton is agreed, suggest moving to an HTML mockup as the next step.

--- a/.agents/skills/automate-test-cases/SKILL.md
+++ b/.agents/skills/automate-test-cases/SKILL.md
@@ -11,6 +11,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Automate test cases
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Write automated tests that match the unticked scenarios in this card's test-cases file, ticking each item as its matching test lands.
 
 1. Read the test-cases file at `.workhorse/test-cases/{card-id}/`. If no file exists, stop and ask the user whether to run `Draft test cases` first

--- a/.agents/skills/draft-spec-changes/SKILL.md
+++ b/.agents/skills/draft-spec-changes/SKILL.md
@@ -11,6 +11,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Draft spec changes
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Produce spec edits directly from the card description — no extended interview.
 
 **Read `.agents/docs/spec-format.md` first.** It defines the writing conventions, the information-architecture rules, and the fold-vs-create-vs-split guidance you must follow. Every edit you make has to conform to it.

--- a/.agents/skills/draft-test-cases/SKILL.md
+++ b/.agents/skills/draft-test-cases/SKILL.md
@@ -11,6 +11,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Draft test cases
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Produce or refine the card's test-cases checklist — the concrete scenarios that verify this card is done. The file is read by both the tester running scenarios by hand and the implementing agent writing automated tests against them.
 
 1. Read the card's specs in `specs/` and any existing test cases at `.workhorse/test-cases/{card-id}/`

--- a/.agents/skills/implement-this/SKILL.md
+++ b/.agents/skills/implement-this/SKILL.md
@@ -13,6 +13,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Implement this
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Implement the work described by this card. The starting point varies — figure out which one applies before writing code.
 
 ### Work out what you're implementing

--- a/.agents/skills/interview/SKILL.md
+++ b/.agents/skills/interview/SKILL.md
@@ -11,6 +11,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Interview me
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Guide the user through developing comprehensive acceptance criteria. Read `.agents/docs/spec-format.md` first so the questions you ask, and the criteria you extract, conform to the spec writing conventions and information-architecture rules.
 
 Methodology:

--- a/.agents/skills/investigate-and-fix/SKILL.md
+++ b/.agents/skills/investigate-and-fix/SKILL.md
@@ -11,6 +11,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Investigate and fix
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 The card describes a bug. Diagnose the cause and apply the fix.
 
 1. **Read the card** — title, description, reproduction steps, error messages, attachments. Treat these as the report

--- a/.agents/skills/mock-this-up/SKILL.md
+++ b/.agents/skills/mock-this-up/SKILL.md
@@ -11,6 +11,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Mock this up
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Produce an HTML mockup for the UI being discussed. Skip extended exploration — go straight to the mockup.
 
 1. Identify the target screen from the card description and conversation context

--- a/.agents/skills/plan-cards/SKILL.md
+++ b/.agents/skills/plan-cards/SKILL.md
@@ -13,6 +13,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Plan cards
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Workshop how to slice this card into smaller spawned cards and capture the breakdown in the card plan at `.workhorse/plans/{card-id}/card-plan.md`.
 
 **The card plan is not the implementation plan.** Do not edit `.workhorse/plans/{card-id}/plan.md` — that is a separate, free-form working document for tech-design notes and build steps. The card plan has a strict shape:

--- a/.agents/skills/plan-implementation/SKILL.md
+++ b/.agents/skills/plan-implementation/SKILL.md
@@ -11,6 +11,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Plan implementation
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Draft or refine the implementation checklist in the card's plan file. The plan turns the card's specs and any existing tech notes into a sequenced checklist of steps that `Implement this` can then work through.
 
 1. Read the card's specs and any existing plan at `.workhorse/plans/{card-id}/`

--- a/.agents/skills/pull-workhorse-updates/SKILL.md
+++ b/.agents/skills/pull-workhorse-updates/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: pull-workhorse-updates
+description: "Pull the current Workhorse release's skills, reference docs, and AGENTS.md framework section onto this card, smart-merging against local edits"
+label: "Pull Workhorse updates"
+pill-order:
+  not-started: 9
+  specifying: 14
+  implementing: 8
+  reviewing: 8
+  complete: 5
+jockey-hint: "Low-traffic maintenance action — surface as an available pill, not a top suggestion. Only promote when the user explicitly asks to pull or update Workhorse's skills, docs, or framework files."
+workhorse-version: 0.1.0
+---
+
+## Your task: Pull Workhorse updates
+
+Bring this workspace's Workhorse framework files up to the current release, smart-merging the new bundle against any local edits. The managed files are the **skills** under `.agents/skills/`, the **reference docs** under `.agents/docs/`, and the **framework section** at the top of `AGENTS.md`. The design library under `.workhorse/design/` is workspace-owned and out of scope — never touch it here.
+
+Workhorse has materialised the current release's bundle into `.workhorse/.pull-bundle/` in this worktree so you can read it directly. That folder is the source of the new versions ("theirs"); the files already in the workspace are "ours". The folder carries its own `.gitignore` so nothing under it is committed — do not merge it into the repo, and leave the folder for Workhorse to manage.
+
+### What's in the bundle folder
+
+- `.workhorse/.pull-bundle/manifest.json` — the authoritative list of managed files. Each entry has the target path (relative to the repo root) and the current bundle version. Read this first
+- `.workhorse/.pull-bundle/skills/{folder}/SKILL.md` — the current version of each shipped skill
+- `.workhorse/.pull-bundle/docs/{name}.md` — the current version of each shipped reference doc
+- `.workhorse/.pull-bundle/AGENTS.section.md` — the current framework section, wrapped in its `<!-- BEGIN:workhorse <version> -->` / `<!-- END:workhorse -->` markers
+
+### Identifying what's managed
+
+- A skill's `SKILL.md` or a reference doc is Workhorse-shipped only if it carries a `workhorse-version` frontmatter field. A file without that field is a purely local file — never touch it
+- The `AGENTS.md` framework section is the region between the `<!-- BEGIN:workhorse ... -->` and `<!-- END:workhorse -->` markers. Everything else in `AGENTS.md` is user-owned — never touch it
+- A file's identity is its path (the skill folder name, or the doc filename). If a user has renamed or moved a shipped file, it has detached from the bundle — treat it as local and leave it
+
+### Procedure
+
+Work through every entry in the manifest, then check for removals:
+
+1. **New file** — a manifest entry with no counterpart in the workspace. Copy the bundle version into its target path verbatim, including its `workhorse-version` frontmatter
+2. **Unchanged local file** — the workspace copy is identical to the bundle version except for a lower `workhorse-version`. Replace it with the bundle version (this just bumps the version)
+3. **Locally edited file** — the workspace copy differs from the bundle version in more than the `workhorse-version`. Smart-merge: take the bundle version as the new baseline and re-apply the user's local intent on top, so the release's improvements land while the user's deliberate edits survive. Set `workhorse-version` to the bundle's version. Read both files fully and reason about intent — do not do a naive line union
+4. **Removed file** — a workspace file that carries a `workhorse-version` but has no manifest entry (its path is no longer shipped). Delete it with `rm <path>`. The user reviews the deletion in the PR and can revert it there to keep it as a local fork
+5. **AGENTS.md framework section** — merge the marked region the same way: bundle section as baseline, the user's edits within the region re-applied on top, written back between the markers with the marker version bumped. If `AGENTS.md` has no Workhorse markers yet, insert the bundle section at the very top of the file. If `AGENTS.md` doesn't exist, create it containing just the section
+6. **`.claude/skills/` symlink** — confirm it exists and points at `../.agents/skills/`. If it's missing or points elsewhere, recreate it. If a real file or directory sits at that path instead of a symlink, leave it alone and note it
+
+### Conflicts and reporting
+
+- Apply straightforward merges directly. Where a merge is genuinely ambiguous — the release and the local edit change the same thing in incompatible ways — stop and ask the user how to resolve it rather than guessing
+- When every managed file already matches the current bundle version, make no changes and report that the workspace is already up to date
+- Summarise what you did: files added, updated (noting which needed a real merge), and removed; whether the AGENTS.md section changed; and any conflicts you surfaced
+
+Your changes are committed to this card's branch by the normal auto-commit, and the user reviews them through this card's PR.

--- a/.agents/skills/spec-review/SKILL.md
+++ b/.agents/skills/spec-review/SKILL.md
@@ -9,6 +9,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Review spec with fresh eyes
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Read the spec files in `specs/` that relate to this card and review them as if you were seeing them for the first time. Set aside the earlier conversation context and check that the specs stand on their own.
 
 Look for:

--- a/.agents/skills/tech-design/SKILL.md
+++ b/.agents/skills/tech-design/SKILL.md
@@ -11,6 +11,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Tech design workshop
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 Workshop the technical approach for this card interactively. The goal is to capture rationale, tradeoffs, and decisions into the card's plan file as prose notes.
 
 1. Read the card's specs and any existing plan at `.workhorse/plans/{card-id}/`

--- a/.agents/skills/workshop/SKILL.md
+++ b/.agents/skills/workshop/SKILL.md
@@ -10,6 +10,8 @@ workhorse-version: 0.1.0
 
 ## Your task: Workshop ideas
 
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
 The user wants to explore and refine an idea. Help them think through approaches, trade-offs, and possibilities. Generate mockups when a visual would help illustrate a concept. This is exploratory — follow the user's curiosity rather than driving toward a specific output.
 
 ### When generating mockups

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,15 @@
-<!-- BEGIN:workhorse -->
+<!-- BEGIN:workhorse 0.1.0 -->
 # Workhorse framework
 
 This workspace uses [Workhorse](https://github.com/beyondessential/workhorse), a spec-driven development workbench. Workhorse ships skills (invokable prompts) and reference docs into this repo to shape how AI agents work here.
 
-- **Skills** live at `.agents/skills/` — each markdown file is one named skill, with YAML frontmatter and a prompt body. `.claude/skills/` is a symlink to the same folder so Claude Code picks them up natively
+- **Skills** live at `.agents/skills/` — each skill is a folder containing a `SKILL.md` with YAML frontmatter and a prompt body. `.claude/skills/` is a symlink to the same folder so Claude Code picks them up natively
 - **Reference docs** live at `.agents/docs/` — long-form guidance that skill bodies cite by path (spec format conventions and similar)
-- **Specs** live at `.workhorse/specs/` (or the workspace's configured specs directory) — acceptance criteria for each piece of work
+- **Specs** live at `specs/` — acceptance criteria for each piece of work, organised into areas by subdirectory
 
-When picking up a task, read the skill whose filename matches what you're being asked to do — it describes how to approach the work and which reference docs to follow.
+When picking up a task, read the skill whose folder name matches what you're being asked to do — its `SKILL.md` describes how to approach the work and which reference docs to follow.
 
-Workhorse plants this section on first adoption and never modifies it again. Edit or remove it freely.
+Workhorse manages this section. Run the **Pull Workhorse updates** skill to bring it, the skills, and the reference docs up to the latest release — local edits you make here are preserved through a smart merge. Edit or remove it freely.
 <!-- END:workhorse -->
 
 # Tamanu - Development Guidelines for AI Assistants


### PR DESCRIPTION
Syncs this workspace's Workhorse framework files with the latest release. Adds a new `pull-workhorse-updates` skill that smart-merges shipped skills, docs, and the AGENTS.md framework section against local edits, using a materialized bundle folder as the source of truth. Also adds a `card-context.md` doc explaining how skills should establish card context (title, identifier, description) when run outside a Workhorse session, and wires a reference to it into every existing skill's task section. Tightens `spec-format.md` wording to reference `specs/` directly instead of a configurable specs directory.

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->