### PR TITLE
feat(settings): TAM-6864: server-scoped settings

### DIFF
--- a/database/model/public/facility_setting_migrations.md
+++ b/database/model/public/facility_setting_migrations.md
@@ -19,3 +19,7 @@ JSON value from the legacy config file.
 {% docs facility_setting_migrations__facility_id %}
 The [facility](#!/source/source.tamanu.tamanu.facilities) the setting is scoped to.
 {% enddocs %}
+
+{% docs facility_setting_migrations__device_id %}
+For machine-level (server scope) carrier rows: the device id of the facility server the value came from. Null for facility-scoped rows, which use facility_id instead.
+{% enddocs %}

--- a/database/model/public/facility_setting_migrations.yml
+++ b/database/model/public/facility_setting_migrations.yml
@@ -49,11 +49,16 @@ sources:
             data_type: character varying(255)
             description: "{{ doc('facility_setting_migrations__facility_id') }}"
             data_tests:
-              - not_null
               - relationships:
                   arguments:
                     to: source('tamanu', 'facilities')
                     field: id
+          - name: device_id
+            data_type: text
+            description: "{{ doc('facility_setting_migrations__device_id') }}"
+            config:
+              meta:
+                masking: text
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in facility_setting_migrations."

--- a/database/model/public/settings.md
+++ b/database/model/public/settings.md
@@ -27,4 +27,9 @@ One of:
 - `global`
 - `central`
 - `facility`
+- `server` (machine-level, keyed by device_id)
+{% enddocs %}
+
+{% docs settings__device_id %}
+For server-scope (machine-level) settings: the device id of the facility server this row belongs to. Null for all other scopes.
 {% enddocs %}

--- a/database/model/public/settings.yml
+++ b/database/model/public/settings.yml
@@ -67,3 +67,9 @@ sources:
                       - global
                       - central
                       - facility
+          - name: device_id
+            data_type: text
+            description: "{{ doc('settings__device_id') }}"
+            config:
+              meta:
+                masking: text

--- a/database/model/public/sync_lookup.md
+++ b/database/model/public/sync_lookup.md
@@ -55,3 +55,7 @@ This is used to sort and filter records efficiently during the sync process.
 {% docs sync_lookup__pushed_by_device_id %}
 The unique device that pushed this record.
 {% enddocs %}
+
+{% docs sync_lookup__device_id %}
+Routing for device-targeted records (currently server-scope settings): when set, the record syncs only to sessions pulling as this device. Distinct from pushed_by_device_id, which is echo suppression.
+{% enddocs %}

--- a/database/model/public/sync_lookup.yml
+++ b/database/model/public/sync_lookup.yml
@@ -79,3 +79,9 @@ sources:
           - name: pushed_by_device_id
             data_type: text
             description: "{{ doc('sync_lookup__pushed_by_device_id') }}"
+          - name: device_id
+            data_type: text
+            description: "{{ doc('sync_lookup__device_id') }}"
+            config:
+              meta:
+                masking: text

--- a/packages/central-server/__tests__/settingsMigrationRoundTrip.test.js
+++ b/packages/central-server/__tests__/settingsMigrationRoundTrip.test.js
@@ -3,6 +3,7 @@ import { fake } from '@tamanu/fake-data/fake';
 import { STEPS as CENTRAL_STEPS } from '../../upgrade/src/steps/1785000000000-migrateCentralConfigToSettings';
 import { STEPS as FACILITY_STEPS } from '../../upgrade/src/steps/1785000000001-migrateFacilityConfigToSettings';
 import { STEPS as SERVER_STEPS } from '../../upgrade/src/steps/1783100000000-migrateServerConfigToSettings';
+import { STEPS as FHIR_STEPS } from '../../upgrade/src/steps/1783100000001-moveFhirOverridesToServerScope';
 import { applyFacilitySettingMigrations } from '../../database/src/sync/applyFacilitySettingMigrations';
 import config from 'config';
 import { cloneDeep, merge } from 'es-toolkit/compat';
@@ -205,5 +206,62 @@ describe('config->settings migration round trip', () => {
     expect(
       await Setting.get('sync.dynamicLimiter.maxLimit', null, SETTINGS_SCOPES.SERVER, deviceId),
     ).toBe(555);
+  });
+
+  it('fhir step: replays the per-facility union merge as one device row', async () => {
+    const KEY = 'fhir.worker.resourceMaterialisationEnabled';
+    const f3 = await models.Facility.create(fake(models.Facility));
+    const f4 = await models.Facility.create(fake(models.Facility));
+    const orphanFacility = await models.Facility.create(fake(models.Facility));
+
+    // both facilities last synced from the same facility server
+    const startTime = new Date();
+    await models.SyncSession.create({
+      startTime,
+      lastConnectionTime: startTime,
+      parameters: { deviceId: 'facility-fhir-device', facilityIds: [f3.id, f4.id] },
+    });
+    // a mobile session must not win the mapping
+    await models.SyncSession.create({
+      startTime: new Date(startTime.getTime() + 1000),
+      lastConnectionTime: startTime,
+      parameters: { deviceId: 'mobile-xyz', facilityIds: [f3.id], isMobile: true },
+    });
+
+    // Encounter/Specimen default to false, so these become real rows (Setting.set
+    // skips default-equal values); Organization: false is a no-op under the merge.
+    await Setting.set(
+      KEY,
+      { Encounter: true, Organization: false },
+      SETTINGS_SCOPES.FACILITY,
+      f3.id,
+    );
+    await Setting.set(KEY, { Specimen: true }, SETTINGS_SCOPES.FACILITY, f4.id);
+    await Setting.set(KEY, { Immunization: true }, SETTINGS_SCOPES.FACILITY, orphanFacility.id);
+
+    const args = {
+      models,
+      sequelize: ctx.store.sequelize,
+      serverType: 'central',
+      toVersion: '9.9.9',
+      log: logStub,
+    };
+    expect(await FHIR_STEPS[0].check(args)).toBe(true);
+    await FHIR_STEPS[0].run(args);
+    expect(await FHIR_STEPS[0].check(args)).toBe(false); // fact-gated
+
+    // any-true merge across the device's facilities; falses are no-ops
+    expect(await Setting.get(KEY, null, SETTINGS_SCOPES.SERVER, 'facility-fhir-device')).toEqual({
+      Encounter: true,
+      Specimen: true,
+    });
+    // nothing routed to the mobile device
+    expect(await Setting.get(KEY, null, SETTINGS_SCOPES.SERVER, 'mobile-xyz')).toBe(undefined);
+    // migrated facility rows are gone; the unmapped facility's row is left alone
+    expect(await Setting.get(KEY, f3.id, SETTINGS_SCOPES.FACILITY)).toBe(undefined);
+    expect(await Setting.get(KEY, f4.id, SETTINGS_SCOPES.FACILITY)).toBe(undefined);
+    expect(await Setting.get(KEY, orphanFacility.id, SETTINGS_SCOPES.FACILITY)).toEqual({
+      Immunization: true,
+    });
   });
 });

--- a/packages/central-server/__tests__/settingsMigrationRoundTrip.test.js
+++ b/packages/central-server/__tests__/settingsMigrationRoundTrip.test.js
@@ -1,7 +1,8 @@
-import { SETTINGS_SCOPES } from '@tamanu/constants';
+import { FACT_DEVICE_ID, SETTINGS_SCOPES } from '@tamanu/constants';
 import { fake } from '@tamanu/fake-data/fake';
 import { STEPS as CENTRAL_STEPS } from '../../upgrade/src/steps/1785000000000-migrateCentralConfigToSettings';
 import { STEPS as FACILITY_STEPS } from '../../upgrade/src/steps/1785000000001-migrateFacilityConfigToSettings';
+import { STEPS as SERVER_STEPS } from '../../upgrade/src/steps/1783100000000-migrateServerConfigToSettings';
 import { applyFacilitySettingMigrations } from '../../database/src/sync/applyFacilitySettingMigrations';
 import config from 'config';
 import { cloneDeep, merge } from 'es-toolkit/compat';
