### PR TITLE
chore(agents): J1: pull latest workhorse skills

### DIFF
--- a/.agents/docs/working-doc-format.md
+++ b/.agents/docs/working-doc-format.md
@@ -1,0 +1,36 @@
+# Working doc format
+
+A working doc is a per-card drafting space where spec-level and implementation thinking co-exist before the card is split into its long-lived artefacts (specs, plan, test cases). This doc defines its shape and voice. The artefact itself is specified in `specs/working-doc/overview.md`.
+
+## When to use one
+
+A working doc suits larger, epic-level cards where the shape of the work is still being found and behaviour and implementation need developing side by side. Most cards don't need one — for those, interview straight into specs and let Tech design write to the plan as usual.
+
+## Voice
+
+Unlike a spec, a working doc is written in working voice:
+
+- Open questions are welcome — track them explicitly as you go
+- Point-in-time reasoning is welcome ("we considered X but…")
+- Implementation detail, options, and trade-offs sit alongside behaviour
+- Nothing here has to be a clean declarative snapshot; that transformation happens at the split
+
+## Conventional shape
+
+The file starts minimal — frontmatter (`status: draft`), an H1 title, an overview line. Build the body up under these conventional sections as material accrues. Use only the sections a card needs, and add others when they help.
+
+- **Behaviour** — what the system should do, at spec level: happy paths, edge cases, interactions. This is the material the split rewrites into specs
+- **Implementation options** — approaches under consideration, with their shape and cost
+- **Open questions** — unresolved decisions, tracked as a checklist so they're easy to see and close off
+- **Trade-offs** — the reasoning behind choices, including rejected options and why
+- **Testing notes** — scenarios worth verifying, which the split lifts into test cases
+
+## Splitting
+
+When the shape is clear, Split working doc fans the material out:
+
+- Behaviour → the card's specs, rewritten into declarative spec voice per `.agents/docs/spec-format.md`
+- Implementation options and trade-offs → the plan
+- Testing notes → the test cases
+
+Resolve open questions before splitting where you can — specs can't carry them. Split working doc warns before proceeding if any remain, and reminds you which still need follow-up afterwards.

--- a/.agents/skills/draft-prd/SKILL.md
+++ b/.agents/skills/draft-prd/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: draft-prd
+description: "Draft or refine the project's PRD from the description and conversation"
+label: "Draft PRD"
+surface: project
+jockey-hint: "Top pill on the project surface when the PRD is empty. Demote once the PRD has substantive content unless the user signals a fresh draft pass."
+workhorse-version: 0.1.0
+---
+
+## Your task: Draft PRD
+
+Produce or refine the project's PRD at `.workhorse/projects/{hash}-{slug}/prd.md`. The agent already knows the project's hash and slug from the workspace context.
+
+This is the PRD-level equivalent of card-level **Implement this** — go straight to drafting from the project description and conversation history. Do not start by asking questions; produce a sensible structure even when no conversation has yet occurred.
+
+### Default scaffolding
+
+Pick **one** starting shape based on the project's material:
+
+- **Component-led** — the project clearly contains multiple workstreams or sub-systems. Use `## ` headings per component, each with a short overview and bullets
+- **Feature-led** — the project is a single workflow or surface. Use `## ` headings per phase or area of the workflow
+- **Mixed** — components with sub-features. Top-level `## ` per component, `### ` per sub-feature
+
+The opening section is always **Overview** — state the operator, workflow, technical, or user problem and the desired simplification. Two or three sentences, not a corporate paragraph.
+
+### Conventions
+
+- **Sparse and concrete** — write close to the shape of future cards. Bullets and sub-bullets, not long explanatory prose
+- **Phrasing for unfilled detail** — where the next layer of thinking belongs in card shaping, leave a direct line such as "detailed shape can be filled in during card shaping" rather than over-specifying
+- **Optional sections only when supported** — Permissions, Expected outcomes, Open questions appear only when the project material gives you something concrete to put under them. They are not default sections
+- **Don't invent** — no requirements, rollout notes, or prioritisation that weren't actually discussed
+- **Real terminology** — use the system's actual names and reference real workflows the conversation surfaced
+- **Direct tone** — no generic product-management phrasing or corporate-template language
+- **Australian/NZ English** spelling
+
+### How to run
+
+1. Read the project's description and any conversation history. Read the existing PRD content at `.workhorse/projects/{hash}-{slug}/prd.md` (it may be empty, mid-draft, or substantive)
+2. If the PRD already has substantive content, **edit in place** — refine, fill in gaps, tighten phrasing. Don't replace work that still applies
+3. If the PRD is empty or sparse, write a fresh draft using the appropriate scaffolding shape
+4. Briefly summarise what you produced and any open questions you couldn't resolve from the available material
+
+### Restrictions on this surface
+
+You are working on the **project surface**, not a card workspace. Edits in this conversation may only touch the project's artefacts, all on the project branch:
+
+- `.workhorse/projects/{hash}-{slug}/prd.md`
+- `.workhorse/projects/{hash}-{slug}/mockups/`
+- `.workhorse/projects/{hash}-{slug}/card-plan.md`
+
+Do **not** edit specs, per-card plans, test cases, card working docs, or any code. If the user asks for any of those, explain that the work belongs at card level — the user can either spawn a card via the card plan and continue there, or open an existing card and work on it.
+
+You may **read** anything from the workspace's main branch for context.

