### PR TITLE
fix(web): TAM-6956: Fixed issue where clicking 'read more' on notes displays them as a single line

### DIFF
--- a/packages/web/app/components/NoteTable.jsx
+++ b/packages/web/app/components/NoteTable.jsx
@@ -30,12 +30,12 @@ const NoteRowContainer = styled.div`
 const NoteContentContainer = styled.div`
   width: 100%;
   position: relative;
-  overflow: hidden;
-  display: -webkit-box;
   white-space: pre-line;
   ${props =>
     !props.$expanded
       ? `
+    overflow: hidden;
+    display: -webkit-box;
     text-overflow: clip;
     -webkit-line-clamp: 20;
             line-clamp: 20;


### PR DESCRIPTION
### Changes

Cherry-pick of #10224 (TAM-6956) to release/2.54. Fixes an issue where clicking "read more" on a note caused its text to display as a single line instead of wrapping normally, by correcting the CSS applied in `NoteTable.jsx`.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