@@ -16,7 +17,13 @@ const logStub = { info: () => {}, warn: () => {}, error: () => {}, debug: () => 
 // fallback reader -> central migration step -> facility carrier -> central apply.
 const LEGACY_CONFIG = {
   mailgun: { from: 'legacy@roundtrip.test' },
-  mail: { transport: { host: 'smtp.example.test', port: 587, auth: { user: 'mailer', pass: 'sekrit-smtp' } } },
+  mail: {
+    transport: {
+      host: 'smtp.example.test',
+      port: 587,
+      auth: { user: 'mailer', pass: 'sekrit-smtp' },
+    },
+  },
   schedules: { outpatientDischarger: { schedule: '30 3 * * *' } },
   localisation: { data: { country: { name: 'Fiji', 'alpha-2': 'FJ', 'alpha-3': 'FJI' } } },
   integrations: {
@@ -24,6 +31,7 @@ const LEGACY_CONFIG = {
     mSupplyMed: { enabled: true, username: 'msu', password: 'mspw' },
   },
   tasking: { upcomingTasksTimeFrame: 9, upcomingTasksShouldBeGeneratedTimeFrame: 96 },
+  sync: { dynamicLimiter: { maxLimit: 20000 } },
 };
 
 describe('config->settings migration round trip', () => {
@@ -56,20 +64,39 @@ describe('config->settings migration round trip', () => {
 
   it('central step: seeds settings, existing wins, secrets split and encrypted', async () => {
     // operator value that must survive
-    await Setting.set('schedules.outpatientDischarger.schedule', '0 5 * * *', SETTINGS_SCOPES.CENTRAL);
+    await Setting.set(
+      'schedules.outpatientDischarger.schedule',
+      '0 5 * * *',
+      SETTINGS_SCOPES.CENTRAL,
+    );
 
     const args = { models, serverType: 'central', toVersion: '9.9.9', log: logStub };
     expect(await CENTRAL_STEPS[0].check(args)).toBe(true);
     await CENTRAL_STEPS[0].run(args);
 
     // existing-wins
-    expect(await Setting.get('schedules.outpatientDischarger.schedule', null, SETTINGS_SCOPES.CENTRAL)).toBe('0 5 * * *');
+    expect(
+      await Setting.get('schedules.outpatientDischarger.schedule', null, SETTINGS_SCOPES.CENTRAL),
+    ).toBe('0 5 * * *');
     // renamed lift
-    expect(await Setting.get('mail.from', null, SETTINGS_SCOPES.CENTRAL)).toBe('legacy@roundtrip.test');
+    expect(await Setting.get('mail.from', null, SETTINGS_SCOPES.CENTRAL)).toBe(
+      'legacy@roundtrip.test',
+    );
     // un-nested localisation (global scope, from central config)
-    expect(await Setting.get('country', null, SETTINGS_SCOPES.GLOBAL)).toMatchObject({ name: 'Fiji', 'alpha-3': 'FJI' });
-    expect(await Setting.get('tasking.upcomingTasksShouldBeGeneratedTimeFrame', null, SETTINGS_SCOPES.GLOBAL)).toBe(96);
-    expect(await Setting.get('integrations.dhis2.username', null, SETTINGS_SCOPES.CENTRAL)).toBe('dhis-user');
+    expect(await Setting.get('country', null, SETTINGS_SCOPES.GLOBAL)).toMatchObject({
+      name: 'Fiji',
+      'alpha-3': 'FJI',
+    });
+    expect(
+      await Setting.get(
+        'tasking.upcomingTasksShouldBeGeneratedTimeFrame',
+        null,
+        SETTINGS_SCOPES.GLOBAL,
+      ),
+    ).toBe(96);
+    expect(await Setting.get('integrations.dhis2.username', null, SETTINGS_SCOPES.CENTRAL)).toBe(
+      'dhis-user',
+    );
 
     // no settings PSK in the test env: the graceful path keeps the password
     // embedded rather than failing the upgrade (encryption path unit-tested)
@@ -79,10 +106,14 @@ describe('config->settings migration round trip', () => {
       port: 587,
       auth: { user: 'mailer', pass: 'sekrit-smtp' },
     });
-    expect(await Setting.get('mail.transportPassword', null, SETTINGS_SCOPES.CENTRAL)).toBe(undefined);
+    expect(await Setting.get('mail.transportPassword', null, SETTINGS_SCOPES.CENTRAL)).toBe(
+      undefined,
+    );
 
     // schema-secrets are never lifted
-    expect(await Setting.get('integrations.telegram.apiToken', null, SETTINGS_SCOPES.CENTRAL)).toBe(undefined);
+    expect(await Setting.get('integrations.telegram.apiToken', null, SETTINGS_SCOPES.CENTRAL)).toBe(
+      undefined,
+    );
 
     // idempotent
     expect(await CENTRAL_STEPS[0].check(args)).toBe(false);
@@ -114,9 +145,65 @@ describe('config->settings migration round trip', () => {
     // one facility already has an operator value: apply must skip it
     await Setting.set('tasking.upcomingTasksTimeFrame', 4, SETTINGS_SCOPES.FACILITY, f2.id);
 
-    await applyFacilitySettingMigrations(models, rows.map(r => r.id));
-    expect(await Setting.get('tasking.upcomingTasksTimeFrame', f1.id, SETTINGS_SCOPES.FACILITY)).toBe(9);
-    expect(await Setting.get('tasking.upcomingTasksTimeFrame', f2.id, SETTINGS_SCOPES.FACILITY)).toBe(4);
-    expect((await Setting.get('integrations.mSupplyMed', f1.id, SETTINGS_SCOPES.FACILITY)).username).toBe('msu');
+    await applyFacilitySettingMigrations(
+      models,
+      rows.map(r => r.id),
+    );
+    expect(
+      await Setting.get('tasking.upcomingTasksTimeFrame', f1.id, SETTINGS_SCOPES.FACILITY),
+    ).toBe(9);
+    expect(
+      await Setting.get('tasking.upcomingTasksTimeFrame', f2.id, SETTINGS_SCOPES.FACILITY),
+    ).toBe(4);
+    expect(
+      (await Setting.get('integrations.mSupplyMed', f1.id, SETTINGS_SCOPES.FACILITY)).username,
+    ).toBe('msu');
+  });
+
+  it('server step + central apply: device-keyed carrier round trip', async () => {
+    const deviceId = 'facility-roundtrip-device';
+    await models.LocalSystemFact.set(FACT_DEVICE_ID, deviceId);
+
+    const args = { models, serverType: 'facility', toVersion: '9.9.9', log: logStub };
+    expect(await SERVER_STEPS[0].check(args)).toBe(true);
+    await SERVER_STEPS[0].run(args);
+    expect(await SERVER_STEPS[0].check(args)).toBe(false); // fact-gated
+
+    const rows = await models.FacilitySettingMigration.findAll({
+      where: { deviceId },
+    });
+    const limiterRow = rows.find(r => r.key === 'sync.dynamicLimiter');
+    expect(limiterRow.value).toMatchObject({ maxLimit: 20000 });
+    expect(limiterRow.facilityId).toBe(null);
+
+    await applyFacilitySettingMigrations(
+      models,
+      rows.map(r => r.id),
+    );
+    expect(
+      await Setting.get('sync.dynamicLimiter.maxLimit', null, SETTINGS_SCOPES.SERVER, deviceId),
+    ).toBe(20000);
+    // routed to the device, invisible to other devices and to the plain server read
+    expect(
+      await Setting.get(
+        'sync.dynamicLimiter.maxLimit',
+        null,
+        SETTINGS_SCOPES.SERVER,
+        'other-device',
+      ),
+    ).toBe(undefined);
+    expect(await Setting.get('sync.dynamicLimiter.maxLimit', null, SETTINGS_SCOPES.SERVER)).toBe(
+      undefined,
+    );
+
+    // re-apply must not clobber an operator's newer central value
+    await Setting.set('sync.dynamicLimiter.maxLimit', 555, SETTINGS_SCOPES.SERVER, null, deviceId);
+    await applyFacilitySettingMigrations(
+      models,
+      rows.map(r => r.id),
+    );
+    expect(
+      await Setting.get('sync.dynamicLimiter.maxLimit', null, SETTINGS_SCOPES.SERVER, deviceId),
+    ).toBe(555);
   });
 });

--- a/packages/central-server/__tests__/sync/CentralSyncManager.setupSnapshotForPull.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.setupSnapshotForPull.test.js
@@ -359,6 +359,45 @@ describe('CentralSyncManager.setupSnapshotForPull', () => {
     });
   });
 
+  describe('device-routed records', () => {
+    it('routes server-scope settings only to their device through the lookup table', async () => {
+      await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 10);
+      await models.Setting.set(
+        'sync.dynamicLimiter.maxLimit',
+        777,
+        'server',
+        null,
+        'device-pull-test',
+      );
+      const facility = await models.Facility.create(fake(models.Facility));
+
+      const centralSyncManager = initializeCentralSyncManager({
+        sync: {
+          lookupTable: { enabled: true },
+          maxRecordsPerSnapshotChunk: 1000000,
+        },
+      });
+      await centralSyncManager.updateLookupTable();
+
+      const pulledSettingKeys = async deviceId => {
+        const { sessionId } = await centralSyncManager.startSession({ deviceId });
+        await waitForSession(centralSyncManager, sessionId);
+        await centralSyncManager.setupSnapshotForPull(
+          sessionId,
+          { since: 1, facilityIds: [facility.id], deviceId },
+          () => true,
+        );
+        const changes = await centralSyncManager.getOutgoingChanges(sessionId, {});
+        return changes.filter(c => c.recordType === 'settings').map(c => c.data.key);
+      };
+
+      expect(await pulledSettingKeys('device-pull-test')).toContain('sync.dynamicLimiter.maxLimit');
+      expect(await pulledSettingKeys('some-other-device')).not.toContain(
+        'sync.dynamicLimiter.maxLimit',
+      );
+    });
+  });
+
   describe('handles concurrent transactions', () => {
     afterEach(async () => {
       // Revert to the original models
@@ -432,7 +471,7 @@ describe('CentralSyncManager.setupSnapshotForPull', () => {
       const outgoingChanges = (await centralSyncManager.getOutgoingChanges(sessionId, {})).filter(
         ({ recordId }) => recordId !== SYSTEM_USER_UUID,
       );
-      
+
       expect(outgoingChanges.length).toBe(3);
       expect(outgoingChanges.map(r => r.recordId).sort()).toEqual(
         [facility, program, survey].map(r => r.id).sort(),

--- a/packages/central-server/__tests__/sync/CentralSyncManager.updateLookupTable.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.updateLookupTable.test.js
@@ -180,6 +180,42 @@ describe('CentralSyncManager.updateLookupTable', () => {
     );
   });
 
+  it('carries device_id for device-routed records (server-scope settings)', async () => {
+    await models.Setting.set(
+      'sync.dynamicLimiter.maxLimit',
+      1234,
+      'server',
+      null,
+      'device-lookup-test',
+    );
+
+    const centralSyncManager = initializeCentralSyncManager({
+      sync: {
+        lookupTable: {
+          enabled: true,
+        },
+        maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+      },
+    });
+
+    await centralSyncManager.updateLookupTable();
+
+    const settingRow = await models.SyncLookup.findOne({
+      where: { recordType: 'settings' },
+    });
+    expect(settingRow).toEqual(
+      expect.objectContaining({
+        deviceId: 'device-lookup-test',
+        facilityId: null,
+        data: expect.objectContaining({
+          key: 'sync.dynamicLimiter.maxLimit',
+          scope: 'server',
+          deviceId: 'device-lookup-test',
+        }),
+      }),
+    );
+  });
+
   it('updates new changes from records into sync lookup table', async () => {
     const patient1 = await models.Patient.create(fake(models.Patient));
 

--- a/packages/central-server/__tests__/sync/snapshotOutgoingChanges.test.js
+++ b/packages/central-server/__tests__/sync/snapshotOutgoingChanges.test.js
@@ -110,7 +110,7 @@ describe('snapshotOutgoingChanges', () => {
         SYNC_SESSION_DIRECTION.OUTGOING,
       );
       expect(
-        Object.keys(syncRecord.data).every((key) => !COLUMNS_EXCLUDED_FROM_SYNC.includes(key)),
+        Object.keys(syncRecord.data).every(key => !COLUMNS_EXCLUDED_FROM_SYNC.includes(key)),
       ).toBe(true);
     }),
   );
@@ -202,7 +202,7 @@ describe('snapshotOutgoingChanges', () => {
 
       const queryReturnValue = [[{ maxId: null, count: 0 }]];
       let resolveFakeModelQuery;
-      const promise = new Promise((resolve) => {
+      const promise = new Promise(resolve => {
         resolveFakeModelQuery = () => resolve(queryReturnValue);
       });
       const fakeModelThatWaitsUntilWeSaySo = {
@@ -265,7 +265,7 @@ describe('snapshotOutgoingChanges', () => {
 
       // wait for snapshot to start and block, and then create a new record
       await sleepAsync(20);
-      const after = ctx.store.sequelize.transaction(async (transaction) => {
+      const after = ctx.store.sequelize.transaction(async transaction => {
         await ReferenceData.create(fakeReferenceData(), {
           transaction,
         });
@@ -288,7 +288,7 @@ describe('snapshotOutgoingChanges', () => {
 
       const queryReturnValue = [[{ maxId: null, count: 0 }]];
       let resolveFakeModelQuery;
-      const promise = new Promise((resolve) => {
+      const promise = new Promise(resolve => {
         resolveFakeModelQuery = () => resolve(queryReturnValue);
       });
       const fakeModelThatWaitsUntilWeSaySo = {
@@ -348,7 +348,7 @@ describe('snapshotOutgoingChanges', () => {
 
       // wait for snapshot to start and block, and then create a new record
       await sleepAsync(20);
-      const after = ctx.store.sequelize.transaction(async (transaction) => {
+      const after = ctx.store.sequelize.transaction(async transaction => {
         await ReferenceData.create(fakeReferenceData(), {
           transaction,
         });
@@ -363,6 +363,79 @@ describe('snapshotOutgoingChanges', () => {
       expect(result).toEqual(1);
     }),
   );
+
+  describe('device-routed records', () => {
+    const snapshotForDevice = async deviceId => {
+      const { SyncSession, LocalSystemFact } = models;
+      const startTime = new Date();
+      const syncSession = await SyncSession.create({
+        startTime,
+        lastConnectionTime: startTime,
+      });
+      const tock = await LocalSystemFact.incrementValue(FACT_CURRENT_SYNC_TICK, 2);
+      await createSnapshotTable(ctx.store.sequelize, syncSession.id);
+      const fullSyncPatientsTable = await createMarkedForSyncPatientsTable(
+        ctx.store.sequelize,
+        syncSession.id,
+        true,
+        [''],
+        tock - 1,
+      );
+      // snapshot everything from the beginning of time so the settings rows
+      // created in the arrange step are always in range
+      await snapshotOutgoingChanges(
+        ctx.store,
+        { Setting: models.Setting },
+        0,
+        0,
+        fullSyncPatientsTable,
+        syncSession.id,
+        [''],
+        deviceId,
+        simplestSessionConfig,
+      );
+      const records = await findSyncSnapshotRecordsOrderByDependency(
+        ctx.store,
+        syncSession.id,
+        SYNC_SESSION_DIRECTION.OUTGOING,
+      );
+      return records.filter(r => r.recordType === 'settings').map(r => r.data.key);
+    };
+
+    it(
+      'routes server-scope settings only to their own device',
+      withErrorShown(async () => {
+        const { Setting } = models;
+        await Setting.set(
+          'sync.dynamicLimiter.maxLimit',
+          4321,
+          'server',
+          null,
+          'device-under-test',
+        );
+
+        const ownKeys = await snapshotForDevice('device-under-test');
+        expect(ownKeys).toContain('sync.dynamicLimiter.maxLimit');
+
+        const otherKeys = await snapshotForDevice('some-other-device');
+        expect(otherKeys).not.toContain('sync.dynamicLimiter.maxLimit');
+
+        // a session with no device id (older clients) must not receive it either
+        const noDeviceKeys = await snapshotForDevice(null);
+        expect(noDeviceKeys).not.toContain('sync.dynamicLimiter.maxLimit');
+      }),
+    );
+
+    it(
+      'still broadcasts global settings to device sessions',
+      withErrorShown(async () => {
+        const { Setting } = models;
+        await Setting.set('supportDeskUrl', 'https://device-routing.test', 'global');
+        const keys = await snapshotForDevice('device-under-test');
+        expect(keys).toContain('supportDeskUrl');
+      }),
+    );
+  });
 
   describe('syncAllLabRequests', () => {
     const setupTestData = async () => {
@@ -503,7 +576,7 @@ describe('snapshotOutgoingChanges', () => {
         syncSession.id,
         SYNC_SESSION_DIRECTION.OUTGOING,
       );
-      expect(outgoingSnapshotRecords.map((r) => r.recordId).sort()).toEqual(
+      expect(outgoingSnapshotRecords.map(r => r.recordId).sort()).toEqual(
         [
           labTest1.id,
           labTest2.id,
@@ -553,7 +626,7 @@ describe('snapshotOutgoingChanges', () => {
         syncSession.id,
         SYNC_SESSION_DIRECTION.OUTGOING,
       );
-      expect(outgoingSnapshotRecords.map((r) => r.recordId).sort()).toEqual(
+      expect(outgoingSnapshotRecords.map(r => r.recordId).sort()).toEqual(
         [
           labTest1.id,
           labTest2.id,

--- a/packages/central-server/app/admin/adminRoutes.js
+++ b/packages/central-server/app/admin/adminRoutes.js
@@ -2,7 +2,8 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { unset, get as getAtPath, set as setAtPath } from 'es-toolkit/compat';
 
-import { SETTINGS_SCOPES } from '@tamanu/constants';
+import { Op } from 'sequelize';
+import { DEVICE_TYPES, SETTINGS_SCOPES } from '@tamanu/constants';
 import { ensurePermissionCheck } from '@tamanu/shared/permissions/middleware';
 import { ForbiddenError, InvalidParameterError, NotFoundError } from '@tamanu/errors';
 import { simplePatch } from '@tamanu/shared/utils/crudHelpers';
@@ -132,15 +133,14 @@ adminRoutes.patch(
 // and mask/encrypt secret fields. Without a scope we have no way to know which
 // fields are secret, so allowing the call would silently bypass masking on read
 // and encryption on write.
-const requireScope = scope => {
+const requireScope = (scope, deviceId) => {
   if (!scope) {
     throw new InvalidParameterError('scope is required');
   }
-  // Server-scope settings are machine-local to each facility server: a row
-  // written here would sit on central and never sync anywhere. Edit them on
-  // the server itself.
-  if (scope === SETTINGS_SCOPES.SERVER) {
-    throw new InvalidParameterError('server scope settings are managed on the server itself');
+  // Server-scope (machine-level) rows are keyed by the target facility server's
+  // device id — without one there is no way to route the setting anywhere.
+  if (scope === SETTINGS_SCOPES.SERVER && !deviceId) {
+    throw new InvalidParameterError('server scope requires a deviceId');
   }
   const schema = getScopedSchema(scope);
   if (!schema) {
@@ -154,10 +154,10 @@ adminRoutes.get(
   asyncHandler(async (req, res) => {
     req.checkPermission('read', 'Setting');
     const { Setting } = req.store.models;
-    const { facilityId, scope } = req.query;
-    const schema = requireScope(scope);
+    const { facilityId, scope, deviceId } = req.query;
+    const schema = requireScope(scope, deviceId);
 
-    const data = await Setting.get('', facilityId, scope);
+    const data = await Setting.get('', facilityId, scope, deviceId);
 
     if (!data || typeof data !== 'object') {
       res.send(data);
@@ -181,7 +181,14 @@ adminRoutes.get(
  *     value, so the bulk write's isEqual check leaves the row alone
  *   - remove empty/null entries so the bulk cleanup soft-deletes them
  */
-async function resolveSecretsForSave(Setting, settings, schema, scope, facilityId) {
+async function resolveSecretsForSave(
+  Setting,
+  settings,
+  schema,
+  scope,
+  facilityId,
+  deviceId = null,
+) {
   const secretPaths = extractSecretPaths(schema);
   if (secretPaths.length === 0) return;
 
@@ -192,7 +199,7 @@ async function resolveSecretsForSave(Setting, settings, schema, scope, facilityI
 
     if (value === SECRET_PLACEHOLDER) {
       const existing = await Setting.findOne({
-        where: { key: path, scope, facilityId },
+        where: { key: path, scope, facilityId, deviceId },
       });
       if (existing) {
         setAtPath(settings, path, existing.value);
@@ -212,13 +219,33 @@ async function resolveSecretsForSave(Setting, settings, schema, scope, facilityI
   }
 }
 
+// Registered facility-server devices, for the server-scope settings device
+// picker. Mobiles also register as sync clients, and a server-scope setting
+// routed to a mobile would pollute its settings table — so only facility
+// servers are offered.
+// ponytail: id-prefix heuristic (initDeviceId's `<deviceType>-` convention); a
+// config-overridden deviceId can evade it — add a device type column if that bites.
+adminRoutes.get(
+  '/devices',
+  asyncHandler(async (req, res) => {
+    req.checkPermission('read', 'Setting');
+    const { Device } = req.store.models;
+    const devices = await Device.findAll({
+      attributes: ['id', 'name', 'scopes', 'lastSeenAt'],
+      where: { id: { [Op.like]: `${DEVICE_TYPES.FACILITY_SERVER}-%` } },
+      order: [['lastSeenAt', 'DESC']],
+    });
+    res.send(devices.map(device => device.forResponse()));
+  }),
+);
+
 adminRoutes.put(
   '/settings',
   asyncHandler(async (req, res) => {
     req.checkPermission('write', 'Setting');
     const { Setting } = req.store.models;
-    const { settings, scope, facilityId = null } = req.body;
-    const schema = requireScope(scope);
+    const { settings, scope, facilityId = null, deviceId = null } = req.body;
+    const schema = requireScope(scope, deviceId);
 
     if (!settings || typeof settings !== 'object') {
       res.json({ code: 200 });
@@ -235,8 +262,8 @@ adminRoutes.put(
       );
     }
 
-    await resolveSecretsForSave(Setting, settings, schema, scope, facilityId);
-    await Setting.set('', settings, scope, facilityId);
+    await resolveSecretsForSave(Setting, settings, schema, scope, facilityId, deviceId);
+    await Setting.set('', settings, scope, facilityId, deviceId);
     await req.aiService?.refreshContexts(req.ctx.settings);
     res.json({ code: 200 });
   }),

--- a/packages/central-server/app/admin/adminRoutes.js
+++ b/packages/central-server/app/admin/adminRoutes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { unset, get as getAtPath, set as setAtPath } from 'es-toolkit/compat';
 
+import { SETTINGS_SCOPES } from '@tamanu/constants';
 import { ensurePermissionCheck } from '@tamanu/shared/permissions/middleware';
 import { ForbiddenError, InvalidParameterError, NotFoundError } from '@tamanu/errors';
 import { simplePatch } from '@tamanu/shared/utils/crudHelpers';
@@ -134,6 +135,12 @@ adminRoutes.patch(
 const requireScope = scope => {
   if (!scope) {
     throw new InvalidParameterError('scope is required');
+  }
+  // Server-scope settings are machine-local to each facility server: a row
+  // written here would sit on central and never sync anywhere. Edit them on
+  // the server itself.
+  if (scope === SETTINGS_SCOPES.SERVER) {
+    throw new InvalidParameterError('server scope settings are managed on the server itself');
   }
   const schema = getScopedSchema(scope);
   if (!schema) {

--- a/packages/central-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/central-server/app/sync/snapshotOutgoingChanges.js
@@ -17,6 +17,7 @@ const snapshotChangesForModel = async (
   markedForSyncPatientsTable,
   sessionId,
   facilityIds,
+  deviceId,
   sessionConfig,
   config,
 ) => {
@@ -106,8 +107,9 @@ const snapshotChangesForModel = async (
           sessionId,
           since,
           // include replacement params used in some model specific sync filters outside of this file
-          // see e.g. Referral.buildSyncFilter
+          // see e.g. Referral.buildSyncFilter or Setting.buildSyncFilter
           facilityIds,
+          deviceId: deviceId ?? null,
           limit: CHUNK_SIZE,
           fromId,
         },
@@ -137,6 +139,7 @@ const snapshotOutgoingChangesFromModels = withConfig(
     markedForSyncPatientsTable,
     sessionId,
     facilityIds,
+    deviceId,
     sessionConfig,
     config,
   ) => {
@@ -166,6 +169,7 @@ const snapshotOutgoingChangesFromModels = withConfig(
           markedForSyncPatientsTable,
           sessionId,
           facilityIds,
+          deviceId,
           sessionConfig,
           config,
         );
@@ -259,29 +263,37 @@ const snapshotOutgoingChangesFromSyncLookup = withConfig(
         WHERE updated_at_sync_tick > :since
         ${fromId ? `AND id > :fromId` : ''}
         AND (
-          --- either no patient_id (meaning we don't care if the record is associate to a patient, eg: reference_data)
-          --- or patient_id has to match the marked for sync patient_ids, eg: encounters
-          ${getPatientRelatedWhereClause(
-            store.models,
-            recordTypes,
-            patientCount,
-            markedForSyncPatientsTable,
-          )}
-          --- either no facility_id (meaning we don't care if the record is associate to a facility, eg: reference_data)
-          --- or facility_id has to match the current facility, eg: patient_facilities
-          AND (
-            facility_id IS NULL
-            OR
-            facility_id in (:facilityIds)
+          (
+            (
+              --- either no patient_id (meaning we don't care if the record is associate to a patient, eg: reference_data)
+              --- or patient_id has to match the marked for sync patient_ids, eg: encounters
+              ${getPatientRelatedWhereClause(
+                store.models,
+                recordTypes,
+                patientCount,
+                markedForSyncPatientsTable,
+              )}
+              --- either no facility_id (meaning we don't care if the record is associate to a facility, eg: reference_data)
+              --- or facility_id has to match the current facility, eg: patient_facilities
+              AND (
+                facility_id IS NULL
+                OR
+                facility_id in (:facilityIds)
+              )
+              --- if syncAllLabRequests is on then sync all records with is_lab_request IS TRUE
+              ${
+                syncAllLabRequests
+                  ? `
+                OR is_lab_request IS TRUE
+              `
+                  : ''
+              }
+            )
+            --- device-routed records (eg. server-scope settings) never broadcast...
+            AND device_id IS NULL
           )
-          --- if syncAllLabRequests is on then sync all records with is_lab_request IS TRUE
-          ${
-            syncAllLabRequests
-              ? `
-            OR is_lab_request IS TRUE
-          `
-              : ''
-          }
+          --- ...they sync only to the session pulling as that device
+          OR device_id = :deviceId
         )
         AND record_type IN (:recordTypes)
         ${
@@ -362,6 +374,7 @@ export const snapshotOutgoingChanges = withConfig(
           markedForSyncPatientsTable,
           sessionId,
           facilityIds,
+          deviceId,
           sessionConfig,
           config,
         );

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -46,7 +46,8 @@ const updateLookupTableForModel = async (
             facility_id,
             encounter_id,
             is_lab_request,
-            updated_at_by_field_sum
+            updated_at_by_field_sum,
+            device_id
           )
           ${select || (await buildSyncLookupSelect(model))}
           FROM
@@ -93,7 +94,8 @@ const updateLookupTableForModel = async (
             facility_id = EXCLUDED.facility_id,
             updated_at_by_field_sum = EXCLUDED.updated_at_by_field_sum,
             is_deleted = EXCLUDED.is_deleted,
-            pushed_by_device_id = EXCLUDED.pushed_by_device_id
+            pushed_by_device_id = EXCLUDED.pushed_by_device_id,
+            device_id = EXCLUDED.device_id
           RETURNING record_id
         )
         SELECT MAX(record_id) as "maxId",
@@ -128,12 +130,12 @@ export const updateLookupTable = withConfig(
   async (models, outgoingModels, since, config, syncLookupTick, debugObject) => {
     const invalidModelNames = Object.values(outgoingModels)
       .filter(
-        (m) =>
+        m =>
           ![SYNC_DIRECTIONS.BIDIRECTIONAL, SYNC_DIRECTIONS.PULL_FROM_CENTRAL].includes(
             m.syncDirection,
           ),
       )
-      .map((m) => m.tableName);
+      .map(m => m.tableName);
 
     if (invalidModelNames.length) {
       throw new Error(

--- a/packages/constants/src/facts.ts
+++ b/packages/constants/src/facts.ts
@@ -30,6 +30,7 @@ export const FACT_CENTRAL_CONFIG_MIGRATED = 'centralConfigMigratedToSettings';
 // Set once a facility server has snapshotted its facility-scoped config into the
 // FacilitySettingMigration carrier to push up to central, so it runs only once.
 export const FACT_FACILITY_CONFIG_MIGRATED = 'facilityConfigMigratedToSettings';
+export const FACT_SERVER_CONFIG_MIGRATED = 'serverConfigMigratedToSettings';
 
 // mSupply integration
 export const FACT_MSUPPLY_MED_INTEGRATION_ENABLED_AT = 'mSupplyMedIntegrationEnabledAt';

--- a/packages/constants/src/facts.ts
+++ b/packages/constants/src/facts.ts
@@ -31,6 +31,7 @@ export const FACT_CENTRAL_CONFIG_MIGRATED = 'centralConfigMigratedToSettings';
 // FacilitySettingMigration carrier to push up to central, so it runs only once.
 export const FACT_FACILITY_CONFIG_MIGRATED = 'facilityConfigMigratedToSettings';
 export const FACT_SERVER_CONFIG_MIGRATED = 'serverConfigMigratedToSettings';
+export const FACT_FHIR_OVERRIDES_MIGRATED = 'fhirFacilityOverridesMigratedToServerScope';
 
 // mSupply integration
 export const FACT_MSUPPLY_MED_INTEGRATION_ENABLED_AT = 'mSupplyMedIntegrationEnabledAt';

--- a/packages/constants/src/settings.ts
+++ b/packages/constants/src/settings.ts
@@ -27,6 +27,9 @@ export const SETTINGS_SCOPES = {
   CENTRAL: 'central',
   GLOBAL: 'global',
   FACILITY: 'facility',
+  // Machine-level knobs for a facility server: stored only in that server's own
+  // DB (facility_id null), never synced, not editable from the central admin.
+  SERVER: 'server',
 } as const;
 
 export const SETTING_EDITORS = {

--- a/packages/database/src/migrations/1785100000000-addDeviceIdToSettings.ts
+++ b/packages/database/src/migrations/1785100000000-addDeviceIdToSettings.ts
@@ -1,0 +1,35 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('settings', 'device_id', {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  });
+  // Server-scope rows (machine-level settings) are keyed by device rather than
+  // facility: many devices' rows share facility_id NULL, so they must be carved
+  // out of the without-facility uniqueness and given their own per-device one.
+  await query.sequelize.query('DROP INDEX settings_alive_key_unique_without_facility_idx');
+  await query.sequelize.query(`
+    CREATE UNIQUE INDEX settings_alive_key_unique_without_facility_idx
+    ON settings (key, scope)
+    WHERE deleted_at IS NULL AND facility_id IS NULL AND device_id IS NULL
+  `);
+  await query.sequelize.query(`
+    CREATE UNIQUE INDEX settings_alive_key_unique_per_device_idx
+    ON settings (key, device_id)
+    WHERE deleted_at IS NULL AND device_id IS NOT NULL
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  // Dropping the column also drops the per-device partial index. Restoring the
+  // original uniqueness fails loudly if device-keyed rows exist (they'd collide
+  // on (key, scope) once the device column is gone) — remove them first by hand.
+  await query.removeColumn('settings', 'device_id');
+  await query.sequelize.query('DROP INDEX settings_alive_key_unique_without_facility_idx');
+  await query.sequelize.query(`
+    CREATE UNIQUE INDEX settings_alive_key_unique_without_facility_idx
+    ON settings (key, scope)
+    WHERE deleted_at IS NULL AND facility_id IS NULL
+  `);
+}

--- a/packages/database/src/migrations/1785100000001-addDeviceIdToSyncLookup.ts
+++ b/packages/database/src/migrations/1785100000001-addDeviceIdToSyncLookup.ts
@@ -1,0 +1,27 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+// Routing dimension for device-targeted records (currently server-scope
+// settings): a lookup row with device_id set syncs only to the session pulling
+// with that device id. Distinct from pushed_by_device_id, which tracks who
+// pushed a record for echo suppression.
+//
+// The partial index is load-bearing: without it the snapshot query's
+// `OR device_id = :deviceId` arm is unindexable and the planner abandons the
+// tick index for a full seq scan on every chunk (benchmarked 4x slower on 3M
+// rows; far worse on production-sized tables). With it, the device arm joins
+// the existing BitmapOr at negligible cost.
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('sync_lookup', 'device_id', {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  });
+  await query.sequelize.query(`
+    CREATE INDEX sync_lookup_device_id_idx
+    ON sync_lookup (device_id)
+    WHERE device_id IS NOT NULL
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeColumn('sync_lookup', 'device_id');
+}

--- a/packages/database/src/migrations/1785100000002-addDeviceIdToFacilitySettingMigrations.ts
+++ b/packages/database/src/migrations/1785100000002-addDeviceIdToFacilitySettingMigrations.ts
@@ -1,0 +1,24 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+// Server-scope (machine-level) settings ride the same carrier as facility ones,
+// keyed by device instead of facility — so facility_id becomes optional.
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('facility_setting_migrations', 'device_id', {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  });
+  // changeColumn with references regenerates the fkey but doesn't reliably
+  // drop NOT NULL — do it directly.
+  await query.sequelize.query(
+    'ALTER TABLE facility_setting_migrations ALTER COLUMN facility_id DROP NOT NULL',
+  );
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  // DESTRUCTIVE: any device-keyed carrier rows (facility_id null) violate the
+  // restored NOT NULL — remove them by hand before rolling back.
+  await query.removeColumn('facility_setting_migrations', 'device_id');
+  await query.sequelize.query(
+    'ALTER TABLE facility_setting_migrations ALTER COLUMN facility_id SET NOT NULL',
+  );
+}

--- a/packages/database/src/models/FacilitySettingMigration.ts
+++ b/packages/database/src/models/FacilitySettingMigration.ts
@@ -13,7 +13,8 @@ export class FacilitySettingMigration extends Model {
   declare id: string;
   declare key: string;
   declare value: unknown;
-  declare facilityId: string;
+  declare facilityId?: string;
+  declare deviceId?: string;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
@@ -21,6 +22,8 @@ export class FacilitySettingMigration extends Model {
         id: primaryKey,
         key: { type: DataTypes.TEXT, allowNull: false },
         value: { type: DataTypes.JSONB, allowNull: false },
+        // Set for machine-level (server scope) rows, which have no facility.
+        deviceId: { type: DataTypes.TEXT, allowNull: true },
       },
       {
         ...options,

--- a/packages/database/src/models/Setting.ts
+++ b/packages/database/src/models/Setting.ts
@@ -1,5 +1,11 @@
 import { DataTypes, Op, Sequelize } from 'sequelize';
-import { isPlainObject, get as getAtPath, set as setAtPath, isEqual, keyBy } from 'es-toolkit/compat';
+import {
+  isPlainObject,
+  get as getAtPath,
+  set as setAtPath,
+  isEqual,
+  keyBy,
+} from 'es-toolkit/compat';
 import { settingsCache } from '@tamanu/settings/cache';
 import { SYNC_DIRECTIONS, SETTINGS_SCOPES } from '@tamanu/constants';
 import { extractDefaults, getScopedSchema } from '@tamanu/settings/schema';
@@ -38,6 +44,7 @@ export class Setting extends Model {
   declare value?: Record<string, any>;
   declare scope: string;
   declare facilityId?: string;
+  declare deviceId?: string;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
@@ -53,6 +60,8 @@ export class Setting extends Model {
           allowNull: false,
           defaultValue: SETTINGS_SCOPES.GLOBAL,
         },
+        // Set for server-scope (machine-level) rows, which sync only to their device.
+        deviceId: { type: DataTypes.TEXT, allowNull: true },
       },
       {
         ...options,
@@ -93,7 +102,13 @@ export class Setting extends Model {
             // settings_alive_key_unique_without_facility_idx
             unique: true,
             fields: ['key', 'scope'],
-            where: { deleted_at: null, facility_id: null },
+            where: { deleted_at: null, facility_id: null, device_id: null },
+          },
+          {
+            // settings_alive_key_unique_per_device_idx
+            unique: true,
+            fields: ['key', 'device_id'],
+            where: { deleted_at: null, device_id: { [Op.ne]: null } },
           },
         ],
       },
@@ -115,6 +130,7 @@ export class Setting extends Model {
     key: SettingPath | '' = '',
     facilityId: string | null = null,
     scopeOverride: (typeof SETTINGS_SCOPES_VALUES)[number] | null = null,
+    deviceId: string | null = null,
   ) {
     const determineScope = () => {
       if (scopeOverride) {
@@ -145,6 +161,9 @@ export class Setting extends Model {
           : {}),
         facilityId: {
           ...(facilityId ? { [Op.eq]: facilityId } : { [Op.is]: null }),
+        },
+        deviceId: {
+          ...(deviceId ? { [Op.eq]: deviceId } : { [Op.is]: null }),
         },
       },
 
@@ -177,8 +196,9 @@ export class Setting extends Model {
     value: unknown,
     scope: (typeof SETTINGS_SCOPES_VALUES)[number] = SETTINGS_SCOPES.GLOBAL,
     facilityId: string | null = null,
+    deviceId: string | null = null,
   ) {
-    const records = buildSettingsRecords(key, value, facilityId, scope);
+    const records = buildSettingsRecords(key, value, facilityId, scope, deviceId);
     const schema = getScopedSchema(scope);
     const defaultsForScope = extractDefaults(schema);
 
@@ -187,6 +207,7 @@ export class Setting extends Model {
         key: records.map(r => r.key),
         scope,
         facilityId,
+        deviceId,
       },
       paranoid: false,
     });
@@ -237,19 +258,22 @@ export class Setting extends Model {
           },
           scope,
           facilityId,
+          deviceId,
         },
       },
     );
   }
 
   static buildSyncFilter() {
-    return `WHERE (facility_id in (:facilityIds) OR scope = '${SETTINGS_SCOPES.GLOBAL}') AND ${this.tableName}.updated_at_sync_tick > :since`;
+    // device_id routes machine-level (server scope) rows to only their device.
+    return `WHERE (facility_id in (:facilityIds) OR scope = '${SETTINGS_SCOPES.GLOBAL}' OR device_id = :deviceId) AND ${this.tableName}.updated_at_sync_tick > :since`;
   }
 
   static async buildSyncLookupQueryDetails() {
     return {
       select: await buildSyncLookupSelect(this, {
         facilityId: 'settings.facility_id',
+        deviceId: 'settings.device_id',
       }),
     };
   }
@@ -294,11 +318,24 @@ function buildSettingsRecords(
   value: unknown,
   facilityId: string | null,
   scope: (typeof SETTINGS_SCOPES_VALUES)[number] = SETTINGS_SCOPES.GLOBAL,
-): { key: string; value: unknown; facilityId: string | null; scope: string }[] {
+  deviceId: string | null = null,
+): {
+  key: string;
+  value: unknown;
+  facilityId: string | null;
+  scope: string;
+  deviceId: string | null;
+}[] {
   if (isPlainObject(value)) {
     return Object.entries(value as Record<string, unknown>).flatMap(([k, v]) =>
-      buildSettingsRecords([keyPrefix, k].filter(Boolean).join('.'), v, facilityId, scope),
+      buildSettingsRecords(
+        [keyPrefix, k].filter(Boolean).join('.'),
+        v,
+        facilityId,
+        scope,
+        deviceId,
+      ),
     );
   }
-  return [{ key: keyPrefix, value, facilityId, scope }];
+  return [{ key: keyPrefix, value, facilityId, scope, deviceId }];
 }

--- a/packages/database/src/models/SyncLookup.ts
+++ b/packages/database/src/models/SyncLookup.ts
@@ -17,6 +17,7 @@ export class SyncLookup extends Model {
   declare isDeleted?: boolean;
   declare updatedAtByFieldSum?: number;
   declare pushedByDeviceId?: string;
+  declare deviceId?: string;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
@@ -33,6 +34,8 @@ export class SyncLookup extends Model {
         isDeleted: { type: DataTypes.BOOLEAN },
         updatedAtByFieldSum: { type: DataTypes.BIGINT },
         pushedByDeviceId: { type: DataTypes.TEXT },
+        // Routing: a row with device_id set syncs only to that device's sessions.
+        deviceId: { type: DataTypes.TEXT },
       },
       {
         ...options,

--- a/packages/database/src/sync/applyFacilitySettingMigrations.ts
+++ b/packages/database/src/sync/applyFacilitySettingMigrations.ts
@@ -17,6 +17,14 @@ export async function applyFacilitySettingMigrations(models: Models, ids: string
     // The carrier column is free-text; the setting path was validated when the row was written.
     const key = row.key as SettingPath;
     try {
+      if (row.deviceId) {
+        // Machine-level row: becomes a device-keyed server-scope setting, which
+        // syncs back down to (only) that device.
+        const existing = await Setting.get(key, null, SETTINGS_SCOPES.SERVER, row.deviceId);
+        if (existing !== undefined) continue;
+        await Setting.set(key, row.value, SETTINGS_SCOPES.SERVER, null, row.deviceId);
+        continue;
+      }
       const existing = await Setting.get(key, row.facilityId, SETTINGS_SCOPES.FACILITY);
       if (existing !== undefined) continue;
       await Setting.set(key, row.value, SETTINGS_SCOPES.FACILITY, row.facilityId);

--- a/packages/database/src/sync/buildSyncLookupSelect.ts
+++ b/packages/database/src/sync/buildSyncLookupSelect.ts
@@ -8,6 +8,7 @@ interface Columns {
   facilityId?: string;
   encounterId?: string;
   isLabRequestValue?: string;
+  deviceId?: string;
 }
 
 /**
@@ -32,7 +33,7 @@ export async function buildSyncLookupSelect(model: typeof Model, columns: Column
   const isFullyRebuilding =
     await model.sequelize.models.LocalSystemFact.isLookupRebuildingModel(table);
   const useUpdatedAtByFieldSum = !!attributes.updatedAtByField;
-  const { patientId, facilityId, encounterId, isLabRequestValue } = columns;
+  const { patientId, facilityId, encounterId, isLabRequestValue, deviceId } = columns;
 
   return `
     SELECT
@@ -43,13 +44,14 @@ export async function buildSyncLookupSelect(model: typeof Model, columns: Column
       sync_device_ticks.device_id,
       json_build_object(
         ${Object.keys(attributes)
-          .filter((a) => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))
-          .map((a) => `'${a}', ${table}.${snake(a)}`)}
+          .filter(a => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))
+          .map(a => `'${a}', ${table}.${snake(a)}`)}
       ),
       ${patientId || 'NULL'},
       ${facilityId || 'NULL'},
       ${encounterId || 'NULL'},
       ${isLabRequestValue || 'FALSE'},
-      ${useUpdatedAtByFieldSum ? 'updated_at_by_field_summary.sum' : 'NULL'}
+      ${useUpdatedAtByFieldSum ? 'updated_at_by_field_summary.sum' : 'NULL'},
+      ${deviceId || 'NULL'}
   `;
 }

--- a/packages/facility-server/__tests__/utilities.js
+++ b/packages/facility-server/__tests__/utilities.js
@@ -3,6 +3,7 @@ import supertest from 'supertest';
 import config from 'config';
 
 import { FACT_FACILITY_IDS } from '@tamanu/constants/facts';
+import { SETTINGS_SCOPES } from '@tamanu/constants';
 import {
   seedDepartments,
   seedFacilities,
@@ -125,14 +126,14 @@ class MockApplicationContext extends ApplicationContext {
       return acc;
     }, {});
     this.settings.global = new ReadSettings(this.models);
+    this.settings.server = new ReadSettings(this.models, undefined, SETTINGS_SCOPES.SERVER);
     // Mirrors resolveSchedules, so tests can construct tasks directly
     this.schedules = await this.settings[facilityIds[0]].get('schedules');
 
     const fhirWorkerEnabled =
       !!config?.integrations?.fhir?.enabled && !!config?.integrations?.fhir?.worker?.enabled;
 
-    const facilityReaders = facilityIds.map(id => this.settings[id]);
-    await initFhirSettingsFromDb(this.settings.global, facilityReaders);
+    await initFhirSettingsFromDb(this.settings.server);
     if (initFhirTriggers) {
       await setFhirRefreshTriggers(this.sequelize, { fhirWorkerEnabled });
     }

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -1,6 +1,7 @@
 import config from 'config';
 import { omit } from 'es-toolkit/compat';
 
+import { SETTINGS_SCOPES } from '@tamanu/constants';
 import { initReporting } from '@tamanu/database/services/reporting';
 import { initBugsnag, log } from '@tamanu/shared/services/logging';
 import { ReadSettings } from '@tamanu/settings/reader';
@@ -62,6 +63,8 @@ export class ApplicationContext {
       return acc;
     }, {});
     this.settings.global = new ReadSettings(this.models);
+    // Machine-level knobs (scope 'server'): local rows only, never synced.
+    this.settings.server = new ReadSettings(this.models, undefined, SETTINGS_SCOPES.SERVER);
 
     const fhirWorkerEnabled =
       !!config?.integrations?.fhir?.enabled && !!config?.integrations?.fhir?.worker?.enabled;

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -69,8 +69,7 @@ export class ApplicationContext {
     const fhirWorkerEnabled =
       !!config?.integrations?.fhir?.enabled && !!config?.integrations?.fhir?.worker?.enabled;
 
-    const facilityReaders = facilityIds.map(id => this.settings[id]);
-    await initFhirSettingsFromDb(this.settings.global, facilityReaders);
+    await initFhirSettingsFromDb(this.settings.server);
     await setFhirRefreshTriggers(this.sequelize, { fhirWorkerEnabled });
 
     return this;

--- a/packages/facility-server/app/sync/FacilitySyncManager.js
+++ b/packages/facility-server/app/sync/FacilitySyncManager.js
@@ -60,10 +60,11 @@ export class FacilitySyncManager {
 
   currentStartTime = 0;
 
-  constructor({ models, sequelize, centralServer }) {
+  constructor({ models, sequelize, centralServer, settings }) {
     this.models = models;
     this.sequelize = sequelize;
     this.centralServer = centralServer;
+    this.settings = settings;
   }
 
   isSyncRunning() {
@@ -246,11 +247,15 @@ export class FacilitySyncManager {
     const pull = (await this.centralServer.streaming())
       ? streamIncomingChanges
       : pullIncomingChanges;
+    // Machine-level pull tuning; contexts without a server reader (some tests)
+    // fall back to config inside pullIncomingChanges.
+    const syncTuning = (await this.settings?.server?.get('sync')) ?? {};
     const { totalPulled, pullUntil } = await pull(
       this.centralServer,
       this.sequelize,
       sessionId,
       pullSince,
+      syncTuning,
     );
 
     if (this.constructor.config.sync.assertIfPulledRecordsUpdatedAfterPushSnapshot) {

--- a/packages/facility-server/app/sync/pullIncomingChanges.js
+++ b/packages/facility-server/app/sync/pullIncomingChanges.js
@@ -11,9 +11,24 @@ import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { calculatePageLimit } from './calculatePageLimit';
 
-const { persistedCacheBatchSize, pauseBetweenCacheBatchInMilliseconds } = config.sync;
+// Machine-level tuning (scope 'server' settings) threaded in by the sync
+// manager; config is the fallback for callers without a server reader.
+const resolveTuning = tuning => ({
+  persistedCacheBatchSize: tuning.persistedCacheBatchSize ?? config.sync.persistedCacheBatchSize,
+  pauseBetweenCacheBatchInMilliseconds:
+    tuning.pauseBetweenCacheBatchInMilliseconds ?? config.sync.pauseBetweenCacheBatchInMilliseconds,
+  dynamicLimiter: tuning.dynamicLimiter ?? config.sync.dynamicLimiter,
+});
 
-export const pullIncomingChanges = async (centralServer, sequelize, sessionId, since) => {
+export const pullIncomingChanges = async (
+  centralServer,
+  sequelize,
+  sessionId,
+  since,
+  tuning = {},
+) => {
+  const { persistedCacheBatchSize, pauseBetweenCacheBatchInMilliseconds, dynamicLimiter } =
+    resolveTuning(tuning);
   const start = Date.now();
 
   // initiating pull also returns the sync tick (or point on the sync timeline) that the
@@ -23,7 +38,7 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
 
   log.info('FacilitySyncManager.pulling', { since, totalToPull });
   let fromId;
-  let limit = calculatePageLimit();
+  let limit = calculatePageLimit(undefined, undefined, dynamicLimiter);
   let totalPulled = 0;
 
   // pull changes a page at a time
@@ -52,11 +67,11 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
     const recordsToSave = records.map(r => {
       delete r.sortOrder;
       return {
-      ...r,
-      data: { ...r.data, updatedAtSyncTick: SYNC_TICK_FLAGS.INCOMING_FROM_CENTRAL_SERVER }, // mark as never updated, so we don't push it back to the central server until the next local update
-      direction: SYNC_SESSION_DIRECTION.INCOMING,
-    };
-  });
+        ...r,
+        data: { ...r.data, updatedAtSyncTick: SYNC_TICK_FLAGS.INCOMING_FROM_CENTRAL_SERVER }, // mark as never updated, so we don't push it back to the central server until the next local update
+        direction: SYNC_SESSION_DIRECTION.INCOMING,
+      };
+    });
 
     // This is an attempt to avoid storing all the pulled data
     // in the memory because we might run into memory issue when:
@@ -69,14 +84,21 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
       await sleepAsync(pauseBetweenCacheBatchInMilliseconds);
     }
 
-    limit = calculatePageLimit(limit, pullTime);
+    limit = calculatePageLimit(limit, pullTime, dynamicLimiter);
   }
 
   log.info('FacilitySyncManager.pulled', { durationMs: Date.now() - start });
   return { totalPulled: totalToPull, pullUntil };
 };
 
-export const streamIncomingChanges = async (centralServer, sequelize, sessionId, since) => {
+export const streamIncomingChanges = async (
+  centralServer,
+  sequelize,
+  sessionId,
+  since,
+  tuning = {},
+) => {
+  const { persistedCacheBatchSize } = resolveTuning(tuning);
   const start = Date.now();
 
   // initiating pull also returns the sync tick (or point on the sync timeline) that the

--- a/packages/mobile/App/migrations/1785100000000-addDeviceIdToSetting.ts
+++ b/packages/mobile/App/migrations/1785100000000-addDeviceIdToSetting.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+const TABLE_NAME = 'settings';
+const COLUMN_NAME = 'deviceId';
+
+// Mirrors the server-side settings.device_id column (server-scope settings are
+// keyed by device). Device-routed rows only sync to their own device, so this
+// stays null on mobile — the column exists so a pulled record round-trips
+// losslessly and reads can guard against misrouted rows.
+export class addDeviceIdToSetting1785100000000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+    await queryRunner.addColumn(
+      table,
+      new TableColumn({
+        name: COLUMN_NAME,
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+    await queryRunner.dropColumn(table, COLUMN_NAME);
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -88,6 +88,7 @@ import { removePatientTitleColumn1778199200000 } from './1778199200000-removePat
 import { addLabTestReferenceRangeColumns1778546880000 } from './1778546880000-addLabTestReferenceRangeColumns';
 import { addSurveyResponseEditMetadata1778560763154 } from './1778560763154-addSurveyResponseEditMetadata';
 import { removeDietIdFromEncounter1781501076000 } from './1781501076000-removeDietIdFromEncounter';
+import { addDeviceIdToSetting1785100000000 } from './1785100000000-addDeviceIdToSetting';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -179,4 +180,5 @@ export const migrationList = [
   addLabTestReferenceRangeColumns1778546880000,
   addSurveyResponseEditMetadata1778560763154,
   removeDietIdFromEncounter1781501076000,
+  addDeviceIdToSetting1785100000000,
 ];

--- a/packages/mobile/App/models/Setting.ts
+++ b/packages/mobile/App/models/Setting.ts
@@ -22,6 +22,11 @@ export class Setting extends BaseModel {
   @Column({ nullable: false })
   scope: string;
 
+  // Mirrors the server column; device-routed (server scope) rows never sync to
+  // mobile, so this stays null here.
+  @Column({ nullable: true })
+  deviceId?: string;
+
   @ManyToOne(() => Facility)
   facility: IFacility;
 
@@ -51,7 +56,9 @@ export class Setting extends BaseModel {
         new Brackets(qb => {
           qb.where('facilityId = :facilityId', { facilityId }).orWhere('facilityId IS NULL');
         }),
-      );
+      )
+      // guard against misrouted device-keyed (server scope) rows polluting reads
+      .andWhere('deviceId IS NULL');
 
     if (key) {
       settingsQueryBuilder.andWhere(

--- a/packages/settings/__tests__/schema.test.js
+++ b/packages/settings/__tests__/schema.test.js
@@ -3,6 +3,7 @@ import {
   globalDefaults,
   centralDefaults,
   facilityDefaults,
+  serverDefaults,
   getKeysByFlag,
   globalSettings,
   facilitySettings,
@@ -317,6 +318,23 @@ describe('Schemas', () => {
       await expect(
         validateSettings({ settings: facilityDefaults, scope: 'facility' }),
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe('Server settings', () => {
+    it('Should validate itself', async () => {
+      await expect(
+        validateSettings({ settings: serverDefaults, scope: 'server' }),
+      ).resolves.not.toThrow();
+    });
+
+    it('Should throw error for invalid settings', async () => {
+      await expect(
+        validateSettings({
+          settings: { sync: { persistedCacheBatchSize: -5 } },
+          scope: 'server',
+        }),
+      ).rejects.toThrow(yup.ValidationError);
     });
   });
 

--- a/packages/settings/src/configToSettings.ts
+++ b/packages/settings/src/configToSettings.ts
@@ -67,7 +67,11 @@ export const CONFIG_TO_SETTINGS: ConfigToSetting[] = [
     scope: SETTINGS_SCOPES.CENTRAL,
   },
   { config: 'telegramBot', setting: 'integrations.telegram', scope: SETTINGS_SCOPES.CENTRAL },
-  { config: 'scheduledReports', setting: 'reporting.scheduledReports', scope: SETTINGS_SCOPES.CENTRAL },
+  {
+    config: 'scheduledReports',
+    setting: 'reporting.scheduledReports',
+    scope: SETTINGS_SCOPES.CENTRAL,
+  },
   {
     config: 'validateQuestionConfigs.enabled',
     setting: 'validateQuestionConfigs.enabled',
@@ -106,6 +110,19 @@ export const CONFIG_TO_SETTINGS: ConfigToSetting[] = [
     setting: 'integrations.mSupplyMed',
     scope: SETTINGS_SCOPES.FACILITY,
   },
+  // Machine-level sync tuning: SERVER scope rows are written locally by the
+  // facility server's own upgrade step (no carrier — they never leave the box).
+  {
+    config: 'sync.persistedCacheBatchSize',
+    setting: 'sync.persistedCacheBatchSize',
+    scope: SETTINGS_SCOPES.SERVER,
+  },
+  {
+    config: 'sync.pauseBetweenCacheBatchInMilliseconds',
+    setting: 'sync.pauseBetweenCacheBatchInMilliseconds',
+    scope: SETTINGS_SCOPES.SERVER,
+  },
+  { config: 'sync.dynamicLimiter', setting: 'sync.dynamicLimiter', scope: SETTINGS_SCOPES.SERVER },
   // Subtree row: lifts every scheduled-task knob under `schedules` in one go.
   { config: 'schedules', setting: 'schedules', scope: SETTINGS_SCOPES.CENTRAL },
   // Legacy `localisation` un-nested into top-level settings (central config only;

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -6,6 +6,8 @@ export {
   centralDefaults,
   globalDefaults,
   facilityDefaults,
+  serverSettings,
+  serverDefaults,
   validateSettings,
   getScopedSchema,
   isSetting,

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -3,11 +3,15 @@ import { ExposedFlag, SettingPath, SettingsSchema } from '../types';
 import { buildSettings } from '..';
 import { settingsCache } from '../cache';
 import { Models } from './readers/SettingsDBReader';
+import { SETTINGS_SCOPES } from '@tamanu/constants';
 import { globalSettings } from '../schema/global';
 import { facilitySettings } from '../schema/facility';
 import { centralSettings } from '../schema/central';
 
 const allSchemas = [globalSettings, facilitySettings, centralSettings];
+
+// Cache key for the machine-scope reader; can't collide with a facility id.
+const SERVER_CACHE_KEY = 'scope:server';
 const getSchemasForSettingsContext = (facilityId?: string): SettingsSchema[] =>
   facilityId ? [facilitySettings, globalSettings] : [centralSettings, globalSettings];
 
@@ -36,9 +40,15 @@ export const getKeysByFlag = (
 export class ReadSettings<Path = SettingPath> {
   models: Models;
   facilityId?: string;
-  constructor(models: Models, facilityId?: string) {
+  scope?: string;
+  constructor(models: Models, facilityId?: string, scope?: string) {
     this.models = models;
     this.facilityId = facilityId;
+    this.scope = scope;
+  }
+
+  private get cacheKey() {
+    return this.scope === SETTINGS_SCOPES.SERVER ? SERVER_CACHE_KEY : this.facilityId;
   }
 
   async get<T extends string | number | object>(key: Path): Promise<T> {
@@ -66,10 +76,10 @@ export class ReadSettings<Path = SettingPath> {
   }
 
   async getAll() {
-    let settings = settingsCache.getAllSettings(this.facilityId);
+    let settings = settingsCache.getAllSettings(this.cacheKey);
     if (!settings) {
-      settings = await buildSettings(this.models, this.facilityId);
-      settingsCache.setAllSettings(settings, this.facilityId);
+      settings = await buildSettings(this.models, this.facilityId, this.scope);
+      settingsCache.setAllSettings(settings, this.cacheKey);
     }
     return settings;
   }

--- a/packages/settings/src/reader/buildSettings.ts
+++ b/packages/settings/src/reader/buildSettings.ts
@@ -1,7 +1,7 @@
 import { SETTINGS_SCOPES } from '@tamanu/constants';
 import { isArray, mergeWith } from 'es-toolkit/compat';
 
-import { centralDefaults, facilityDefaults, globalDefaults } from '../schema';
+import { centralDefaults, facilityDefaults, globalDefaults, serverDefaults } from '../schema';
 import { Models, SettingsDBReader } from './readers/SettingsDBReader';
 import { SettingsJSONReader } from './readers/SettingsJSONReader';
 import { SettingsConfigReader } from './readers/SettingsConfigReader';
@@ -12,7 +12,17 @@ import { SettingsConfigReader } from './readers/SettingsConfigReader';
  * config value for any key that has no setting yet, so config moving into settings
  * never changes behaviour. They sit below recorded settings and above schema defaults.
  */
-function getReaderCascade(models: Models, facilityId?: string) {
+function getReaderCascade(models: Models, facilityId?: string, scope?: string) {
+  // Machine-level settings: local rows only (facility_id null, never synced),
+  // config fallback for keys mid-move, then schema defaults. No global
+  // fallthrough — server keys live in exactly one schema.
+  if (scope === SETTINGS_SCOPES.SERVER) {
+    return [
+      new SettingsDBReader(models, SETTINGS_SCOPES.SERVER),
+      new SettingsConfigReader(SETTINGS_SCOPES.SERVER),
+      new SettingsJSONReader(serverDefaults),
+    ];
+  }
   return facilityId
     ? [
         new SettingsDBReader(models, SETTINGS_SCOPES.FACILITY, facilityId),
@@ -32,8 +42,8 @@ function getReaderCascade(models: Models, facilityId?: string) {
       ];
 }
 
-export async function buildSettings(models: Models, facilityId?: string) {
-  const readers = getReaderCascade(models, facilityId);
+export async function buildSettings(models: Models, facilityId?: string, scope?: string) {
+  const readers = getReaderCascade(models, facilityId, scope);
   let settings = {};
   for (const reader of readers) {
     const value = await reader.getSettings();

--- a/packages/settings/src/reader/buildSettings.ts
+++ b/packages/settings/src/reader/buildSettings.ts
@@ -13,14 +13,17 @@ import { SettingsConfigReader } from './readers/SettingsConfigReader';
  * never changes behaviour. They sit below recorded settings and above schema defaults.
  */
 function getReaderCascade(models: Models, facilityId?: string, scope?: string) {
-  // Machine-level settings: local rows only (facility_id null, never synced),
-  // config fallback for keys mid-move, then schema defaults. No global
-  // fallthrough — server keys live in exactly one schema.
+  // Machine-level settings, keyed by this machine's device id. Global sits
+  // below server in the cascade so a dual-declared key (e.g. fhir) is a true
+  // per-server override of the global value, mirroring the facility cascade.
   if (scope === SETTINGS_SCOPES.SERVER) {
     return [
       new SettingsDBReader(models, SETTINGS_SCOPES.SERVER),
+      new SettingsDBReader(models, SETTINGS_SCOPES.GLOBAL),
       new SettingsConfigReader(SETTINGS_SCOPES.SERVER),
+      new SettingsConfigReader(SETTINGS_SCOPES.GLOBAL),
       new SettingsJSONReader(serverDefaults),
+      new SettingsJSONReader(globalDefaults),
     ];
   }
   return facilityId

--- a/packages/settings/src/reader/readers/SettingsDBReader.ts
+++ b/packages/settings/src/reader/readers/SettingsDBReader.ts
@@ -1,15 +1,22 @@
+import { FACT_DEVICE_ID, SETTINGS_SCOPES } from '@tamanu/constants';
+
 import { Reader, ReaderSettingResult } from './Reader';
 
 /* eslint-disable no-unused-vars */
 interface SettingModel {
   get: (
     key: string,
-    facilityId?: string,
+    facilityId?: string | null,
     scope?: string,
+    deviceId?: string | null,
   ) => Promise<undefined | ReaderSettingResult>;
+}
+interface FactModel {
+  get: (key: string) => Promise<string | undefined | null>;
 }
 export interface Models {
   Setting: SettingModel;
+  LocalSystemFact?: FactModel;
 }
 
 export class SettingsDBReader extends Reader {
@@ -25,10 +32,15 @@ export class SettingsDBReader extends Reader {
   }
 
   async getSettings() {
-    const { Setting } = this.models;
+    const { Setting, LocalSystemFact } = this.models;
+    if (this.scope === SETTINGS_SCOPES.SERVER) {
+      // Server-scope rows are keyed by this machine's device id, resolved
+      // lazily so the reader can be built before device init has run.
+      const deviceId = await LocalSystemFact?.get(FACT_DEVICE_ID);
+      if (!deviceId) return undefined; // fall through to config fallback / defaults
+      return Setting.get('', undefined, this.scope, deviceId);
+    }
     // Get all settings for the selected scope/facility
-    const settings = await Setting.get('', this.facilityId, this.scope);
-
-    return settings;
+    return Setting.get('', this.facilityId, this.scope);
   }
 }

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -16,7 +16,6 @@ import {
   vaccinationsSchema,
   datelessTimeStringSchema,
   durationStringSchema,
-  fhirResourceMaterialisationSchema,
 } from './definitions';
 
 export const facilitySettings = {
@@ -342,24 +341,6 @@ export const facilitySettings = {
           description:
             'Reject client requests to this facility server that do not arrive over HTTPS. Overrides the global `security.requireHttps` default for this facility; leave unset to follow the global setting. Requires a TLS-terminating proxy that is listed in `proxy.trusted` and forwards the `X-Forwarded-Proto` header, otherwise all requests will be rejected. Can only be enabled from an HTTPS connection.',
           type: yup.boolean().nullable(),
-        },
-      },
-    },
-    fhir: {
-      name: 'FHIR',
-      description: 'FHIR integration settings (facility-level overrides)',
-      highRisk: true,
-      properties: {
-        worker: {
-          name: 'FHIR worker',
-          description: 'FHIR worker settings',
-          properties: {
-            resourceMaterialisationEnabled: {
-              ...fhirResourceMaterialisationSchema,
-              infoBanner:
-                'Resource materialisation settings are merged across all facilities on this server. Enabling a resource type here will enable it server-wide, even if other facilities have it disabled.',
-            },
-          },
         },
       },
     },

--- a/packages/settings/src/schema/index.ts
+++ b/packages/settings/src/schema/index.ts
@@ -1,6 +1,7 @@
 export * from './central';
 export * from './facility';
 export * from './global';
+export * from './server';
 export * from './validation';
 export * from './utils';
 export {

--- a/packages/settings/src/schema/server.ts
+++ b/packages/settings/src/schema/server.ts
@@ -1,0 +1,74 @@
+import * as yup from 'yup';
+
+import { extractDefaults } from './utils';
+
+/**
+ * Machine-level settings for a facility server. Rows live only in that server's
+ * own DB (scope 'server', facility_id null): the sync filter never sends them
+ * anywhere, and the central admin panel refuses the scope — they are edited on
+ * the machine itself (psql/bestool). This is the home for per-server tuning that
+ * makes no sense keyed by facility on a multi-facility server.
+ */
+export const serverSettings = {
+  name: 'Server settings',
+  description: 'Machine-level settings for this facility server, stored locally and never synced',
+  properties: {
+    sync: {
+      description: 'Sync throughput tuning for this server',
+      highRisk: true,
+      properties: {
+        persistedCacheBatchSize: {
+          name: 'Persisted cache batch size',
+          description: 'How many pulled records are written to the snapshot table per batch',
+          type: yup.number().integer().positive(),
+          defaultValue: 10000,
+        },
+        pauseBetweenCacheBatchInMilliseconds: {
+          name: 'Pause between cache batches',
+          description: 'Sleep between snapshot-table write batches, to relieve database load',
+          type: yup.number().integer().min(0),
+          defaultValue: 50,
+          unit: 'ms',
+        },
+        dynamicLimiter: {
+          description: 'Adaptive page sizing for sync pulls, targeting a time per page',
+          properties: {
+            initialLimit: {
+              name: 'Initial limit',
+              description: 'Records per pull page at the start of a session',
+              type: yup.number().integer().positive(),
+              defaultValue: 10,
+            },
+            minLimit: {
+              name: 'Minimum limit',
+              description: 'Smallest allowed pull page',
+              type: yup.number().integer().positive(),
+              defaultValue: 1,
+            },
+            maxLimit: {
+              name: 'Maximum limit',
+              description: 'Largest allowed pull page',
+              type: yup.number().integer().positive(),
+              defaultValue: 10000,
+            },
+            optimalTimePerPageMs: {
+              name: 'Optimal time per page',
+              description: 'Page size adapts to aim for this duration per pull page',
+              type: yup.number().integer().positive(),
+              defaultValue: 2000,
+              unit: 'ms',
+            },
+            maxLimitChangePerPage: {
+              name: 'Max limit change per page',
+              description: 'Cap on page-size growth/shrink between pages, as a fraction',
+              type: yup.number().positive(),
+              defaultValue: 0.2,
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const serverDefaults = extractDefaults(serverSettings);

--- a/packages/settings/src/schema/server.ts
+++ b/packages/settings/src/schema/server.ts
@@ -1,18 +1,34 @@
 import * as yup from 'yup';
 
 import { extractDefaults } from './utils';
+import { fhirResourceMaterialisationSchema } from './definitions';
 
 /**
- * Machine-level settings for a facility server. Rows live only in that server's
- * own DB (scope 'server', facility_id null): the sync filter never sends them
- * anywhere, and the central admin panel refuses the scope — they are edited on
- * the machine itself (psql/bestool). This is the home for per-server tuning that
- * makes no sense keyed by facility on a multi-facility server.
+ * Machine-level settings for a facility server, keyed by its device id. Rows
+ * are authored on central (admin panel, Server scope) and sync only to the
+ * device they belong to. This is the home for per-server settings that make no
+ * sense keyed by facility on a multi-facility server. Keys declared both here
+ * and in the global schema (e.g. fhir) resolve server row -> global row ->
+ * defaults, mirroring the facility-overrides-global cascade.
  */
 export const serverSettings = {
   name: 'Server settings',
-  description: 'Machine-level settings for this facility server, stored locally and never synced',
+  description: 'Machine-level settings for a facility server, keyed by its device id',
   properties: {
+    fhir: {
+      name: 'FHIR',
+      description: 'FHIR integration settings (server-level overrides)',
+      highRisk: true,
+      properties: {
+        worker: {
+          name: 'FHIR worker',
+          description: 'FHIR worker settings',
+          properties: {
+            resourceMaterialisationEnabled: fhirResourceMaterialisationSchema,
+          },
+        },
+      },
+    },
     sync: {
       description: 'Sync throughput tuning for this server',
       highRisk: true,

--- a/packages/settings/src/schema/validation.ts
+++ b/packages/settings/src/schema/validation.ts
@@ -2,6 +2,7 @@ import { SETTINGS_SCOPES } from '@tamanu/constants';
 import { globalSettings } from './global';
 import { centralSettings } from './central';
 import { facilitySettings } from './facility';
+import { serverSettings } from './server';
 import * as yup from 'yup';
 import _, { cloneDeep, isArray, mergeWith } from 'es-toolkit/compat';
 import { SettingsSchema } from '../types';
@@ -11,37 +12,44 @@ const SCOPE_TO_SCHEMA = {
   [SETTINGS_SCOPES.GLOBAL]: globalSettings,
   [SETTINGS_SCOPES.CENTRAL]: centralSettings,
   [SETTINGS_SCOPES.FACILITY]: facilitySettings,
+  [SETTINGS_SCOPES.SERVER]: serverSettings,
 };
 
 // Flattening stops at keys the schema declares as settings, so an object-typed
 // setting (e.g. imagingTypes) reaches its yup schema whole instead of
 // dissolving into leaf keys the schema doesn't know (and never validating).
 const flattenSettings = (obj: unknown, settingKeys: Set<string>, parentKey = '') => {
-  return Object.entries(obj).reduce((acc, [key, value]) => {
-    const fullKey = parentKey ? `${parentKey}.${key}` : key;
+  return Object.entries(obj).reduce(
+    (acc, [key, value]) => {
+      const fullKey = parentKey ? `${parentKey}.${key}` : key;
 
-    if (_.isObject(value) && !Array.isArray(value) && !settingKeys.has(fullKey)) {
-      Object.assign(acc, flattenSettings(value, settingKeys, fullKey));
-    } else {
-      acc[fullKey] = value;
-    }
+      if (_.isObject(value) && !Array.isArray(value) && !settingKeys.has(fullKey)) {
+        Object.assign(acc, flattenSettings(value, settingKeys, fullKey));
+      } else {
+        acc[fullKey] = value;
+      }
 
-    return acc;
-  }, {} as Record<string, unknown>);
+      return acc;
+    },
+    {} as Record<string, unknown>,
+  );
 };
 
 const flattenSchema = (schema: SettingsSchema, parentKey = '') => {
-  return Object.entries(schema.properties).reduce((acc, [key, value]) => {
-    const fullKey = parentKey ? `${parentKey}.${key}` : key;
+  return Object.entries(schema.properties).reduce(
+    (acc, [key, value]) => {
+      const fullKey = parentKey ? `${parentKey}.${key}` : key;
 
-    if (isSetting(value)) {
-      acc[fullKey] = value.secret ? value.type.nullable() : value.type;
-    } else {
-      Object.assign(acc, flattenSchema(value, fullKey));
-    }
+      if (isSetting(value)) {
+        acc[fullKey] = value.secret ? value.type.nullable() : value.type;
+      } else {
+        Object.assign(acc, flattenSchema(value, fullKey));
+      }
 
-    return acc;
-  }, {} as Record<string, yup.AnySchema>);
+      return acc;
+    },
+    {} as Record<string, yup.AnySchema>,
+  );
 };
 
 export const getScopedSchema = (scope: string) => {
@@ -65,9 +73,7 @@ export const validateSettings = async ({
 
   const flattenedSchema = flattenSchema(schemaValue);
   const flattenedSettings = flattenSettings(settings, new Set(Object.keys(flattenedSchema)));
-  const yupSchema = yup
-    .object()
-    .shape(flattenedSchema);
+  const yupSchema = yup.object().shape(flattenedSchema);
 
   await yupSchema.validate(flattenedSettings, { abortEarly: false, strict: true });
 };

--- a/packages/shared/src/utils/fhir/fhirSettings.js
+++ b/packages/shared/src/utils/fhir/fhirSettings.js
@@ -23,31 +23,17 @@ export function resetFhirSettings() {
  * Load FHIR settings from the database at server startup.
  * Cached for the process lifetime (these settings have requiresRestart: true in the schema).
  *
- * @param {ReadSettings} globalSettings - global-scoped settings reader
- * @param {ReadSettings[]} [facilitySettings] - facility-scoped settings readers.
- *   resourceMaterialisationEnabled is union-merged across facilities so a single
- *   worker pool materialises everything needed.
+ * @param {ReadSettings} settingsReader - central reader on central; the server
+ *   (machine-scope) reader on facility servers, whose cascade resolves the
+ *   per-server resourceMaterialisationEnabled override before the global value.
  */
-export async function initFhirSettingsFromDb(globalSettings, facilitySettings = []) {
+export async function initFhirSettingsFromDb(settingsReader) {
   if (loaded) return;
 
-  const fhir = await globalSettings.get('fhir');
-
-  const globalMatEnabled = fhir.worker.resourceMaterialisationEnabled;
-
-  const perFacilityResults = await Promise.all(
-    facilitySettings.map(fs => fs.get('fhir.worker.resourceMaterialisationEnabled')),
-  );
-  let mergedMatEnabled = { ...globalMatEnabled };
-  for (const perFacility of perFacilityResults) {
-    if (!perFacility) continue;
-    for (const [key, val] of Object.entries(perFacility)) {
-      if (val) mergedMatEnabled[key] = true;
-    }
-  }
+  const fhir = await settingsReader.get('fhir');
 
   settings = {
-    resourceMaterialisationEnabled: mergedMatEnabled,
+    resourceMaterialisationEnabled: fhir.worker.resourceMaterialisationEnabled,
     extensions: fhir.extensions,
     nullLastNameValue: fhir.nullLastNameValue,
     assigners: fhir.assigners,

--- a/packages/upgrade/__tests__/steps/1783100000000-migrateServerConfigToSettings.test.ts
+++ b/packages/upgrade/__tests__/steps/1783100000000-migrateServerConfigToSettings.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FACT_SERVER_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
+
+vi.mock('@tamanu/settings', () => ({
+  configOverridesForScope: vi.fn(),
+}));
+
+import { configOverridesForScope } from '@tamanu/settings';
+import { STEPS } from '../../src/steps/1783100000000-migrateServerConfigToSettings.js';
+
+const step = STEPS[0];
+
+const makeArgs = () => ({
+  models: {
+    Setting: { set: vi.fn() },
+    LocalSystemFact: { get: vi.fn().mockResolvedValue(undefined), set: vi.fn() },
+  },
+  serverType: 'facility',
+  toVersion: '2.99.0',
+});
+
+describe('1783100000000-migrateServerConfigToSettings', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('check', () => {
+    it('runs on facility when not yet migrated', async () => {
+      expect(await step.check(makeArgs())).toBe(true);
+    });
+    it('skips when already migrated', async () => {
+      const args = makeArgs();
+      args.models.LocalSystemFact.get.mockResolvedValue('2.50.0');
+      expect(await step.check(args)).toBe(false);
+    });
+    it('skips on a central server', async () => {
+      expect(await step.check({ ...makeArgs(), serverType: 'central' })).toBe(false);
+    });
+  });
+
+  describe('run', () => {
+    it('writes each overridden subtree as a local server-scope setting', async () => {
+      configOverridesForScope.mockReturnValue({
+        sync: { persistedCacheBatchSize: 5000, dynamicLimiter: { maxLimit: 20000 } },
+      });
+      const args = makeArgs();
+      await step.run(args);
+      expect(configOverridesForScope).toHaveBeenCalledWith(SETTINGS_SCOPES.SERVER);
+      expect(args.models.Setting.set).toHaveBeenCalledWith(
+        'sync',
+        { persistedCacheBatchSize: 5000, dynamicLimiter: { maxLimit: 20000 } },
+        SETTINGS_SCOPES.SERVER,
+      );
+      expect(args.models.LocalSystemFact.set).toHaveBeenCalledWith(
+        FACT_SERVER_CONFIG_MIGRATED,
+        '2.99.0',
+      );
+    });
+
+    it('writes nothing (but still records the fact) on a stock config', async () => {
+      configOverridesForScope.mockReturnValue({});
+      const args = makeArgs();
+      await step.run(args);
+      expect(args.models.Setting.set).not.toHaveBeenCalled();
+      expect(args.models.LocalSystemFact.set).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/upgrade/__tests__/steps/1783100000000-migrateServerConfigToSettings.test.ts
+++ b/packages/upgrade/__tests__/steps/1783100000000-migrateServerConfigToSettings.test.ts
@@ -1,22 +1,48 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { FACT_SERVER_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
+import { FACT_DEVICE_ID, FACT_SERVER_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
 
 vi.mock('@tamanu/settings', () => ({
+  CONFIG_TO_SETTINGS: [
+    { config: 'sync.dynamicLimiter', setting: 'sync.dynamicLimiter', scope: 'server' },
+    { config: 'language', setting: 'language', scope: 'central' }, // filtered out (not server)
+  ],
   configOverridesForScope: vi.fn(),
 }));
 
 import { configOverridesForScope } from '@tamanu/settings';
-import { STEPS } from '../../src/steps/1783100000000-migrateServerConfigToSettings.js';
+import {
+  STEPS,
+  serverConfigRows,
+} from '../../src/steps/1783100000000-migrateServerConfigToSettings.js';
 
 const step = STEPS[0];
 
-const makeArgs = () => ({
+const makeArgs = (deviceId: string | null = 'facility-server-abc') => ({
   models: {
-    Setting: { set: vi.fn() },
-    LocalSystemFact: { get: vi.fn().mockResolvedValue(undefined), set: vi.fn() },
+    FacilitySettingMigration: { upsert: vi.fn() },
+    LocalSystemFact: {
+      get: vi.fn(async (key: string) => (key === FACT_DEVICE_ID ? deviceId : undefined)),
+      set: vi.fn(),
+    },
   },
   serverType: 'facility',
   toVersion: '2.99.0',
+});
+
+describe('serverConfigRows', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps server-scoped keys with a config value and drops the rest', () => {
+    configOverridesForScope.mockReturnValue({ sync: { dynamicLimiter: { maxLimit: 20000 } } });
+    expect(serverConfigRows()).toEqual([
+      { key: 'sync.dynamicLimiter', value: { maxLimit: 20000 } },
+    ]);
+  });
+
+  it('drops a server key with no local config value', () => {
+    configOverridesForScope.mockReturnValue({});
+    expect(serverConfigRows()).toEqual([]);
+  });
 });
 
 describe('1783100000000-migrateServerConfigToSettings', () => {
@@ -28,7 +54,7 @@ describe('1783100000000-migrateServerConfigToSettings', () => {
     });
     it('skips when already migrated', async () => {
       const args = makeArgs();
-      args.models.LocalSystemFact.get.mockResolvedValue('2.50.0');
+      args.models.LocalSystemFact.get = vi.fn().mockResolvedValue('2.50.0');
       expect(await step.check(args)).toBe(false);
     });
     it('skips on a central server', async () => {
@@ -37,18 +63,17 @@ describe('1783100000000-migrateServerConfigToSettings', () => {
   });
 
   describe('run', () => {
-    it('writes each overridden subtree as a local server-scope setting', async () => {
-      configOverridesForScope.mockReturnValue({
-        sync: { persistedCacheBatchSize: 5000, dynamicLimiter: { maxLimit: 20000 } },
-      });
+    it('writes device-keyed carrier rows for overridden values', async () => {
+      configOverridesForScope.mockReturnValue({ sync: { dynamicLimiter: { maxLimit: 20000 } } });
       const args = makeArgs();
       await step.run(args);
       expect(configOverridesForScope).toHaveBeenCalledWith(SETTINGS_SCOPES.SERVER);
-      expect(args.models.Setting.set).toHaveBeenCalledWith(
-        'sync',
-        { persistedCacheBatchSize: 5000, dynamicLimiter: { maxLimit: 20000 } },
-        SETTINGS_SCOPES.SERVER,
-      );
+      expect(args.models.FacilitySettingMigration.upsert).toHaveBeenCalledWith({
+        id: 'facility-server-abc;sync.dynamicLimiter',
+        key: 'sync.dynamicLimiter',
+        value: { maxLimit: 20000 },
+        deviceId: 'facility-server-abc',
+      });
       expect(args.models.LocalSystemFact.set).toHaveBeenCalledWith(
         FACT_SERVER_CONFIG_MIGRATED,
         '2.99.0',
@@ -59,8 +84,16 @@ describe('1783100000000-migrateServerConfigToSettings', () => {
       configOverridesForScope.mockReturnValue({});
       const args = makeArgs();
       await step.run(args);
-      expect(args.models.Setting.set).not.toHaveBeenCalled();
+      expect(args.models.FacilitySettingMigration.upsert).not.toHaveBeenCalled();
       expect(args.models.LocalSystemFact.set).toHaveBeenCalled();
+    });
+
+    it('retries next upgrade when the device id is not initialised yet', async () => {
+      configOverridesForScope.mockReturnValue({ sync: { dynamicLimiter: { maxLimit: 20000 } } });
+      const args = makeArgs(null);
+      await step.run(args);
+      expect(args.models.FacilitySettingMigration.upsert).not.toHaveBeenCalled();
+      expect(args.models.LocalSystemFact.set).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/upgrade/src/steps/1783100000000-migrateServerConfigToSettings.ts
+++ b/packages/upgrade/src/steps/1783100000000-migrateServerConfigToSettings.ts
@@ -1,24 +1,50 @@
-import { FACT_SERVER_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
-import { configOverridesForScope } from '@tamanu/settings';
+import { FACT_DEVICE_ID, FACT_SERVER_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
+import { CONFIG_TO_SETTINGS, configOverridesForScope } from '@tamanu/settings';
+import { get as getAtPath } from 'es-toolkit/compat';
 
 import type { Steps, StepArgs } from '../step.ts';
 import { END } from '../step.js';
+import { carrierId } from './1785000000001-migrateFacilityConfigToSettings.js';
 
-// On the first facility upgrade, snapshot each server-scoped (machine-level)
-// config value into a local Setting row. Unlike the facility step there is no
-// carrier: server-scope rows live only in this server's own DB and never sync.
-// Fact-gated to run once; the config fallback reader serves these values until
-// then, so timing isn't load-bearing.
+// Flat {key, value} for each server-scoped (machine-level) config value present
+// locally. Secrets and keys with no local config value are already dropped by
+// configOverridesForScope.
+export const serverConfigRows = () => {
+  const overrides = configOverridesForScope(SETTINGS_SCOPES.SERVER);
+  return CONFIG_TO_SETTINGS.filter(entry => entry.scope === SETTINGS_SCOPES.SERVER)
+    .map(entry => ({ key: entry.setting, value: getAtPath(overrides, entry.setting) }))
+    .filter(row => row.value !== undefined);
+};
+
+// On the first facility upgrade, snapshot each server-scoped config value into the
+// FacilitySettingMigration carrier, keyed by this machine's device id. The row
+// pushes up and central turns it into a device-keyed server-scope Setting, which
+// syncs back down to (only) this device — central stays the single author of all
+// settings rows. Fact-gated to run once; the config fallback reader serves these
+// values until the setting arrives, so timing isn't load-bearing.
 export const STEPS: Steps = [
   {
     at: END,
     async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
       return serverType === 'facility' && !(await LocalSystemFact.get(FACT_SERVER_CONFIG_MIGRATED));
     },
-    async run({ toVersion, models: { Setting, LocalSystemFact } }: StepArgs) {
-      const overrides = configOverridesForScope(SETTINGS_SCOPES.SERVER);
-      for (const [key, value] of Object.entries(overrides)) {
-        await Setting.set(key, value, SETTINGS_SCOPES.SERVER);
+    async run({ toVersion, models: { FacilitySettingMigration, LocalSystemFact } }: StepArgs) {
+      const rows = serverConfigRows();
+      if (rows.length) {
+        const deviceId = await LocalSystemFact.get(FACT_DEVICE_ID);
+        if (!deviceId) {
+          // no device id means this server has never initialised — nothing to
+          // migrate yet; leave the fact unset so the next upgrade retries
+          return;
+        }
+        for (const { key, value } of rows) {
+          await FacilitySettingMigration.upsert({
+            id: carrierId(deviceId, key),
+            key,
+            value,
+            deviceId,
+          });
+        }
       }
       await LocalSystemFact.set(FACT_SERVER_CONFIG_MIGRATED, toVersion);
     },

--- a/packages/upgrade/src/steps/1783100000000-migrateServerConfigToSettings.ts
+++ b/packages/upgrade/src/steps/1783100000000-migrateServerConfigToSettings.ts
@@ -1,0 +1,26 @@
+import { FACT_SERVER_CONFIG_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
+import { configOverridesForScope } from '@tamanu/settings';
+
+import type { Steps, StepArgs } from '../step.ts';
+import { END } from '../step.js';
+
+// On the first facility upgrade, snapshot each server-scoped (machine-level)
+// config value into a local Setting row. Unlike the facility step there is no
+// carrier: server-scope rows live only in this server's own DB and never sync.
+// Fact-gated to run once; the config fallback reader serves these values until
+// then, so timing isn't load-bearing.
+export const STEPS: Steps = [
+  {
+    at: END,
+    async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
+      return serverType === 'facility' && !(await LocalSystemFact.get(FACT_SERVER_CONFIG_MIGRATED));
+    },
+    async run({ toVersion, models: { Setting, LocalSystemFact } }: StepArgs) {
+      const overrides = configOverridesForScope(SETTINGS_SCOPES.SERVER);
+      for (const [key, value] of Object.entries(overrides)) {
+        await Setting.set(key, value, SETTINGS_SCOPES.SERVER);
+      }
+      await LocalSystemFact.set(FACT_SERVER_CONFIG_MIGRATED, toVersion);
+    },
+  },
+];

--- a/packages/upgrade/src/steps/1783100000001-moveFhirOverridesToServerScope.ts
+++ b/packages/upgrade/src/steps/1783100000001-moveFhirOverridesToServerScope.ts
@@ -1,0 +1,90 @@
+import { Op, QueryTypes } from 'sequelize';
+import { FACT_FHIR_OVERRIDES_MIGRATED, SETTINGS_SCOPES } from '@tamanu/constants';
+
+import type { Steps, StepArgs } from '../step.ts';
+import { END } from '../step.js';
+
+const OVERRIDE_KEY = 'fhir.worker.resourceMaterialisationEnabled';
+
+// The facility server a facility belongs to, per its most recent non-mobile
+// sync session. Facilities that have never synced from a facility server
+// resolve to null.
+const deviceForFacility = async (sequelize: any, facilityId: string) => {
+  const [row] = await sequelize.query(
+    `
+      SELECT parameters->>'deviceId' AS "deviceId"
+      FROM sync_sessions
+      WHERE parameters->'facilityIds' @> :facilityJson::jsonb
+        AND COALESCE(parameters->>'isMobile', 'false') != 'true'
+        AND parameters->>'deviceId' IS NOT NULL
+      ORDER BY start_time DESC
+      LIMIT 1
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { facilityJson: JSON.stringify([facilityId]) },
+    },
+  );
+  return (row as { deviceId?: string } | undefined)?.deviceId ?? null;
+};
+
+// fhir.worker.resourceMaterialisationEnabled used to be facility-overridable,
+// with the values of every facility on a server union-merged at boot (any-true
+// wins; a facility false never disabled anything). It is now a server-scope
+// (device-keyed) setting. This central step replays that merge once: facility
+// rows are grouped by the device that serves them and any-true values become a
+// device row, then the facility rows are removed (the deletion syncs down).
+// Facilities with no known device are left untouched with a warning — their
+// rows are inert either way, since nothing reads the facility key any more.
+export const STEPS: Steps = [
+  {
+    at: END,
+    async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
+      return serverType === 'central' && !(await LocalSystemFact.get(FACT_FHIR_OVERRIDES_MIGRATED));
+    },
+    async run({ sequelize, models: { Setting, LocalSystemFact }, log, toVersion }: StepArgs) {
+      // settings are stored one row per leaf: `<key>.<ResourceType>` -> boolean
+      const facilityRows = await Setting.findAll({
+        where: {
+          scope: SETTINGS_SCOPES.FACILITY,
+          key: { [Op.like]: `${OVERRIDE_KEY}.%` },
+        },
+      });
+
+      const deviceByFacility = new Map<string, string | null>();
+      const enabledByDevice = new Map<string, Record<string, boolean>>();
+      const migratedRowIds: string[] = [];
+      for (const row of facilityRows) {
+        if (!deviceByFacility.has(row.facilityId!)) {
+          deviceByFacility.set(row.facilityId!, await deviceForFacility(sequelize, row.facilityId));
+        }
+        const deviceId = deviceByFacility.get(row.facilityId!);
+        if (!deviceId) {
+          log.warn('moveFhirOverridesToServerScope: no known device for facility; leaving row', {
+            facilityId: row.facilityId,
+          });
+          continue;
+        }
+        const resource = row.key.slice(OVERRIDE_KEY.length + 1);
+        const enabled = enabledByDevice.get(deviceId) ?? {};
+        if (row.value) enabled[resource] = true;
+        enabledByDevice.set(deviceId, enabled);
+        migratedRowIds.push(row.id);
+      }
+
+      for (const [deviceId, enabled] of enabledByDevice.entries()) {
+        if (Object.keys(enabled).length === 0) continue;
+        const existing = await Setting.get(OVERRIDE_KEY, null, SETTINGS_SCOPES.SERVER, deviceId);
+        if (existing !== undefined) continue; // never clobber an operator's value
+        await Setting.set(OVERRIDE_KEY, enabled, SETTINGS_SCOPES.SERVER, null, deviceId);
+      }
+
+      if (migratedRowIds.length) {
+        // soft delete, so the removal syncs down to the facility copies
+        await Setting.destroy({ where: { id: migratedRowIds } });
+      }
+
+      await LocalSystemFact.set(FACT_FHIR_OVERRIDES_MIGRATED, toVersion);
+    },
+  },
+];

--- a/packages/web/app/api/queries/useAdminSettingsQuery.js
+++ b/packages/web/app/api/queries/useAdminSettingsQuery.js
@@ -4,17 +4,17 @@ import { SETTINGS_SCOPES } from '@tamanu/constants';
 
 // Fetch admin-scoped settings from central server
 // Use `select` in options to transform the returned data if needed
-export const useAdminSettingsQuery = (scope, facilityId, options = {}) => {
+export const useAdminSettingsQuery = (scope, facilityId, deviceId, options = {}) => {
   const api = useApi();
 
   return useQuery(
-    ['scopedSettings', scope, facilityId],
-    () => api.get('admin/settings', { scope, facilityId }),
+    ['scopedSettings', scope, facilityId, deviceId],
+    () => api.get('admin/settings', { scope, facilityId, deviceId }),
     {
-      enabled: scope !== SETTINGS_SCOPES.FACILITY || !!facilityId,
+      enabled:
+        (scope !== SETTINGS_SCOPES.FACILITY || !!facilityId) &&
+        (scope !== SETTINGS_SCOPES.SERVER || !!deviceId),
       ...options,
     },
   );
 };
-
-

--- a/packages/web/app/views/administration/settings/SettingsView.jsx
+++ b/packages/web/app/views/administration/settings/SettingsView.jsx
@@ -53,9 +53,11 @@ const tabs = [
     key: SETTING_TABS.EDITOR,
     icon: <SettingsIcon />,
     render: props => {
-      // Don't show the editor if the scope is facility and no facility is selected
-      const { facilityId, scope } = props.values;
-      const shouldShowEditor = scope !== SETTINGS_SCOPES.FACILITY || !!facilityId;
+      // Don't show the editor until the scope's target (facility/server) is selected
+      const { facilityId, deviceId, scope } = props.values;
+      const shouldShowEditor =
+        (scope !== SETTINGS_SCOPES.FACILITY || !!facilityId) &&
+        (scope !== SETTINGS_SCOPES.SERVER || !!deviceId);
       return (
         <TabContainer data-testid="tabcontainer-6tbj">
           <ScopeSelectorFields {...props} data-testid="scopeselectorfields-mdma" />
@@ -87,33 +89,34 @@ export const SettingsView = () => {
   const api = useApi();
   const [scope, setScope] = useState(SETTINGS_SCOPES.GLOBAL);
   const [facilityId, setFacilityId] = useState(null);
+  const [deviceId, setDeviceId] = useState(null);
 
   const { data: settingsSnapshot = {}, error: settingsFetchError } = useAdminSettingsQuery(
     scope,
     facilityId,
+    deviceId,
     {
       select: data => applyDefaults(data, scope),
     },
   );
 
-  const { data: globalSettings } = useAdminSettingsQuery(
-    SETTINGS_SCOPES.GLOBAL,
-    null,
-    {
-      enabled: scope === SETTINGS_SCOPES.FACILITY,
-      select: (data) => applyDefaults(data, SETTINGS_SCOPES.GLOBAL),
-    },
-  );
+  const { data: globalSettings } = useAdminSettingsQuery(SETTINGS_SCOPES.GLOBAL, null, null, {
+    enabled: scope === SETTINGS_SCOPES.FACILITY,
+    select: data => applyDefaults(data, SETTINGS_SCOPES.GLOBAL),
+  });
 
   const queryClient = useQueryClient();
 
   const handleSubmit = async ({ settings }) => {
     try {
       await validateSettings({ settings, scope });
-      await api.put('admin/settings', { settings, facilityId, scope });
-      const savedSettings = applyDefaults(await api.get('admin/settings', { scope, facilityId }), scope);
+      await api.put('admin/settings', { settings, facilityId, deviceId, scope });
+      const savedSettings = applyDefaults(
+        await api.get('admin/settings', { scope, facilityId, deviceId }),
+        scope,
+      );
       notifySuccess('Settings saved');
-      queryClient.invalidateQueries(['scopedSettings', scope, facilityId]);
+      queryClient.invalidateQueries(['scopedSettings', scope, facilityId, deviceId]);
       return { settings: savedSettings };
     } catch (error) {
       if (error instanceof ValidationError) {
@@ -142,7 +145,7 @@ export const SettingsView = () => {
       ) : (
         <Form
           enableReinitialize
-          initialValues={{ scope, facilityId, settings: settingsSnapshot }}
+          initialValues={{ scope, facilityId, deviceId, settings: settingsSnapshot }}
           onSubmit={handleSubmit}
           render={props => (
             <SettingsForm
@@ -151,6 +154,8 @@ export const SettingsView = () => {
               setScope={setScope}
               facilityId={facilityId}
               setFacilityId={setFacilityId}
+              deviceId={deviceId}
+              setDeviceId={setDeviceId}
               globalSettings={scope === SETTINGS_SCOPES.FACILITY ? globalSettings : undefined}
               data-testid="settingsform-lqhf"
             />
@@ -175,6 +180,8 @@ const SettingsForm = ({
   setScope,
   facilityId,
   setFacilityId,
+  deviceId,
+  setDeviceId,
   globalSettings,
 }) => {
   const { ability } = useAuth();
@@ -211,6 +218,16 @@ const SettingsForm = ({
     }
     setScope(newScope);
     setFacilityId(null);
+    setDeviceId(null);
+  };
+
+  const handleDeviceChange = async e => {
+    const newDeviceId = e.target.value;
+    if (newDeviceId !== deviceId && dirty) {
+      const dismissChanges = await handleShowWarningModal();
+      if (!dismissChanges) return;
+    }
+    setDeviceId(newDeviceId);
   };
 
   const handleFacilityChange = async e => {
@@ -241,6 +258,8 @@ const SettingsForm = ({
         onScopeChange={handleChangeScope}
         facilityId={facilityId}
         onFacilityChange={handleFacilityChange}
+        deviceId={deviceId}
+        onDeviceChange={handleDeviceChange}
         globalSettings={globalSettings}
         data-testid="styledtabdisplay-teef"
       />

--- a/packages/web/app/views/administration/settings/components/ScopeSelectorFields.jsx
+++ b/packages/web/app/views/administration/settings/components/ScopeSelectorFields.jsx
@@ -30,10 +30,17 @@ const SCOPE_OPTIONS = [
     label: 'Facility (Single Facility)',
     value: SETTINGS_SCOPES.FACILITY,
   },
+  {
+    label: 'Server (Single Facility Server)',
+    value: SETTINGS_SCOPES.SERVER,
+  },
 ];
 
+const formatLastSeen = lastSeenAt =>
+  lastSeenAt ? new Date(lastSeenAt).toLocaleDateString() : 'never seen';
+
 export const ScopeSelectorFields = React.memo(
-  ({ scope, onScopeChange, facilityId, onFacilityChange }) => {
+  ({ scope, onScopeChange, facilityId, onFacilityChange, deviceId, onDeviceChange }) => {
     const api = useApi();
     const { data: facilitiesArray = [], error } = useQuery(
       ['facilitiesList'],
@@ -42,10 +49,22 @@ export const ScopeSelectorFields = React.memo(
         enabled: scope === SETTINGS_SCOPES.FACILITY,
       },
     );
+    const { data: devicesArray = [], error: devicesError } = useQuery(
+      ['devicesList'],
+      () => api.get('admin/devices'),
+      {
+        enabled: scope === SETTINGS_SCOPES.SERVER,
+      },
+    );
 
-    const facilityOptions = facilitiesArray.map((facility) => ({
+    const facilityOptions = facilitiesArray.map(facility => ({
       label: facility.name,
       value: facility.id,
+    }));
+
+    const deviceOptions = devicesArray.map(device => ({
+      label: `${device.name ?? device.id} (last seen ${formatLastSeen(device.lastSeenAt)})`,
+      value: device.id,
     }));
 
     return (
@@ -66,6 +85,25 @@ export const ScopeSelectorFields = React.memo(
           error={!!error}
           data-testid="scopeselectinput-zxel"
         />
+        {scope === SETTINGS_SCOPES.SERVER && (
+          <ScopeDynamicSelectInput
+            name="deviceId"
+            options={deviceOptions}
+            label={
+              <TranslatedText
+                stringId="admin.settings.device.label"
+                fallback="Server device"
+                data-testid="translatedtext-device-label"
+              />
+            }
+            value={deviceId}
+            onChange={onDeviceChange}
+            required
+            isClearable={false}
+            error={!!devicesError}
+            data-testid="scopedynamicselectinput-device"
+          />
+        )}
         {scope === SETTINGS_SCOPES.FACILITY && (
           <ScopeDynamicSelectInput
             name="facilityId"


### PR DESCRIPTION
## Changes

experiment

Adds a fourth settings scope, `server`, for machine-level settings on a facility server — settings that make no sense keyed by facility when one server serves several facility ids (TAM-6863's device identity is the natural key). Server-scope rows are **centrally managed and device-routed**: central is the single author, and sync delivers each row only to the facility server it belongs to.

**Routing.** `settings.device_id` + `sync_lookup.device_id` (with a load-bearing partial index — see benchmark below). The snapshot predicate (both lookup and legacy paths) gains a device guard: broadcast/facility rows require `device_id IS NULL`; device rows sync only to the session pulling as that device (`OR device_id = :deviceId`, already a replacement param). Mobile never receives device rows; its settings table gains the mirrored column (TypeORM migration) and a defensive `deviceId IS NULL` read guard, and the admin device picker lists facility servers only.

**First tenants.** Sync pull tuning (`sync.persistedCacheBatchSize`, `sync.pauseBetweenCacheBatchInMilliseconds`, `sync.dynamicLimiter.*`) — never centrally manageable before (ops edit config on the box). The sync manager resolves tuning once per run via the `settings.server` reader (device rows → config fallback → schema defaults) and threads it into pull/stream.

**Migration.** A fact-gated facility upgrade step snapshots non-default config values into the `facility_setting_migrations` carrier keyed by deviceId (`facility_id` now nullable); central applies them as device-keyed server settings (skip-if-exists), which sync back down. Round-trip covered in `settingsMigrationRoundTrip.test.js`.

**Admin.** Settings GET/PUT accept `deviceId` (required for server scope); new `GET /admin/devices` feeds the scope picker's device dropdown ("Server (Single Facility Server)").

**Benchmark** (3M-row synthetic sync_lookup, production-shaped chunk query): old predicate ~28ms/chunk (BitmapOr on the tick index). New predicate **without** the device index: planner falls to parallel seq scan, ~110ms/chunk — 4x, far worse at production scale. With the partial index (`WHERE device_id IS NOT NULL`): **~25ms/chunk, plan and cost identical to old** (device arm joins the BitmapOr at 0.003ms). The index ships in the migration.

**Tests**: device routing on both snapshot paths (own device receives, other device / null-device sessions excluded, globals still broadcast), lookup build carries device_id, carrier round trip incl. operator-value-wins, upgrade step unit tests, settings schema/reader tests. dbt models regenerated for the three table changes.

Review focus: the predicate change in `snapshotOutgoingChanges.js` + `Setting.buildSyncFilter`, the lookup column plumbing, and the carrier change.

**Follow-up in this PR — fhir moves to server scope.** `fhir.worker.resourceMaterialisationEnabled` was facility-overridable with boot-time union-merging across a server's facilities (and an infoBanner explaining that enabling for one facility enabled it server-wide). It's now a server-scope override: the server reader cascade falls through to global (server row → global row → defaults, mirroring the facility cascade), `initFhirSettingsFromDb` collapses to a single reader with the merge logic deleted, and the banner is gone. A fact-gated central upgrade step replays the old merge once — facility rows grouped by the device that serves them (latest non-mobile sync session), any-true values become one device row (never clobbering an operator's server value), migrated facility rows soft-deleted so the removal syncs down; unmapped facilities are left untouched with a warning (their rows are inert). Covered in the round-trip test.