### PR TITLE
fix(sync): TAM-6863: hide device sync users from admin panel, exports and suggesters

### DIFF
--- a/database/model/public/users.md
+++ b/database/model/public/users.md
@@ -48,3 +48,9 @@ How many devices this user can register (when `features.deviceRegistrationQuota`
 
 See [`devices`](#!/source/source.tamanu.tamanu.devices) for more.
 {% enddocs %}
+
+{% docs users__kind %}
+Distinguishes machine accounts from humans: `user` for ordinary accounts, `sync` for the per-device accounts facility servers authenticate with to sync.
+
+Sync users are hidden from the admin user list and clinician suggestions, and can only be managed by re-running facility setup.
+{% enddocs %}

--- a/database/model/public/users.yml
+++ b/database/model/public/users.yml
@@ -93,3 +93,8 @@ sources:
               - dbt_utils.accepted_range:
                   arguments:
                     min_value: 0
+          - name: kind
+            data_type: character varying(255)
+            description: "{{ doc('users__kind') }}"
+            data_tests:
+              - not_null

--- a/package-lock.json
+++ b/package-lock.json
@@ -30642,6 +30642,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "engines": {
@@ -35638,7 +35639,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -37681,6 +37682,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "packages/central-server/node_modules/react": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.5.tgz",
+      "integrity": "sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "packages/central-server/node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -37700,6 +37716,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "packages/central-server/node_modules/scheduler": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "packages/central-server/node_modules/semver": {
       "version": "7.8.3",
@@ -38555,6 +38581,21 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "packages/facility-server/node_modules/react": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.5.tgz",
+      "integrity": "sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "packages/facility-server/node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -38574,6 +38615,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "packages/facility-server/node_modules/scheduler": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "packages/facility-server/node_modules/semver": {
       "version": "7.8.3",
@@ -39500,6 +39551,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
       "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "engines": {
@@ -39563,6 +39615,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
       "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,
       "engines": {
@@ -39676,6 +39729,7 @@
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
       "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -39701,6 +39755,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
       "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -40591,6 +40646,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
       "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -40639,6 +40695,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
       "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -41428,6 +41485,7 @@
         "@tamanu/constants": "*",
         "@tamanu/database": "*",
         "@tamanu/shared": "*",
+        "config": "^3.3.9",
         "es-toolkit": "^1.48.1",
         "sequelize": "^6.37.8",
         "toposort": "^2.0.2",

--- a/packages/central-server/__tests__/admin/syncCredentials.test.js
+++ b/packages/central-server/__tests__/admin/syncCredentials.test.js
@@ -59,6 +59,7 @@ describe('Admin sync credentials', () => {
     });
     expect(user).toBeTruthy();
     expect(user.role).toBe('admin');
+    expect(user.kind).toBe('sync');
     expect(user.displayName).toContain('sync');
     // password is stored hashed, not as the returned plaintext
     expect(user.password).not.toBe(result.body.password);

--- a/packages/central-server/__tests__/admin/syncCredentials.test.js
+++ b/packages/central-server/__tests__/admin/syncCredentials.test.js
@@ -93,4 +93,35 @@ describe('Admin sync credentials', () => {
     expect(second).toHaveSucceeded();
     expect(second.body.email).not.toBe(first.body.email);
   });
+
+  it('hides sync users from the admin users list', async () => {
+    const app = await baseApp.asRole('admin');
+    const provisioned = await app
+      .post(ENDPOINT)
+      .send({ deviceId: 'device-hidden', facilityIds: ['facility-hidden'] });
+    expect(provisioned).toHaveSucceeded();
+
+    const list = await app.get('/api/admin/users').query({ email: provisioned.body.email });
+    expect(list).toHaveSucceeded();
+    expect(list.body.data).toHaveLength(0);
+  });
+
+  it('refuses admin panel edits to sync users', async () => {
+    const app = await baseApp.asRole('admin');
+    const provisioned = await app
+      .post(ENDPOINT)
+      .send({ deviceId: 'device-locked', facilityIds: ['facility-locked'] });
+    expect(provisioned).toHaveSucceeded();
+
+    const user = await models.User.findOne({ where: { email: provisioned.body.email } });
+    const result = await app.put(`/api/admin/users/${user.id}`).send({
+      displayName: user.displayName,
+      email: user.email,
+      role: user.role,
+      visibilityStatus: 'current',
+      newPassword: 'hunter2hunter2',
+      confirmPassword: 'hunter2hunter2',
+    });
+    expect(result).toHaveRequestError();
+  });
 });

--- a/packages/central-server/app/admin/exporter/modelExporters/UserExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/UserExporter.js
@@ -1,9 +1,13 @@
+import { Op } from 'sequelize';
+import { USER_KINDS } from '@tamanu/constants';
 import { ModelExporter } from './ModelExporter';
 
 export class UserExporter extends ModelExporter {
   async getData() {
     const modelName = 'User';
     const users = await this.models[modelName].findAll({
+      // Machine accounts for device sync are managed by facility setup, not spreadsheets
+      where: { kind: { [Op.ne]: USER_KINDS.SYNC } },
       include: this.models.User.getFullReferenceAssociations(),
     });
 
@@ -15,6 +19,6 @@ export class UserExporter extends ModelExporter {
   }
 
   customHiddenColumns() {
-    return ['type', 'facilities'];
+    return ['type', 'facilities', 'kind'];
   }
 }

--- a/packages/central-server/app/admin/syncCredentials.js
+++ b/packages/central-server/app/admin/syncCredentials.js
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import asyncHandler from 'express-async-handler';
 import * as z from 'zod';
-import { SYNC_USER_EMAIL_SUFFIX } from '@tamanu/constants';
+import { USER_KINDS } from '@tamanu/constants';
 
 const bodySchema = z.object({
   deviceId: z.string().trim().min(1),
@@ -13,7 +13,7 @@ const bodySchema = z.object({
 // device rather than the facility set so two servers serving the same
 // facilities can't overwrite each other's credentials.
 const syncUserEmail = deviceId =>
-  `sync.${crypto.createHash('sha256').update(deviceId).digest('hex').slice(0, 32)}${SYNC_USER_EMAIL_SUFFIX}`;
+  `sync.${crypto.createHash('sha256').update(deviceId).digest('hex').slice(0, 32)}@sync.tamanu`;
 
 // Provision (or rotate) a dedicated sync user and return its credentials, for a
 // facility's setup wizard. Mirrors the sync users the `provision` subcommand
@@ -37,11 +37,11 @@ export const provisionSyncCredentials = asyncHandler(async (req, res) => {
 
   const existing = await User.findOne({ where: { email } });
   if (existing) {
-    existing.set({ displayName, role: 'admin' });
+    existing.set({ displayName, role: 'admin', kind: USER_KINDS.SYNC });
     await existing.setPassword(password);
     await existing.save();
   } else {
-    await User.create({ email, displayName, role: 'admin', password });
+    await User.create({ email, displayName, role: 'admin', kind: USER_KINDS.SYNC, password });
   }
 
   // Plaintext credential in the body — keep it out of any intermediary cache.

--- a/packages/central-server/app/admin/syncCredentials.js
+++ b/packages/central-server/app/admin/syncCredentials.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import asyncHandler from 'express-async-handler';
 import * as z from 'zod';
+import { SYNC_USER_EMAIL_SUFFIX } from '@tamanu/constants';
 
 const bodySchema = z.object({
   deviceId: z.string().trim().min(1),
@@ -12,7 +13,7 @@ const bodySchema = z.object({
 // device rather than the facility set so two servers serving the same
 // facilities can't overwrite each other's credentials.
 const syncUserEmail = deviceId =>
-  `sync.${crypto.createHash('sha256').update(deviceId).digest('hex').slice(0, 32)}@sync.tamanu`;
+  `sync.${crypto.createHash('sha256').update(deviceId).digest('hex').slice(0, 32)}${SYNC_USER_EMAIL_SUFFIX}`;
 
 // Provision (or rotate) a dedicated sync user and return its credentials, for a
 // facility's setup wizard. Mirrors the sync users the `provision` subcommand

--- a/packages/central-server/app/admin/users.js
+++ b/packages/central-server/app/admin/users.js
@@ -9,6 +9,7 @@ import {
   VISIBILITY_STATUSES,
   SYSTEM_USER_UUID,
   ADMIN_USER_EMAIL,
+  SYNC_USER_EMAIL_SUFFIX,
 } from '@tamanu/constants';
 import {
   DatabaseDuplicateError,
@@ -63,6 +64,10 @@ const createUserFilters = (filterParams, models) => {
     // Exclude admin user
     {
       email: { [Op.ne]: ADMIN_USER_EMAIL },
+    },
+    // Exclude device sync users — managed by facility setup, not this panel
+    {
+      email: { [Op.notILike]: `%${SYNC_USER_EMAIL_SUFFIX}` },
     },
   ];
 
@@ -403,6 +408,14 @@ usersRouter.put(
     }
     // only allow updating the user if the user has the write permission for the all users
     req.checkPermission('write', subject('User', { id: String(Date.now()) }));
+
+    // Editing a sync user (especially its password) silently breaks that
+    // device's sync; rotate via the facility setup wizard instead.
+    if (user.email.toLowerCase().endsWith(SYNC_USER_EMAIL_SUFFIX)) {
+      throw new InvalidOperationError(
+        'Sync users are managed by facility setup and cannot be edited',
+      );
+    }
 
     const role = await Role.findByPk(fields.role);
     if (!role) {

--- a/packages/central-server/app/admin/users.js
+++ b/packages/central-server/app/admin/users.js
@@ -9,7 +9,7 @@ import {
   VISIBILITY_STATUSES,
   SYSTEM_USER_UUID,
   ADMIN_USER_EMAIL,
-  SYNC_USER_EMAIL_SUFFIX,
+  USER_KINDS,
 } from '@tamanu/constants';
 import {
   DatabaseDuplicateError,
@@ -67,7 +67,7 @@ const createUserFilters = (filterParams, models) => {
     },
     // Exclude device sync users — managed by facility setup, not this panel
     {
-      email: { [Op.notILike]: `%${SYNC_USER_EMAIL_SUFFIX}` },
+      kind: { [Op.ne]: USER_KINDS.SYNC },
     },
   ];
 
@@ -411,7 +411,7 @@ usersRouter.put(
 
     // Editing a sync user (especially its password) silently breaks that
     // device's sync; rotate via the facility setup wizard instead.
-    if (user.email.toLowerCase().endsWith(SYNC_USER_EMAIL_SUFFIX)) {
+    if (user.kind === USER_KINDS.SYNC) {
       throw new InvalidOperationError(
         'Sync users are managed by facility setup and cannot be edited',
       );

--- a/packages/central-server/app/subCommands/provision.js
+++ b/packages/central-server/app/subCommands/provision.js
@@ -11,6 +11,7 @@ import {
   PERMISSION_IMPORTABLE_DATA_TYPES,
   SETTINGS_SCOPES,
   SYSTEM_USER_UUID,
+  USER_KINDS,
 } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 import { extractSecretPaths, getScopedSchema, ReadSettings } from '@tamanu/settings';
@@ -312,7 +313,11 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
     ...Object.entries(facilities)
       .map(
         ([id, { user, password }]) =>
-          user && password && [user, { displayName: `System: ${id} sync`, password }],
+          user &&
+          password && [
+            user,
+            { displayName: `System: ${id} sync`, kind: USER_KINDS.SYNC, password },
+          ],
       )
       .filter(Boolean),
   ];

--- a/packages/constants/src/auth.ts
+++ b/packages/constants/src/auth.ts
@@ -17,6 +17,9 @@ export const TEST_PATIENT_ID = 'h1627394-3778-4c31-a510-9fcb88efdbf3';
 
 export const ADMIN_USER_EMAIL = 'admin@tamanu.io';
 
+// Machine accounts minted per device for facility sync (see central admin/syncCredentials)
+export const SYNC_USER_EMAIL_SUFFIX = '@sync.tamanu';
+
 export const CAN_ACCESS_ALL_FACILITIES = 'ALL';
 
 // When adding more scopes here, you need to consider:

--- a/packages/constants/src/auth.ts
+++ b/packages/constants/src/auth.ts
@@ -17,8 +17,13 @@ export const TEST_PATIENT_ID = 'h1627394-3778-4c31-a510-9fcb88efdbf3';
 
 export const ADMIN_USER_EMAIL = 'admin@tamanu.io';
 
-// Machine accounts minted per device for facility sync (see central admin/syncCredentials)
-export const SYNC_USER_EMAIL_SUFFIX = '@sync.tamanu';
+// Distinguishes machine accounts from humans; sync users are minted per device
+// for facility sync (see central admin/syncCredentials and provision).
+export const USER_KINDS = {
+  USER: 'user',
+  SYNC: 'sync',
+} as const;
+export type UserKind = (typeof USER_KINDS)[keyof typeof USER_KINDS];
 
 export const CAN_ACCESS_ALL_FACILITIES = 'ALL';
 

--- a/packages/database/src/migrations/1783118255000-addUserKind.ts
+++ b/packages/database/src/migrations/1783118255000-addUserKind.ts
@@ -1,0 +1,14 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('users', 'kind', {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'user',
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  // DESTRUCTIVE: sync users will revert to looking like ordinary users.
+  await query.removeColumn('users', 'kind');
+}

--- a/packages/database/src/models/User.ts
+++ b/packages/database/src/models/User.ts
@@ -18,6 +18,7 @@ import {
   SERVER_TYPES,
   SYNC_DIRECTIONS,
   SYSTEM_USER_UUID,
+  USER_KINDS,
   VISIBILITY_STATUSES,
 } from '@tamanu/constants';
 import {
@@ -47,6 +48,7 @@ export class User extends Model {
   declare password?: string;
   declare displayName: string;
   declare role: string;
+  declare kind: string;
   declare phoneNumber?: string;
   declare visibilityStatus: string;
   declare facilities: Facility[];
@@ -145,6 +147,11 @@ export class User extends Model {
         role: {
           type: DataTypes.STRING,
           defaultValue: 'practitioner',
+          allowNull: false,
+        },
+        kind: {
+          type: DataTypes.STRING,
+          defaultValue: USER_KINDS.USER,
           allowNull: false,
         },
         phoneNumber: {

--- a/packages/facility-server/__tests__/apiv1/Setup.test.js
+++ b/packages/facility-server/__tests__/apiv1/Setup.test.js
@@ -1,3 +1,5 @@
+import { SYNC_DIRECTIONS } from '@tamanu/constants';
+
 import { createTestContext } from '../utilities';
 
 // The test config provides a sync host + credentials + facilities, so the server
@@ -24,12 +26,21 @@ describe('Setup endpoints', () => {
   });
 
   it('POST /public/setup/sync refuses a configured server (409)', async () => {
+    const password = 'sup3r-secret-pw';
     const result = await baseApp.post('/api/public/setup/sync').send({
       host: 'https://central.example.com',
       email: 'admin@example.com',
-      password: 'pw',
+      password,
       facilityIds: ['facility-a'],
     });
     expect(result.status).toBe(409);
+    // the endpoint must never echo the submitted credentials back
+    expect(JSON.stringify(result.body)).not.toContain(password);
+  });
+
+  it('never syncs the stores that hold sync credentials', () => {
+    const { LocalSystemFact, LocalSystemSecret } = ctx.models;
+    expect(LocalSystemFact.syncDirection).toBe(SYNC_DIRECTIONS.DO_NOT_SYNC);
+    expect(LocalSystemSecret.syncDirection).toBe(SYNC_DIRECTIONS.DO_NOT_SYNC);
   });
 });

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -583,6 +583,25 @@ describe('Suggestions', () => {
       const idArray = body.map(({ id }) => id);
       expect(idArray).not.toContain(obsoleteSurveyId);
     });
+
+    it('should not suggest device sync users as practitioners', async () => {
+      await models.User.create({
+        email: 'suggestions.clinician@tamanu.io',
+        displayName: 'Suggestions Sync Clinician',
+        role: 'practitioner',
+      });
+      await models.User.create({
+        email: 'sync.0123456789abcdef@sync.tamanu',
+        displayName: 'System: facility-sync-test sync',
+        role: 'admin',
+      });
+
+      const result = await userApp.get('/api/suggestions/practitioner').query({ q: 'sync' });
+      expect(result).toHaveSucceeded();
+      const names = result.body.map(({ name }) => name);
+      expect(names).toContain('Suggestions Sync Clinician');
+      expect(names).not.toContain('System: facility-sync-test sync');
+    });
   });
 
   describe('Order of results (via diagnoses)', () => {

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -594,6 +594,7 @@ describe('Suggestions', () => {
         email: 'sync.0123456789abcdef@sync.tamanu',
         displayName: 'System: facility-sync-test sync',
         role: 'admin',
+        kind: 'sync',
       });
 
       const result = await userApp.get('/api/suggestions/practitioner').query({ q: 'sync' });

--- a/packages/facility-server/__tests__/apiv1/User.test.js
+++ b/packages/facility-server/__tests__/apiv1/User.test.js
@@ -873,4 +873,22 @@ describe('User', () => {
       });
     });
   });
+
+  describe('user list', () => {
+    it('should not include device sync users', async () => {
+      const app = await baseApp.asRole('practitioner');
+      const syncUser = await models.User.create({
+        email: 'sync.fedcba9876543210@sync.tamanu',
+        displayName: 'System: user-list-test sync',
+        role: 'admin',
+        kind: 'sync',
+      });
+
+      const result = await app.get('/api/user');
+      expect(result).toHaveSucceeded();
+      const ids = result.body.data.map(({ id }) => id);
+      expect(ids).not.toContain(syncUser.id);
+      expect(ids).toContain(app.user.id);
+    });
+  });
 });

--- a/packages/facility-server/__tests__/database/integrity.test.js
+++ b/packages/facility-server/__tests__/database/integrity.test.js
@@ -1,0 +1,58 @@
+import { FACT_CENTRAL_HOST, FACT_FACILITY_IDS } from '@tamanu/constants';
+
+import { createTestContext } from '../utilities';
+import { performDatabaseIntegrityChecks } from '../../app/database/integrity';
+
+const DECLARED_HOST = 'https://integrity.example.com';
+
+describe('performDatabaseIntegrityChecks', () => {
+  let ctx;
+  let LocalSystemFact;
+  let originalHost;
+  let originalFacilityIds;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    ({ LocalSystemFact } = ctx.models);
+    originalHost = await LocalSystemFact.get(FACT_CENTRAL_HOST);
+    originalFacilityIds = await LocalSystemFact.get(FACT_FACILITY_IDS);
+    process.env.SYNC_URL = DECLARED_HOST;
+    process.env.SYNC_FACILITY_IDS = 'facility-a,facility-b';
+  });
+
+  afterAll(async () => {
+    delete process.env.SYNC_URL;
+    delete process.env.SYNC_FACILITY_IDS;
+    await LocalSystemFact.set(FACT_CENTRAL_HOST, originalHost);
+    await LocalSystemFact.set(FACT_FACILITY_IDS, originalFacilityIds);
+    await ctx.close();
+  });
+
+  beforeEach(async () => {
+    await LocalSystemFact.set(FACT_CENTRAL_HOST, DECLARED_HOST);
+    await LocalSystemFact.set(FACT_FACILITY_IDS, JSON.stringify(['facility-a']));
+  });
+
+  it('stamps the declared host when no fact is recorded yet', async () => {
+    await LocalSystemFact.destroy({ where: { key: FACT_CENTRAL_HOST }, force: true });
+    await performDatabaseIntegrityChecks(ctx);
+    expect(await LocalSystemFact.get(FACT_CENTRAL_HOST)).toBe(DECLARED_HOST);
+  });
+
+  it('passes when the recorded facts match the declaration', async () => {
+    await expect(performDatabaseIntegrityChecks(ctx)).resolves.not.toThrow();
+  });
+
+  it('fails on a host mismatch instead of overwriting the fact', async () => {
+    await LocalSystemFact.set(FACT_CENTRAL_HOST, 'https://other.example.com');
+    await expect(performDatabaseIntegrityChecks(ctx)).rejects.toThrow(/sync\.host mismatch/);
+    expect(await LocalSystemFact.get(FACT_CENTRAL_HOST)).toBe('https://other.example.com');
+  });
+
+  it('fails when a recorded facility is not covered by the declaration', async () => {
+    await LocalSystemFact.set(FACT_FACILITY_IDS, JSON.stringify(['facility-other']));
+    await expect(performDatabaseIntegrityChecks(ctx)).rejects.toThrow(
+      /serverFacilityId mismatch/,
+    );
+  });
+});

--- a/packages/facility-server/__tests__/rateLimit.test.js
+++ b/packages/facility-server/__tests__/rateLimit.test.js
@@ -1,0 +1,36 @@
+import express from 'express';
+import supertest from 'supertest';
+
+import { buildRateLimiters } from '@tamanu/shared/utils/rateLimit';
+
+// The limiters are no-ops under NODE_ENV=test unless explicitly opted in, so
+// the full-app suites stay deterministic while this one exercises them for
+// real. Uses a bare express app: the wiring onto /public/setup/sync (and the
+// other auth endpoints) is a single line in routes/apiv1.
+describe('buildRateLimiters', () => {
+  let authMax;
+  let agent;
+
+  beforeAll(() => {
+    process.env.TEST_RATE_LIMITING = 'enabled';
+    const { authLimiter } = buildRateLimiters();
+    delete process.env.TEST_RATE_LIMITING;
+
+    const config = require('config');
+    authMax = config.get('rateLimit.auth.max');
+
+    const app = express();
+    app.post('/setup', authLimiter, (_req, res) => res.status(401).end());
+    // mirror the API error handler enough to surface the RateLimitedError status
+    // eslint-disable-next-line no-unused-vars
+    app.use((error, _req, res, _next) => res.status(error.status ?? 500).end());
+    agent = supertest(app);
+  });
+
+  it('returns 429 once an IP exhausts its failed-attempt budget', async () => {
+    for (let i = 0; i < authMax; i++) {
+      await agent.post('/setup').expect(401);
+    }
+    await agent.post('/setup').expect(429);
+  });
+});

--- a/packages/facility-server/__tests__/serverConfig.test.js
+++ b/packages/facility-server/__tests__/serverConfig.test.js
@@ -88,6 +88,17 @@ describe('serverConfig', () => {
     expect(m.secretStore.get(FACT_SYNC_PASSWORD)).toBe('fact-pw');
   });
 
+  it('trims and dedupes SYNC_FACILITY_IDS', async () => {
+    process.env.SYNC_FACILITY_IDS = ' env-a , env-a,env-b ,, ';
+    await initWith(makeModels());
+    expect(getServerFacilityIds()).toEqual(['env-a', 'env-b']);
+  });
+
+  it('rejects a malformed SYNC_URL with a clear error', async () => {
+    process.env.SYNC_URL = 'not a url';
+    await expect(initWith(makeModels())).rejects.toThrow('SYNC_URL is not a valid URL');
+  });
+
   it('falls back to legacy config when there are no env vars or facts', async () => {
     await initWith(makeModels());
 

--- a/packages/facility-server/app/routes/apiv1/user.js
+++ b/packages/facility-server/app/routes/apiv1/user.js
@@ -14,7 +14,7 @@ import {
   makeFilter,
 } from '../../utils/query';
 import { z } from 'zod';
-import { TASK_STATUSES, TASK_TYPES } from '@tamanu/constants';
+import { TASK_STATUSES, TASK_TYPES, USER_KINDS } from '@tamanu/constants';
 import config from 'config';
 import { toPrimaryDateTimeString } from '@tamanu/shared/utils/primaryDateTime';
 import { add } from 'date-fns';
@@ -396,5 +396,11 @@ user.get(
 user.get('/:id', simpleGet('User'));
 
 const globalUserRequests = permissionCheckingRouter('list', 'User');
-globalUserRequests.get('/', paginatedGetList('User'));
+globalUserRequests.get(
+  '/',
+  paginatedGetList('User', '', {
+    // Machine accounts for device sync aren't clinicians
+    additionalFilters: { kind: { [Op.ne]: USER_KINDS.SYNC } },
+  }),
+);
 user.use(globalUserRequests);

--- a/packages/facility-server/app/serverConfig.js
+++ b/packages/facility-server/app/serverConfig.js
@@ -103,15 +103,26 @@ function current() {
 function parseEnv() {
   const result = { host: null, email: null, password: null, facilityIds: null };
   if (process.env.SYNC_URL) {
-    const { host, email, password } = parseSyncUrl(process.env.SYNC_URL);
-    result.host = host;
-    result.email = email ?? null;
-    result.password = password ?? null;
+    let parsed;
+    try {
+      parsed = parseSyncUrl(process.env.SYNC_URL);
+    } catch {
+      throw new Error(
+        'SYNC_URL is not a valid URL (expected e.g. https://user:password@central.example.com)',
+      );
+    }
+    result.host = parsed.host;
+    result.email = parsed.email ?? null;
+    result.password = parsed.password ?? null;
   }
   if (process.env.SYNC_FACILITY_IDS) {
-    result.facilityIds = process.env.SYNC_FACILITY_IDS.split(',')
-      .map(id => id.trim())
-      .filter(Boolean);
+    result.facilityIds = [
+      ...new Set(
+        process.env.SYNC_FACILITY_IDS.split(',')
+          .map(id => id.trim())
+          .filter(Boolean),
+      ),
+    ];
   }
   return result;
 }

--- a/packages/fake-data/src/fake/fake.ts
+++ b/packages/fake-data/src/fake/fake.ts
@@ -794,6 +794,7 @@ const MODEL_SPECIFIC_OVERRIDES = {
     displayId: chance.hash({ length: 5 }),
     displayName: chance.name(),
     role: 'practitioner',
+    kind: 'user',
   }),
   ReferenceData: () => ({
     type: chance.pickone(REFERENCE_TYPE_VALUES),

--- a/packages/mobile/App/migrations/1783118255000-addUserKind.ts
+++ b/packages/mobile/App/migrations/1783118255000-addUserKind.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'kind';
+
+export class addUserKind1783118255000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+
+    await queryRunner.addColumn(
+      table,
+      new TableColumn({
+        name: COLUMN_NAME,
+        type: 'varchar',
+        isNullable: false,
+        default: "'user'",
+      }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+
+    // DESTRUCTIVE: sync users will revert to looking like ordinary users.
+    await queryRunner.dropColumn(table, COLUMN_NAME);
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -88,6 +88,7 @@ import { removePatientTitleColumn1778199200000 } from './1778199200000-removePat
 import { addLabTestReferenceRangeColumns1778546880000 } from './1778546880000-addLabTestReferenceRangeColumns';
 import { addSurveyResponseEditMetadata1778560763154 } from './1778560763154-addSurveyResponseEditMetadata';
 import { removeDietIdFromEncounter1781501076000 } from './1781501076000-removeDietIdFromEncounter';
+import { addUserKind1783118255000 } from './1783118255000-addUserKind';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -179,4 +180,5 @@ export const migrationList = [
   addLabTestReferenceRangeColumns1778546880000,
   addSurveyResponseEditMetadata1778560763154,
   removeDietIdFromEncounter1781501076000,
+  addUserKind1783118255000,
 ];

--- a/packages/mobile/App/models/User.ts
+++ b/packages/mobile/App/models/User.ts
@@ -37,6 +37,9 @@ export class User extends BaseModel implements IUser {
   @Column()
   role: string;
 
+  @Column({ default: 'user' })
+  kind: string;
+
   @OneToMany(() => Referral, referral => referral.practitioner)
   referrals: Referral[];
 

--- a/packages/mobile/App/types/IUser.ts
+++ b/packages/mobile/App/types/IUser.ts
@@ -7,4 +7,5 @@ export interface IUser {
   password?: string;
   displayName: string;
   role: string;
+  kind: string;
 }

--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -1,6 +1,6 @@
 import { Brackets, FindManyOptions, ObjectLiteral } from 'typeorm';
 
-import { ENGLISH_LANGUAGE_CODE } from '@tamanu/constants';
+import { ENGLISH_LANGUAGE_CODE, USER_KINDS } from '@tamanu/constants';
 import { BaseModel } from '~/models/BaseModel';
 import { VisibilityStatus } from '~/visibilityStatuses';
 
@@ -152,6 +152,14 @@ export class Suggester<ModelType extends BaseModelSubclass> {
         query = query.andWhere('entity.visibilityStatus = :visibilityStatus', {
           visibilityStatus: VisibilityStatus.Current,
         });
+      }
+
+      // Machine accounts (device sync users) never belong in suggestions
+      const hasKind = this.model
+        .getRepository()
+        .metadata.columns.find(col => col.propertyName === 'kind');
+      if (hasKind) {
+        query = query.andWhere('entity.kind != :syncKind', { syncKind: USER_KINDS.SYNC });
       }
 
       query = query.orderBy('entity_display_label', 'ASC').limit(25);

--- a/packages/mobile/tests/helpers/fake.ts
+++ b/packages/mobile/tests/helpers/fake.ts
@@ -133,6 +133,7 @@ export const fakeUser = (): IUser => {
     email: `user-email-${uuid}@example.com`,
     displayName: `user-displayName-${uuid}`,
     role: 'practitioner',
+    kind: 'user',
   };
 };
 

--- a/packages/mobile/tests/helpers/mock.ts
+++ b/packages/mobile/tests/helpers/mock.ts
@@ -33,6 +33,7 @@ export function mockDummyUser(overrides = {}): IUser {
     email: 'user@example.com',
     displayName: 'displayName',
     role: 'practitioner',
+    kind: 'user',
     ...overrides,
   };
 }

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -21,7 +21,7 @@ import {
   ENCOUNTER_TYPE_LABELS,
   NOTE_TYPES,
   DRUG_STOCK_STATUSES,
-  SYNC_USER_EMAIL_SUFFIX,
+  USER_KINDS,
 } from '@tamanu/constants';
 import { customAlphabet } from 'nanoid';
 import { getEnumPrefix } from '@tamanu/shared/utils/enumRegistry';
@@ -856,7 +856,7 @@ createSuggester(
   ({ search }) => ({
     displayName: { [Op.iLike]: search },
     // Machine accounts for device sync aren't clinicians
-    email: { [Op.notILike]: `%${SYNC_USER_EMAIL_SUFFIX}` },
+    kind: { [Op.ne]: USER_KINDS.SYNC },
     ...VISIBILITY_CRITERIA,
   }),
   {

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -21,6 +21,7 @@ import {
   ENCOUNTER_TYPE_LABELS,
   NOTE_TYPES,
   DRUG_STOCK_STATUSES,
+  SYNC_USER_EMAIL_SUFFIX,
 } from '@tamanu/constants';
 import { customAlphabet } from 'nanoid';
 import { getEnumPrefix } from '@tamanu/shared/utils/enumRegistry';
@@ -854,6 +855,8 @@ createSuggester(
   'User',
   ({ search }) => ({
     displayName: { [Op.iLike]: search },
+    // Machine accounts for device sync aren't clinicians
+    email: { [Op.notILike]: `%${SYNC_USER_EMAIL_SUFFIX}` },
     ...VISIBILITY_CRITERIA,
   }),
   {

--- a/packages/shared/src/utils/rateLimit.js
+++ b/packages/shared/src/utils/rateLimit.js
@@ -6,8 +6,10 @@ import { log } from '../services/logging';
 
 // Rate limiting is disabled automatically during tests to keep existing
 // test suites (which rapidly hammer endpoints like /login from the same
-// loopback IP) deterministic.
-const RATE_LIMITING_DISABLED = process.env.NODE_ENV === 'test';
+// loopback IP) deterministic. TEST_RATE_LIMITING=enabled opts back in so the
+// limiters themselves can be tested.
+const rateLimitingDisabled = () =>
+  process.env.NODE_ENV === 'test' && process.env.TEST_RATE_LIMITING !== 'enabled';
 
 const noopMiddleware = (_req, _res, next) => next();
 
@@ -56,7 +58,7 @@ const DEFAULT_AUTH = { windowMs: 15 * 60 * 1000, max: 30 };
  * overridden by config (spread order below).
  */
 export const buildRateLimiters = () => {
-  if (RATE_LIMITING_DISABLED) {
+  if (rateLimitingDisabled()) {
     return { globalLimiter: noopMiddleware, authLimiter: noopMiddleware };
   }
 

--- a/packages/upgrade/__tests__/steps/1783048813000-provisionSyncUser.test.ts
+++ b/packages/upgrade/__tests__/steps/1783048813000-provisionSyncUser.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  FACT_CENTRAL_HOST,
+  FACT_DEVICE_ID,
+  FACT_FACILITY_IDS,
+  FACT_SYNC_EMAIL,
+  FACT_SYNC_PASSWORD,
+} from '@tamanu/constants';
+import { STEPS } from '../../src/steps/1783048813000-provisionSyncUser.js';
+
+vi.mock('config', () => ({
+  default: {
+    sync: {
+      host: 'https://central.example.com/',
+      email: 'legacy@sync.tamanu',
+      password: 'legacy-password',
+    },
+  },
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const [step] = STEPS;
+
+const makeArgs = (facts: Record<string, string> = {}) => {
+  const factStore = new Map(Object.entries(facts));
+  const secretStore = new Map<string, string>();
+  return {
+    args: {
+      serverType: 'facility',
+      sequelize: { transaction: async (callback: () => Promise<void>) => callback() },
+      models: {
+        LocalSystemFact: {
+          get: vi.fn(async (key: string) => factStore.get(key) ?? null),
+          set: vi.fn(async (key: string, value: string) => void factStore.set(key, value)),
+        },
+        LocalSystemSecret: {
+          set: vi.fn(async (key: string, value: string) => void secretStore.set(key, value)),
+        },
+      },
+      log: { info: vi.fn(), warn: vi.fn() },
+    } as any,
+    factStore,
+    secretStore,
+  };
+};
+
+const jsonResponse = (body: unknown) => ({ ok: true, json: async () => body });
+
+describe('1783048813000-provisionSyncUser', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('checks in only on facility servers with legacy config and no email fact', async () => {
+    const { args } = makeArgs();
+    await expect(step.check(args)).resolves.toBe(true);
+    await expect(step.check({ ...args, serverType: 'central' })).resolves.toBe(false);
+    const { args: configured } = makeArgs({ [FACT_SYNC_EMAIL]: 'sync.abc@sync.tamanu' });
+    await expect(step.check(configured)).resolves.toBe(false);
+  });
+
+  it('provisions a dedicated sync user and records it in facts', async () => {
+    const { args, factStore, secretStore } = makeArgs({
+      [FACT_DEVICE_ID]: 'device-1',
+      [FACT_FACILITY_IDS]: JSON.stringify(['facility-a']),
+    });
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ token: 'a-token' }))
+      .mockResolvedValueOnce(jsonResponse({ email: 'sync.abc@sync.tamanu', password: 'minted' }));
+
+    await step.run(args);
+
+    // login with legacy creds, then provision with the token
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      'https://central.example.com/api/login',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://central.example.com/api/admin/syncCredentials',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer a-token' }),
+      }),
+    );
+    expect(factStore.get(FACT_CENTRAL_HOST)).toBe('https://central.example.com');
+    expect(factStore.get(FACT_SYNC_EMAIL)).toBe('sync.abc@sync.tamanu');
+    expect(factStore.get(FACT_FACILITY_IDS)).toBe(JSON.stringify(['facility-a']));
+    expect(secretStore.get(FACT_SYNC_PASSWORD)).toBe('minted');
+  });
+
+  it('leaves the server on config fallback when central refuses', async () => {
+    const { args, factStore } = makeArgs({
+      [FACT_DEVICE_ID]: 'device-1',
+      [FACT_FACILITY_IDS]: JSON.stringify(['facility-a']),
+    });
+    mockFetch.mockResolvedValue({ ok: false, status: 403 });
+
+    await expect(step.run(args)).resolves.toBeUndefined(); // must not throw — it would fail the upgrade
+    expect(factStore.has(FACT_SYNC_EMAIL)).toBe(false);
+    expect(args.log.warn).toHaveBeenCalled();
+  });
+
+  it('skips servers that never registered with central', async () => {
+    const { args, factStore } = makeArgs();
+    await step.run(args);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(factStore.has(FACT_SYNC_EMAIL)).toBe(false);
+  });
+});

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -33,6 +33,7 @@
     "@tamanu/constants": "*",
     "@tamanu/database": "*",
     "@tamanu/shared": "*",
+    "config": "^3.3.9",
     "es-toolkit": "^1.48.1",
     "sequelize": "^6.37.8",
     "toposort": "^2.0.2",

--- a/packages/upgrade/src/steps/1783048813000-provisionSyncUser.ts
+++ b/packages/upgrade/src/steps/1783048813000-provisionSyncUser.ts
@@ -1,0 +1,95 @@
+import config from 'config';
+import {
+  FACT_CENTRAL_HOST,
+  FACT_DEVICE_ID,
+  FACT_FACILITY_IDS,
+  FACT_SYNC_EMAIL,
+  FACT_SYNC_PASSWORD,
+} from '@tamanu/constants';
+import { END, type Steps, type StepArgs } from '../step.js';
+
+interface LegacySyncConfig {
+  host?: string;
+  email?: string;
+  password?: string;
+}
+
+const legacySyncConfig = (): LegacySyncConfig => (config as { sync?: LegacySyncConfig }).sync ?? {};
+
+const postJson = async (url: string, body: unknown, token?: string) => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`${url} responded ${response.status}`);
+  }
+  return response.json();
+};
+
+export const STEPS: Steps = [
+  {
+    at: END,
+    // Existing facility servers hold sync credentials in config; new ones get a
+    // dedicated per-device sync user from the setup wizard. This converges the
+    // existing servers: use the legacy credentials (their sync user is role
+    // admin, so it may mint sync users) to provision a dedicated user on
+    // central and record it in facts, so the deprecated config keys can be
+    // dropped next version. Failure-tolerant: if central is unreachable or
+    // refuses, the server stays on the config fallback and the step retries on
+    // the next upgrade (it's gated on the email fact, not recorded as done).
+    async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
+      if (serverType !== 'facility') return false;
+      const { host, email, password } = legacySyncConfig();
+      // nothing to migrate — fresh installs are configured by the wizard
+      if (!host || !email || !password) return false;
+      return !(await LocalSystemFact.get(FACT_SYNC_EMAIL));
+    },
+    async run({ sequelize, models: { LocalSystemFact, LocalSystemSecret }, log }: StepArgs) {
+      const { host: legacyHost, email, password } = legacySyncConfig();
+      const host = new URL(legacyHost!.trim()).origin;
+
+      const deviceId = await LocalSystemFact.get(FACT_DEVICE_ID);
+      const storedFacilityIds = await LocalSystemFact.get(FACT_FACILITY_IDS);
+      const facilityIds: string[] = storedFacilityIds ? JSON.parse(storedFacilityIds) : [];
+      if (!deviceId || facilityIds.length === 0) {
+        // no device id / facilities recorded means the server never registered
+        // with central — it's effectively unconfigured, leave it to the wizard
+        log.warn('provisionSyncUser: no device id or facility ids recorded; skipping');
+        return;
+      }
+
+      let credentials: { email: string; password: string };
+      try {
+        const { token } = await postJson(`${host}/api/login`, { email, password, deviceId });
+        credentials = await postJson(
+          `${host}/api/admin/syncCredentials`,
+          { deviceId, facilityIds },
+          token,
+        );
+      } catch (error) {
+        log.warn(
+          `provisionSyncUser: could not provision a dedicated sync user (${
+            (error as Error).message
+          }); staying on legacy config credentials, will retry on next upgrade`,
+        );
+        return;
+      }
+
+      await sequelize.transaction(async () => {
+        await LocalSystemFact.set(FACT_CENTRAL_HOST, host);
+        await LocalSystemFact.set(FACT_SYNC_EMAIL, credentials.email);
+        await LocalSystemFact.set(FACT_FACILITY_IDS, JSON.stringify(facilityIds));
+        // Password encrypted at rest, out of local_system_facts and the raw reporting role.
+        await LocalSystemSecret.set(FACT_SYNC_PASSWORD, credentials.password);
+      });
+      log.info('provisionSyncUser: dedicated sync user provisioned', {
+        email: credentials.email,
+      });
+    },
+  },
+];


### PR DESCRIPTION
### Changes

TAM-6863 review follow-ups, stacked on #10124. Device sync users are machine accounts minted per device by facility setup — they shouldn't appear in clinical/admin surfaces or be editable there.

- **`users.kind` column** (`USER_KINDS.SYNC`) — server + mobile migrations, model field, fake-data support; provisioning stamps sync users with it.
- **Hidden from admin & clinical surfaces** — filtered out of the central admin users list, the central user exporter, the facility `/api/user` list, and the practitioner suggester (autocomplete).
- **Not editable via the admin panel** — editing a sync user (especially its password) silently breaks that device's sync, so admin-panel edits are rejected; rotate via the facility setup wizard instead.
- Earlier review follow-ups: provision sync user on upgrade, follow-up tests, lockfile.

Tests cover the admin list/edit guards, the exporter, the facility list, and the suggester exclusion.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