--- a/.agents/skills/review-prd/SKILL.md
+++ b/.agents/skills/review-prd/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: review-prd
+description: "Fresh-eyes review of the project's PRD for gaps, contradictions, vague phrasing, and unresolved decisions"
+label: "Review PRD"
+surface: project
+workhorse-version: 0.1.0
+---
+
+## Your task: Review PRD with fresh eyes
+
+Read the project's PRD at `.workhorse/projects/{hash}-{slug}/prd.md` as if you were seeing it for the first time. Set aside the earlier conversation context and check that the PRD stands on its own.
+
+Look for:
+
+- **Missing sections** — areas the project clearly cares about but the PRD doesn't cover
+- **Contradictions** — statements that disagree with each other or with the project description
+- **Vague phrasing** — sentences that sound like a PRD but don't say anything concrete. Stacking adjectives, corporate-template language, "seamless / robust / scalable"
+- **Unresolved decisions** — open questions that should be named but aren't, or named questions that have actually been decided and should be folded into prose
+- **Unticketable bullets** — items written so abstractly that nobody could turn them into a card without re-interviewing
+
+Be specific. Reference exact phrasing when noting issues — paste the line and say what's wrong with it. Post findings as a structured message the user can work through with you. Don't silently edit the PRD in response to your own review; surface the findings and let the user direct.
+
+### Restrictions on this surface
+
+You are working on the **project surface**, not a card workspace. Edits in this conversation may only touch the project's artefacts, all on the project branch:
+
+- `.workhorse/projects/{hash}-{slug}/prd.md`
+- `.workhorse/projects/{hash}-{slug}/mockups/`
+- `.workhorse/projects/{hash}-{slug}/card-plan.md`
+
+Do **not** edit specs, per-card plans, test cases, card working docs, or any code. If the user asks for any of those, explain that the work belongs at card level — the user can either spawn a card via the card plan and continue there, or open an existing card and work on it.
+
+You may **read** anything from the workspace's main branch for context.

--- a/.agents/skills/split-working-doc/SKILL.md
+++ b/.agents/skills/split-working-doc/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: split-working-doc
+description: "Split a working doc into the card's specs, plan, and test cases once its shape is clear"
+label: "Split working doc"
+pill-order:
+  specifying: 8
+jockey-hint: "Surface as soon as the card has a working doc in draft — the moment it exists, regardless of how developed it looks. On cards with no draft working doc, do not include in pills or suggestions at all."
+workhorse-version: 0.1.0
+---
+
+## Your task: Split the working doc
+
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
+Separate the material in the card's working doc into its long-lived and card-scoped artefacts. Read `.agents/docs/working-doc-format.md` and `.agents/docs/spec-format.md` first.
+
+1. Read the working doc at `.workhorse/working-docs/{card-id}/working-doc.md`.
+2. **Check for unresolved open questions.** If any remain, warn the user and ask them to confirm before proceeding — specs can't carry open questions.
+3. Fan the material out:
+   - Behavioural material → the card's specs, rewritten from working voice into declarative spec voice, following the fold-vs-create rules and writing conventions in `.agents/docs/spec-format.md`. Default to editing existing specs.
+   - Implementation options and trade-offs → the plan at `.workhorse/plans/{card-id}/plan.md` (see `specs/plan/overview.md`).
+   - Testing notes → the test cases at `.workhorse/test-cases/{card-id}/` (see `specs/test-cases/overview.md`).
+4. **Rewrite, don't move** — no working-voice, point-in-time, or open-question material may land in the specs.
+5. If the doc has already been split once, reconcile the material into the existing specs, plan, and test cases rather than creating duplicates.
+6. Set the working doc's `status` to `complete`. Leave the doc itself in place — it stays as the record of the reasoning.
+7. After splitting, remind the user which open questions still need follow-up.
+
+Generate or update mockups for any UI-facing behaviour as part of the split, following the Design sourcing process from your system prompt.

