### PR TITLE
feat(sync): TAM-6864: share settings PSK across servers

### DIFF
--- a/packages/central-server/__tests__/admin/facilitySettingsPskMigration.test.js
+++ b/packages/central-server/__tests__/admin/facilitySettingsPskMigration.test.js
@@ -1,0 +1,128 @@
+import {
+  FACT_CENTRAL_HOST,
+  FACT_DEVICE_ID,
+  FACT_SYNC_EMAIL,
+  FACT_SYNC_PASSWORD,
+  FACT_SETTINGS_PSK,
+} from '@tamanu/constants';
+
+import { createTestContext } from '../utilities';
+// The real migration step that runs on a facility upgrade.
+import { STEPS as FACILITY_PSK_STEPS } from '../../../upgrade/src/steps/1785200000000-provisionFacilitySettingsPsk';
+
+// End-to-end for provisionFacilitySettingsPsk: the step's own code (login ->
+// GET /admin/settingsPsk -> store) runs against a LIVE central — real DB, real
+// login route, real permission check, real PSK. Only the facility's local k/v
+// store is faked (it's a trivial LocalSystemFact/Secret shim). The step calls
+// global.fetch with absolute URLs; we route those through supertest so the whole
+// server side is exercised without binding a port. This is the half the mocked
+// upgrade unit test can't cover.
+const [facilityPskStep] = FACILITY_PSK_STEPS;
+
+describe('provisionFacilitySettingsPsk against a live central', () => {
+  let ctx;
+  let realFetch;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+  afterAll(async () => ctx.close());
+  beforeEach(() => {
+    realFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  // Route the step's absolute-URL fetch calls through the real express app.
+  const routeFetchThroughApp = () => {
+    global.fetch = async (url, opts = {}) => {
+      const { pathname } = new URL(url);
+      const method = (opts.method || 'GET').toUpperCase();
+      let res;
+      if (method === 'POST') {
+        res = await ctx.baseApp.post(pathname).send(opts.body ? JSON.parse(opts.body) : undefined);
+      } else {
+        const req = ctx.baseApp.get(pathname);
+        if (opts.headers) req.set(opts.headers);
+        res = await req;
+      }
+      return {
+        ok: res.status >= 200 && res.status < 300,
+        status: res.status,
+        json: async () => res.body,
+      };
+    };
+  };
+
+  const makeFacility = ({ centralHost, email, password, deviceId }) => {
+    const facts = new Map([
+      [FACT_CENTRAL_HOST, centralHost],
+      [FACT_SYNC_EMAIL, email],
+      [FACT_DEVICE_ID, deviceId],
+    ]);
+    const secrets = new Map([[FACT_SYNC_PASSWORD, password]]);
+    return {
+      secrets,
+      args: {
+        serverType: 'facility',
+        models: {
+          LocalSystemFact: { get: async k => facts.get(k) ?? null },
+          LocalSystemSecret: {
+            get: async k => secrets.get(k) ?? null,
+            setIfAbsent: async (k, v) => {
+              if (!secrets.has(k)) secrets.set(k, v);
+            },
+          },
+        },
+        log: { info: () => {}, warn: () => {} },
+      },
+    };
+  };
+
+  it('pulls the deployment PSK from central using its sync credentials', async () => {
+    const deviceId = 'facility-migration-device';
+
+    // central provisions the facility's sync credentials (+ mints the PSK)
+    const admin = await ctx.baseApp.asRole('admin');
+    const provision = await admin
+      .post('/api/admin/syncCredentials')
+      .send({ deviceId, facilityIds: ['facility-migration'] });
+    expect(provision).toHaveSucceeded();
+    const { email, password, settingsPsk } = provision.body;
+
+    // facility, configured but with no PSK yet, runs the real migration step
+    routeFetchThroughApp();
+    const facility = makeFacility({
+      centralHost: 'https://central.test/',
+      email,
+      password,
+      deviceId,
+    });
+
+    expect(await facilityPskStep.check(facility.args)).toBe(true);
+    await facilityPskStep.run(facility.args);
+
+    // it fetched and stored central's PSK, byte-for-byte
+    expect(facility.secrets.get(FACT_SETTINGS_PSK)).toBe(settingsPsk);
+  });
+
+  it('is a no-op when the facility already has a PSK (no login attempted)', async () => {
+    const facility = makeFacility({
+      centralHost: 'https://central.test/',
+      email: 'sync@already.has',
+      password: 'pw',
+      deviceId: 'device-has-psk',
+    });
+    facility.secrets.set(FACT_SETTINGS_PSK, 'ab'.repeat(32));
+
+    let called = false;
+    global.fetch = async () => {
+      called = true;
+      throw new Error('should not be called');
+    };
+    await facilityPskStep.run(facility.args);
+    expect(called).toBe(false);
+    expect(facility.secrets.get(FACT_SETTINGS_PSK)).toBe('ab'.repeat(32));
+  });
+});

--- a/packages/central-server/__tests__/admin/settingsPskSyncUserPull.test.js
+++ b/packages/central-server/__tests__/admin/settingsPskSyncUserPull.test.js
@@ -1,0 +1,66 @@
+import { FACT_SETTINGS_PSK } from '@tamanu/constants';
+import { createTestContext } from '../utilities';
+
+// The facility settings-PSK migration (provisionFacilitySettingsPsk) does NOT use an
+// admin session — it logs in with its stored *sync* credentials and calls the admin
+// endpoint with that token. syncCredentials.test.js only exercises GET /settingsPsk via
+// baseApp.asRole('admin'), which fabricates an admin session and never touches /api/login
+// nor a kind:'sync' user. This proves the real production path: a provisioned sync user
+// (role admin, kind sync) authenticating through the real login and pulling the PSK.
+const CRED_ENDPOINT = '/api/admin/syncCredentials';
+const PSK_ENDPOINT = '/api/admin/settingsPsk';
+
+describe('settings PSK — facility sync-user pull (real login + auth)', () => {
+  let ctx;
+  let baseApp;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    ({ models } = ctx.store);
+  });
+  afterAll(async () => ctx.close());
+
+  it('a provisioned sync user can log in and pull the deployment PSK', async () => {
+    const deviceId = 'psk-sync-pull-device';
+
+    // 1. central mints sync credentials (+ the deployment PSK) for the facility
+    const admin = await baseApp.asRole('admin');
+    const provision = await admin
+      .post(CRED_ENDPOINT)
+      .send({ deviceId, facilityIds: ['facility-psk-pull'] });
+    expect(provision).toHaveSucceeded();
+    const { email, password, settingsPsk } = provision.body;
+    expect(settingsPsk).toMatch(/^[0-9a-f]{64}$/);
+
+    // 2. facility logs in with those sync credentials via the real login route
+    const login = await baseApp.post('/api/login').send({ email, password, deviceId });
+    expect(login).toHaveSucceeded();
+    const { token } = login.body;
+    expect(token).toEqual(expect.any(String));
+
+    // 3. facility pulls the PSK with the sync user's own token — the assertion a
+    //    mocked test can't make: kind:'sync' + role:'admin' is actually authorised here
+    const pull = await baseApp.get(PSK_ENDPOINT).set('Authorization', `Bearer ${token}`);
+    expect(pull).toHaveSucceeded();
+    expect(pull.body.settingsPsk).toBe(settingsPsk);
+
+    // and it really is a sync-kind user, not a regular admin
+    const user = await models.User.findOne({ where: { email } });
+    expect(user.kind).toBe('sync');
+    expect(user.role).toBe('admin');
+  });
+
+  it('the PSK handed out matches the one stored on central', async () => {
+    const admin = await baseApp.asRole('admin');
+    const provision = await admin
+      .post(CRED_ENDPOINT)
+      .send({ deviceId: 'psk-sync-pull-device-2', facilityIds: ['facility-psk-pull-2'] });
+    expect(provision).toHaveSucceeded();
+
+    const stored = await models.LocalSystemSecret.get(FACT_SETTINGS_PSK);
+    expect(stored).toMatch(/^[0-9a-f]{64}$/);
+    expect(provision.body.settingsPsk).toBe(stored);
+  });
+});

