### PR TITLE
feat(admin): TAM-6864: settings editor search

### DIFF
--- a/packages/settings/src/schema/central.ts
+++ b/packages/settings/src/schema/central.ts
@@ -141,12 +141,14 @@ export const centralSettings = {
           defaultValue: '24h',
         },
         loginTokenDurationMinutes: {
+          name: 'Login token duration',
           description: 'How long a patient-portal login code is valid',
           type: yup.number().positive().integer(),
           unit: 'minutes',
           defaultValue: 20,
         },
         registerTokenDurationMinutes: {
+          name: 'Register token duration',
           description: 'How long a patient-portal registration link is valid',
           type: yup.number().positive().integer(),
           unit: 'minutes',

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -430,8 +430,10 @@ export const globalSettings = {
       exposedToWeb: true,
       properties: {
         assignmentMaxFutureMonths: {
+          name: 'Assignment max future',
           description: 'The maximum number of months allowed when creating location assignments',
           type: yup.number().min(1),
+          unit: 'months',
           defaultValue: 24,
         },
       },
@@ -440,9 +442,11 @@ export const globalSettings = {
       description: 'Reporting database settings',
       properties: {
         secretRotationDays: {
+          name: 'Secret rotation',
           description:
             'Auto-rotate the reporting/raw role secret once it is older than this many days (new passwords take effect as servers restart). 0 disables rotation.',
           type: yup.number().integer().min(0),
+          unit: 'days',
           defaultValue: 90,
         },
       },
@@ -1468,6 +1472,7 @@ export const globalSettings = {
             width: {
               type: yup.number().min(0),
               defaultValue: 50.8,
+              unit: 'mm',
             },
           },
         },
@@ -1700,16 +1705,19 @@ export const globalSettings = {
             lockoutThreshold: {
               description: 'Number of failed attempts before account is locked',
               type: yup.number().positive().integer(),
+              unit: 'attempts',
               defaultValue: 10,
             },
             observationWindow: {
-              description: 'Time interval in minutes that attempts must occur within',
+              description: 'Time interval that attempts must occur within',
               type: yup.number().positive().integer(),
+              unit: 'minutes',
               defaultValue: 10,
             },
             lockoutDuration: {
-              description: 'Duration of lockout in minutes',
+              description: 'Duration of lockout',
               type: yup.number().positive(),
+              unit: 'minutes',
               defaultValue: 10,
             },
           },
@@ -2006,6 +2014,7 @@ export const globalSettings = {
         recentNotificationsTimeFrame: {
           description: 'Settings for the time frame of recent notifications',
           type: yup.number(),
+          unit: 'hours',
           defaultValue: 48,
         },
       },

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -109,6 +109,26 @@ describe('filterSettingsSchema', () => {
     expect(JSON.stringify(schema)).toBe(before);
   });
 
+  it('prefers setting-name matches over category-name matches', () => {
+    const fielded = {
+      properties: {
+        // category display name mentions "previously"; its key/paths don't
+        fields: { name: 'Previously localised fields', properties: {
+          displayId: { type: 'string' },
+        } },
+        reports: { properties: {
+          previouslyUsed: { type: 'boolean', name: 'Previously used' },
+        } },
+      },
+    };
+    // setting-name tier wins: only the setting shows
+    expect(Object.keys(filterSettingsSchema(fielded, 'previously').properties)).toEqual([
+      'reports',
+    ]);
+    // with no setting hit, the category-name tier is reachable
+    expect(Object.keys(filterSettingsSchema(fielded, 'localised').properties)).toEqual(['fields']);
+  });
+
   it('prefers name/path matches over description matches', () => {
     const tiered = {
       properties: {

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -62,6 +62,26 @@ describe('filterSettingsSchema', () => {
     expect(filterSettingsSchema(schema, 'zzz-no-such-setting')).toBeNull();
   });
 
+  it('matches at word starts only, including camelCase boundaries', () => {
+    const pagey = {
+      properties: {
+        ageDisplayFormat: { type: 'string', name: 'Age display format' },
+        fhir: {
+          properties: {
+            maxPageSize: { type: 'number' },
+            defaultCount: { type: 'number', description: 'Number of results per page' },
+          },
+        },
+      },
+    };
+    // "age" must not surface page/pageSize (substring inside a word)...
+    expect(Object.keys(filterSettingsSchema(pagey, 'age').properties)).toEqual([
+      'ageDisplayFormat',
+    ]);
+    // ...but "page" still matches both the camelCase segment and the prose word
+    expect(filterSettingsSchema(pagey, 'page').properties.fhir).toBeTruthy();
+  });
+
   it('does not mutate the input schema', () => {
     const before = JSON.stringify(schema);
     filterSettingsSchema(schema, 'from');

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -25,55 +25,54 @@ const schema = {
 
 describe('filterSettingsSchema', () => {
   it('returns the schema unchanged for an empty query', () => {
-    expect(filterSettingsSchema(schema, '  ')).toBe(schema);
+    expect(filterSettingsSchema(schema, '  ').schema).toBe(schema);
   });
 
   it('matches on setting display name, keeping the group structure above it', () => {
-    const result = filterSettingsSchema(schema, 'from address');
+    const { schema: result } = filterSettingsSchema(schema, 'from address');
     expect(Object.keys(result.properties)).toEqual(['mail']);
     expect(Object.keys(result.properties.mail.properties)).toEqual(['from']);
   });
 
   it('matches on dotted path and description', () => {
-    const byPath = filterSettingsSchema(schema, 'mail.transport.host');
+    const byPath = filterSettingsSchema(schema, 'mail.transport.host').schema;
     expect(byPath.properties.mail.properties.transport.properties.host).toBeTruthy();
 
-    const byDescription = filterSettingsSchema(schema, 'smtp relay');
+    const byDescription = filterSettingsSchema(schema, 'smtp relay').schema;
     expect(byDescription.properties.mail.properties.transport.properties.host).toBeTruthy();
     expect(byDescription.properties.mail.properties.from).toBeUndefined();
   });
 
-  it('flags matched descriptions for the results view', () => {
-    const result = filterSettingsSchema(schema, 'smtp relay');
-    expect(result.properties.mail.properties.transport.properties.host.__matchedDescription).toBe(
-      true,
-    );
+  it('reports matched descriptions in the metadata for the results view', () => {
+    const { schema: result, meta } = filterSettingsSchema(schema, 'smtp relay');
+    const host = result.properties.mail.properties.transport.properties.host;
+    expect(meta.get(host).matchedDescription).toBe(true);
   });
 
-  it('flags exact display-name matches and the groups above them', () => {
-    const result = filterSettingsSchema(schema, 'from address');
-    expect(result.properties.mail.properties.from.__exactMatch).toBe(true);
-    expect(result.properties.mail.__hasExactMatch).toBe(true);
-    // word-start-but-not-exact hits carry no exact flag
+  it('reports exact display-name matches and the groups above them', () => {
+    const { schema: result, meta } = filterSettingsSchema(schema, 'from address');
+    expect(meta.get(result.properties.mail.properties.from).exact).toBe(true);
+    expect(meta.get(result.properties.mail).hasExact).toBe(true);
+    // word-start-but-not-exact hits are not exact
     const partial = filterSettingsSchema(schema, 'from');
-    expect(partial.properties.mail.properties.from.__exactMatch).toBeUndefined();
+    expect(partial.meta.get(partial.schema.properties.mail.properties.from).exact).toBe(false);
   });
 
   it('keeps the whole subtree when a group itself matches', () => {
-    const result = filterSettingsSchema(schema, 'mail');
+    const { schema: result, meta } = filterSettingsSchema(schema, 'mail');
     const mail = result.properties.mail;
     expect(Object.keys(mail.properties)).toEqual(Object.keys(schema.properties.mail.properties));
     expect(mail.properties.transport.properties.host).toBeTruthy();
     // "mail" equals the group's display name exactly
-    expect(mail.__exactMatch).toBe(true);
+    expect(meta.get(mail).exact).toBe(true);
   });
 
   it('matches root-level settings and startCase-derived names', () => {
     // key vaccinations has no name; "reminder days" derives from the key reminderDays
-    const result = filterSettingsSchema(schema, 'reminder days');
+    const result = filterSettingsSchema(schema, 'reminder days').schema;
     expect(Object.keys(result.properties)).toEqual(['vaccinations']);
 
-    const topLevel = filterSettingsSchema(schema, 'top level');
+    const topLevel = filterSettingsSchema(schema, 'top level').schema;
     expect(Object.keys(topLevel.properties)).toEqual(['topLevelFlag']);
   });
 
@@ -81,7 +80,7 @@ describe('filterSettingsSchema', () => {
     expect(filterSettingsSchema(schema, 'zzz-no-such-setting')).toBeNull();
   });
 
-  it('does not mutate the input schema', () => {
+  it('does not mutate or annotate the input schema', () => {
     const before = JSON.stringify(schema);
     filterSettingsSchema(schema, 'from');
     expect(JSON.stringify(schema)).toBe(before);
@@ -103,17 +102,17 @@ describe('filterSettingsSchema', () => {
     };
 
     it('ranks word-start name hits above mid-word description hits', () => {
-      const result = filterSettingsSchema(pagey, 'age');
+      const { schema: result, meta } = filterSettingsSchema(pagey, 'age');
       // "age" starts a word only in Age display format; "page" hits are kept but sink
-      expect(result.properties.ageDisplayFormat.__matchTier).toBe(1);
-      expect(result.properties.fhir.__matchTier).toBeGreaterThan(1);
+      expect(meta.get(result.properties.ageDisplayFormat).tier).toBe(1);
+      expect(meta.get(result.properties.fhir).tier).toBeGreaterThan(1);
     });
 
     it('ranks name hits above description hits', () => {
-      const result = filterSettingsSchema(pagey, 'page');
+      const { schema: result, meta } = filterSettingsSchema(pagey, 'page');
       const { maxPageSize, defaultCount } = result.properties.fhir.properties;
-      expect(maxPageSize.__matchTier).toBe(1); // camelCase word-start in the key
-      expect(defaultCount.__matchTier).toBeGreaterThan(maxPageSize.__matchTier);
+      expect(meta.get(maxPageSize).tier).toBe(1); // camelCase word-start in the key
+      expect(meta.get(defaultCount).tier).toBeGreaterThan(meta.get(maxPageSize).tier);
     });
 
     it('ranks setting-name hits above category-name hits', () => {
@@ -129,9 +128,9 @@ describe('filterSettingsSchema', () => {
           },
         },
       };
-      const result = filterSettingsSchema(fielded, 'previously');
-      expect(result.properties.reports.__matchTier).toBe(1);
-      expect(result.properties.fields.__matchTier).toBe(3);
+      const { schema: result, meta } = filterSettingsSchema(fielded, 'previously');
+      expect(meta.get(result.properties.reports).tier).toBe(1);
+      expect(meta.get(result.properties.fields).tier).toBe(3);
       // the category-name match still brings its whole subtree
       expect(result.properties.fields.properties.displayId).toBeTruthy();
     });
@@ -152,7 +151,7 @@ describe('filterSettingsSchema', () => {
           },
         },
       };
-      const result = filterSettingsSchema(grouped, 'age');
+      const result = filterSettingsSchema(grouped, 'age').schema;
       expect(Object.keys(result.properties)).toEqual(['ageDisplayFormat']);
     });
 
@@ -163,9 +162,9 @@ describe('filterSettingsSchema', () => {
           notes: { type: 'string', description: 'Shown on the nation-wide report' },
         },
       };
-      const result = filterSettingsSchema(tiered, 'nation');
-      expect(result.properties.donation.__matchTier).toBe(2);
-      expect(result.properties.notes.__matchTier).toBe(5);
+      const { schema: result, meta } = filterSettingsSchema(tiered, 'nation');
+      expect(meta.get(result.properties.donation).tier).toBe(2);
+      expect(meta.get(result.properties.notes).tier).toBe(5);
     });
   });
 });

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -34,14 +34,12 @@ describe('filterSettingsSchema', () => {
     expect(Object.keys(result.properties.mail.properties)).toEqual(['from']);
   });
 
-  it('matches on dotted path and description', () => {
+  it('matches on dotted path but not description', () => {
     const byPath = filterSettingsSchema(schema, 'mail.transport.host');
     expect(byPath.properties.mail.properties.transport.properties.host).toBeTruthy();
 
-    const byDescription = filterSettingsSchema(schema, 'smtp relay');
-    expect(Object.keys(byDescription.properties)).toEqual(['mail']);
-    expect(byDescription.properties.mail.properties.transport.properties.host).toBeTruthy();
-    expect(byDescription.properties.mail.properties.from).toBeUndefined();
+    // descriptions are invisible in the results, so matching on them reads as noise
+    expect(filterSettingsSchema(schema, 'smtp relay')).toBeNull();
   });
 
   it('keeps the whole subtree when a group itself matches', () => {
@@ -74,12 +72,14 @@ describe('filterSettingsSchema', () => {
         },
       },
     };
-    // "age" must not surface page/pageSize (substring inside a word)...
+    // "age" must not surface pageSize (substring inside a word)...
     expect(Object.keys(filterSettingsSchema(pagey, 'age').properties)).toEqual([
       'ageDisplayFormat',
     ]);
-    // ...but "page" still matches both the camelCase segment and the prose word
-    expect(filterSettingsSchema(pagey, 'page').properties.fhir).toBeTruthy();
+    // ...but "page" still matches the camelCase segment
+    const paged = filterSettingsSchema(pagey, 'page');
+    expect(paged.properties.fhir.properties.maxPageSize).toBeTruthy();
+    expect(paged.properties.fhir.properties.defaultCount).toBeUndefined();
   });
 
   it('does not mutate the input schema', () => {

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { filterSettingsSchema } from '../../app/views/administration/settings/filterSettingsSchema';
+import {
+  filterSettingsSchema,
+  textMatchesQuery,
+} from '../../app/views/administration/settings/filterSettingsSchema';
 
 const schema = {
   properties: {
@@ -34,12 +37,19 @@ describe('filterSettingsSchema', () => {
     expect(Object.keys(result.properties.mail.properties)).toEqual(['from']);
   });
 
-  it('matches on dotted path but not description', () => {
+  it('matches on dotted path and description', () => {
     const byPath = filterSettingsSchema(schema, 'mail.transport.host');
     expect(byPath.properties.mail.properties.transport.properties.host).toBeTruthy();
 
-    // descriptions are invisible in the results, so matching on them reads as noise
-    expect(filterSettingsSchema(schema, 'smtp relay')).toBeNull();
+    const byDescription = filterSettingsSchema(schema, 'smtp relay');
+    expect(byDescription.properties.mail.properties.transport.properties.host).toBeTruthy();
+    expect(byDescription.properties.mail.properties.from).toBeUndefined();
+  });
+
+  it('textMatchesQuery reports substring hits for the results view', () => {
+    expect(textMatchesQuery('SMTP relay hostname', 'relay')).toBe(true);
+    expect(textMatchesQuery('SMTP relay hostname', 'zzz')).toBe(false);
+    expect(textMatchesQuery(undefined, 'relay')).toBe(false);
   });
 
   it('keeps the whole subtree when a group itself matches', () => {
@@ -86,5 +96,26 @@ describe('filterSettingsSchema', () => {
     const before = JSON.stringify(schema);
     filterSettingsSchema(schema, 'from');
     expect(JSON.stringify(schema)).toBe(before);
+  });
+
+  it('prefers name/path matches over description matches', () => {
+    const tiered = {
+      properties: {
+        relayMode: { type: 'string', name: 'Relay mode' },
+        transportHost: { type: 'string', description: 'SMTP relay hostname' },
+      },
+    };
+    // both mention "relay", but only the name match shows while one exists
+    expect(Object.keys(filterSettingsSchema(tiered, 'relay').properties)).toEqual(['relayMode']);
+    // description tier still reachable when no name/path matches
+    expect(Object.keys(filterSettingsSchema(tiered, 'smtp').properties)).toEqual([
+      'transportHost',
+    ]);
+  });
+
+  it('falls back to substring matching when word-start finds nothing', () => {
+    // no word starts with "nation", but vaccinations contains it
+    const result = filterSettingsSchema(schema, 'nation');
+    expect(Object.keys(result.properties)).toEqual(['vaccinations']);
   });
 });

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { filterSettingsSchema } from '../../app/views/administration/settings/filterSettingsSchema';
+
+const schema = {
+  properties: {
+    topLevelFlag: { type: 'boolean', name: 'Top level flag' },
+    mail: {
+      name: 'Mail',
+      properties: {
+        from: { type: 'string', name: 'From address' },
+        transport: {
+          properties: {
+            host: { type: 'string', description: 'SMTP relay hostname' },
+          },
+        },
+      },
+    },
+    vaccinations: {
+      properties: {
+        reminderDays: { type: 'number', name: 'Reminder days' },
+      },
+    },
+  },
+};
+
+describe('filterSettingsSchema', () => {
+  it('returns the schema unchanged for an empty query', () => {
+    expect(filterSettingsSchema(schema, '  ')).toBe(schema);
+  });
+
+  it('matches on setting display name, keeping the group structure above it', () => {
+    const result = filterSettingsSchema(schema, 'from address');
+    expect(Object.keys(result.properties)).toEqual(['mail']);
+    expect(Object.keys(result.properties.mail.properties)).toEqual(['from']);
+  });
+
+  it('matches on dotted path and description', () => {
+    const byPath = filterSettingsSchema(schema, 'mail.transport.host');
+    expect(byPath.properties.mail.properties.transport.properties.host).toBeTruthy();
+
+    const byDescription = filterSettingsSchema(schema, 'smtp relay');
+    expect(Object.keys(byDescription.properties)).toEqual(['mail']);
+    expect(byDescription.properties.mail.properties.transport.properties.host).toBeTruthy();
+    expect(byDescription.properties.mail.properties.from).toBeUndefined();
+  });
+
+  it('keeps the whole subtree when a group itself matches', () => {
+    const result = filterSettingsSchema(schema, 'mail');
+    expect(result.properties.mail).toBe(schema.properties.mail);
+  });
+
+  it('matches root-level settings and startCase-derived names', () => {
+    // key vaccinations has no name; "reminder days" derives from the key reminderDays
+    const result = filterSettingsSchema(schema, 'reminder days');
+    expect(Object.keys(result.properties)).toEqual(['vaccinations']);
+
+    const topLevel = filterSettingsSchema(schema, 'top level');
+    expect(Object.keys(topLevel.properties)).toEqual(['topLevelFlag']);
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(filterSettingsSchema(schema, 'zzz-no-such-setting')).toBeNull();
+  });
+
+  it('does not mutate the input schema', () => {
+    const before = JSON.stringify(schema);
+    filterSettingsSchema(schema, 'from');
+    expect(JSON.stringify(schema)).toBe(before);
+  });
+});

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -136,6 +136,26 @@ describe('filterSettingsSchema', () => {
       expect(result.properties.fields.properties.displayId).toBeTruthy();
     });
 
+    it('ignores group descriptions — they are invisible in results', () => {
+      const grouped = {
+        properties: {
+          ageDisplayFormat: { type: 'string', name: 'Age display format' },
+          layouts: {
+            properties: {
+              // group description contains "homepage" ⊃ "age"; must NOT drag
+              // the whole subtree in (nothing visible would explain it)
+              mobileModules: {
+                description: 'The homepage modules on mobile',
+                properties: { programRegistries: { type: 'boolean' } },
+              },
+            },
+          },
+        },
+      };
+      const result = filterSettingsSchema(grouped, 'age');
+      expect(Object.keys(result.properties)).toEqual(['ageDisplayFormat']);
+    });
+
     it('ranks substring name hits below word-start ones but above description hits', () => {
       const tiered = {
         properties: {

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  filterSettingsSchema,
-  textMatchesQuery,
-} from '../../app/views/administration/settings/filterSettingsSchema';
+import { filterSettingsSchema } from '../../app/views/administration/settings/filterSettingsSchema';
 
 const schema = {
   properties: {
@@ -46,15 +43,29 @@ describe('filterSettingsSchema', () => {
     expect(byDescription.properties.mail.properties.from).toBeUndefined();
   });
 
-  it('textMatchesQuery reports substring hits for the results view', () => {
-    expect(textMatchesQuery('SMTP relay hostname', 'relay')).toBe(true);
-    expect(textMatchesQuery('SMTP relay hostname', 'zzz')).toBe(false);
-    expect(textMatchesQuery(undefined, 'relay')).toBe(false);
+  it('flags matched descriptions for the results view', () => {
+    const result = filterSettingsSchema(schema, 'smtp relay');
+    expect(result.properties.mail.properties.transport.properties.host.__matchedDescription).toBe(
+      true,
+    );
+  });
+
+  it('flags exact display-name matches and the groups above them', () => {
+    const result = filterSettingsSchema(schema, 'from address');
+    expect(result.properties.mail.properties.from.__exactMatch).toBe(true);
+    expect(result.properties.mail.__hasExactMatch).toBe(true);
+    // word-start-but-not-exact hits carry no exact flag
+    const partial = filterSettingsSchema(schema, 'from');
+    expect(partial.properties.mail.properties.from.__exactMatch).toBeUndefined();
   });
 
   it('keeps the whole subtree when a group itself matches', () => {
     const result = filterSettingsSchema(schema, 'mail');
-    expect(result.properties.mail).toBe(schema.properties.mail);
+    const mail = result.properties.mail;
+    expect(Object.keys(mail.properties)).toEqual(Object.keys(schema.properties.mail.properties));
+    expect(mail.properties.transport.properties.host).toBeTruthy();
+    // "mail" equals the group's display name exactly
+    expect(mail.__exactMatch).toBe(true);
   });
 
   it('matches root-level settings and startCase-derived names', () => {

--- a/packages/web/__tests__/utils/filterSettingsSchema.test.js
+++ b/packages/web/__tests__/utils/filterSettingsSchema.test.js
@@ -81,7 +81,15 @@ describe('filterSettingsSchema', () => {
     expect(filterSettingsSchema(schema, 'zzz-no-such-setting')).toBeNull();
   });
 
-  it('matches at word starts only, including camelCase boundaries', () => {
+  it('does not mutate the input schema', () => {
+    const before = JSON.stringify(schema);
+    filterSettingsSchema(schema, 'from');
+    expect(JSON.stringify(schema)).toBe(before);
+  });
+
+  // Rank-don't-hide: weaker matches are kept but carry a worse (higher) tier,
+  // so the results view sorts them below the strong ones instead of hiding them.
+  describe('match tiers', () => {
     const pagey = {
       properties: {
         ageDisplayFormat: { type: 'string', name: 'Age display format' },
@@ -93,60 +101,51 @@ describe('filterSettingsSchema', () => {
         },
       },
     };
-    // "age" must not surface pageSize (substring inside a word)...
-    expect(Object.keys(filterSettingsSchema(pagey, 'age').properties)).toEqual([
-      'ageDisplayFormat',
-    ]);
-    // ...but "page" still matches the camelCase segment
-    const paged = filterSettingsSchema(pagey, 'page');
-    expect(paged.properties.fhir.properties.maxPageSize).toBeTruthy();
-    expect(paged.properties.fhir.properties.defaultCount).toBeUndefined();
-  });
 
-  it('does not mutate the input schema', () => {
-    const before = JSON.stringify(schema);
-    filterSettingsSchema(schema, 'from');
-    expect(JSON.stringify(schema)).toBe(before);
-  });
+    it('ranks word-start name hits above mid-word description hits', () => {
+      const result = filterSettingsSchema(pagey, 'age');
+      // "age" starts a word only in Age display format; "page" hits are kept but sink
+      expect(result.properties.ageDisplayFormat.__matchTier).toBe(1);
+      expect(result.properties.fhir.__matchTier).toBeGreaterThan(1);
+    });
 
-  it('prefers setting-name matches over category-name matches', () => {
-    const fielded = {
-      properties: {
-        // category display name mentions "previously"; its key/paths don't
-        fields: { name: 'Previously localised fields', properties: {
-          displayId: { type: 'string' },
-        } },
-        reports: { properties: {
-          previouslyUsed: { type: 'boolean', name: 'Previously used' },
-        } },
-      },
-    };
-    // setting-name tier wins: only the setting shows
-    expect(Object.keys(filterSettingsSchema(fielded, 'previously').properties)).toEqual([
-      'reports',
-    ]);
-    // with no setting hit, the category-name tier is reachable
-    expect(Object.keys(filterSettingsSchema(fielded, 'localised').properties)).toEqual(['fields']);
-  });
+    it('ranks name hits above description hits', () => {
+      const result = filterSettingsSchema(pagey, 'page');
+      const { maxPageSize, defaultCount } = result.properties.fhir.properties;
+      expect(maxPageSize.__matchTier).toBe(1); // camelCase word-start in the key
+      expect(defaultCount.__matchTier).toBeGreaterThan(maxPageSize.__matchTier);
+    });
 
-  it('prefers name/path matches over description matches', () => {
-    const tiered = {
-      properties: {
-        relayMode: { type: 'string', name: 'Relay mode' },
-        transportHost: { type: 'string', description: 'SMTP relay hostname' },
-      },
-    };
-    // both mention "relay", but only the name match shows while one exists
-    expect(Object.keys(filterSettingsSchema(tiered, 'relay').properties)).toEqual(['relayMode']);
-    // description tier still reachable when no name/path matches
-    expect(Object.keys(filterSettingsSchema(tiered, 'smtp').properties)).toEqual([
-      'transportHost',
-    ]);
-  });
+    it('ranks setting-name hits above category-name hits', () => {
+      const fielded = {
+        properties: {
+          // category display name mentions "previously"; its key/paths don't
+          fields: {
+            name: 'Previously localised fields',
+            properties: { displayId: { type: 'string' } },
+          },
+          reports: {
+            properties: { previouslyUsed: { type: 'boolean', name: 'Previously used' } },
+          },
+        },
+      };
+      const result = filterSettingsSchema(fielded, 'previously');
+      expect(result.properties.reports.__matchTier).toBe(1);
+      expect(result.properties.fields.__matchTier).toBe(3);
+      // the category-name match still brings its whole subtree
+      expect(result.properties.fields.properties.displayId).toBeTruthy();
+    });
 
-  it('falls back to substring matching when word-start finds nothing', () => {
-    // no word starts with "nation", but vaccinations contains it
-    const result = filterSettingsSchema(schema, 'nation');
-    expect(Object.keys(result.properties)).toEqual(['vaccinations']);
+    it('ranks substring name hits below word-start ones but above description hits', () => {
+      const tiered = {
+        properties: {
+          donation: { type: 'string', name: 'Donation' },
+          notes: { type: 'string', description: 'Shown on the nation-wide report' },
+        },
+      };
+      const result = filterSettingsSchema(tiered, 'nation');
+      expect(result.properties.donation.__matchTier).toBe(2);
+      expect(result.properties.notes.__matchTier).toBe(5);
+    });
   });
 });

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -257,7 +257,8 @@ export const EditorView = memo(
       // root's own name ("Central server settings") is not a category heading —
       // drop it so unscoped results don't render it as a bogus title.
       if (!filtered || category) return filtered;
-      const { name, ...rootWithoutName } = filtered.schema;
+      const rootWithoutName = { ...filtered.schema };
+      delete rootWithoutName.name;
       return { ...filtered, schema: rootWithoutName };
     }, [isSearchRender, category, schemaForCategory, scope, deferredSearchQuery]);
 

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -40,13 +40,17 @@ const StyledSelectInput = styled(SelectInput)`
 `;
 
 const StyledSearchInput = styled(SearchInput)`
-  width: 18.75rem;
+  // Preferred width matching the selects, but yields (down to a usable floor)
+  // before crowding the sub-category select or wrapping the action buttons.
+  flex: 0 1 18.75rem;
+  min-width: 11rem;
 `;
 
 const SearchAndActions = styled.div`
   align-items: center;
   display: flex;
   gap: 1.5rem;
+  margin-left: auto;
 `;
 
 const NoSearchResults = styled(Box)`
@@ -58,6 +62,11 @@ const CategoryOptions = styled(Box)`
   display: flex;
   justify-content: space-between;
   align-items: end;
+  // Breathing room between the selects and the search/actions group; wrap the
+  // right group onto its own line rather than crushing it when both selects
+  // are showing on a narrow window.
+  gap: 1rem;
+  flex-wrap: wrap;
 `;
 
 const CategoriesWrapper = styled.div`
@@ -75,6 +84,10 @@ const CategoriesWrapper = styled.div`
 const ButtonGroup = styled.div`
   display: flex;
   gap: 1rem;
+  // Never squash the actions: keep them one line and let the search shrink or
+  // the group wrap instead.
+  flex-shrink: 0;
+  white-space: nowrap;
 `;
 
 const UNCATEGORISED_KEY = 'uncategorised';
@@ -251,13 +264,28 @@ export const EditorView = memo(
         if (!dismissChanges) return;
         await resetForm();
       }
+      setSearchQuery('');
       setSubCategory(null);
       setCategory(newCategory);
       setFailedSubmits(0);
     };
 
     const handleChangeSubcategory = e => {
+      setSearchQuery('');
       setSubCategory(e.target.value);
+    };
+
+    // Search and category selection are mutually exclusive views: typing a
+    // query clears the selection, picking a category clears the query. Just
+    // clearing the selection here — no warning/reset — since form edits live in
+    // values.settings by full path and survive the view switch.
+    const handleChangeSearch = e => {
+      const query = e.target.value;
+      setSearchQuery(query);
+      if (query.trim()) {
+        setCategory(null);
+        setSubCategory(null);
+      }
     };
 
     // Search results render from the schema root, so their paths are already
@@ -338,7 +366,6 @@ export const EditorView = memo(
               value={category}
               onChange={handleChangeCategory}
               options={categoryOptions}
-              disabled={isSearching}
               data-testid="styledselectinput-kvyx"
             />
             {subCategoryOptions && (
@@ -355,7 +382,6 @@ export const EditorView = memo(
                   value={subCategory}
                   onChange={handleChangeSubcategory}
                   options={subCategoryOptions}
-                  disabled={isSearching}
                   data-testid="styleddynamicselectfield-d62r"
                 />
               </Box>
@@ -365,7 +391,7 @@ export const EditorView = memo(
             <StyledSearchInput
               placeholder={getTranslation('admin.settings.search.placeholder', 'Search settings')}
               value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
+              onChange={handleChangeSearch}
               onClear={() => setSearchQuery('')}
               data-testid="styledsearchinput-s3ar"
             />

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -252,7 +252,13 @@ export const EditorView = memo(
       if (!isSearchRender) return null;
       const baseSchema = category ? schemaForCategory : getScopedSchema(scope);
       if (!baseSchema) return null;
-      return filterSettingsSchema(baseSchema, deferredSearchQuery);
+      const filtered = filterSettingsSchema(baseSchema, deferredSearchQuery);
+      // Scoped search keeps the category's heading for context, but the scope
+      // root's own name ("Central server settings") is not a category heading —
+      // drop it so unscoped results don't render it as a bogus title.
+      if (!filtered || category) return filtered;
+      const { name, ...rootWithoutName } = filtered.schema;
+      return { ...filtered, schema: rootWithoutName };
     }, [isSearchRender, category, schemaForCategory, scope, deferredSearchQuery]);
 
     const handleChangeScope = () => {

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -205,14 +205,17 @@ export const EditorView = memo(
     const [subCategory, setSubCategory] = useState(null);
     const [searchQuery, setSearchQuery] = useState('');
     const [failedSubmits, setFailedSubmits] = useState(0);
-    const isSearching = searchQuery.trim().length > 0;
+    // A single character matches half the schema and means nothing yet — the
+    // category view stays put until the query is at least two characters.
+    const MIN_SEARCH_LENGTH = 2;
+    const isSearching = searchQuery.trim().length >= MIN_SEARCH_LENGTH;
     // Broad queries can match hundreds of settings; deferring lets typing stay
     // responsive (React keeps showing the previous results and time-slices the
     // re-filter/re-render in the background) instead of freezing per keystroke.
     const deferredSearchQuery = useDeferredValue(searchQuery);
     // Drives what the body renders (and so path resolution); may lag isSearching
     // by a beat while a deferred render is pending.
-    const isSearchRender = deferredSearchQuery.trim().length > 0;
+    const isSearchRender = deferredSearchQuery.trim().length >= MIN_SEARCH_LENGTH;
 
     // Real changes only: a value returned to its inherited/default (stored as
     // undefined) is not a change, unlike Formik's built-in `dirty`.
@@ -439,6 +442,7 @@ export const EditorView = memo(
               resolveSettingsPath={getSettingPath}
               handleChangeSetting={handleChangeSetting}
               facilityId={facilityId}
+              searchQuery={isSearchRender ? deferredSearchQuery : undefined}
               data-testid="category-cbjk"
             />
             </SettingsSubmitContext.Provider>

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -1,6 +1,5 @@
 import React, { memo, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import {
-  capitalize,
   cloneDeep,
   get,
   isEqual,
@@ -8,7 +7,6 @@ import {
   omitBy,
   pickBy,
   set,
-  startCase,
 } from 'es-toolkit/compat';
 import styled from 'styled-components';
 import { Box, Divider } from '@material-ui/core';
@@ -23,6 +21,7 @@ import { Colors } from '../../../constants/styles';
 import { Category } from './components/Category';
 import { SettingsSubmitContext } from './components/SettingsSubmitContext';
 import { filterSettingsSchema } from './filterSettingsSchema';
+import { formatSettingName } from './formatSettingName';
 import { notifyError } from '../../../utils';
 
 const SettingsWrapper = styled.div`
@@ -85,7 +84,8 @@ const ButtonGroup = styled.div`
 
 const UNCATEGORISED_KEY = 'uncategorised';
 
-export const formatSettingName = (name, path) => name || capitalize(startCase(path));
+// a single character matches half the schema
+const MIN_SEARCH_LENGTH = 2;
 
 const recursiveJsonParse = obj => {
   if (typeof obj !== 'object') return obj;
@@ -199,8 +199,6 @@ export const EditorView = memo(
     const [subCategory, setSubCategory] = useState(null);
     const [searchQuery, setSearchQuery] = useState('');
     const [failedSubmits, setFailedSubmits] = useState(0);
-    // a single character matches half the schema
-    const MIN_SEARCH_LENGTH = 2;
     // defer filtering so broad queries don't freeze typing
     const deferredSearchQuery = useDeferredValue(searchQuery);
     // drives the rendered body; lags the input while a deferred render is pending

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -246,7 +246,9 @@ export const EditorView = memo(
     // prepareSchema's copy) so root-level settings keep their real top-level
     // paths, and results render from the root so headings and inherited flags
     // (highRisk, requiresRestart) flow through the normal Category recursion.
-    const searchResultSchema = useMemo(() => {
+    // Yields { schema, meta } — meta carries the per-node match metadata the
+    // results view sorts and annotates by — or null when nothing matches.
+    const searchResult = useMemo(() => {
       if (!isSearchRender) return null;
       const baseSchema = category ? schemaForCategory : getScopedSchema(scope);
       if (!baseSchema) return null;
@@ -422,7 +424,7 @@ export const EditorView = memo(
           </SearchAndActions>
         </CategoryOptions>
         <Divider data-testid="divider-tp55" />
-        {isSearchRender && !searchResultSchema && (
+        {isSearchRender && !searchResult && (
           <NoSearchResults data-testid="nosearchresults-s3ar">
             <TranslatedText
               stringId="admin.settings.search.noResults"
@@ -431,17 +433,18 @@ export const EditorView = memo(
             />
           </NoSearchResults>
         )}
-        {(isSearchRender ? searchResultSchema : schemaForCategory) && (
+        {(isSearchRender ? searchResult?.schema : schemaForCategory) && (
           <CategoriesWrapper p={2} data-testid="categorieswrapper-0ae4">
             <SettingsSubmitContext.Provider value={failedSubmits}>
             <Category
-              schema={isSearchRender ? searchResultSchema : schemaForCategory}
+              schema={isSearchRender ? searchResult.schema : schemaForCategory}
               getSettingValue={getSettingValue}
               getGlobalSettingValue={getGlobalSettingValue}
               resolveSettingsPath={getSettingPath}
               handleChangeSetting={handleChangeSetting}
               facilityId={facilityId}
               searchQuery={isSearchRender ? deferredSearchQuery : undefined}
+              searchMeta={isSearchRender ? searchResult.meta : undefined}
               data-testid="category-cbjk"
             />
             </SettingsSubmitContext.Provider>

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -238,15 +238,18 @@ export const EditorView = memo(
       [scopedSchema, effectiveCategory, subCategory],
     );
 
-    // Search spans every category, so filter the raw scoped schema (not
-    // prepareSchema's copy): root-level settings keep their real top-level
+    // Search is scoped to the current selection: within the selected
+    // category/sub-category when one is chosen, across every category
+    // otherwise. The unscoped case filters the raw scoped schema (not
+    // prepareSchema's copy) so root-level settings keep their real top-level
     // paths, and results render from the root so headings and inherited flags
     // (highRisk, requiresRestart) flow through the normal Category recursion.
-    const searchResultSchema = useMemo(
-      () =>
-        isSearchRender ? filterSettingsSchema(getScopedSchema(scope), deferredSearchQuery) : null,
-      [isSearchRender, scope, deferredSearchQuery],
-    );
+    const searchResultSchema = useMemo(() => {
+      if (!isSearchRender) return null;
+      const baseSchema = category ? schemaForCategory : getScopedSchema(scope);
+      if (!baseSchema) return null;
+      return filterSettingsSchema(baseSchema, deferredSearchQuery);
+    }, [isSearchRender, category, schemaForCategory, scope, deferredSearchQuery]);
 
     const handleChangeScope = () => {
       setSubCategory(null);
@@ -263,36 +266,22 @@ export const EditorView = memo(
         if (!dismissChanges) return;
         await resetForm();
       }
-      setSearchQuery('');
       setSubCategory(null);
       setCategory(newCategory);
       setFailedSubmits(0);
     };
 
     const handleChangeSubcategory = e => {
-      setSearchQuery('');
       setSubCategory(e.target.value);
     };
 
-    // Search and category selection are mutually exclusive views: typing a
-    // query clears the selection, picking a category clears the query. Just
-    // clearing the selection here — no warning/reset — since form edits live in
-    // values.settings by full path and survive the view switch.
-    const handleChangeSearch = e => {
-      const query = e.target.value;
-      setSearchQuery(query);
-      if (query.trim()) {
-        setCategory(null);
-        setSubCategory(null);
-      }
-    };
-
-    // Search results render from the schema root, so their paths are already
-    // complete; category view paths need the selected category prefixed. Keyed
-    // to isSearchRender (not isSearching) so path semantics always match the
-    // tree currently on screen, even mid-deferral.
+    // Unscoped search renders from the schema root, so its paths are already
+    // complete; the category view AND category-scoped search render from the
+    // selected category, so paths need the selection prefixed. Keyed to
+    // isSearchRender (not isSearching) so path semantics always match the tree
+    // currently on screen, even mid-deferral.
     const getSettingPath = path =>
-      isSearchRender
+      isSearchRender && !category
         ? path
         : `${effectiveCategory === UNCATEGORISED_KEY ? '' : `${effectiveCategory}.`}${
             subCategory ? `${subCategory}.` : ''
@@ -388,9 +377,13 @@ export const EditorView = memo(
           </Box>
           <SearchAndActions data-testid="searchandactions-s3ar">
             <StyledSearchInput
-              placeholder={getTranslation('admin.settings.search.placeholder', 'Search settings')}
+              placeholder={
+                category
+                  ? getTranslation('admin.settings.search.placeholderScoped', 'Search in category')
+                  : getTranslation('admin.settings.search.placeholder', 'Search settings')
+              }
               value={searchQuery}
-              onChange={handleChangeSearch}
+              onChange={e => setSearchQuery(e.target.value)}
               onClear={() => setSearchQuery('')}
               data-testid="styledsearchinput-s3ar"
             />

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useDeferredValue, useEffect, useMemo, useState } from 'react';
+import React, { memo, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import {
   cloneDeep,
   get,
@@ -12,6 +12,7 @@ import styled from 'styled-components';
 import { Box, Divider } from '@material-ui/core';
 
 import { useFormikContext } from 'formik';
+import { SETTINGS_SCOPES } from '@tamanu/constants';
 import { getScopedSchema, isSetting } from '@tamanu/settings/schema';
 
 import { DynamicSelectField, SearchInput, TranslatedText } from '../../../components';
@@ -22,6 +23,7 @@ import { Category } from './components/Category';
 import { SettingsSubmitContext } from './components/SettingsSubmitContext';
 import { filterSettingsSchema } from './filterSettingsSchema';
 import { formatSettingName } from './formatSettingName';
+import { readUrlParam, writeUrlParams } from './urlState';
 import { notifyError } from '../../../utils';
 
 const SettingsWrapper = styled.div`
@@ -59,7 +61,6 @@ const CategoryOptions = styled(Box)`
   display: flex;
   justify-content: space-between;
   align-items: end;
-  // the search field shrinks before anything wraps or crushes
   gap: 1rem;
 `;
 
@@ -86,6 +87,25 @@ const UNCATEGORISED_KEY = 'uncategorised';
 
 // a single character matches half the schema
 const MIN_SEARCH_LENGTH = 2;
+
+const SCOPE_LABELS = {
+  [SETTINGS_SCOPES.GLOBAL]: 'Global',
+  [SETTINGS_SCOPES.CENTRAL]: 'Central',
+  [SETTINGS_SCOPES.FACILITY]: 'Facility',
+};
+
+const NoResultsHint = styled.div`
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  opacity: 0.7;
+`;
+
+const countSettings = schema =>
+  Object.values(schema.properties ?? {}).reduce(
+    (total, node) => total + (isSetting(node) || !node.properties ? 1 : countSettings(node)),
+    0,
+  );
+
 
 const recursiveJsonParse = obj => {
   if (typeof obj !== 'object') return obj;
@@ -195,10 +215,25 @@ export const EditorView = memo(
     const { facilityId } = values;
     const { initialValues } = useFormikContext();
     const { getTranslation } = useTranslation();
-    const [category, setCategory] = useState(null);
-    const [subCategory, setSubCategory] = useState(null);
-    const [searchQuery, setSearchQuery] = useState('');
+    // Selection, search, and the overrides filter are deep-linkable (see
+    // urlState.js); an invalid category/sub-category param is just dropped.
+    const [category, setCategory] = useState(() => {
+      const fromUrl = readUrlParam('category');
+      return fromUrl && fromUrl in (getScopedSchema(scope)?.properties ?? {}) ? fromUrl : null;
+    });
+    const [subCategory, setSubCategory] = useState(() => {
+      const fromUrl = readUrlParam('subCategory');
+      const parent = readUrlParam('category');
+      return fromUrl && getScopedSchema(scope)?.properties?.[parent]?.properties?.[fromUrl]
+        ? fromUrl
+        : null;
+    });
+    const [searchQuery, setSearchQuery] = useState(() => readUrlParam('q') ?? '');
     const [failedSubmits, setFailedSubmits] = useState(0);
+
+    useEffect(() => {
+      writeUrlParams({ category, subCategory, q: searchQuery });
+    }, [category, subCategory, searchQuery]);
     // defer filtering so broad queries don't freeze typing
     const deferredSearchQuery = useDeferredValue(searchQuery);
     // drives the rendered body; lags the input while a deferred render is pending
@@ -244,13 +279,44 @@ export const EditorView = memo(
       return { ...filtered, schema: rootWithoutName };
     }, [isSearchRender, category, schemaForCategory, scope, deferredSearchQuery]);
 
+    // When nothing matched, say where matches DO exist — the schemas are
+    // disjoint per scope, so "no results" here often just means "wrong scope".
+    const searchHints = useMemo(() => {
+      if (!isSearchRender || searchResult) return null;
+      const hints = [];
+      if (category) {
+        const wholeScope = filterSettingsSchema(getScopedSchema(scope), deferredSearchQuery);
+        if (wholeScope) hints.push(`${countSettings(wholeScope.schema)} elsewhere in this scope`);
+      }
+      for (const other of Object.values(SETTINGS_SCOPES)) {
+        if (other === scope) continue;
+        const otherSchema = getScopedSchema(other);
+        if (!otherSchema) continue;
+        const filtered = filterSettingsSchema(otherSchema, deferredSearchQuery);
+        if (filtered) {
+          hints.push(`${countSettings(filtered.schema)} in the ${SCOPE_LABELS[other]} scope`);
+        }
+      }
+      return hints.length ? hints : null;
+    }, [isSearchRender, searchResult, category, scope, deferredSearchQuery]);
+
     const handleChangeScope = () => {
       setSubCategory(null);
       setCategory(null);
       setSearchQuery('');
     };
 
-    useEffect(handleChangeScope, [scope]);
+    // Reset the selection when the scope changes — but not on mount, or the
+    // deep-linked state read from the URL would be immediately clobbered.
+    const isFirstRender = useRef(true);
+    useEffect(() => {
+      if (isFirstRender.current) {
+        isFirstRender.current = false;
+        return;
+      }
+      handleChangeScope();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scope]);
 
     const handleChangeCategory = async e => {
       const newCategory = e.target.value ?? null; // null when cleared via the x
@@ -414,6 +480,16 @@ export const EditorView = memo(
               fallback="No settings match your search"
               data-testid="translatedtext-s3nr"
             />
+            {searchHints && (
+              <NoResultsHint data-testid="noresultshint-s3ar">
+                <TranslatedText
+                  stringId="admin.settings.search.matchesElsewhere"
+                  fallback="Matches elsewhere:"
+                  data-testid="translatedtext-mel1"
+                />{' '}
+                {searchHints.join(' · ')}
+              </NoResultsHint>
+            )}
           </NoSearchResults>
         )}
         {(isSearchRender ? searchResult?.schema : schemaForCategory) && (

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useState } from 'react';
+import React, { memo, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import {
   capitalize,
   cloneDeep,
@@ -16,11 +16,13 @@ import { Box, Divider } from '@material-ui/core';
 import { useFormikContext } from 'formik';
 import { getScopedSchema, isSetting } from '@tamanu/settings/schema';
 
-import { DynamicSelectField, TranslatedText } from '../../../components';
+import { DynamicSelectField, SearchInput, TranslatedText } from '../../../components';
+import { useTranslation } from '../../../contexts/Translation';
 import { SelectInput, OutlinedButton, Button } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
 import { Category } from './components/Category';
 import { SettingsSubmitContext } from './components/SettingsSubmitContext';
+import { filterSettingsSchema } from './filterSettingsSchema';
 import { notifyError } from '../../../utils';
 
 const SettingsWrapper = styled.div`
@@ -35,6 +37,21 @@ const StyledDynamicSelectField = styled(DynamicSelectField)`
 
 const StyledSelectInput = styled(SelectInput)`
   width: 18.75rem;
+`;
+
+const StyledSearchInput = styled(SearchInput)`
+  width: 18.75rem;
+`;
+
+const SearchAndActions = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 1.5rem;
+`;
+
+const NoSearchResults = styled(Box)`
+  padding: 1.25rem;
+  color: ${Colors.midText};
 `;
 
 const CategoryOptions = styled(Box)`
@@ -171,9 +188,19 @@ export const EditorView = memo(
   }) => {
     const { facilityId } = values;
     const { initialValues } = useFormikContext();
+    const { getTranslation } = useTranslation();
     const [category, setCategory] = useState(null);
     const [subCategory, setSubCategory] = useState(null);
+    const [searchQuery, setSearchQuery] = useState('');
     const [failedSubmits, setFailedSubmits] = useState(0);
+    const isSearching = searchQuery.trim().length > 0;
+    // Broad queries can match hundreds of settings; deferring lets typing stay
+    // responsive (React keeps showing the previous results and time-slices the
+    // re-filter/re-render in the background) instead of freezing per keystroke.
+    const deferredSearchQuery = useDeferredValue(searchQuery);
+    // Drives what the body renders (and so path resolution); may lag isSearching
+    // by a beat while a deferred render is pending.
+    const isSearchRender = deferredSearchQuery.trim().length > 0;
 
     // Real changes only: a value returned to its inherited/default (stored as
     // undefined) is not a change, unlike Formik's built-in `dirty`.
@@ -199,9 +226,20 @@ export const EditorView = memo(
       [scopedSchema, effectiveCategory, subCategory],
     );
 
+    // Search spans every category, so filter the raw scoped schema (not
+    // prepareSchema's copy): root-level settings keep their real top-level
+    // paths, and results render from the root so headings and inherited flags
+    // (highRisk, requiresRestart) flow through the normal Category recursion.
+    const searchResultSchema = useMemo(
+      () =>
+        isSearchRender ? filterSettingsSchema(getScopedSchema(scope), deferredSearchQuery) : null,
+      [isSearchRender, scope, deferredSearchQuery],
+    );
+
     const handleChangeScope = () => {
       setSubCategory(null);
       setCategory(null);
+      setSearchQuery('');
     };
 
     useEffect(handleChangeScope, [scope]);
@@ -222,10 +260,16 @@ export const EditorView = memo(
       setSubCategory(e.target.value);
     };
 
+    // Search results render from the schema root, so their paths are already
+    // complete; category view paths need the selected category prefixed. Keyed
+    // to isSearchRender (not isSearching) so path semantics always match the
+    // tree currently on screen, even mid-deferral.
     const getSettingPath = path =>
-      `${effectiveCategory === UNCATEGORISED_KEY ? '' : `${effectiveCategory}.`}${
-        subCategory ? `${subCategory}.` : ''
-      }${path}`;
+      isSearchRender
+        ? path
+        : `${effectiveCategory === UNCATEGORISED_KEY ? '' : `${effectiveCategory}.`}${
+            subCategory ? `${subCategory}.` : ''
+          }${path}`;
 
     const handleChangeSetting = (path, value) => {
       const settingObject = cloneDeep(values.settings);
@@ -294,6 +338,7 @@ export const EditorView = memo(
               value={category}
               onChange={handleChangeCategory}
               options={categoryOptions}
+              disabled={isSearching}
               data-testid="styledselectinput-kvyx"
             />
             {subCategoryOptions && (
@@ -310,11 +355,20 @@ export const EditorView = memo(
                   value={subCategory}
                   onChange={handleChangeSubcategory}
                   options={subCategoryOptions}
+                  disabled={isSearching}
                   data-testid="styleddynamicselectfield-d62r"
                 />
               </Box>
             )}
           </Box>
+          <SearchAndActions data-testid="searchandactions-s3ar">
+            <StyledSearchInput
+              placeholder={getTranslation('admin.settings.search.placeholder', 'Search settings')}
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              onClear={() => setSearchQuery('')}
+              data-testid="styledsearchinput-s3ar"
+            />
           <ButtonGroup data-testid="buttongroup-oe3l">
             <OutlinedButton
               onClick={() => resetForm()}
@@ -339,13 +393,23 @@ export const EditorView = memo(
               />
             </Button>
           </ButtonGroup>
+          </SearchAndActions>
         </CategoryOptions>
         <Divider data-testid="divider-tp55" />
-        {schemaForCategory && (
+        {isSearchRender && !searchResultSchema && (
+          <NoSearchResults data-testid="nosearchresults-s3ar">
+            <TranslatedText
+              stringId="admin.settings.search.noResults"
+              fallback="No settings match your search"
+              data-testid="translatedtext-s3nr"
+            />
+          </NoSearchResults>
+        )}
+        {(isSearchRender ? searchResultSchema : schemaForCategory) && (
           <CategoriesWrapper p={2} data-testid="categorieswrapper-0ae4">
             <SettingsSubmitContext.Provider value={failedSubmits}>
             <Category
-              schema={schemaForCategory}
+              schema={isSearchRender ? searchResultSchema : schemaForCategory}
               getSettingValue={getSettingValue}
               getGlobalSettingValue={getGlobalSettingValue}
               resolveSettingsPath={getSettingPath}

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -62,11 +62,10 @@ const CategoryOptions = styled(Box)`
   display: flex;
   justify-content: space-between;
   align-items: end;
-  // Breathing room between the selects and the search/actions group; wrap the
-  // right group onto its own line rather than crushing it when both selects
-  // are showing on a narrow window.
+  // Breathing room between the selects and the search/actions group; when the
+  // window narrows the search field shrinks (see StyledSearchInput) rather
+  // than anything wrapping or crushing.
   gap: 1rem;
-  flex-wrap: wrap;
 `;
 
 const CategoriesWrapper = styled.div`

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -208,7 +208,6 @@ export const EditorView = memo(
     // A single character matches half the schema and means nothing yet — the
     // category view stays put until the query is at least two characters.
     const MIN_SEARCH_LENGTH = 2;
-    const isSearching = searchQuery.trim().length >= MIN_SEARCH_LENGTH;
     // Broad queries can match hundreds of settings; deferring lets typing stay
     // responsive (React keeps showing the previous results and time-slices the
     // re-filter/re-render in the background) instead of freezing per keystroke.

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -40,8 +40,6 @@ const StyledSelectInput = styled(SelectInput)`
 `;
 
 const StyledSearchInput = styled(SearchInput)`
-  // Preferred width matching the selects, but yields (down to a usable floor)
-  // before crowding the sub-category select or wrapping the action buttons.
   flex: 0 1 18.75rem;
   min-width: 11rem;
 `;
@@ -62,9 +60,7 @@ const CategoryOptions = styled(Box)`
   display: flex;
   justify-content: space-between;
   align-items: end;
-  // Breathing room between the selects and the search/actions group; when the
-  // window narrows the search field shrinks (see StyledSearchInput) rather
-  // than anything wrapping or crushing.
+  // the search field shrinks before anything wraps or crushes
   gap: 1rem;
 `;
 
@@ -83,8 +79,6 @@ const CategoriesWrapper = styled.div`
 const ButtonGroup = styled.div`
   display: flex;
   gap: 1rem;
-  // Never squash the actions: keep them one line and let the search shrink or
-  // the group wrap instead.
   flex-shrink: 0;
   white-space: nowrap;
 `;
@@ -205,15 +199,11 @@ export const EditorView = memo(
     const [subCategory, setSubCategory] = useState(null);
     const [searchQuery, setSearchQuery] = useState('');
     const [failedSubmits, setFailedSubmits] = useState(0);
-    // A single character matches half the schema and means nothing yet — the
-    // category view stays put until the query is at least two characters.
+    // a single character matches half the schema
     const MIN_SEARCH_LENGTH = 2;
-    // Broad queries can match hundreds of settings; deferring lets typing stay
-    // responsive (React keeps showing the previous results and time-slices the
-    // re-filter/re-render in the background) instead of freezing per keystroke.
+    // defer filtering so broad queries don't freeze typing
     const deferredSearchQuery = useDeferredValue(searchQuery);
-    // Drives what the body renders (and so path resolution); may lag isSearching
-    // by a beat while a deferred render is pending.
+    // drives the rendered body; lags the input while a deferred render is pending
     const isSearchRender = deferredSearchQuery.trim().length >= MIN_SEARCH_LENGTH;
 
     // Real changes only: a value returned to its inherited/default (stored as
@@ -240,22 +230,16 @@ export const EditorView = memo(
       [scopedSchema, effectiveCategory, subCategory],
     );
 
-    // Search is scoped to the current selection: within the selected
-    // category/sub-category when one is chosen, across every category
-    // otherwise. The unscoped case filters the raw scoped schema (not
-    // prepareSchema's copy) so root-level settings keep their real top-level
-    // paths, and results render from the root so headings and inherited flags
-    // (highRisk, requiresRestart) flow through the normal Category recursion.
-    // Yields { schema, meta } — meta carries the per-node match metadata the
-    // results view sorts and annotates by — or null when nothing matches.
+    // Search within the selection when a category is chosen, across everything
+    // otherwise (filtering the raw scoped schema, not prepareSchema's copy, so
+    // root-level settings keep their real paths). Null when nothing matches.
     const searchResult = useMemo(() => {
       if (!isSearchRender) return null;
       const baseSchema = category ? schemaForCategory : getScopedSchema(scope);
       if (!baseSchema) return null;
       const filtered = filterSettingsSchema(baseSchema, deferredSearchQuery);
-      // Scoped search keeps the category's heading for context, but the scope
-      // root's own name ("Central server settings") is not a category heading —
-      // drop it so unscoped results don't render it as a bogus title.
+      // the scope root's name ("Central server settings") is not a category
+      // heading — drop it for unscoped results
       if (!filtered || category) return filtered;
       const rootWithoutName = { ...filtered.schema };
       delete rootWithoutName.name;
@@ -277,10 +261,7 @@ export const EditorView = memo(
         if (!dismissChanges) return;
         await resetForm();
       }
-      // Picking a category is an explicit "show me this category": drop any
-      // active query rather than silently keeping it as a filter the user has
-      // to notice over in the search box. (Typing a query with a category
-      // selected still scopes to it — that combination is deliberate.)
+      // picking a category is a fresh intent — drop any active query
       setSearchQuery('');
       setSubCategory(null);
       setCategory(newCategory);
@@ -292,11 +273,8 @@ export const EditorView = memo(
       setSubCategory(e.target.value);
     };
 
-    // Unscoped search renders from the schema root, so its paths are already
-    // complete; the category view AND category-scoped search render from the
-    // selected category, so paths need the selection prefixed. Keyed to
-    // isSearchRender (not isSearching) so path semantics always match the tree
-    // currently on screen, even mid-deferral.
+    // Unscoped search renders from the schema root, so paths are already
+    // complete; the category view and scoped search need the selection prefixed.
     const getSettingPath = path =>
       isSearchRender && !category
         ? path

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -155,7 +155,10 @@ const getSchemaForCategory = (schema, category, subCategory) => {
   const categorySchema = schema.properties[category];
   if (!categorySchema) return null;
   if (subCategory) {
-    const subCategorySchema = categorySchema.properties[subCategory];
+    // A stale sub-category can outlive a scope/category switch for one render
+    // before the reset effect runs; render nothing rather than crash.
+    const subCategorySchema = categorySchema.properties?.[subCategory];
+    if (!subCategorySchema) return null;
     const isHighRisk = categorySchema.highRisk || subCategorySchema.highRisk;
     const infoBanner = categorySchema.infoBanner || subCategorySchema.infoBanner;
     const needsRestart = categorySchema.requiresRestart || subCategorySchema.requiresRestart;

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -266,12 +266,18 @@ export const EditorView = memo(
         if (!dismissChanges) return;
         await resetForm();
       }
+      // Picking a category is an explicit "show me this category": drop any
+      // active query rather than silently keeping it as a filter the user has
+      // to notice over in the search box. (Typing a query with a category
+      // selected still scopes to it — that combination is deliberate.)
+      setSearchQuery('');
       setSubCategory(null);
       setCategory(newCategory);
       setFailedSubmits(0);
     };
 
     const handleChangeSubcategory = e => {
+      setSearchQuery('');
       setSubCategory(e.target.value);
     };
 

--- a/packages/web/app/views/administration/settings/SettingsView.jsx
+++ b/packages/web/app/views/administration/settings/SettingsView.jsx
@@ -1,5 +1,5 @@
 import SettingsIcon from '@mui/icons-material/Settings';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
 
@@ -20,6 +20,7 @@ import { notifyError, notifySuccess } from '../../../utils';
 import { EditorView } from './EditorView';
 import { ScopeSelectorFields } from './components/ScopeSelectorFields';
 import { WarningModal } from './components/WarningModal';
+import { readUrlParam, writeUrlParams } from './urlState';
 
 const SETTING_TABS = /** @type {const} */ ({
   EDITOR: 'editor',
@@ -84,8 +85,17 @@ const tabs = [
 
 export const SettingsView = () => {
   const api = useApi();
-  const [scope, setScope] = useState(SETTINGS_SCOPES.GLOBAL);
-  const [facilityId, setFacilityId] = useState(null);
+  // Scope and facility are deep-linkable (see urlState.js); a bad param just
+  // falls back to the defaults.
+  const [scope, setScope] = useState(() => {
+    const fromUrl = readUrlParam('scope');
+    return Object.values(SETTINGS_SCOPES).includes(fromUrl) ? fromUrl : SETTINGS_SCOPES.GLOBAL;
+  });
+  const [facilityId, setFacilityId] = useState(() => readUrlParam('facilityId'));
+
+  useEffect(() => {
+    writeUrlParams({ scope, facilityId });
+  }, [scope, facilityId]);
 
   // Snapshot holds only this scope's explicit overrides (no schema defaults filled);
   // un-set settings read as undefined so the editor shows the effective value.

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -123,9 +123,10 @@ const InfoBannerAlert = styled(Alert)`
   margin-inline-end: 1.25rem;
 `;
 
-// Same colour as the row hover band so highlights read as part of one system.
+// One step up the primary ramp from the row hover band (primary10), so the
+// highlight stays visible when its row is hovered.
 const Mark = styled.mark`
-  background-color: ${Colors.primary10};
+  background-color: ${Colors.primary30};
   border-radius: 2px;
   color: inherit;
 `;

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -123,9 +123,11 @@ const InfoBannerAlert = styled(Alert)`
   margin-inline-end: 1.25rem;
 `;
 
+// Same colour as the row hover band so highlights read as part of one system.
 const Mark = styled.mark`
   background-color: ${Colors.primary10};
   border-radius: 2px;
+  color: inherit;
 `;
 
 // Description line shown under a setting's name when a search hit is in the
@@ -161,7 +163,7 @@ const highlightMatches = (text, query) => {
   return parts;
 };
 
-const CategoryTitle = memo(({ name, path, description, depth }) => {
+const CategoryTitle = memo(({ name, path, description, depth, searchQuery }) => {
   const categoryTitle = formatSettingName(name, path.split('.').pop());
   if (!categoryTitle) return null;
   return (
@@ -171,7 +173,7 @@ const CategoryTitle = memo(({ name, path, description, depth }) => {
       data-testid="themedtooltip-j5ux"
     >
       <StyledHeading $indent={depth} data-testid="styledheading-js44">
-        {categoryTitle}
+        {searchQuery ? highlightMatches(categoryTitle, searchQuery) : categoryTitle}
       </StyledHeading>
     </ThemedTooltip>
   );
@@ -218,9 +220,13 @@ const SettingName = memo(
       data-testid="themedtooltip-2qoa"
     >
       <SettingNameLabel color={disabled && 'textTertiary'} data-testid="settingnamelabel-xr19">
-        {searchQuery
-          ? highlightMatches(formatSettingName(name, path.split('.').pop()), searchQuery)
-          : formatSettingName(name, path.split('.').pop())}
+        {/* single span: the label is inline-flex with a gap, so bare highlight
+            fragments would render as separate flex items with gaps between */}
+        <span>
+          {searchQuery
+            ? highlightMatches(formatSettingName(name, path.split('.').pop()), searchQuery)
+            : formatSettingName(name, path.split('.').pop())}
+        </span>
         {disabled ? (
           <StyledLockIcon data-testid="styledlockicon-x3w0" />
         ) : (
@@ -294,6 +300,7 @@ export const Category = ({
         path={path}
         depth={depth}
         description={schema.description}
+        searchQuery={searchQuery}
         data-testid="categorytitle-0pic"
       />
       {schema.infoBanner && (

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -123,29 +123,25 @@ const InfoBannerAlert = styled(Alert)`
   margin-inline-end: 1.25rem;
 `;
 
-// One step up the primary ramp from the row hover band (primary10), so the
-// highlight stays visible when its row is hovered.
+// a step above the hover band (primary10) so highlights survive row hover
 const Mark = styled.mark`
   background-color: ${Colors.primary30};
   border-radius: 2px;
   color: inherit;
 `;
 
-// Description line shown under a setting's name when a search hit is in the
-// description — otherwise the match reason is invisible (tooltip-only).
+// description shown under the row when the search hit is in it
 const MatchedDescription = styled(BodyText)`
   color: ${Colors.midText};
   font-size: 13px;
   grid-column: 1 / -1;
   margin-block: -8px 13px;
-  // The name's text inset is the outer label's per-depth margin PLUS the
-  // nested inner label's base 1.25rem — match both so this aligns with it.
+  // outer label's per-depth margin + inner label's base 1.25rem
   margin-inline-start: ${props => 2.5 + (props.$indent ?? 0) * 1.25}rem;
   max-inline-size: 60ch;
 `;
 
-// Wraps each occurrence of `query` in text with a highlight mark. Substring
-// (not word-start) so it explains rows from either matching tier.
+// substring (not word-start) so it explains rows from either matching tier
 const highlightMatches = (text, query) => {
   const needle = query?.trim();
   if (!needle) return text;
@@ -220,8 +216,7 @@ const SettingName = memo(
       data-testid="themedtooltip-2qoa"
     >
       <SettingNameLabel color={disabled && 'textTertiary'} data-testid="settingnamelabel-xr19">
-        {/* single span: the label is inline-flex with a gap, so bare highlight
-            fragments would render as separate flex items with gaps between */}
+        {/* one span: the label is inline-flex with a gap, so bare fragments would gap apart */}
         <span>
           {searchQuery
             ? highlightMatches(formatSettingName(name, path.split('.').pop()), searchQuery)
@@ -265,9 +260,8 @@ const SettingName = memo(
   </SettingNameLabel>
 ));
 
-// Search ordering comes from the filter's metadata (absent outside search, so
-// the category view is unaffected): exact hits (and groups holding one) first,
-// then by match tier (strong matches lead, weak ones sink).
+// search ordering from the filter's metadata (absent outside search):
+// exact hits first, then match tier
 const sortProperties = searchMeta => ([a0, a1], [b0, b1]) => {
   const aMeta = searchMeta?.get(a1);
   const bMeta = searchMeta?.get(b1);
@@ -343,10 +337,6 @@ export const Category = ({
         const disabled = !canWriteHighRisk && isHighRisk;
         const isMultiEntry =
           editor === SETTING_EDITORS.MAPPING || editor === SETTING_EDITORS.OBJECT_LIST;
-        // When a search hit is in the description, surface it under the row —
-        // the tooltip-only description makes such matches look inexplicable.
-        // The metadata comes from filterSettingsSchema, the single source of
-        // match logic; it only exists for search-filtered schema copies.
         const showMatchedDescription =
           Boolean(searchQuery) && Boolean(searchMeta?.get(propertySchema)?.matchedDescription);
 

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -266,11 +266,15 @@ const SettingName = memo(
 ));
 
 const sortProperties = ([a0, a1], [b0, b1]) => {
-  // Exact search hits (and groups holding one) first — flags only exist on
-  // search-filtered schema copies, so the category view is unaffected.
+  // Search ordering — flags only exist on search-filtered schema copies, so
+  // the category view is unaffected. Exact hits (and groups holding one)
+  // first, then by match tier (strong matches lead, weak ones sink).
   const aExact = Boolean(a1.__exactMatch || a1.__hasExactMatch);
   const bExact = Boolean(b1.__exactMatch || b1.__hasExactMatch);
   if (aExact !== bExact) return aExact ? -1 : 1;
+  const aTier = a1.__matchTier ?? Infinity;
+  const bTier = b1.__matchTier ?? Infinity;
+  if (aTier !== bTier) return aTier - bTier;
   const aName = a1.name || a0;
   const bName = b1.name || b0;
   const isTopLevelA = isSetting(a1);

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import LockIcon from '@mui/icons-material/Lock';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { Alert } from '@material-ui/lab';
+import BlockIcon from '@mui/icons-material/Block';
 import KeyIcon from '@mui/icons-material/Key';
 import WarningIcon from '@mui/icons-material/WarningAmber';
 import { escapeRegExp } from 'es-toolkit/compat';
@@ -39,6 +40,12 @@ const StyledHighRiskIcon = styled(WarningIcon)`
   font-size: 1.125rem;
   margin-inline-start: 0.25rem;
   color: ${Colors.orange};
+`;
+
+const StyledDeprecatedIcon = styled(BlockIcon)`
+  font-size: 1.125rem;
+  margin-inline-start: 0.25rem;
+  color: ${Colors.midText};
 `;
 
 const Wrapper = styled.div`
@@ -184,6 +191,7 @@ const SettingName = memo(
     isSecret,
     requiresRestart,
     highRisk,
+    deprecated,
     depth,
     alignTop,
     searchQuery,
@@ -257,6 +265,20 @@ const SettingName = memo(
         <StyledHighRiskIcon data-testid="styledhighriskicon-hr01" />
       </ThemedTooltip>
     )}
+    {deprecated && (
+      <ThemedTooltip
+        title={
+          <TranslatedText
+            stringId="admin.settings.deprecatedTooltip"
+            fallback="Deprecated — will be removed in a future version"
+            data-testid="translatedtext-dp01"
+          />
+        }
+        data-testid="themedtooltip-dp01"
+      >
+        <StyledDeprecatedIcon data-testid="styleddeprecatedicon-dp01" />
+      </ThemedTooltip>
+    )}
   </SettingNameLabel>
 ));
 
@@ -325,6 +347,7 @@ export const Category = ({
           unit,
           highRisk,
           requiresRestart,
+          deprecated,
           suggesterEndpoint,
           secret,
           editor,
@@ -334,6 +357,7 @@ export const Category = ({
         const needsRestart = schema.requiresRestart || requiresRestart;
         const isSecret = Boolean(secret);
         const isHighRisk = schema.highRisk || highRisk || isSecret;
+        const isDeprecated = Boolean(schema.deprecated || deprecated);
         const disabled = !canWriteHighRisk && isHighRisk;
         const isMultiEntry =
           editor === SETTING_EDITORS.MAPPING || editor === SETTING_EDITORS.OBJECT_LIST;
@@ -347,7 +371,12 @@ export const Category = ({
               path={newPath}
               depth={depth + 1}
               // Pass down inherited properties to the child category
-              schema={{ ...propertySchema, highRisk: isHighRisk, requiresRestart: needsRestart }}
+              schema={{
+                ...propertySchema,
+                highRisk: isHighRisk,
+                requiresRestart: needsRestart,
+                deprecated: isDeprecated,
+              }}
               getSettingValue={getSettingValue}
               getGlobalSettingValue={getGlobalSettingValue}
               resolveSettingsPath={resolveSettingsPath}
@@ -371,6 +400,7 @@ export const Category = ({
               description={description}
               isSecret={isSecret}
               highRisk={schema.highRisk || highRisk}
+              deprecated={isDeprecated}
               alignTop={isMultiEntry}
               searchQuery={searchQuery}
               data-testid={`settingname-g0r7-${testIdSuffix}`}

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -15,7 +15,6 @@ import { ThemedTooltip } from '../../../../components/Tooltip';
 import { SettingInput, ResetToDefaultButton } from './SettingInput';
 import { useAuth } from '../../../../contexts/Auth';
 import { formatSettingName } from '../EditorView';
-import { textMatchesQuery } from '../filterSettingsSchema';
 
 const StyledLockIcon = styled(LockIcon)`
   flex-shrink: 0;
@@ -267,6 +266,11 @@ const SettingName = memo(
 ));
 
 const sortProperties = ([a0, a1], [b0, b1]) => {
+  // Exact search hits (and groups holding one) first — flags only exist on
+  // search-filtered schema copies, so the category view is unaffected.
+  const aExact = Boolean(a1.__exactMatch || a1.__hasExactMatch);
+  const bExact = Boolean(b1.__exactMatch || b1.__hasExactMatch);
+  if (aExact !== bExact) return aExact ? -1 : 1;
   const aName = a1.name || a0;
   const bName = b1.name || b0;
   const isTopLevelA = isSetting(a1);
@@ -334,8 +338,10 @@ export const Category = ({
           editor === SETTING_EDITORS.MAPPING || editor === SETTING_EDITORS.OBJECT_LIST;
         // When a search hit is in the description, surface it under the row —
         // the tooltip-only description makes such matches look inexplicable.
+        // The flag is set by filterSettingsSchema, the single source of match
+        // logic; it only exists on search-filtered schema copies.
         const showMatchedDescription =
-          Boolean(searchQuery) && textMatchesQuery(description, searchQuery);
+          Boolean(searchQuery) && Boolean(propertySchema.__matchedDescription);
 
         if (!type) {
           return (

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -74,7 +74,7 @@ const SettingLine = styled(BodyText)`
   // cleanly. Background only — no padding/margin — to leave subgrid alignment
   // untouched.
   &:nth-of-type(even) {
-    background-color: ${Colors.background};
+    background-color: ${Colors.background}66;
   }
 
   // Highlight on hover, and keep it while a control on the row is focused —
@@ -256,7 +256,7 @@ const SettingName = memo(
         title={
           <TranslatedText
             stringId="admin.settings.highRiskWarningTooltip"
-            fallback="High-risk setting — changes can have significant effects"
+            fallback="High-risk setting, changes can have significant effects"
             data-testid="translatedtext-hr01"
           />
         }

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -15,6 +15,7 @@ import { ThemedTooltip } from '../../../../components/Tooltip';
 import { SettingInput, ResetToDefaultButton } from './SettingInput';
 import { useAuth } from '../../../../contexts/Auth';
 import { formatSettingName } from '../EditorView';
+import { escapeRegExp } from '../filterSettingsSchema';
 
 const StyledLockIcon = styled(LockIcon)`
   flex-shrink: 0;
@@ -148,8 +149,7 @@ const MatchedDescription = styled(BodyText)`
 const highlightMatches = (text, query) => {
   const needle = query?.trim();
   if (!needle) return text;
-  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const matcher = new RegExp(escaped, 'gi');
+  const matcher = new RegExp(escapeRegExp(needle), 'gi');
   const parts = [];
   let last = 0;
   let match;
@@ -265,15 +265,17 @@ const SettingName = memo(
   </SettingNameLabel>
 ));
 
-const sortProperties = ([a0, a1], [b0, b1]) => {
-  // Search ordering — flags only exist on search-filtered schema copies, so
-  // the category view is unaffected. Exact hits (and groups holding one)
-  // first, then by match tier (strong matches lead, weak ones sink).
-  const aExact = Boolean(a1.__exactMatch || a1.__hasExactMatch);
-  const bExact = Boolean(b1.__exactMatch || b1.__hasExactMatch);
+// Search ordering comes from the filter's metadata (absent outside search, so
+// the category view is unaffected): exact hits (and groups holding one) first,
+// then by match tier (strong matches lead, weak ones sink).
+const sortProperties = searchMeta => ([a0, a1], [b0, b1]) => {
+  const aMeta = searchMeta?.get(a1);
+  const bMeta = searchMeta?.get(b1);
+  const aExact = Boolean(aMeta?.exact || aMeta?.hasExact);
+  const bExact = Boolean(bMeta?.exact || bMeta?.hasExact);
   if (aExact !== bExact) return aExact ? -1 : 1;
-  const aTier = a1.__matchTier ?? Infinity;
-  const bTier = b1.__matchTier ?? Infinity;
+  const aTier = aMeta?.tier ?? Infinity;
+  const bTier = bMeta?.tier ?? Infinity;
   if (aTier !== bTier) return aTier - bTier;
   const aName = a1.name || a0;
   const bName = b1.name || b0;
@@ -296,11 +298,12 @@ export const Category = ({
   handleChangeSetting,
   facilityId,
   searchQuery,
+  searchMeta,
 }) => {
   const { ability } = useAuth();
   const canWriteHighRisk = ability.can('manage', 'all');
   if (!schema) return null;
-  const sortedProperties = Object.entries(schema.properties).sort(sortProperties);
+  const sortedProperties = Object.entries(schema.properties).sort(sortProperties(searchMeta));
 
   return (
     <Wrapper data-testid="wrapper-sc1t">
@@ -342,10 +345,10 @@ export const Category = ({
           editor === SETTING_EDITORS.MAPPING || editor === SETTING_EDITORS.OBJECT_LIST;
         // When a search hit is in the description, surface it under the row —
         // the tooltip-only description makes such matches look inexplicable.
-        // The flag is set by filterSettingsSchema, the single source of match
-        // logic; it only exists on search-filtered schema copies.
+        // The metadata comes from filterSettingsSchema, the single source of
+        // match logic; it only exists for search-filtered schema copies.
         const showMatchedDescription =
-          Boolean(searchQuery) && Boolean(propertySchema.__matchedDescription);
+          Boolean(searchQuery) && Boolean(searchMeta?.get(propertySchema)?.matchedDescription);
 
         if (!type) {
           return (
@@ -361,6 +364,7 @@ export const Category = ({
               handleChangeSetting={handleChangeSetting}
               facilityId={facilityId}
               searchQuery={searchQuery}
+              searchMeta={searchMeta}
               data-testid={`category-9y74-${testIdSuffix}`}
             />
           );

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -5,6 +5,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import { Alert } from '@material-ui/lab';
 import KeyIcon from '@mui/icons-material/Key';
 import WarningIcon from '@mui/icons-material/WarningAmber';
+import { escapeRegExp } from 'es-toolkit/compat';
 
 import { SETTING_EDITORS } from '@tamanu/constants';
 import { isSetting } from '@tamanu/settings/schema';
@@ -14,8 +15,7 @@ import { Colors } from '../../../../constants';
 import { ThemedTooltip } from '../../../../components/Tooltip';
 import { SettingInput, ResetToDefaultButton } from './SettingInput';
 import { useAuth } from '../../../../contexts/Auth';
-import { formatSettingName } from '../EditorView';
-import { escapeRegExp } from '../filterSettingsSchema';
+import { formatSettingName } from '../formatSettingName';
 
 const StyledLockIcon = styled(LockIcon)`
   flex-shrink: 0;

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -15,6 +15,7 @@ import { ThemedTooltip } from '../../../../components/Tooltip';
 import { SettingInput, ResetToDefaultButton } from './SettingInput';
 import { useAuth } from '../../../../contexts/Auth';
 import { formatSettingName } from '../EditorView';
+import { textMatchesQuery } from '../filterSettingsSchema';
 
 const StyledLockIcon = styled(LockIcon)`
   flex-shrink: 0;
@@ -122,6 +123,44 @@ const InfoBannerAlert = styled(Alert)`
   margin-inline-end: 1.25rem;
 `;
 
+const Mark = styled.mark`
+  background-color: ${Colors.primary10};
+  border-radius: 2px;
+`;
+
+// Description line shown under a setting's name when a search hit is in the
+// description — otherwise the match reason is invisible (tooltip-only).
+const MatchedDescription = styled(BodyText)`
+  color: ${Colors.midText};
+  font-size: 13px;
+  grid-column: 1 / -1;
+  margin-block: -8px 13px;
+  // The name's text inset is the outer label's per-depth margin PLUS the
+  // nested inner label's base 1.25rem — match both so this aligns with it.
+  margin-inline-start: ${props => 2.5 + (props.$indent ?? 0) * 1.25}rem;
+  max-inline-size: 60ch;
+`;
+
+// Wraps each occurrence of `query` in text with a highlight mark. Substring
+// (not word-start) so it explains rows from either matching tier.
+const highlightMatches = (text, query) => {
+  const needle = query?.trim();
+  if (!needle) return text;
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matcher = new RegExp(escaped, 'gi');
+  const parts = [];
+  let last = 0;
+  let match;
+  while ((match = matcher.exec(text))) {
+    parts.push(text.slice(last, match.index));
+    parts.push(<Mark key={match.index}>{match[0]}</Mark>);
+    last = match.index + match[0].length;
+  }
+  if (last === 0) return text;
+  parts.push(text.slice(last));
+  return parts;
+};
+
 const CategoryTitle = memo(({ name, path, description, depth }) => {
   const categoryTitle = formatSettingName(name, path.split('.').pop());
   if (!categoryTitle) return null;
@@ -139,7 +178,18 @@ const CategoryTitle = memo(({ name, path, description, depth }) => {
 });
 
 const SettingName = memo(
-  ({ name, path, description, disabled, isSecret, requiresRestart, highRisk, depth, alignTop }) => (
+  ({
+    name,
+    path,
+    description,
+    disabled,
+    isSecret,
+    requiresRestart,
+    highRisk,
+    depth,
+    alignTop,
+    searchQuery,
+  }) => (
   <SettingNameLabel
     $indent={depth}
     $alignTop={alignTop}
@@ -168,7 +218,9 @@ const SettingName = memo(
       data-testid="themedtooltip-2qoa"
     >
       <SettingNameLabel color={disabled && 'textTertiary'} data-testid="settingnamelabel-xr19">
-        {formatSettingName(name, path.split('.').pop())}
+        {searchQuery
+          ? highlightMatches(formatSettingName(name, path.split('.').pop()), searchQuery)
+          : formatSettingName(name, path.split('.').pop())}
         {disabled ? (
           <StyledLockIcon data-testid="styledlockicon-x3w0" />
         ) : (
@@ -228,6 +280,7 @@ export const Category = ({
   resolveSettingsPath,
   handleChangeSetting,
   facilityId,
+  searchQuery,
 }) => {
   const { ability } = useAuth();
   const canWriteHighRisk = ability.can('manage', 'all');
@@ -271,6 +324,10 @@ export const Category = ({
         const disabled = !canWriteHighRisk && isHighRisk;
         const isMultiEntry =
           editor === SETTING_EDITORS.MAPPING || editor === SETTING_EDITORS.OBJECT_LIST;
+        // When a search hit is in the description, surface it under the row —
+        // the tooltip-only description makes such matches look inexplicable.
+        const showMatchedDescription =
+          Boolean(searchQuery) && textMatchesQuery(description, searchQuery);
 
         if (!type) {
           return (
@@ -285,6 +342,7 @@ export const Category = ({
               resolveSettingsPath={resolveSettingsPath}
               handleChangeSetting={handleChangeSetting}
               facilityId={facilityId}
+              searchQuery={searchQuery}
               data-testid={`category-9y74-${testIdSuffix}`}
             />
           );
@@ -302,6 +360,7 @@ export const Category = ({
               isSecret={isSecret}
               highRisk={schema.highRisk || highRisk}
               alignTop={isMultiEntry}
+              searchQuery={searchQuery}
               data-testid={`settingname-g0r7-${testIdSuffix}`}
             />
             <SettingInput
@@ -334,6 +393,11 @@ export const Category = ({
                   onReset={() => handleChangeSetting(newPath, undefined)}
                 />
               </RowActions>
+            )}
+            {showMatchedDescription && (
+              <MatchedDescription $indent={depth} data-testid={`matcheddesc-${testIdSuffix}`}>
+                {highlightMatches(description, searchQuery)}
+              </MatchedDescription>
             )}
           </SettingLine>
         );

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -138,7 +138,7 @@ const ListRow = styled.div`
 
 const RemoveItemButton = styled(IconButton)`
   color: ${Colors.midText};
-  margin-block-start: 4px; // align with the input, not its helper text
+  margin-block-start: 10px;
   padding: 4px;
 
   &:hover {

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -26,7 +26,7 @@ import { ConditionalTooltip } from '../../../../components/Tooltip';
 import { MultiAutocompleteInput } from '../../../../components/Field/MultiAutocompleteField';
 import { useSuggester } from '../../../../api';
 import { useParsedCronExpression } from '../../../../utils/useParsedCronExpression';
-import { formatSettingName } from '../EditorView';
+import { formatSettingName } from '../formatSettingName';
 import { SettingsSubmitContext } from './SettingsSubmitContext';
 
 // Shared width for the main setting inputs so they all fill the input column

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -6,7 +6,17 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { TimePicker } from '@mui/x-date-pickers/TimePicker';
+import { format as formatDate, isValid as isValidDate, parse as parseDate } from 'date-fns';
 import { SECRET_PLACEHOLDER } from '@tamanu/settings/schema';
+import {
+  PAD_REFERENCE_DATA_FIELDS,
+  PAD_TEXT_FIELDS,
+  PATIENT_MODEL_SEARCH_FIELDS,
+  VACCINE_STATUS,
+  VACCINE_STATUS_LABELS,
+  isValidAdditionalSearchField,
+} from '@tamanu/constants';
 import EditIcon from '@mui/icons-material/Edit';
 import { useFormikContext } from 'formik';
 import {
@@ -24,6 +34,7 @@ import { JSONEditor } from './JSONEditor';
 import { MarkdownEditorModal } from './MarkdownEditorModal';
 import { ConditionalTooltip } from '../../../../components/Tooltip';
 import { MultiAutocompleteInput } from '../../../../components/Field/MultiAutocompleteField';
+import { SearchMultiSelectInput } from '../../../../components/Field/SearchMultiSelectField';
 import { useSuggester } from '../../../../api';
 import { useParsedCronExpression } from '../../../../utils/useParsedCronExpression';
 import { formatSettingName } from '../formatSettingName';
@@ -183,6 +194,12 @@ const SETTING_TYPES = {
   OBJECT: 'object',
   ARRAY: 'array',
 };
+
+const AGE_DISPLAY_UNITS = ['days', 'weeks', 'months', 'years'].map(v => ({
+  value: v,
+  label: startCase(v),
+}));
+const DURATION_UNITS = ['years', 'months', 'days'];
 
 const normalize = val => (val === null || val === '' ? '' : val);
 
@@ -345,6 +362,62 @@ const CronSettingInput = ({ value, onChange, error, disabled }) => {
           <CronHelpText data-testid="cron-parsed-preview">{parsed}</CronHelpText>
         )}
       </div>
+    </Flexbox>
+  );
+};
+
+const StyledTimePicker = styled(TimePicker)`
+  .MuiInputBase-root {
+    background: ${Colors.white};
+    border-radius: 4px;
+  }
+
+  .MuiInputBase-input {
+    color: ${Colors.darkestText};
+    font-size: 15px;
+    line-height: 18px;
+    padding-block: 13px;
+    padding-inline: 15px 12px;
+  }
+
+  .MuiOutlinedInput-notchedOutline {
+    border-color: ${Colors.outline};
+  }
+
+  .MuiInputBase-root:hover .MuiOutlinedInput-notchedOutline,
+  .MuiInputBase-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+    border-color: ${Colors.primary};
+    border-width: 1px;
+  }
+`;
+
+// 24-hour time-of-day input for settings typed with datelessTimeStringSchema
+// (assignment/booking slot start & end times). The value is stored as a plain
+// "HH:mm" string; the MUI picker works in Dates, so we parse in and format out
+// across that boundary. Emits '' when cleared or while the entry is invalid so
+// the schema falls back to its default rather than persisting a bad value. The
+// AdapterDateFns LocalizationProvider is already applied app-wide in Root.
+const TimeSettingInput = ({ value, onChange, error, disabled }) => {
+  const parsed = value ? parseDate(value, 'HH:mm', new Date()) : null;
+  const dateValue = parsed && isValidDate(parsed) ? parsed : null;
+  return (
+    <Flexbox data-testid="flexbox-time">
+      <StyledTimePicker
+        value={dateValue}
+        onChange={next => onChange(next && isValidDate(next) ? formatDate(next, 'HH:mm') : '')}
+        ampm={false}
+        views={['hours', 'minutes']}
+        format="HH:mm"
+        disabled={disabled}
+        slotProps={{
+          textField: {
+            error: Boolean(error),
+            helperText: error?.message,
+            style: { width: SETTING_INPUT_WIDTH },
+            'data-testid': 'timepicker-setting',
+          },
+        }}
+      />
     </Flexbox>
   );
 };
@@ -1021,6 +1094,361 @@ const ObjectListSettingInput = ({ value, fields, innerType, onChange, disabled, 
   );
 };
 
+const toNonNegativeInt = raw => {
+  if (raw === '' || raw === null || raw === undefined) return undefined;
+  const n = Math.floor(Number(raw));
+  return Number.isNaN(n) ? undefined : Math.max(0, n);
+};
+
+const DURATION_UNIT_OPTIONS = DURATION_UNITS.map(unit => ({ value: unit, label: unit }));
+
+const durationUnitOf = duration => Object.keys(duration ?? {})[0] ?? 'days';
+const durationAmount = duration => (duration ?? {})[durationUnitOf(duration)];
+
+// The age format as a ladder: display-unit bands with a switch age between
+// each pair. Returns the boundary list ([] for an empty setting), or null when
+// the stored ranges don't form a contiguous single-unit partition from birth
+// (each max matching the next min, last range open) — shapes the sentence
+// editor can't represent, which fall back to the JSON editor.
+const asAgeLadder = rows => {
+  if (!Array.isArray(rows)) return null;
+  const cuts = [];
+  for (let i = 0; i < rows.length; i++) {
+    const range = rows[i]?.range ?? {};
+    if (i === 0 && durationAmount(range.min?.duration)) return null;
+    if (i < rows.length - 1) {
+      const cut = range.max?.duration;
+      if (!cut || Object.keys(cut).length !== 1) return null;
+      if (!isEqual(cut, rows[i + 1]?.range?.min?.duration)) return null;
+      cuts.push(cut);
+    } else if (range.max) {
+      return null;
+    }
+  }
+  return cuts;
+};
+
+// Canonical contiguous form: min inclusive, max exclusive, boundaries shared
+// verbatim between neighbours, last range open.
+const buildAgeRows = (units, cuts) =>
+  units.map((as, i) => ({
+    as,
+    range: {
+      min: i === 0 ? { duration: { days: 0 }, exclusive: false } : { duration: cuts[i - 1] },
+      ...(i < units.length - 1 ? { max: { duration: cuts[i], exclusive: true } } : {}),
+    },
+  }));
+
+const SentenceCard = styled.div`
+  align-items: center;
+  background: ${Colors.white};
+  border: 1px solid ${Colors.outline};
+  border-radius: 4px;
+  display: grid;
+  gap: 0.6rem 0.5rem;
+  grid-template-columns: max-content 7rem max-content 3.5rem 6.5rem max-content 1.5rem;
+  padding: 0.9rem 1rem;
+`;
+
+const SentenceText = styled.span`
+  color: ${Colors.midText};
+  font-size: 13px;
+`;
+
+const ThresholdInput = styled(NumberInput)`
+  width: 3.5rem;
+
+  && .MuiInputBase-input {
+    font-size: 13px;
+    padding-block: 5px;
+    padding-inline: 4px;
+    text-align: center;
+  }
+`;
+
+const Ladder = styled.div`
+  background: ${Colors.white};
+  border: 1px solid ${Colors.outline};
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  max-width: 23rem;
+  padding: 0.75rem 0.9rem;
+`;
+
+const LadderBand = styled.div`
+  align-items: center;
+  background: ${Colors.background};
+  border-radius: 4px;
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.45rem 0.6rem;
+`;
+
+const LadderCut = styled.div`
+  align-items: center;
+  color: ${Colors.midText};
+  display: flex;
+  font-size: 12px;
+  gap: 0.4rem;
+  padding-block: 0.15rem;
+  padding-inline-start: 1.75rem;
+  white-space: nowrap;
+`;
+
+const VACCINE_STATUS_OPTIONS = Object.values(VACCINE_STATUS).map(status => ({
+  value: status,
+  label: VACCINE_STATUS_LABELS[status] ?? startCase(status),
+}));
+
+// Editor for `upcomingVaccinations.thresholds`, drawn as the thing it is: a
+// ladder of bands over "days until due", most-future at the top, with each
+// boundary entered exactly once between the bands it separates. The stored
+// rows are (threshold, status) pairs where a status applies above its
+// threshold and the `-Infinity` sentinel is the bottom band; the consumer
+// picks by value, not array order, so the ladder can simply keep rows in
+// display order.
+const VaccinationThresholdsInput = ({ value, onChange, disabled, error }) => {
+  const rows = Array.isArray(value) ? value : [];
+  const update = (index, patch) =>
+    onChange(rows.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+  const addBand = () => {
+    const lastNumeric = [...rows].reverse().find(row => typeof row.threshold === 'number');
+    const next = {
+      threshold: (lastNumeric?.threshold ?? 35) - 7,
+      status: VACCINE_STATUS.SCHEDULED,
+    };
+    const sentinelLast = rows.length > 0 && rows[rows.length - 1].threshold === '-Infinity';
+    onChange(sentinelLast ? [...rows.slice(0, -1), next, rows[rows.length - 1]] : [...rows, next]);
+  };
+
+  return (
+    <ListInputWrapper
+      style={{ width: 'auto', maxWidth: '460px' }}
+      data-error-anchor={error ? 'true' : undefined}
+      data-testid="vaccinethresholds"
+    >
+      {rows.length > 0 && (
+        <Ladder>
+          {rows.map((row, index) => {
+            const isSentinel = row.threshold === '-Infinity';
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <React.Fragment key={index}>
+                <LadderBand data-testid={`vthreshold-band-${index}`}>
+                  <SelectInput
+                    value={row.status}
+                    options={VACCINE_STATUS_OPTIONS}
+                    onChange={e => update(index, { status: e.target.value })}
+                    disabled={disabled}
+                    style={{ width: '150px' }}
+                    data-testid={`vthreshold-status-${index}`}
+                  />
+                  {isSentinel && (
+                    <EmptyListText data-testid={`vthreshold-sentinel-${index}`}>
+                      everything else
+                    </EmptyListText>
+                  )}
+                  {!disabled && !isSentinel && (
+                    <RemoveItemButton
+                      onClick={() => onChange(rows.filter((_, i) => i !== index))}
+                      size="small"
+                      aria-label="remove band"
+                      style={{ marginBlockStart: 0, marginInlineStart: 'auto' }}
+                      data-testid={`vthreshold-remove-${index}`}
+                    >
+                      <DeleteOutlineIcon style={{ fontSize: 18 }} />
+                    </RemoveItemButton>
+                  )}
+                </LadderBand>
+                {!isSentinel && (
+                  <LadderCut data-testid={`vthreshold-cut-${index}`}>
+                    when more than
+                    <ThresholdInput
+                      value={row.threshold ?? ''}
+                      disabled={disabled}
+                      onChange={e =>
+                        update(index, {
+                          threshold: e.target.value === '' ? 0 : Number(e.target.value),
+                        })
+                      }
+                      data-testid={`vthreshold-value-${index}`}
+                    />
+                    days until due
+                  </LadderCut>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </Ladder>
+      )}
+
+      {rows.length === 0 && (
+        <EmptyListText data-testid="vthreshold-empty">No thresholds</EmptyListText>
+      )}
+
+      {!disabled && (
+        <AddItemButton onClick={addBand} data-testid="vthreshold-add">
+          <AddIcon style={{ fontSize: 16 }} /> Add band
+        </AddItemButton>
+      )}
+
+      {error && <ListError data-testid="vthreshold-error">{error.message}</ListError>}
+    </ListInputWrapper>
+  );
+};
+
+// The valid additional-search fields: every searchable patient / additional-data
+// field name, minus those already searched by default. A fixed set, so it's a
+// multi-select rather than free text (no typos, no invalid entries).
+const SEARCH_FIELD_OPTIONS = Array.from(
+  new Set([...PATIENT_MODEL_SEARCH_FIELDS, ...PAD_TEXT_FIELDS, ...PAD_REFERENCE_DATA_FIELDS]),
+)
+  .filter(isValidAdditionalSearchField)
+  .map(field => ({ value: field, label: startCase(field) }));
+
+const AdditionalSearchFieldsInput = ({ value, onChange, disabled, error }) => (
+  <ListInputWrapper
+    style={{ width: 'auto' }}
+    data-error-anchor={error ? 'true' : undefined}
+    data-testid="additionalsearchfields"
+  >
+    <SearchMultiSelectInput
+      value={Array.isArray(value) ? value : []}
+      options={SEARCH_FIELD_OPTIONS}
+      onChange={e => onChange(e.target.value)}
+      disabled={disabled}
+      label="Search fields"
+      data-testid="additionalsearchfields-select"
+    />
+    {error && <ListError data-testid="additionalsearchfields-error">{error.message}</ListError>}
+  </ListInputWrapper>
+);
+
+// Editor for `ageDisplayFormat`, written the way it reads: N display units
+// with a switch age between each pair ("show in days until 8 days old, then
+// in weeks until 1 month old, ..., then in years onward"). Each boundary is
+// entered exactly once, so the ranges can't gap or overlap, and exclusivity
+// is canonical rather than user-visible.
+const AgeDisplayFormatInput = ({ value, onChange, disabled, error }) => {
+  const rows = Array.isArray(value) ? value : [];
+  const cuts = asAgeLadder(rows) ?? [];
+  const units = rows.map(row => row.as);
+
+  const commit = (nextUnits, nextCuts) => onChange(buildAgeRows(nextUnits, nextCuts));
+  const setUnit = (index, unit) =>
+    commit(units.map((u, i) => (i === index ? unit : u)), cuts);
+  const setCut = (index, cut) => commit(units, cuts.map((c, i) => (i === index ? cut : c)));
+  const addRow = () => {
+    if (units.length === 0) {
+      commit(['years'], []);
+      return;
+    }
+    const lastCut = cuts[cuts.length - 1] ?? { years: 1 };
+    commit([...units.slice(0, -1), 'months', units[units.length - 1]], [...cuts, { ...lastCut }]);
+  };
+  const removeRow = index => {
+    const nextUnits = units.filter((_, i) => i !== index);
+    const nextCuts = cuts.filter((_, i) => i !== Math.min(index, cuts.length - 1));
+    commit(nextUnits, nextCuts);
+  };
+
+  return (
+    <ListInputWrapper
+      style={{ width: 'auto', maxWidth: '520px' }}
+      data-error-anchor={error ? 'true' : undefined}
+      data-testid="agedisplayformat"
+    >
+      {units.length > 0 && (
+        <SentenceCard>
+          {units.map((unit, index) => {
+            const isLast = index === units.length - 1;
+            const cut = cuts[index];
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <React.Fragment key={index}>
+                <SentenceText>{index === 0 ? 'Show age in' : 'then in'}</SentenceText>
+                <SelectInput
+                  value={unit}
+                  options={AGE_DISPLAY_UNITS}
+                  onChange={e => setUnit(index, e.target.value)}
+                  disabled={disabled}
+                  isClearable={false}
+                  data-testid={`agefmt-as-${index}`}
+                />
+                {isLast ? (
+                  <SentenceText style={{ gridColumn: '3 / 7' }} data-testid="agefmt-onward">
+                    onward
+                  </SentenceText>
+                ) : (
+                  <>
+                    <SentenceText>until</SentenceText>
+                    <ThresholdInput
+                      value={durationAmount(cut) ?? ''}
+                      disabled={disabled}
+                      inputProps={{ min: 0, step: 1 }}
+                      onChange={e =>
+                        setCut(index, {
+                          [durationUnitOf(cut)]: toNonNegativeInt(e.target.value) ?? 0,
+                        })
+                      }
+                      data-testid={`agefmt-cut-${index}-amount`}
+                    />
+                    <SelectInput
+                      value={durationUnitOf(cut)}
+                      options={DURATION_UNIT_OPTIONS}
+                      onChange={e => setCut(index, { [e.target.value]: durationAmount(cut) ?? 0 })}
+                      disabled={disabled}
+                      isClearable={false}
+                      data-testid={`agefmt-cut-${index}-unit`}
+                    />
+                    <SentenceText>old</SentenceText>
+                  </>
+                )}
+                {!disabled && units.length > 1 ? (
+                  <RemoveItemButton
+                    onClick={() => removeRow(index)}
+                    size="small"
+                    aria-label="remove range"
+                    style={{ marginBlockStart: 0 }}
+                    data-testid={`agefmt-remove-${index}`}
+                  >
+                    <DeleteOutlineIcon style={{ fontSize: 18 }} />
+                  </RemoveItemButton>
+                ) : (
+                  <span />
+                )}
+              </React.Fragment>
+            );
+          })}
+        </SentenceCard>
+      )}
+
+      {units.length === 0 && <EmptyListText data-testid="agefmt-empty">No ranges</EmptyListText>}
+
+      {!disabled && (
+        <AddItemButton onClick={addRow} data-testid="agefmt-add">
+          <AddIcon style={{ fontSize: 16 }} /> Add range
+        </AddItemButton>
+      )}
+
+      {error && <ListError data-testid="agefmt-error">{error.message}</ListError>}
+    </ListInputWrapper>
+  );
+};
+
+// Only canonical contiguous data can be shown faithfully as sentences;
+// anything else (gaps, overlaps, combined durations, no open range) falls
+// back to the generic JSON editor.
+AgeDisplayFormatInput.accepts = value => asAgeLadder(value) !== null;
+
+const CUSTOM_SETTING_INPUTS = {
+  ageDisplayFormat: AgeDisplayFormatInput,
+  'upcomingVaccinations.thresholds': VaccinationThresholdsInput,
+  'patientSearch.additionalSearchFields': AdditionalSearchFieldsInput,
+};
+
 export const SettingInput = ({
   path,
   settingsPath,
@@ -1041,6 +1469,16 @@ export const SettingInput = ({
   options,
 }) => {
   const { type } = typeSchema;
+
+  // Strings validated by datelessTimeStringSchema get the time picker.
+  const isTimeString = useMemo(() => {
+    if (type !== SETTING_TYPES.STRING) return false;
+    try {
+      return (typeSchema.describe?.().tests ?? []).some(t => t.name === 'datelessTimeString');
+    } catch {
+      return false;
+    }
+  }, [type, typeSchema]);
 
   // A string setting constrained with yup `.oneOf([...])` becomes a dropdown:
   // pull the allowed values straight off the schema so there's no second list
@@ -1293,6 +1731,25 @@ export const SettingInput = ({
     }
   }
 
+  const CustomInput = CUSTOM_SETTING_INPUTS[settingsPath];
+  const customValue = displayValue == null ? defaultValue : displayValue;
+  // an editor may declare what data shapes it can faithfully represent;
+  // anything else falls through to the generic editors (ultimately JSON)
+  const customDeclined =
+    Boolean(CustomInput?.accepts) && !CustomInput.accepts(customValue);
+  if (CustomInput && !customDeclined) {
+    return (
+      <LongTextFlexbox data-testid="flexbox-custom-input">
+        <CustomInput
+          value={customValue}
+          onChange={handleChangeValue}
+          disabled={disabled}
+          error={shownError}
+        />
+      </LongTextFlexbox>
+    );
+  }
+
   switch (typeKey) {
     case SETTING_TYPES.BOOLEAN:
       return (
@@ -1307,6 +1764,16 @@ export const SettingInput = ({
         </Flexbox>
       );
     case SETTING_TYPES.STRING:
+      if (isTimeString) {
+        return (
+          <TimeSettingInput
+            value={displayValue ?? ''}
+            onChange={handleChangeValue}
+            error={shownError}
+            disabled={disabled}
+          />
+        );
+      }
       return (
         <Flexbox data-testid="flexbox-wwbe">
           {hasSelectOptions ? (
@@ -1480,6 +1947,12 @@ export const SettingInput = ({
               error={shownError}
               data-testid="jsoneditor-6t9w"
             />
+            {customDeclined && (
+              <BoundsHintText data-testid="jsoneditor-custom-declined">
+                The stored value doesn&rsquo;t fit the structured editor, so it&rsquo;s
+                shown as JSON. Fix it here or reset to default.
+              </BoundsHintText>
+            )}
             {jsonErrorText && (
               <ListError data-testid="jsoneditor-error-text">{jsonErrorText}</ListError>
             )}

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -13,31 +13,18 @@ export const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const NO_MATCH = Infinity;
 
 /**
- * Filters `schema` to the settings matching `query`, case-insensitively.
- * Rank-don't-hide: nothing that matches is dropped; instead every kept node
- * gets match metadata the results view sorts by, so strong matches lead and
- * weak ones sink instead of vanishing. Tiers, best first: setting name/path
- * before category name/path before description (leaf-only — group descriptions
- * are invisible in results), and word-start matches ("age" → "Age display
- * format", never "page") before substring-anywhere ones ("nation" →
- * Vaccinations). A group whose own name or path matches keeps its whole
- * subtree, and the group structure above each match is kept so results render
- * with their category headings.
+ * Filters `schema` to the settings matching `query`, case-insensitively,
+ * keeping the group structure above each match. Rank-don't-hide: every match
+ * is kept and tiered (setting name/path > category name/path > description,
+ * word-start > substring) so the view sorts strong matches first instead of
+ * hiding weak ones. A group whose own name or path matches keeps its whole
+ * subtree.
  *
- * Returns `{ schema, meta }` — a filtered copy plus a WeakMap from its nodes to
- * `{ tier, exact, hasExact, matchedDescription }`:
- * - `tier`: the node's best tier (own or descendant); lower sorts first
- * - `exact`: the query equals the node's whole display name; sorts before
- *   everything
- * - `hasExact`: a group holding an exact match somewhere below
- * - `matchedDescription`: the description contains the query, so the view
- *   surfaces it inline (a tooltip-only hit reads as an inexplicable result)
- * Keeping metadata out of the schema nodes means the domain shape never grows
- * presentation fields, and unfiltered schemas can't carry stale flags.
- *
- * Returns null when nothing matches, and the schema unchanged (empty meta) for
- * an empty query. Copies rather than mutates: the scoped schema is a shared
- * singleton and mutating it corrupts every later schema walk.
+ * Returns `{ schema, meta }`: a filtered copy plus a WeakMap from its nodes to
+ * `{ tier, exact, hasExact, matchedDescription }` — kept out of the schema so
+ * the domain shape never grows presentation fields. Null when nothing matches;
+ * the schema unchanged for an empty query. Copies rather than mutates: the
+ * scoped schema is a shared singleton.
  */
 export const filterSettingsSchema = (schema, query) => {
   const meta = new WeakMap();
@@ -53,9 +40,8 @@ export const filterSettingsSchema = (schema, query) => {
     const name = displayName(node, key);
     if (atWordStart(name) || atWordStart(path)) return isLeaf ? 1 : 3;
     if (anywhere(name) || anywhere(path)) return isLeaf ? 2 : 4;
-    // Description tiers are leaf-only: a group's description is never shown in
-    // the results, and a hit there would drag in its entire subtree of
-    // non-matching settings with nothing visible to explain why.
+    // leaf-only: group descriptions are never shown, and a hit there would
+    // drag in a whole subtree with nothing visible to explain why
     if (!isLeaf) return NO_MATCH;
     if (atWordStart(node.description)) return 5;
     if (anywhere(node.description)) return 6;
@@ -83,9 +69,8 @@ export const filterSettingsSchema = (schema, query) => {
     let bestChild = NO_MATCH;
     let hasExact = false;
     for (const [childKey, child] of Object.entries(node.properties)) {
-      // An own-matched group keeps its whole subtree: children that didn't
-      // match themselves ride along as-is (they can't need metadata — an exact
-      // or description hit would have made them match).
+      // an own-matched group keeps its whole subtree; non-matching children
+      // ride along as-is (a hit would have made them match)
       const kept =
         filterNode(child, childKey, path ? `${path}.${childKey}` : childKey) ??
         (ownMatched ? child : null);

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -1,0 +1,44 @@
+import { capitalize, startCase } from 'es-toolkit/compat';
+import { isSetting } from '@tamanu/settings/schema';
+
+// Same display-name derivation as the editor rows (see formatSettingName).
+const displayName = (node, key) => node.name || capitalize(startCase(key));
+
+const matches = (needle, ...haystacks) =>
+  haystacks.some(text => typeof text === 'string' && text.toLowerCase().includes(needle));
+
+/**
+ * Returns a copy of `schema` containing only the settings matching `query`
+ * (case-insensitive, against display name, dotted key path, and description),
+ * keeping the group structure above each match so results render with their
+ * category headings. A group whose own name or path matches keeps its whole
+ * subtree. Returns null when nothing matches, and the schema unchanged for an
+ * empty query. Copies rather than mutates: the scoped schema is a shared
+ * singleton and mutating it corrupts every later schema walk.
+ */
+export const filterSettingsSchema = (schema, query) => {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return schema;
+
+  const filterNode = (node, key, path) => {
+    if (matches(needle, displayName(node, key), path, node.description)) return node;
+    if (isSetting(node) || !node.properties) return null;
+    const properties = {};
+    for (const [childKey, child] of Object.entries(node.properties)) {
+      const kept = filterNode(child, childKey, path ? `${path}.${childKey}` : childKey);
+      if (kept) properties[childKey] = kept;
+    }
+    if (Object.keys(properties).length === 0) return null;
+    return { ...node, properties };
+  };
+
+  // Filter the root's children directly rather than the root itself, so a
+  // query matching some root-level name can't return the entire schema.
+  const properties = {};
+  for (const [key, node] of Object.entries(schema.properties)) {
+    const kept = filterNode(node, key, key);
+    if (kept) properties[key] = kept;
+  }
+  if (Object.keys(properties).length === 0) return null;
+  return { ...schema, properties };
+};

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -8,46 +8,46 @@ const displayName = (node, key) => node.name || capitalize(startCase(key));
 // "max page size"), then lowercase for case-insensitive comparison.
 const normalise = text => text.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
 
-const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+export const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const NO_MATCH = Infinity;
 
 /**
- * Returns a copy of `schema` containing every setting matching `query`,
- * case-insensitively. Rank-don't-hide: nothing that matches is dropped;
- * instead each kept node carries a match tier the results view sorts by, so
- * strong matches lead and weak ones sink instead of vanishing. Tiers, best
- * first: setting name/path before category name/path before description, and
- * word-start matches ("age" → "Age display format", never "page") before
- * substring-anywhere ones ("nation" → Vaccinations). A group whose own name or
- * path matches keeps its whole subtree, and the group structure above each
- * match is kept so results render with their category headings. Returns null
- * when nothing matches, and the schema unchanged for an empty query. Copies
- * rather than mutates: the scoped schema is a shared singleton and mutating it
- * corrupts every later schema walk.
+ * Filters `schema` to the settings matching `query`, case-insensitively.
+ * Rank-don't-hide: nothing that matches is dropped; instead every kept node
+ * gets match metadata the results view sorts by, so strong matches lead and
+ * weak ones sink instead of vanishing. Tiers, best first: setting name/path
+ * before category name/path before description (leaf-only — group descriptions
+ * are invisible in results), and word-start matches ("age" → "Age display
+ * format", never "page") before substring-anywhere ones ("nation" →
+ * Vaccinations). A group whose own name or path matches keeps its whole
+ * subtree, and the group structure above each match is kept so results render
+ * with their category headings.
  *
- * Presentation flags on kept nodes (single source of truth for match logic —
- * the view never re-derives matches):
- * - `__matchTier`: the node's best tier (own or descendant); lower sorts first
- * - `__exactMatch`: the query equals the node's whole display name; sorts
- *   before everything
- * - `__hasExactMatch`: a group holding an exact match somewhere below
- * - `__matchedDescription`: the description contains the query, so the view
+ * Returns `{ schema, meta }` — a filtered copy plus a WeakMap from its nodes to
+ * `{ tier, exact, hasExact, matchedDescription }`:
+ * - `tier`: the node's best tier (own or descendant); lower sorts first
+ * - `exact`: the query equals the node's whole display name; sorts before
+ *   everything
+ * - `hasExact`: a group holding an exact match somewhere below
+ * - `matchedDescription`: the description contains the query, so the view
  *   surfaces it inline (a tooltip-only hit reads as an inexplicable result)
+ * Keeping metadata out of the schema nodes means the domain shape never grows
+ * presentation fields, and unfiltered schemas can't carry stale flags.
+ *
+ * Returns null when nothing matches, and the schema unchanged (empty meta) for
+ * an empty query. Copies rather than mutates: the scoped schema is a shared
+ * singleton and mutating it corrupts every later schema walk.
  */
 export const filterSettingsSchema = (schema, query) => {
+  const meta = new WeakMap();
   const needle = normalise(query.trim());
-  if (!needle) return schema;
+  if (!needle) return { schema, meta };
 
   const wordStart = new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(needle)}`);
   const atWordStart = text => typeof text === 'string' && wordStart.test(normalise(text));
   const anywhere = text => typeof text === 'string' && normalise(text).includes(needle);
 
-  // Tiers, lower is better: setting names outrank category names outrank
-  // descriptions, and within each, word-start matches outrank
-  // substring-anywhere ones. Leaf paths carry their category prefix, so a
-  // category hit usually surfaces its settings at the name tiers anyway; the
-  // category tiers matter when only the category's display name matches.
   const tierOf = (node, key, path) => {
     const isLeaf = isSetting(node) || !node.properties;
     const name = displayName(node, key);
@@ -69,34 +69,41 @@ export const filterSettingsSchema = (schema, query) => {
 
     if (isSetting(node) || !node.properties) {
       if (own === NO_MATCH) return null;
-      const out = { ...node, __matchTier: own };
-      if (isExact(node, key)) out.__exactMatch = true;
-      if (anywhere(node.description)) out.__matchedDescription = true;
+      const out = { ...node };
+      meta.set(out, {
+        tier: own,
+        exact: isExact(node, key),
+        matchedDescription: anywhere(node.description),
+      });
       return out;
     }
 
     const ownMatched = own !== NO_MATCH;
     const properties = {};
     let bestChild = NO_MATCH;
-    let hasExactMatch = false;
+    let hasExact = false;
     for (const [childKey, child] of Object.entries(node.properties)) {
       // An own-matched group keeps its whole subtree: children that didn't
-      // match themselves ride along as-is (they can't need flags — an exact or
-      // description hit would have made them match).
+      // match themselves ride along as-is (they can't need metadata — an exact
+      // or description hit would have made them match).
       const kept =
         filterNode(child, childKey, path ? `${path}.${childKey}` : childKey) ??
         (ownMatched ? child : null);
       if (kept) {
         properties[childKey] = kept;
-        bestChild = Math.min(bestChild, kept.__matchTier ?? NO_MATCH);
-        hasExactMatch ||= Boolean(kept.__exactMatch || kept.__hasExactMatch);
+        const childMeta = meta.get(kept);
+        bestChild = Math.min(bestChild, childMeta?.tier ?? NO_MATCH);
+        hasExact ||= Boolean(childMeta?.exact || childMeta?.hasExact);
       }
     }
     if (!ownMatched && Object.keys(properties).length === 0) return null;
 
-    const out = { ...node, properties, __matchTier: Math.min(own, bestChild) };
-    if (hasExactMatch) out.__hasExactMatch = true;
-    if (isExact(node, key)) out.__exactMatch = true;
+    const out = { ...node, properties };
+    meta.set(out, {
+      tier: Math.min(own, bestChild),
+      exact: isExact(node, key),
+      hasExact,
+    });
     return out;
   };
 
@@ -108,5 +115,5 @@ export const filterSettingsSchema = (schema, query) => {
     if (kept) properties[key] = kept;
   }
   if (Object.keys(properties).length === 0) return null;
-  return { ...schema, properties };
+  return { schema: { ...schema, properties }, meta };
 };

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -18,8 +18,9 @@ const matches = (needleRegExp, ...haystacks) =>
 
 /**
  * Returns a copy of `schema` containing only the settings matching `query`
- * (case-insensitive at word starts, against display name, dotted key path, and
- * description),
+ * (case-insensitive at word starts, against display name and dotted key path —
+ * not description: it's invisible in the results, so matches on it read as
+ * noise),
  * keeping the group structure above each match so results render with their
  * category headings. A group whose own name or path matches keeps its whole
  * subtree. Returns null when nothing matches, and the schema unchanged for an
@@ -32,7 +33,7 @@ export const filterSettingsSchema = (schema, query) => {
   const needleRegExp = new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(needle)}`);
 
   const filterNode = (node, key, path) => {
-    if (matches(needleRegExp, displayName(node, key), path, node.description)) return node;
+    if (matches(needleRegExp, displayName(node, key), path)) return node;
     if (isSetting(node) || !node.properties) return null;
     const properties = {};
     for (const [childKey, child] of Object.entries(node.properties)) {

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -14,10 +14,11 @@ const NO_MATCH = Infinity;
 
 /**
  * Returns a copy of `schema` containing only the settings matching `query`,
- * case-insensitively. Matches are tiered — name/path word-start, name/path
- * substring, description word-start, description substring — and only the best
- * populated tier is kept, so "age" finds "Age display format" without every
- * "page" mention, while "nation" still falls back to finding Vaccinations.
+ * case-insensitively. Matches are tiered — setting name/path before category
+ * name/path before description, and word-start before substring within each —
+ * and only the best populated tier is kept, so "age" finds "Age display
+ * format" without every "page" mention, while "nation" still falls back to
+ * finding Vaccinations.
  * A group whose own name or path matches keeps its whole subtree. Keeps the
  * group structure above each match so results render with their category
  * headings. Returns null when nothing matches, and the schema unchanged for an
@@ -39,14 +40,18 @@ export const filterSettingsSchema = (schema, query) => {
   const atWordStart = text => typeof text === 'string' && wordStart.test(normalise(text));
   const anywhere = text => typeof text === 'string' && normalise(text).includes(needle);
 
-  // Tiers: names/paths outrank descriptions, word-start matches outrank
-  // substring-anywhere ones. Lower is better.
+  // Tiers, lower is better: setting names outrank category names outrank
+  // descriptions, and within each, word-start matches outrank
+  // substring-anywhere ones. Leaf paths carry their category prefix, so a
+  // category hit usually surfaces its settings at the name tiers anyway; the
+  // category tiers matter when only the category's display name matches.
   const tierOf = (node, key, path) => {
+    const isLeaf = isSetting(node) || !node.properties;
     const name = displayName(node, key);
-    if (atWordStart(name) || atWordStart(path)) return 1;
-    if (anywhere(name) || anywhere(path)) return 2;
-    if (atWordStart(node.description)) return 3;
-    if (anywhere(node.description)) return 4;
+    if (atWordStart(name) || atWordStart(path)) return isLeaf ? 1 : 3;
+    if (anywhere(name) || anywhere(path)) return isLeaf ? 2 : 4;
+    if (atWordStart(node.description)) return 5;
+    if (anywhere(node.description)) return 6;
     return NO_MATCH;
   };
 
@@ -104,6 +109,10 @@ export const filterSettingsSchema = (schema, query) => {
     if (Object.keys(properties).length === 0) return null;
     const out = { ...node, properties };
     if (hasExactMatch) out.__hasExactMatch = true;
+    // A container kept only for its children can still be the exact-named
+    // thing the user typed (its own tier just lost to a better one) — flag it
+    // so it still sorts first.
+    if (isExact(node, key)) out.__exactMatch = true;
     return out;
   };
 

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -10,72 +10,116 @@ const normalise = text => text.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCas
 
 const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-// Match only at word starts: "age" finds "Age display format" but not "page".
-const matches = (needleRegExp, ...haystacks) =>
-  haystacks.some(text => typeof text === 'string' && needleRegExp.test(normalise(text)));
-
-/**
- * Whether `text` contains `query` (case-insensitive substring). Used by the
- * results view to show *why* a row matched (e.g. render the description when
- * the hit was in it, invisible otherwise) — substring on purpose, so it
- * explains rows from either matching tier.
- */
-export const textMatchesQuery = (text, query) => {
-  const needle = query?.trim().toLowerCase();
-  if (!needle || typeof text !== 'string') return false;
-  return text.toLowerCase().includes(needle);
-};
+const NO_MATCH = Infinity;
 
 /**
  * Returns a copy of `schema` containing only the settings matching `query`,
- * case-insensitively, in tiers (see below): display name and dotted key path
- * outrank description, word-start matches outrank substring ones. The results
- * view surfaces matched descriptions inline so a description hit is visible,
- * not baffling. Keeps the group structure above each match so results render
- * with their category headings. A group whose own name or path matches keeps its whole
- * subtree. Returns null when nothing matches, and the schema unchanged for an
+ * case-insensitively. Matches are tiered — name/path word-start, name/path
+ * substring, description word-start, description substring — and only the best
+ * populated tier is kept, so "age" finds "Age display format" without every
+ * "page" mention, while "nation" still falls back to finding Vaccinations.
+ * A group whose own name or path matches keeps its whole subtree. Keeps the
+ * group structure above each match so results render with their category
+ * headings. Returns null when nothing matches, and the schema unchanged for an
  * empty query. Copies rather than mutates: the scoped schema is a shared
  * singleton and mutating it corrupts every later schema walk.
+ *
+ * Kept nodes carry presentation flags for the results view (single source of
+ * truth for match logic — the view never re-derives matches):
+ * - `__exactMatch`: the query equals the node's whole display name; sorts first
+ * - `__hasExactMatch`: a group holding an exact match somewhere below
+ * - `__matchedDescription`: the description contains the query, so the view
+ *   surfaces it inline (a tooltip-only hit reads as an inexplicable result)
  */
 export const filterSettingsSchema = (schema, query) => {
   const needle = normalise(query.trim());
   if (!needle) return schema;
 
-  const filterWith = (needleRegExp, includeDescriptions) => {
-    const filterNode = (node, key, path) => {
-      const haystacks = [displayName(node, key), path];
-      if (includeDescriptions) haystacks.push(node.description);
-      if (matches(needleRegExp, ...haystacks)) return node;
-      if (isSetting(node) || !node.properties) return null;
-      const properties = {};
-      for (const [childKey, child] of Object.entries(node.properties)) {
-        const kept = filterNode(child, childKey, path ? `${path}.${childKey}` : childKey);
-        if (kept) properties[childKey] = kept;
-      }
-      if (Object.keys(properties).length === 0) return null;
-      return { ...node, properties };
-    };
+  const wordStart = new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(needle)}`);
+  const atWordStart = text => typeof text === 'string' && wordStart.test(normalise(text));
+  const anywhere = text => typeof text === 'string' && normalise(text).includes(needle);
 
-    // Filter the root's children directly rather than the root itself, so a
-    // query matching some root-level name can't return the entire schema.
-    const properties = {};
-    for (const [key, node] of Object.entries(schema.properties)) {
-      const kept = filterNode(node, key, key);
-      if (kept) properties[key] = kept;
-    }
-    if (Object.keys(properties).length === 0) return null;
-    return { ...schema, properties };
+  // Tiers: names/paths outrank descriptions, word-start matches outrank
+  // substring-anywhere ones. Lower is better.
+  const tierOf = (node, key, path) => {
+    const name = displayName(node, key);
+    if (atWordStart(name) || atWordStart(path)) return 1;
+    if (anywhere(name) || anywhere(path)) return 2;
+    if (atWordStart(node.description)) return 3;
+    if (anywhere(node.description)) return 4;
+    return NO_MATCH;
   };
 
-  // Tiered matching, first non-empty tier wins: names/paths outrank
-  // descriptions, and word-start matches ("age" finds "Age display format" but
-  // not "page") outrank substring-anywhere ones ("nation" -> vaccination).
-  const wordStart = new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(needle)}`);
-  const anywhere = new RegExp(escapeRegExp(needle));
-  return (
-    filterWith(wordStart, false) ??
-    filterWith(anywhere, false) ??
-    filterWith(wordStart, true) ??
-    filterWith(anywhere, true)
-  );
+  const isExact = (node, key) => normalise(displayName(node, key)) === needle;
+
+  // Copies a kept node, attaching the presentation flags; groups kept whole
+  // (own-name matches) recurse so nested exact/description hits still flag.
+  const decorate = (node, key) => {
+    const out = { ...node };
+    if (!isSetting(node) && node.properties) {
+      let hasExactMatch = false;
+      const properties = {};
+      for (const [childKey, child] of Object.entries(node.properties)) {
+        const decorated = decorate(child, childKey);
+        properties[childKey] = decorated;
+        hasExactMatch ||= Boolean(decorated.__exactMatch || decorated.__hasExactMatch);
+      }
+      out.properties = properties;
+      if (hasExactMatch) out.__hasExactMatch = true;
+    }
+    if (isExact(node, key)) out.__exactMatch = true;
+    if (anywhere(node.description)) out.__matchedDescription = true;
+    return out;
+  };
+
+  // Single analysis pass: each node's own tier plus the best tier in its
+  // subtree, so the prune pass below can keep exactly the best populated tier
+  // without re-walking the schema per tier.
+  const analyse = (node, key, path) => {
+    const own = tierOf(node, key, path);
+    if (isSetting(node) || !node.properties) return { node, key, own, best: own };
+    let best = own;
+    const children = {};
+    for (const [childKey, child] of Object.entries(node.properties)) {
+      const analysed = analyse(child, childKey, path ? `${path}.${childKey}` : childKey);
+      children[childKey] = analysed;
+      if (analysed.best < best) best = analysed.best;
+    }
+    return { node, key, own, best, children };
+  };
+
+  const build = (analysed, targetTier) => {
+    const { node, key, own, best, children } = analysed;
+    if (own <= targetTier) return decorate(node, key);
+    if (!children || best > targetTier) return null;
+    const properties = {};
+    let hasExactMatch = false;
+    for (const [childKey, childAnalysed] of Object.entries(children)) {
+      const kept = build(childAnalysed, targetTier);
+      if (kept) {
+        properties[childKey] = kept;
+        hasExactMatch ||= Boolean(kept.__exactMatch || kept.__hasExactMatch);
+      }
+    }
+    if (Object.keys(properties).length === 0) return null;
+    const out = { ...node, properties };
+    if (hasExactMatch) out.__hasExactMatch = true;
+    return out;
+  };
+
+  // Analyse/prune the root's children directly rather than the root itself, so
+  // a query matching some root-level name can't return the entire schema.
+  const analysedChildren = Object.entries(schema.properties).map(([key, node]) => [
+    key,
+    analyse(node, key, key),
+  ]);
+  const targetTier = Math.min(...analysedChildren.map(([, analysed]) => analysed.best));
+  if (targetTier === NO_MATCH) return null;
+
+  const properties = {};
+  for (const [key, analysed] of analysedChildren) {
+    const kept = build(analysed, targetTier);
+    if (kept) properties[key] = kept;
+  }
+  return { ...schema, properties };
 };

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -1,14 +1,11 @@
-import { capitalize, startCase } from 'es-toolkit/compat';
+import { escapeRegExp } from 'es-toolkit/compat';
 import { isSetting } from '@tamanu/settings/schema';
 
-// Same display-name derivation as the editor rows (see formatSettingName).
-const displayName = (node, key) => node.name || capitalize(startCase(key));
+import { formatSettingName } from './formatSettingName';
 
 // Split camelCase so key paths expose word boundaries ("maxPageSize" ->
 // "max page size"), then lowercase for case-insensitive comparison.
 const normalise = text => text.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
-
-export const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const NO_MATCH = Infinity;
 
@@ -37,7 +34,7 @@ export const filterSettingsSchema = (schema, query) => {
 
   const tierOf = (node, key, path) => {
     const isLeaf = isSetting(node) || !node.properties;
-    const name = displayName(node, key);
+    const name = formatSettingName(node.name, key);
     if (atWordStart(name) || atWordStart(path)) return isLeaf ? 1 : 3;
     if (anywhere(name) || anywhere(path)) return isLeaf ? 2 : 4;
     // leaf-only: group descriptions are never shown, and a hit there would
@@ -48,7 +45,7 @@ export const filterSettingsSchema = (schema, query) => {
     return NO_MATCH;
   };
 
-  const isExact = (node, key) => normalise(displayName(node, key)) === needle;
+  const isExact = (node, key) => normalise(formatSettingName(node.name, key)) === needle;
 
   const filterNode = (node, key, path) => {
     const own = tierOf(node, key, path);

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -13,21 +13,24 @@ const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const NO_MATCH = Infinity;
 
 /**
- * Returns a copy of `schema` containing only the settings matching `query`,
- * case-insensitively. Matches are tiered — setting name/path before category
- * name/path before description, and word-start before substring within each —
- * and only the best populated tier is kept, so "age" finds "Age display
- * format" without every "page" mention, while "nation" still falls back to
- * finding Vaccinations.
- * A group whose own name or path matches keeps its whole subtree. Keeps the
- * group structure above each match so results render with their category
- * headings. Returns null when nothing matches, and the schema unchanged for an
- * empty query. Copies rather than mutates: the scoped schema is a shared
- * singleton and mutating it corrupts every later schema walk.
+ * Returns a copy of `schema` containing every setting matching `query`,
+ * case-insensitively. Rank-don't-hide: nothing that matches is dropped;
+ * instead each kept node carries a match tier the results view sorts by, so
+ * strong matches lead and weak ones sink instead of vanishing. Tiers, best
+ * first: setting name/path before category name/path before description, and
+ * word-start matches ("age" → "Age display format", never "page") before
+ * substring-anywhere ones ("nation" → Vaccinations). A group whose own name or
+ * path matches keeps its whole subtree, and the group structure above each
+ * match is kept so results render with their category headings. Returns null
+ * when nothing matches, and the schema unchanged for an empty query. Copies
+ * rather than mutates: the scoped schema is a shared singleton and mutating it
+ * corrupts every later schema walk.
  *
- * Kept nodes carry presentation flags for the results view (single source of
- * truth for match logic — the view never re-derives matches):
- * - `__exactMatch`: the query equals the node's whole display name; sorts first
+ * Presentation flags on kept nodes (single source of truth for match logic —
+ * the view never re-derives matches):
+ * - `__matchTier`: the node's best tier (own or descendant); lower sorts first
+ * - `__exactMatch`: the query equals the node's whole display name; sorts
+ *   before everything
  * - `__hasExactMatch`: a group holding an exact match somewhere below
  * - `__matchedDescription`: the description contains the query, so the view
  *   surfaces it inline (a tooltip-only hit reads as an inexplicable result)
@@ -57,78 +60,49 @@ export const filterSettingsSchema = (schema, query) => {
 
   const isExact = (node, key) => normalise(displayName(node, key)) === needle;
 
-  // Copies a kept node, attaching the presentation flags; groups kept whole
-  // (own-name matches) recurse so nested exact/description hits still flag.
-  const decorate = (node, key) => {
-    const out = { ...node };
-    if (!isSetting(node) && node.properties) {
-      let hasExactMatch = false;
-      const properties = {};
-      for (const [childKey, child] of Object.entries(node.properties)) {
-        const decorated = decorate(child, childKey);
-        properties[childKey] = decorated;
-        hasExactMatch ||= Boolean(decorated.__exactMatch || decorated.__hasExactMatch);
-      }
-      out.properties = properties;
-      if (hasExactMatch) out.__hasExactMatch = true;
-    }
-    if (isExact(node, key)) out.__exactMatch = true;
-    if (anywhere(node.description)) out.__matchedDescription = true;
-    return out;
-  };
-
-  // Single analysis pass: each node's own tier plus the best tier in its
-  // subtree, so the prune pass below can keep exactly the best populated tier
-  // without re-walking the schema per tier.
-  const analyse = (node, key, path) => {
+  const filterNode = (node, key, path) => {
     const own = tierOf(node, key, path);
-    if (isSetting(node) || !node.properties) return { node, key, own, best: own };
-    let best = own;
-    const children = {};
-    for (const [childKey, child] of Object.entries(node.properties)) {
-      const analysed = analyse(child, childKey, path ? `${path}.${childKey}` : childKey);
-      children[childKey] = analysed;
-      if (analysed.best < best) best = analysed.best;
-    }
-    return { node, key, own, best, children };
-  };
 
-  const build = (analysed, targetTier) => {
-    const { node, key, own, best, children } = analysed;
-    if (own <= targetTier) return decorate(node, key);
-    if (!children || best > targetTier) return null;
+    if (isSetting(node) || !node.properties) {
+      if (own === NO_MATCH) return null;
+      const out = { ...node, __matchTier: own };
+      if (isExact(node, key)) out.__exactMatch = true;
+      if (anywhere(node.description)) out.__matchedDescription = true;
+      return out;
+    }
+
+    const ownMatched = own !== NO_MATCH;
     const properties = {};
+    let bestChild = NO_MATCH;
     let hasExactMatch = false;
-    for (const [childKey, childAnalysed] of Object.entries(children)) {
-      const kept = build(childAnalysed, targetTier);
+    for (const [childKey, child] of Object.entries(node.properties)) {
+      // An own-matched group keeps its whole subtree: children that didn't
+      // match themselves ride along as-is (they can't need flags — an exact or
+      // description hit would have made them match).
+      const kept =
+        filterNode(child, childKey, path ? `${path}.${childKey}` : childKey) ??
+        (ownMatched ? child : null);
       if (kept) {
         properties[childKey] = kept;
+        bestChild = Math.min(bestChild, kept.__matchTier ?? NO_MATCH);
         hasExactMatch ||= Boolean(kept.__exactMatch || kept.__hasExactMatch);
       }
     }
-    if (Object.keys(properties).length === 0) return null;
-    const out = { ...node, properties };
+    if (!ownMatched && Object.keys(properties).length === 0) return null;
+
+    const out = { ...node, properties, __matchTier: Math.min(own, bestChild) };
     if (hasExactMatch) out.__hasExactMatch = true;
-    // A container kept only for its children can still be the exact-named
-    // thing the user typed (its own tier just lost to a better one) — flag it
-    // so it still sorts first.
     if (isExact(node, key)) out.__exactMatch = true;
     return out;
   };
 
-  // Analyse/prune the root's children directly rather than the root itself, so
-  // a query matching some root-level name can't return the entire schema.
-  const analysedChildren = Object.entries(schema.properties).map(([key, node]) => [
-    key,
-    analyse(node, key, key),
-  ]);
-  const targetTier = Math.min(...analysedChildren.map(([, analysed]) => analysed.best));
-  if (targetTier === NO_MATCH) return null;
-
+  // Filter the root's children directly rather than the root itself, so a
+  // query matching some root-level name can't return the entire schema.
   const properties = {};
-  for (const [key, analysed] of analysedChildren) {
-    const kept = build(analysed, targetTier);
+  for (const [key, node] of Object.entries(schema.properties)) {
+    const kept = filterNode(node, key, key);
     if (kept) properties[key] = kept;
   }
+  if (Object.keys(properties).length === 0) return null;
   return { ...schema, properties };
 };

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -53,6 +53,10 @@ export const filterSettingsSchema = (schema, query) => {
     const name = displayName(node, key);
     if (atWordStart(name) || atWordStart(path)) return isLeaf ? 1 : 3;
     if (anywhere(name) || anywhere(path)) return isLeaf ? 2 : 4;
+    // Description tiers are leaf-only: a group's description is never shown in
+    // the results, and a hit there would drag in its entire subtree of
+    // non-matching settings with nothing visible to explain why.
+    if (!isLeaf) return NO_MATCH;
     if (atWordStart(node.description)) return 5;
     if (anywhere(node.description)) return 6;
     return NO_MATCH;

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -4,12 +4,22 @@ import { isSetting } from '@tamanu/settings/schema';
 // Same display-name derivation as the editor rows (see formatSettingName).
 const displayName = (node, key) => node.name || capitalize(startCase(key));
 
-const matches = (needle, ...haystacks) =>
-  haystacks.some(text => typeof text === 'string' && text.toLowerCase().includes(needle));
+// Split camelCase so key paths expose word boundaries ("maxPageSize" ->
+// "max page size"), then lowercase for case-insensitive comparison.
+const normalise = text => text.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+
+const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Match only at word starts: "age" finds "Age display format" but not "page" —
+// a bare substring test surfaces baffling results via words inside descriptions
+// the user can't even see.
+const matches = (needleRegExp, ...haystacks) =>
+  haystacks.some(text => typeof text === 'string' && needleRegExp.test(normalise(text)));
 
 /**
  * Returns a copy of `schema` containing only the settings matching `query`
- * (case-insensitive, against display name, dotted key path, and description),
+ * (case-insensitive at word starts, against display name, dotted key path, and
+ * description),
  * keeping the group structure above each match so results render with their
  * category headings. A group whose own name or path matches keeps its whole
  * subtree. Returns null when nothing matches, and the schema unchanged for an
@@ -17,11 +27,12 @@ const matches = (needle, ...haystacks) =>
  * singleton and mutating it corrupts every later schema walk.
  */
 export const filterSettingsSchema = (schema, query) => {
-  const needle = query.trim().toLowerCase();
+  const needle = normalise(query.trim());
   if (!needle) return schema;
+  const needleRegExp = new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(needle)}`);
 
   const filterNode = (node, key, path) => {
-    if (matches(needle, displayName(node, key), path, node.description)) return node;
+    if (matches(needleRegExp, displayName(node, key), path, node.description)) return node;
     if (isSetting(node) || !node.properties) return null;
     const properties = {};
     for (const [childKey, child] of Object.entries(node.properties)) {

--- a/packages/web/app/views/administration/settings/filterSettingsSchema.js
+++ b/packages/web/app/views/administration/settings/filterSettingsSchema.js
@@ -10,19 +10,29 @@ const normalise = text => text.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCas
 
 const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-// Match only at word starts: "age" finds "Age display format" but not "page" —
-// a bare substring test surfaces baffling results via words inside descriptions
-// the user can't even see.
+// Match only at word starts: "age" finds "Age display format" but not "page".
 const matches = (needleRegExp, ...haystacks) =>
   haystacks.some(text => typeof text === 'string' && needleRegExp.test(normalise(text)));
 
 /**
- * Returns a copy of `schema` containing only the settings matching `query`
- * (case-insensitive at word starts, against display name and dotted key path —
- * not description: it's invisible in the results, so matches on it read as
- * noise),
- * keeping the group structure above each match so results render with their
- * category headings. A group whose own name or path matches keeps its whole
+ * Whether `text` contains `query` (case-insensitive substring). Used by the
+ * results view to show *why* a row matched (e.g. render the description when
+ * the hit was in it, invisible otherwise) — substring on purpose, so it
+ * explains rows from either matching tier.
+ */
+export const textMatchesQuery = (text, query) => {
+  const needle = query?.trim().toLowerCase();
+  if (!needle || typeof text !== 'string') return false;
+  return text.toLowerCase().includes(needle);
+};
+
+/**
+ * Returns a copy of `schema` containing only the settings matching `query`,
+ * case-insensitively, in tiers (see below): display name and dotted key path
+ * outrank description, word-start matches outrank substring ones. The results
+ * view surfaces matched descriptions inline so a description hit is visible,
+ * not baffling. Keeps the group structure above each match so results render
+ * with their category headings. A group whose own name or path matches keeps its whole
  * subtree. Returns null when nothing matches, and the schema unchanged for an
  * empty query. Copies rather than mutates: the scoped schema is a shared
  * singleton and mutating it corrupts every later schema walk.
@@ -30,27 +40,42 @@ const matches = (needleRegExp, ...haystacks) =>
 export const filterSettingsSchema = (schema, query) => {
   const needle = normalise(query.trim());
   if (!needle) return schema;
-  const needleRegExp = new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(needle)}`);
 
-  const filterNode = (node, key, path) => {
-    if (matches(needleRegExp, displayName(node, key), path)) return node;
-    if (isSetting(node) || !node.properties) return null;
+  const filterWith = (needleRegExp, includeDescriptions) => {
+    const filterNode = (node, key, path) => {
+      const haystacks = [displayName(node, key), path];
+      if (includeDescriptions) haystacks.push(node.description);
+      if (matches(needleRegExp, ...haystacks)) return node;
+      if (isSetting(node) || !node.properties) return null;
+      const properties = {};
+      for (const [childKey, child] of Object.entries(node.properties)) {
+        const kept = filterNode(child, childKey, path ? `${path}.${childKey}` : childKey);
+        if (kept) properties[childKey] = kept;
+      }
+      if (Object.keys(properties).length === 0) return null;
+      return { ...node, properties };
+    };
+
+    // Filter the root's children directly rather than the root itself, so a
+    // query matching some root-level name can't return the entire schema.
     const properties = {};
-    for (const [childKey, child] of Object.entries(node.properties)) {
-      const kept = filterNode(child, childKey, path ? `${path}.${childKey}` : childKey);
-      if (kept) properties[childKey] = kept;
+    for (const [key, node] of Object.entries(schema.properties)) {
+      const kept = filterNode(node, key, key);
+      if (kept) properties[key] = kept;
     }
     if (Object.keys(properties).length === 0) return null;
-    return { ...node, properties };
+    return { ...schema, properties };
   };
 
-  // Filter the root's children directly rather than the root itself, so a
-  // query matching some root-level name can't return the entire schema.
-  const properties = {};
-  for (const [key, node] of Object.entries(schema.properties)) {
-    const kept = filterNode(node, key, key);
-    if (kept) properties[key] = kept;
-  }
-  if (Object.keys(properties).length === 0) return null;
-  return { ...schema, properties };
+  // Tiered matching, first non-empty tier wins: names/paths outrank
+  // descriptions, and word-start matches ("age" finds "Age display format" but
+  // not "page") outrank substring-anywhere ones ("nation" -> vaccination).
+  const wordStart = new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(needle)}`);
+  const anywhere = new RegExp(escapeRegExp(needle));
+  return (
+    filterWith(wordStart, false) ??
+    filterWith(anywhere, false) ??
+    filterWith(wordStart, true) ??
+    filterWith(anywhere, true)
+  );
 };

--- a/packages/web/app/views/administration/settings/formatSettingName.js
+++ b/packages/web/app/views/administration/settings/formatSettingName.js
@@ -1,0 +1,6 @@
+import { capitalize, startCase } from 'es-toolkit/compat';
+
+// The display name of a schema node: its declared name, or one derived from
+// its key ("maxPageSize" -> "Max page size"). Shared by the editor rows and
+// the search filter so matching and rendering always agree on the name.
+export const formatSettingName = (name, path) => name || capitalize(startCase(path));

--- a/packages/web/app/views/administration/settings/urlState.js
+++ b/packages/web/app/views/administration/settings/urlState.js
@@ -1,0 +1,21 @@
+// Deep-linkable editor state: scope, selection, and search live in the query
+// string so a settings view can be shared or bookmarked. Written with
+// replaceState — no history spam, and no router round-trip for state the
+// route itself doesn't care about.
+
+export const readUrlParam = key => new URLSearchParams(window.location.search).get(key);
+
+export const writeUrlParams = updates => {
+  const params = new URLSearchParams(window.location.search);
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === null || value === undefined || value === '') params.delete(key);
+    else params.set(key, value);
+  }
+  const search = params.toString();
+  window.history.replaceState(
+    // preserve the router's own history state
+    window.history.state,
+    '',
+    `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`,
+  );
+};


### PR DESCRIPTION
### Changes

<img width="1232" height="792" alt="Screenshot 2026-07-09 at 7 03 00 AM" src="https://github.com/user-attachments/assets/9afd0fae-3a77-429e-8839-b0ed15b1c4ec" />

Adds search to the settings editor (admin panel, Editor tab), plus some editor polish.

**Search**
- Search field (magnifying glass, clear button) on the right of the options bar. Queries need 2+ characters.
- **Scoped**: with no category selected it searches every category in the current scope; with a category/sub-category selected it searches within it (placeholder switches to "Search in category"). Picking a category clears the query (most-recent intent wins); clearing the query returns to the selection.
- **Ranked matching (rank-don't-hide)**: every match is kept and sorted by strength — exact name first, then setting name/path, category name/path, description, with word-start beating substring within each. Word-start is camelCase-aware, so "age" puts *Age display format* on top while "page" mentions sink to the bottom instead of vanishing.
- **Visible match reasons**: hits are highlighted in setting names and category headings, and when the hit is in a description the description renders inline under the row (highlighted) instead of hiding in a tooltip.
- **Responsive typing**: filtering/rendering is deferred (`useDeferredValue`), so broad queries never freeze the input.
- Results render through the existing `Category` recursion from the schema root — headings, inherited `highRisk`/`requiresRestart`, secret masking, permissions, and reset-to-default behave exactly as in the category view. Edits share the same form state, so Save/Clear work unchanged across views.
- **Facility scope**: unchanged gating — the editor (and search) only appears once a facility is selected; searches filter the facility-scoped schema with inherited global values shown.
- Options bar stays a single line: the search field shrinks before anything wraps or crushes.
- `filterSettingsSchema` is a pure helper returning `{ schema, meta }` (match metadata in a WeakMap, kept out of the schema shape), with vitest coverage (tiering, word-start vs substring, group-subtree matches, no mutation of the shared schema singleton).

> Stacked on #10165 (the general editor polish — banner indent, input widths, multi-entry alignment, markdown editor scroll fix — was moved there).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Auto-merge upstream** <!-- #auto-merge -->
- [ ] **Save suppressions** <!-- #save-suppressions -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the config/settings reference or any relevant runbook(s)
- ...call out additions or changes to **config files** for the deployment team