--- a/.agents/skills/start-working-doc/SKILL.md
+++ b/.agents/skills/start-working-doc/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: start-working-doc
+description: "Start a working doc — a drafting space where spec-level and implementation thinking co-exist before splitting into specs, plan, and test cases"
+label: "Start working doc"
+pill-order:
+  not-started: 8
+  specifying: 13
+jockey-hint: "Good fit for larger, epic-level cards where behaviour and implementation need shaping together before committing to specs. Low-traffic — most cards skip it. Demote once a working doc exists on the card."
+workhorse-version: 0.1.0
+---
+
+## Your task: Start a working doc
+
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
+Scaffold a new working doc for this card. A working doc is a per-card drafting space where spec-level and implementation thinking co-exist before the card is split into its long-lived artefacts. It suits larger, epic-level cards; most cards don't need one.
+
+1. Read `.agents/docs/working-doc-format.md` for the shape and voice of a working doc.
+2. Create the file at `.workhorse/working-docs/{card-id}/working-doc.md` with `status: draft` frontmatter, an H1 title derived from the card, and a one-line overview. Keep it minimal — do not pre-draft the body sections.
+3. Point the user at **Interview me** and **Tech design** to build the doc up, and mention **Split working doc** as the move for when the shape is clear.
+
+Do not start interviewing or drafting body content from this skill — creation only.

--- a/.agents/skills/start-working-doc/SKILL.md
+++ b/.agents/skills/start-working-doc/SKILL.md
@@ -17,6 +17,6 @@ Scaffold a new working doc for this card. A working doc is a per-card drafting s
 
 1. Read `.agents/docs/working-doc-format.md` for the shape and voice of a working doc.
 2. Create the file at `.workhorse/working-docs/{card-id}/working-doc.md` with `status: draft` frontmatter, an H1 title derived from the card, and a one-line overview. Keep it minimal — do not pre-draft the body sections.
-3. Point the user at **Interview me** and **Tech design** to build the doc up, and mention **Split working doc** as the move for when the shape is clear.
+3. Invite the user to keep talking — workshopping behaviour and implementation together — and accrue that conversation into the working doc under the sections in `.agents/docs/working-doc-format.md`, rather than letting it flow into specs or the plan. Mention **Split working doc** as the move for when the shape is clear.
 
 Do not start interviewing or drafting body content from this skill — creation only.

--- a/.agents/skills/workshop-project-design/SKILL.md
+++ b/.agents/skills/workshop-project-design/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: workshop-project-design
+description: "Produce or refine a project-level mockup illustrating a section of the PRD"
+label: "Workshop design"
+surface: project
+jockey-hint: "Always available on the project surface but never the top pill — surface in the secondary group. Useful at any point in the project's lifecycle."
+workhorse-version: 0.1.0
+---
+
+## Your task: Workshop design (project surface)
+
+Produce or refine a project-level mockup. Project mockups live at `.workhorse/projects/{hash}-{slug}/mockups/{slug}.html` on the project branch — they sit alongside the PRD until a card carries them forward at card-creation time.
+
+### Pick the section first
+
+Project PRDs often contain more than one logical section (component-led or mixed shapes). **If the PRD has more than one section that could plausibly be the target, ask which section the mockup is for** before generating. If there's only one section, or the user has already named it, skip the question and proceed.
+
+### Source the visual language before authoring
+
+Follow the Design sourcing process from your system prompt — do not skip steps:
+
+1. **Read the actual implementation** of the section being mocked in the target repo. The shipped code is the baseline — components, layout, spacing, copy
+2. **Read implementations of similar components** elsewhere in the target repo for any new elements not yet present
+3. **Cross-check against `.workhorse/design/`** — design system, component docs, philosophy notes. The design library wins on clash
+4. **Do not reference mockups from other cards or other projects** as inspiration — they are point-in-time artefacts
+
+### Author and preserve
+
+- Standalone HTML with inline CSS, like card-level mockups
+- Author fresh markup only for the feature or area being explored. For every other region of the screen, be visually faithful to the current implementation — same layout, components, copy, spacing, styling
+- Do not let stale styling from earlier mockups leak into unchanged regions
+- Include an HTML comment header at the top linking to the PRD section being illustrated, e.g. `<!-- prd: components/registration -->`
+
+### How to run
+
+1. Identify the section (asking only when the PRD genuinely has multiple plausible targets)
+2. Source the visual language as above
+3. Write the file at `.workhorse/projects/{hash}-{slug}/mockups/{slug}.html`
+4. Briefly summarise what you produced
+
+### Restrictions on this surface
+
+You are working on the **project surface**, not a card workspace. Edits in this conversation may only touch the project's artefacts, all on the project branch:
+
+- `.workhorse/projects/{hash}-{slug}/prd.md`
+- `.workhorse/projects/{hash}-{slug}/mockups/`
+- `.workhorse/projects/{hash}-{slug}/card-plan.md`
+
+Do **not** edit specs, per-card plans, test cases, card working docs, or any code. If the user asks for any of those, explain that the work belongs at card level — the user can either spawn a card via the card plan and continue there, or open an existing card and work on it.
+
+You may **read** anything from the workspace's main branch for context.