--- a/packages/central-server/__tests__/admin/syncCredentials.test.js
+++ b/packages/central-server/__tests__/admin/syncCredentials.test.js
@@ -53,6 +53,8 @@ describe('Admin sync credentials', () => {
     expect(result).toHaveSucceeded();
     expect(result.body.email).toEqual(expect.any(String));
     expect(result.body.password).toEqual(expect.any(String));
+    // deployment-wide settings PSK: a 32-byte (64 hex char) key
+    expect(result.body.settingsPsk).toMatch(/^[0-9a-f]{64}$/);
 
     const user = await models.User.scope('withPassword').findOne({
       where: { email: result.body.email },
@@ -78,6 +80,8 @@ describe('Admin sync credentials', () => {
     expect(second).toHaveSucceeded();
     expect(second.body.email).toBe(first.body.email);
     expect(second.body.password).not.toBe(first.body.password);
+    // the settings PSK is deployment-wide and stable — not rotated like the password
+    expect(second.body.settingsPsk).toBe(first.body.settingsPsk);
 
     const users = await models.User.findAll({ where: { email: first.body.email } });
     expect(users).toHaveLength(1);
@@ -124,5 +128,27 @@ describe('Admin sync credentials', () => {
       confirmPassword: 'hunter2hunter2',
     });
     expect(result).toHaveRequestError();
+  });
+
+  describe('GET /admin/settingsPsk', () => {
+    const PSK_ENDPOINT = '/api/admin/settingsPsk';
+
+    it('rejects unauthenticated requests', async () => {
+      const result = await baseApp.get(PSK_ENDPOINT);
+      expect(result).toHaveRequestError();
+    });
+
+    it('forbids non-admin users', async () => {
+      const app = await baseApp.asRole('practitioner');
+      const result = await app.get(PSK_ENDPOINT);
+      expect(result).toBeForbidden();
+    });
+
+    it('returns the settings PSK to an admin', async () => {
+      const app = await baseApp.asRole('admin');
+      const result = await app.get(PSK_ENDPOINT);
+      expect(result).toHaveSucceeded();
+      expect(result.body.settingsPsk).toMatch(/^[0-9a-f]{64}$/);
+    });
   });
 });

--- a/packages/central-server/app/admin/adminRoutes.js
+++ b/packages/central-server/app/admin/adminRoutes.js
@@ -30,7 +30,7 @@ import { referenceDataManageRouter } from './referenceDataManage';
 import { reportsRouter } from './reports/reportRoutes';
 import { roleRouter, rolesRouter } from './roles';
 import { syncLastCompleted } from './sync';
-import { provisionSyncCredentials } from './syncCredentials';
+import { provisionSyncCredentials, getSettingsPsk } from './syncCredentials';
 import { templateRoutes } from './template';
 import { translationRouter } from './translation';
 import { userPreferencesRouter } from './userPreferences';
@@ -78,6 +78,7 @@ adminRoutes.use('/export', exporterRouter);
 
 adminRoutes.get('/sync/lastCompleted', syncLastCompleted);
 adminRoutes.post('/syncCredentials', provisionSyncCredentials);
+adminRoutes.get('/settingsPsk', getSettingsPsk);
 
 adminRoutes.get('/fhir/jobStats', fhirJobStats);
 

--- a/packages/central-server/app/admin/syncCredentials.js
+++ b/packages/central-server/app/admin/syncCredentials.js
@@ -1,7 +1,8 @@
 import crypto from 'node:crypto';
 import asyncHandler from 'express-async-handler';
 import * as z from 'zod';
-import { USER_KINDS } from '@tamanu/constants';
+import { USER_KINDS, FACT_SETTINGS_PSK } from '@tamanu/constants';
+import { ensureSettingsPsk } from '@tamanu/shared/utils/crypto';
 
 const bodySchema = z.object({
   deviceId: z.string().trim().min(1),
@@ -24,7 +25,7 @@ export const provisionSyncCredentials = asyncHandler(async (req, res) => {
   const { deviceId, facilityIds } = bodySchema.parse(req.body);
   const uniqueFacilityIds = [...new Set(facilityIds.map(id => id.trim()))].sort();
 
-  const { User } = req.store.models;
+  const { User, LocalSystemSecret } = req.store.models;
 
   const email = syncUserEmail(deviceId);
   // Summarise rather than listing every id so the display name stays short for
@@ -44,6 +45,27 @@ export const provisionSyncCredentials = asyncHandler(async (req, res) => {
     await User.create({ email, displayName, role: 'admin', kind: USER_KINDS.SYNC, password });
   }
 
+  // Hand the facility the deployment-wide settings PSK so secrets central
+  // encrypts into synced settings are decryptable there. Generated here if this
+  // is the first server to need it; facilities never mint their own.
+  await ensureSettingsPsk(LocalSystemSecret);
+  const settingsPsk = await LocalSystemSecret.get(FACT_SETTINGS_PSK);
+
   // Plaintext credential in the body — keep it out of any intermediary cache.
-  res.set('Cache-Control', 'no-store').send({ email, password });
+  res.set('Cache-Control', 'no-store').send({ email, password, settingsPsk });
+});
+
+// Returns the deployment-wide settings PSK to an authed facility that already has
+// sync credentials but no PSK yet (provisioned before the PSK existed). Read-only:
+// central mints the PSK on its own upgrade and when provisioning sync credentials,
+// so a GET only reads it. If it's somehow absent this returns null and the facility
+// retries on its next upgrade — the GET never writes. Unlike provisionSyncCredentials
+// it doesn't rotate the sync password, so a facility can call it repeatedly.
+export const getSettingsPsk = asyncHandler(async (req, res) => {
+  req.checkPermission('manage', 'all');
+
+  const { LocalSystemSecret } = req.store.models;
+  const settingsPsk = await LocalSystemSecret.get(FACT_SETTINGS_PSK);
+
+  res.set('Cache-Control', 'no-store').send({ settingsPsk });
 });

--- a/packages/central-server/app/admin/syncCredentials.js
+++ b/packages/central-server/app/admin/syncCredentials.js
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import asyncHandler from 'express-async-handler';
 import * as z from 'zod';
 import { USER_KINDS, FACT_SETTINGS_PSK } from '@tamanu/constants';
+import { log } from '@tamanu/shared/services/logging';
 import { ensureSettingsPsk } from '@tamanu/shared/utils/crypto';
 
 const bodySchema = z.object({
@@ -63,6 +64,9 @@ export const provisionSyncCredentials = asyncHandler(async (req, res) => {
 // it doesn't rotate the sync password, so a facility can call it repeatedly.
 export const getSettingsPsk = asyncHandler(async (req, res) => {
   req.checkPermission('manage', 'all');
+
+  // Raw key material leaves the server here — keep a trace of who took it.
+  log.info('Settings PSK read via admin API', { userId: req.user?.id });
 
   const { LocalSystemSecret } = req.store.models;
   const settingsPsk = await LocalSystemSecret.get(FACT_SETTINGS_PSK);

--- a/packages/constants/src/facts.ts
+++ b/packages/constants/src/facts.ts
@@ -36,6 +36,12 @@ export const FACT_FACILITY_CONFIG_MIGRATED = 'facilityConfigMigratedToSettings';
 // mSupply integration
 export const FACT_MSUPPLY_MED_INTEGRATION_ENABLED_AT = 'mSupplyMedIntegrationEnabledAt';
 
+// Deployment-wide pre-shared key that encrypts integration secrets in the
+// settings table. Generated on central and pulled by facilities (settings sync
+// central→facility, so a per-host key can't decrypt cross-server secrets). Held
+// here encrypted at rest under the per-host config key, like the other secrets.
+export const FACT_SETTINGS_PSK = 'settingsPsk';
+
 // Random per-server secret the reporting/raw role passwords are derived from.
 export const FACT_REPORTING_ROLE_SECRET = 'reportingRoleSecret';
 // When that secret was last (re)generated, for automatic age-based rotation.

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -3,9 +3,15 @@ import { Sequelize } from 'sequelize';
 import pg from 'pg';
 import util from 'util';
 
-import { SYNC_DIRECTIONS, AUDIT_USERID_KEY, SYSTEM_USER_UUID } from '@tamanu/constants';
+import {
+  SYNC_DIRECTIONS,
+  AUDIT_USERID_KEY,
+  SYSTEM_USER_UUID,
+  FACT_SETTINGS_PSK,
+} from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 import { serviceContext, serviceName } from '@tamanu/shared/services/logging/context';
+import { setSettingsPskSource } from '@tamanu/shared/utils/crypto';
 
 import { assertUpToDate, migrate, NON_SYNCING_TABLES } from './migrations';
 import * as models from '../models';
@@ -264,6 +270,12 @@ export async function initDatabase(dbOptions) {
   // add isInsideTransaction and isTransactionReady helpers to avoid exposing the asynclocalstorage
   sequelize.isInsideTransaction = isInsideTransaction;
   sequelize.isTransactionReady = isTransactionReady;
+
+  // Let the shared crypto helpers read the settings PSK from the local secrets
+  // store without shared/ importing a database model. Every entrypoint (both
+  // servers, the upgrade command) goes through initDatabase, so this is the one
+  // place the model is guaranteed available.
+  setSettingsPskSource(() => models.LocalSystemSecret.get(FACT_SETTINGS_PSK));
 
   return { sequelize, models };
 }

--- a/packages/facility-server/app/routes/apiv1/setup.js
+++ b/packages/facility-server/app/routes/apiv1/setup.js
@@ -12,6 +12,7 @@ import {
   FACT_SETTINGS_PSK,
 } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
+import { clearSettingsPskCache } from '@tamanu/shared/utils/crypto';
 
 import { isServerConfigured, initServerConfig } from '../../serverConfig';
 import { version } from '../../serverInfo';
@@ -155,6 +156,9 @@ export const setupSyncHandler = asyncHandler(async (req, res) => {
     // an older central that doesn't serve it yet; a later sync/upgrade fills it.
     if (syncCredentials.settingsPsk) {
       await LocalSystemSecret.setIfAbsent(FACT_SETTINGS_PSK, syncCredentials.settingsPsk);
+      // The server keeps running after setup: drop any key buffer cached from the
+      // legacy config fallback so reads pick up the pulled PSK without a restart.
+      clearSettingsPskCache();
     }
   });
 

--- a/packages/facility-server/app/routes/apiv1/setup.js
+++ b/packages/facility-server/app/routes/apiv1/setup.js
@@ -9,6 +9,7 @@ import {
   FACT_SYNC_EMAIL,
   FACT_SYNC_PASSWORD,
   FACT_FACILITY_IDS,
+  FACT_SETTINGS_PSK,
 } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 
@@ -150,6 +151,11 @@ export const setupSyncHandler = asyncHandler(async (req, res) => {
     await LocalSystemFact.set(FACT_FACILITY_IDS, JSON.stringify(uniqueFacilityIds));
     // Password encrypted at rest, out of local_system_facts and the raw reporting role.
     await LocalSystemSecret.set(FACT_SYNC_PASSWORD, syncCredentials.password);
+    // Deployment-wide settings PSK, pulled from central. Absent when talking to
+    // an older central that doesn't serve it yet; a later sync/upgrade fills it.
+    if (syncCredentials.settingsPsk) {
+      await LocalSystemSecret.setIfAbsent(FACT_SETTINGS_PSK, syncCredentials.settingsPsk);
+    }
   });
 
   if (alreadyConfigured) {

--- a/packages/shared/__tests__/utils/settingsPsk.test.js
+++ b/packages/shared/__tests__/utils/settingsPsk.test.js
@@ -33,6 +33,18 @@ describe('getSettingsPskKeyBuffer', () => {
     setSettingsPskSource(async () => other);
     expect(await getSettingsPskKeyBuffer()).toEqual(Buffer.from(other, 'hex'));
   });
+
+  // Buffer.from(x, 'hex') silently drops bad chars, so a corrupt/empty PSK must be
+  // rejected here rather than surfacing later as an opaque "Decryption failed".
+  it.each([
+    ['an empty string', ''],
+    ['a non-hex string', 'not-a-valid-hex-psk'],
+    ['a too-short hex string', 'abcd'],
+    ['odd-length hex', 'a'.repeat(63)],
+  ])('rejects %s with a clear error instead of a silent bad key', async (_label, badPsk) => {
+    setSettingsPskSource(async () => badPsk);
+    await expect(getSettingsPskKeyBuffer()).rejects.toThrow(/Settings PSK must be exactly 64 hex/);
+  });
 });
 
 describe('ensureSettingsPsk', () => {

--- a/packages/shared/__tests__/utils/settingsPsk.test.js
+++ b/packages/shared/__tests__/utils/settingsPsk.test.js
@@ -1,0 +1,54 @@
+// No crypto.settingsPsk in config, so getConfigSecret throws SecretNotConfigured
+// and the generate path (rather than the legacy config-seed path) is exercised.
+jest.mock('config', () => ({
+  __esModule: true,
+  default: { get: () => undefined },
+}));
+
+import { FACT_SETTINGS_PSK } from '@tamanu/constants';
+import {
+  setSettingsPskSource,
+  getSettingsPskKeyBuffer,
+  ensureSettingsPsk,
+} from '../../src/utils/crypto';
+
+const HEX = 'ab'.repeat(32); // 64 hex chars = 32 bytes
+
+afterEach(() => {
+  setSettingsPskSource(null);
+});
+
+describe('getSettingsPskKeyBuffer', () => {
+  it('reads the PSK from the registered source', async () => {
+    setSettingsPskSource(async () => HEX);
+    const buffer = await getSettingsPskKeyBuffer();
+    expect(buffer).toEqual(Buffer.from(HEX, 'hex'));
+  });
+
+  it('re-registering the source replaces the cached value', async () => {
+    setSettingsPskSource(async () => HEX);
+    await getSettingsPskKeyBuffer();
+
+    const other = 'cd'.repeat(32);
+    setSettingsPskSource(async () => other);
+    expect(await getSettingsPskKeyBuffer()).toEqual(Buffer.from(other, 'hex'));
+  });
+});
+
+describe('ensureSettingsPsk', () => {
+  it('generates and stores a 64-hex PSK when none exists', async () => {
+    const store = { get: jest.fn().mockResolvedValue(null), setIfAbsent: jest.fn() };
+    await ensureSettingsPsk(store);
+
+    expect(store.setIfAbsent).toHaveBeenCalledTimes(1);
+    const [key, value] = store.setIfAbsent.mock.calls[0];
+    expect(key).toBe(FACT_SETTINGS_PSK);
+    expect(value).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is a no-op when a PSK already exists', async () => {
+    const store = { get: jest.fn().mockResolvedValue(HEX), setIfAbsent: jest.fn() };
+    await ensureSettingsPsk(store);
+    expect(store.setIfAbsent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/utils/crypto.js
+++ b/packages/shared/src/utils/crypto.js
@@ -183,6 +183,18 @@ export async function getSettingsPskKeyBuffer() {
       const psk =
         (settingsPskSource && (await settingsPskSource())) ??
         (await getConfigSecret('crypto.settingsPsk'));
+      // Validate before use. Buffer.from(x, 'hex') silently drops invalid/odd
+      // characters, so a corrupt or empty PSK would otherwise yield a wrong-length
+      // key whose only symptom is an opaque "Decryption failed" far from the cause.
+      // Fail here, at the source, with a message that names the problem.
+      const expectedHexLength = KEY_LENGTH_BYTES * 2;
+      if (typeof psk !== 'string' || !new RegExp(`^[0-9a-f]{${expectedHexLength}}$`, 'i').test(psk)) {
+        throw new Error(
+          `Settings PSK must be exactly ${expectedHexLength} hex characters ` +
+            `(${KEY_LENGTH_BYTES} bytes for AES-${KEY_LENGTH}); the local secrets store ` +
+            `may be unprovisioned or corrupt`,
+        );
+      }
       return Buffer.from(psk, 'hex');
     })().catch(err => {
       settingsPskKeyBufferPromise = null;

--- a/packages/shared/src/utils/crypto.js
+++ b/packages/shared/src/utils/crypto.js
@@ -4,6 +4,8 @@ import { promises as fs } from 'fs';
 import { promisify } from 'util';
 import readSync from 'read';
 
+import { FACT_SETTINGS_PSK } from '@tamanu/constants';
+
 const read = promisify(readSync);
 
 const SECRET_VERSION = 'S1';
@@ -147,6 +149,22 @@ export async function getConfigSecret(name) {
   return decryptSecret(keyBuffer, encryptedValue);
 }
 
+// Resolves the deployment-wide settings PSK as a hex string. Registered once
+// per process where the database (and so the LocalSystemSecret model) is
+// available — see setSettingsPskSource, wired from initDatabase. Kept out of
+// this module directly because shared/ must not import database models.
+let settingsPskSource = null;
+
+/**
+ * Point the settings-PSK reader at the local secrets store. Called from
+ * initDatabase with the LocalSystemSecret model bound. Clears the cached buffer
+ * so a re-registration (e.g. in tests) takes effect.
+ */
+export function setSettingsPskSource(source) {
+  settingsPskSource = source;
+  settingsPskKeyBufferPromise = null;
+}
+
 // The settings PSK key never changes at runtime so we decrypt it once and
 // reuse the buffer. A failed first read clears the cache so the next call
 // retries instead of permanently breaking secret access.
@@ -155,7 +173,16 @@ let settingsPskKeyBufferPromise = null;
 export async function getSettingsPskKeyBuffer() {
   if (!settingsPskKeyBufferPromise) {
     settingsPskKeyBufferPromise = (async () => {
-      const psk = await getConfigSecret('crypto.settingsPsk');
+      // Local secrets store is the source of truth. Fall back to the legacy
+      // crypto.settingsPsk config value while deployments converge; this
+      // fallback is removed once the local store is guaranteed populated.
+      // ?? not ||: only a genuinely unset source (null/undefined = not yet
+      // provisioned) falls back. A falsy-but-present value (e.g. '' from a
+      // corrupted row) passes through and fails loudly rather than silently
+      // decrypting with the wrong key.
+      const psk =
+        (settingsPskSource && (await settingsPskSource())) ??
+        (await getConfigSecret('crypto.settingsPsk'));
       return Buffer.from(psk, 'hex');
     })().catch(err => {
       settingsPskKeyBufferPromise = null;
@@ -163,6 +190,28 @@ export async function getSettingsPskKeyBuffer() {
     });
   }
   return settingsPskKeyBufferPromise;
+}
+
+// Adopts the legacy crypto.settingsPsk config value if one is present, otherwise
+// generates a fresh key. Both branches yield a hex PSK string.
+async function resolveOrGeneratePsk() {
+  try {
+    return await getConfigSecret('crypto.settingsPsk');
+  } catch (err) {
+    if (!(err instanceof SecretNotConfiguredError)) throw err;
+    return (await generateSecretKey()).toString('hex');
+  }
+}
+
+/**
+ * Ensures a settings PSK exists in the local secrets store. Central only:
+ * facilities pull the PSK from central and must never mint their own (that was
+ * the per-host bug). Idempotent via setIfAbsent.
+ */
+export async function ensureSettingsPsk(localSystemSecret) {
+  if (await localSystemSecret.get(FACT_SETTINGS_PSK)) return;
+  const psk = await resolveOrGeneratePsk();
+  await localSystemSecret.setIfAbsent(FACT_SETTINGS_PSK, psk);
 }
 
 /** Reads and decrypts a secret stored in the settings table. */

--- a/packages/shared/src/utils/crypto.js
+++ b/packages/shared/src/utils/crypto.js
@@ -165,6 +165,16 @@ export function setSettingsPskSource(source) {
   settingsPskKeyBufferPromise = null;
 }
 
+/**
+ * Drop the cached key buffer so the next read re-resolves the PSK. Needed when
+ * the PSK lands in the local store on a *running* server (the setup wizard):
+ * an earlier read may have cached the legacy per-host config key, which would
+ * otherwise be used until restart.
+ */
+export function clearSettingsPskCache() {
+  settingsPskKeyBufferPromise = null;
+}
+
 // The settings PSK key never changes at runtime so we decrypt it once and
 // reuse the buffer. A failed first read clears the cache so the next call
 // retries instead of permanently breaking secret access.

--- a/packages/upgrade/__tests__/steps/1783048813000-provisionSyncUser.test.ts
+++ b/packages/upgrade/__tests__/steps/1783048813000-provisionSyncUser.test.ts
@@ -5,6 +5,7 @@ import {
   FACT_FACILITY_IDS,
   FACT_SYNC_EMAIL,
   FACT_SYNC_PASSWORD,
+  FACT_SETTINGS_PSK,
 } from '@tamanu/constants';
 import { STEPS } from '../../src/steps/1783048813000-provisionSyncUser.js';
 
@@ -36,7 +37,11 @@ const makeArgs = (facts: Record<string, string> = {}) => {
           set: vi.fn(async (key: string, value: string) => void factStore.set(key, value)),
         },
         LocalSystemSecret: {
+          get: vi.fn(async (key: string) => secretStore.get(key) ?? null),
           set: vi.fn(async (key: string, value: string) => void secretStore.set(key, value)),
+          setIfAbsent: vi.fn(async (key: string, value: string) => {
+            if (!secretStore.has(key)) secretStore.set(key, value);
+          }),
         },
       },
       log: { info: vi.fn(), warn: vi.fn() },
@@ -89,6 +94,23 @@ describe('1783048813000-provisionSyncUser', () => {
     expect(factStore.get(FACT_SYNC_EMAIL)).toBe('sync.abc@sync.tamanu');
     expect(factStore.get(FACT_FACILITY_IDS)).toBe(JSON.stringify(['facility-a']));
     expect(secretStore.get(FACT_SYNC_PASSWORD)).toBe('minted');
+  });
+
+  it('stores the settings PSK when central returns one', async () => {
+    const { args, secretStore } = makeArgs({
+      [FACT_DEVICE_ID]: 'device-1',
+      [FACT_FACILITY_IDS]: JSON.stringify(['facility-a']),
+    });
+    const psk = 'ab'.repeat(32); // 64 hex chars
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ token: 'a-token' }))
+      .mockResolvedValueOnce(
+        jsonResponse({ email: 'sync.abc@sync.tamanu', password: 'minted', settingsPsk: psk }),
+      );
+
+    await step.run(args);
+
+    expect(secretStore.get(FACT_SETTINGS_PSK)).toBe(psk);
   });
 
   it('leaves the server on config fallback when central refuses', async () => {

--- a/packages/upgrade/__tests__/steps/settingsPsk.test.ts
+++ b/packages/upgrade/__tests__/steps/settingsPsk.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  FACT_CENTRAL_HOST,
+  FACT_DEVICE_ID,
+  FACT_SYNC_EMAIL,
+  FACT_SYNC_PASSWORD,
+  FACT_SETTINGS_PSK,
+} from '@tamanu/constants';
+import { generateSecretKey } from '@tamanu/shared/utils/crypto';
+
+import { STEPS as CENTRAL_STEPS } from '../../src/steps/1785100000000-provisionCentralSettingsPsk.js';
+import { STEPS as FACILITY_STEPS } from '../../src/steps/1785200000000-provisionFacilitySettingsPsk.js';
+
+// No legacy crypto.settingsPsk configured -> central generates a fresh PSK.
+vi.mock('config', () => ({ default: {} }));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as any;
+
+const [centralStep] = CENTRAL_STEPS;
+const [facilityStep] = FACILITY_STEPS;
+
+const makeArgs = (
+  serverType: string,
+  facts: Record<string, string> = {},
+  secrets: Record<string, string> = {},
+) => {
+  const factStore = new Map(Object.entries(facts));
+  const secretStore = new Map(Object.entries(secrets));
+  return {
+    args: {
+      serverType,
+      models: {
+        LocalSystemFact: {
+          get: vi.fn(async (k: string) => factStore.get(k) ?? null),
+        },
+        LocalSystemSecret: {
+          get: vi.fn(async (k: string) => secretStore.get(k) ?? null),
+          setIfAbsent: vi.fn(async (k: string, v: string) => {
+            if (!secretStore.has(k)) secretStore.set(k, v);
+          }),
+        },
+      },
+      log: { info: vi.fn(), warn: vi.fn() },
+    } as any,
+    factStore,
+    secretStore,
+  };
+};
+
+const jsonResponse = (body: unknown) => ({ ok: true, json: async () => body });
+const HEX64 = /^[0-9a-f]{64}$/;
+
+beforeEach(() => mockFetch.mockReset());
+
+describe('1785100000000-provisionCentralSettingsPsk', () => {
+  it('runs on central only', async () => {
+    expect(await centralStep.check(makeArgs('central').args)).toBe(true);
+    expect(await centralStep.check(makeArgs('facility').args)).toBe(false);
+  });
+
+  it('generates a 32-byte PSK when none exists', async () => {
+    const { args, secretStore } = makeArgs('central');
+    await centralStep.run(args);
+    expect(secretStore.get(FACT_SETTINGS_PSK)).toMatch(HEX64);
+  });
+
+  it('is idempotent — a second run keeps the same PSK', async () => {
+    const { args, secretStore } = makeArgs('central');
+    await centralStep.run(args);
+    const first = secretStore.get(FACT_SETTINGS_PSK);
+    await centralStep.run(args);
+    expect(secretStore.get(FACT_SETTINGS_PSK)).toBe(first);
+  });
+});
+
+describe('1785200000000-provisionFacilitySettingsPsk', () => {
+  const configured = {
+    [FACT_CENTRAL_HOST]: 'https://central.example.com/',
+    [FACT_SYNC_EMAIL]: 'facility@sync.tamanu',
+    [FACT_DEVICE_ID]: 'facility-device-1',
+  };
+  const withPassword = { [FACT_SYNC_PASSWORD]: 'sync-password' };
+
+  it('runs only on a configured facility', async () => {
+    expect(await facilityStep.check(makeArgs('central', configured).args)).toBe(false);
+    expect(await facilityStep.check(makeArgs('facility', {}).args)).toBe(false);
+    expect(await facilityStep.check(makeArgs('facility', configured).args)).toBe(true);
+  });
+
+  it('pulls the PSK from central and stores it', async () => {
+    const CENTRAL_PSK = (await generateSecretKey()).toString('hex');
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url?.endsWith('/api/login')) return jsonResponse({ token: 'tok' });
+      if (url?.endsWith('/api/admin/settingsPsk')) return jsonResponse({ settingsPsk: CENTRAL_PSK });
+      return jsonResponse({}); // tolerate unrelated calls; real calls asserted below
+    });
+    const { args, secretStore } = makeArgs('facility', configured, withPassword);
+    await facilityStep.run(args);
+    expect(secretStore.get(FACT_SETTINGS_PSK)).toBe(CENTRAL_PSK);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://central.example.com/api/admin/settingsPsk',
+      expect.objectContaining({ headers: { Authorization: 'Bearer tok' } }),
+    );
+  });
+
+  it('no-ops (no network) when the PSK is already present', async () => {
+    const { args, secretStore } = makeArgs('facility', configured, {
+      ...withPassword,
+      [FACT_SETTINGS_PSK]: 'existing-psk',
+    });
+    await facilityStep.run(args);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(secretStore.get(FACT_SETTINGS_PSK)).toBe('existing-psk');
+  });
+
+  it('is failure-tolerant when central is unreachable — warns, stores nothing, does not throw', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 502 });
+    const { args, secretStore } = makeArgs('facility', configured, withPassword);
+    await expect(facilityStep.run(args)).resolves.not.toThrow();
+    expect(secretStore.has(FACT_SETTINGS_PSK)).toBe(false);
+    expect(args.log.warn).toHaveBeenCalled();
+  });
+
+  it('skips (no network) when sync config is incomplete', async () => {
+    const { args, secretStore } = makeArgs('facility', configured, {}); // no password
+    await facilityStep.run(args);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(secretStore.has(FACT_SETTINGS_PSK)).toBe(false);
+    expect(args.log.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/upgrade/__tests__/toposort.test.ts
+++ b/packages/upgrade/__tests__/toposort.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest';
-import { START, END, MigrationStr } from '../src/step.js';
+import { START, END, MigrationStr, StepStr } from '../src/step.js';
 import { MIGRATIONS_END, MIGRATIONS_START, orderSteps } from '../src/listSteps.js';
 
 const PENDING_MIGRATIONS: MigrationStr[] = [
@@ -153,4 +153,26 @@ it('migration dependency', async () => {
     'upgrade/bar/0',
     END,
   ]);
+});
+
+it('handles the same migration referenced by multiple steps (no cycle)', async () => {
+  const MIG = 'migration/1744602896344-addLookupTicksTable' as MigrationStr;
+  const mkStep = (id: StepStr) => ({
+    id,
+    file: id,
+    step: {
+      at: END,
+      before: [] as MigrationStr[],
+      after: [MIG],
+      check: () => Promise.resolve(true),
+      run: () => Promise.resolve(),
+    },
+  });
+
+  // listSteps collects one ref per step, so two steps depending on MIG pass it
+  // through twice — this used to make toposort throw "Cyclic dependency".
+  const { order } = await orderSteps([mkStep('upgrade/a/0'), mkStep('upgrade/b/0')], [MIG, MIG]);
+
+  expect(order.indexOf('upgrade/a/0')).toBeGreaterThan(order.indexOf(MIG));
+  expect(order.indexOf('upgrade/b/0')).toBeGreaterThan(order.indexOf(MIG));
 });

--- a/packages/upgrade/src/listSteps.ts
+++ b/packages/upgrade/src/listSteps.ts
@@ -59,7 +59,14 @@ export async function orderSteps(steps: ResolvedStep[], migrations: MigrationStr
   // the result but doesn't make it absolute. when there are no before/after deps,
   // then START steps will always be before migrations, and the END steps will
   // always be after migrations.
-  const edges: Edge[] = edgeFilter(migrations.map((mig, i) => [migrations[i - 1], mig]))
+  //
+  // Dedupe first: the same migration may be referenced by several steps (e.g.
+  // multiple steps that all run after a table is created). A repeated entry would
+  // produce contradictory chain edges (X→Y and Y→X) and make toposort throw
+  // "Cyclic dependency". Set preserves first-seen order.
+  const uniqueMigrations = [...new Set(migrations)];
+
+  const edges: Edge[] = edgeFilter(uniqueMigrations.map((mig, i) => [uniqueMigrations[i - 1], mig]))
     .concat(
       steps.flatMap(({ id, step }) => {
         const topo: Edge[] = [];
@@ -91,8 +98,8 @@ export async function orderSteps(steps: ResolvedStep[], migrations: MigrationStr
       edgeFilter([
         [START, END],
         [START, MIGRATIONS_START],
-        [MIGRATIONS_START, migrations[0]],
-        [migrations[migrations.length - 1], MIGRATIONS_END],
+        [MIGRATIONS_START, uniqueMigrations[0]],
+        [uniqueMigrations[uniqueMigrations.length - 1], MIGRATIONS_END],
         [MIGRATIONS_END, END],
       ]),
     );

--- a/packages/upgrade/src/steps/1783048813000-provisionSyncUser.ts
+++ b/packages/upgrade/src/steps/1783048813000-provisionSyncUser.ts
@@ -5,6 +5,7 @@ import {
   FACT_FACILITY_IDS,
   FACT_SYNC_EMAIL,
   FACT_SYNC_PASSWORD,
+  FACT_SETTINGS_PSK,
 } from '@tamanu/constants';
 import { END, type Steps, type StepArgs } from '../step.js';
 
@@ -63,7 +64,7 @@ export const STEPS: Steps = [
         return;
       }
 
-      let credentials: { email: string; password: string };
+      let credentials: { email: string; password: string; settingsPsk?: string };
       try {
         const { token } = await postJson(`${host}/api/login`, { email, password, deviceId });
         credentials = await postJson(
@@ -86,6 +87,10 @@ export const STEPS: Steps = [
         await LocalSystemFact.set(FACT_FACILITY_IDS, JSON.stringify(facilityIds));
         // Password encrypted at rest, out of local_system_facts and the raw reporting role.
         await LocalSystemSecret.set(FACT_SYNC_PASSWORD, credentials.password);
+        // Deployment-wide settings PSK from central (absent on older central).
+        if (credentials.settingsPsk) {
+          await LocalSystemSecret.setIfAbsent(FACT_SETTINGS_PSK, credentials.settingsPsk);
+        }
       });
       log.info('provisionSyncUser: dedicated sync user provisioned', {
         email: credentials.email,

--- a/packages/upgrade/src/steps/1785100000000-provisionCentralSettingsPsk.ts
+++ b/packages/upgrade/src/steps/1785100000000-provisionCentralSettingsPsk.ts
@@ -1,0 +1,27 @@
+import { ensureSettingsPsk } from '@tamanu/shared/utils/crypto';
+
+import { END, needsMigration, type Steps, type StepArgs } from '../step.js';
+
+export const STEPS: Steps = [
+  {
+    at: END,
+    // Needs the local_system_secrets table (at: END alone doesn't order after
+    // migrations — the dependency does).
+    after: [needsMigration('1782200000000-createLocalSystemSecretsTable.ts')],
+    // Central owns the deployment-wide settings PSK: generate it once, or adopt a
+    // legacy crypto.settingsPsk config value, into the local secrets store. It must
+    // exist before any facility pulls it and before an admin saves a settings
+    // secret. Facilities never generate their own — they pull this from central.
+    //
+    // check() gates on server type only. The PSK-presence test lives in
+    // ensureSettingsPsk (run-time): local_system_secrets is created by a migration
+    // in this same upgrade, so it may not exist when check() is evaluated during
+    // planning. ensureSettingsPsk is idempotent, so re-running each upgrade is fine.
+    async check({ serverType }: StepArgs) {
+      return serverType === 'central';
+    },
+    async run({ models: { LocalSystemSecret } }: StepArgs) {
+      await ensureSettingsPsk(LocalSystemSecret);
+    },
+  },
+];

--- a/packages/upgrade/src/steps/1785200000000-provisionFacilitySettingsPsk.ts
+++ b/packages/upgrade/src/steps/1785200000000-provisionFacilitySettingsPsk.ts
@@ -1,0 +1,80 @@
+import {
+  FACT_CENTRAL_HOST,
+  FACT_DEVICE_ID,
+  FACT_SYNC_EMAIL,
+  FACT_SYNC_PASSWORD,
+  FACT_SETTINGS_PSK,
+} from '@tamanu/constants';
+import { END, needsMigration, type Steps, type StepArgs } from '../step.js';
+
+const postJson = async (url: string, body: unknown) => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error(`${url} responded ${response.status}`);
+  return response.json();
+};
+
+const getJson = async (url: string, token: string) => {
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!response.ok) throw new Error(`${url} responded ${response.status}`);
+  return response.json();
+};
+
+export const STEPS: Steps = [
+  {
+    at: END,
+    // Needs the local_system_secrets table (at: END alone doesn't order after
+    // migrations — the dependency does).
+    after: [needsMigration('1782200000000-createLocalSystemSecretsTable.ts')],
+    // Facilities configured before the settings PSK existed have sync credentials
+    // but no PSK (fresh installs get it from the setup wizard, and config-credential
+    // servers get it while provisioning their sync user). Pull it from central using
+    // the stored sync credentials. Failure-tolerant: gated on the PSK fact, not
+    // recorded as done, so it retries on the next upgrade if central is unreachable.
+    // Gate on server type + already-configured (the sync email fact lives on the
+    // long-lived local_system_facts table). The PSK-presence check is in run():
+    // local_system_secrets may not exist when check() is evaluated during planning
+    // (it's created by a migration in this same upgrade).
+    async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
+      if (serverType !== 'facility') return false;
+      return Boolean(await LocalSystemFact.get(FACT_SYNC_EMAIL));
+    },
+    async run({ models: { LocalSystemFact, LocalSystemSecret }, log }: StepArgs) {
+      if (await LocalSystemSecret.get(FACT_SETTINGS_PSK)) return;
+
+      const host = await LocalSystemFact.get(FACT_CENTRAL_HOST);
+      const email = await LocalSystemFact.get(FACT_SYNC_EMAIL);
+      const password = await LocalSystemSecret.get(FACT_SYNC_PASSWORD);
+      const deviceId = await LocalSystemFact.get(FACT_DEVICE_ID);
+      if (!host || !email || !password || !deviceId) {
+        log.warn('provisionFacilitySettingsPsk: incomplete sync config; skipping');
+        return;
+      }
+
+      const origin = new URL(host.trim()).origin;
+      let settingsPsk: string | undefined;
+      try {
+        const { token } = await postJson(`${origin}/api/login`, { email, password, deviceId });
+        ({ settingsPsk } = await getJson(`${origin}/api/admin/settingsPsk`, token));
+      } catch (error) {
+        log.warn(
+          `provisionFacilitySettingsPsk: could not fetch the settings PSK (${
+            (error as Error).message
+          }); will retry on next upgrade`,
+        );
+        return;
+      }
+
+      if (!settingsPsk) {
+        log.warn('provisionFacilitySettingsPsk: central returned no settings PSK; will retry');
+        return;
+      }
+
+      await LocalSystemSecret.setIfAbsent(FACT_SETTINGS_PSK, settingsPsk);
+      log.info('provisionFacilitySettingsPsk: settings PSK stored from central');
+    },
+  },
+];

--- a/packages/upgrade/src/steps/1785200000000-provisionFacilitySettingsPsk.ts
+++ b/packages/upgrade/src/steps/1785200000000-provisionFacilitySettingsPsk.ts
@@ -35,7 +35,11 @@ export const STEPS: Steps = [
     // the stored sync credentials. Failure-tolerant: gated on the PSK fact, not
     // recorded as done, so it retries on the next upgrade if central is unreachable.
     // Gate on server type + already-configured (the sync email fact lives on the
-    // long-lived local_system_facts table). The PSK-presence check is in run():
+    // long-lived local_system_facts table). Facts only, not the env>fact>config
+    // resolution: env-credential (k8s) servers never store these facts, but they
+    // are provisioned a deployment-wide crypto.settingsPsk out-of-band, which the
+    // key reader's config fallback serves — so they don't need this pull.
+    // The PSK-presence check is in run():
     // local_system_secrets may not exist when check() is evaluated during planning
     // (it's created by a migration in this same upgrade).
     async check({ serverType, models: { LocalSystemFact } }: StepArgs) {


### PR DESCRIPTION
### Changes

Makes the settings PSK — the key that encrypts integration secrets held in the
`settings` table — a single **deployment-wide** value instead of a per-host key.
Settings pull central→facility, so a per-host key can't decrypt secrets another
server encrypted. Central now owns the PSK and facilities pull it.

- **Stored** as a `local_system_secrets` fact (`FACT_SETTINGS_PSK`): `DO_NOT_SYNC`,
  non-logged, encrypted at rest under the per-host config key. No new table/migration.
- **Read** via `getSettingsPskKeyBuffer()` from the local store, wired at
  `initDatabase` (the one hook common to both servers and the upgrade command, so
  `shared/` needn't import a DB model). Transitional `crypto.settingsPsk` config
  fallback, removed once deployments converge.
- **Central** generates or adopts a legacy `crypto.settingsPsk` (`ensureSettingsPsk`)
  on upgrade and lazily in `syncCredentials`; returns it in the authed
  `syncCredentials` response and via a rotation-free `GET /admin/settingsPsk`.
- **Facilities** store it: setup wizard, `provisionSyncUser` (config-credential
  servers), and a new upgrade step that pulls it for already-provisioned installs.
- No bootstrap cycle: the sync password rides the config key, not the PSK.

Replaces the per-host PSK generation in ansible (removed in the ops PR).

> Stacked on #10165. Not locally test-verified (worktree build) — relying on CI.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Auto-merge upstream** <!-- #auto-merge -->
- [ ] **Save suppressions** <!-- #save-suppressions -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the config/settings reference or any relevant runbook(s)
- ...call out additions or changes to **config files** for the deployment team