--- a/.agents/skills/workshop-project/SKILL.md
+++ b/.agents/skills/workshop-project/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: workshop-project
+description: "Workshop the shape of this project — audience, components, ambiguities — before drafting the PRD"
+label: "Workshop project"
+surface: project
+jockey-hint: "Top pill on the project surface when the PRD is empty and no project conversation has occurred yet. Demote sharply once the PRD has substantive content or once the conversation has clearly moved past shaping."
+workhorse-version: 0.1.0
+---
+
+## Your task: Workshop project
+
+Interview the user toward shaping the project before the PRD is drafted in earnest. The goal is to get enough definition that **Draft PRD** can produce a useful first version — not to write the PRD yourself.
+
+Things to push on:
+
+1. **Audience** — who the project is for, in concrete terms (operators, testers, integrators, end users, …). Avoid generic "the team"
+2. **Boundary** — what the project includes and what it deliberately does not. Pressure-test the edges
+3. **Components or features** — natural divisions inside the project, the seams future cards will follow
+4. **Terminology** — names, ownership, and any conflicting language across the team
+5. **Open questions** — anything genuinely unresolved, named explicitly so they don't get lost
+
+Methodology:
+
+- Ask focused questions, one or two at a time. Number them so the user can reply by number
+- Take what the user says at face value first, then probe the implications
+- Don't draft the PRD during this skill; capture material in conversation. `Draft PRD` is the next step
+- If the user gives you enough to start sketching structure (component-led, feature-led, mixed), say which shape you'd recommend and why, but leave the draft to **Draft PRD**
+
+### Restrictions on this surface
+
+You are working on the **project surface**, not a card workspace. Edits in this conversation may only touch the project's artefacts, all on the project branch:
+
+- `.workhorse/projects/{hash}-{slug}/prd.md`
+- `.workhorse/projects/{hash}-{slug}/mockups/`
+- `.workhorse/projects/{hash}-{slug}/card-plan.md`
+
+Do **not** edit specs, per-card plans, test cases, card working docs, or any code. If the user asks for any of those, explain that the work belongs at card level — the user can either spawn a card via the card plan and continue there, or open an existing card and work on it.
+
+You may **read** anything from the workspace's main branch for context.


### PR DESCRIPTION
Syncs `.agents/` with the latest upstream workhorse skill set, adding project- and card-level PRD/design tooling that wasn't previously present in this repo.

- Adds `working-doc-format.md`, documenting the new working-doc artefact (a per-card drafting space that later splits into specs, plan, and test cases)
- Adds card-level skills `start-working-doc` and `split-working-doc` for creating and fanning out working docs
- Adds project-surface skills `workshop-project`, `draft-prd`, `review-prd`, and `workshop-project-design` for shaping and drafting a project's PRD and its mockups, each scoped to only touch project-level artefacts (prd.md, mockups/, card-plan.md)

No existing skills or specs are modified — this is purely additive, bringing the agent skill library up to date.

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->