### PR TITLE
docs(settings): TAM-6864: settings spec

### DIFF
--- a/llm/project-rules/settings.md
+++ b/llm/project-rules/settings.md
@@ -1,8 +1,10 @@
 # Settings - Tamanu
 
-How runtime settings work, and how to read them. Settings are DB-backed and
-editable in the admin panel. A setting with no stored value resolves to its
-schema `defaultValue`.
+How to work with settings in code. Product behaviour — scopes, resolution,
+live-apply, exposure, config vs settings — is specified in
+`specs/administration/settings/`; this is the how-to-code companion. Settings are
+DB-backed, editable in the admin panel, and resolve to a schema `defaultValue`
+when unset.
 
 ## Schemas
 
@@ -18,25 +20,21 @@ with `extractDefaults()` (e.g. `facilityDefaults`). Useful leaf flags:
 `secret`, `highRisk`, `deprecated`, `unit`, `suggesterEndpoint`.
 
 A `secret: true` leaf must **not** declare a `defaultValue` (a schema test
-enforces this — a default would have to live in source control). When saved
-through the admin panel the value is **stored encrypted** (AES, using the
-`crypto.settingsPsk` key) and masked in the UI, so it's never read back to the
-client. Read it with `getSettingSecret(settings, 'dot.path')`, which decrypts;
-a plain `get()` returns the raw encrypted blob (see `ai.anthropicApiKey`,
+enforces this). Its value is stored encrypted and masked in the UI (see
+`specs/administration/settings/secret-encryption.md`); read it with
+`getSettingSecret(settings, 'dot.path')`, which decrypts — a plain `get()`
+returns the raw encrypted blob (see `ai.anthropicApiKey`,
 `integrations.dhis2.password`).
 
 **Scope a setting by where it is read:** only read on facility → put it in
 `facility.ts`; only on central → `central.ts`; both → `global.ts`. Don't put a
 facility-only setting in `global.ts`.
 
-**Facility overrides.** A subtree may be declared in *both* `global.ts` and
-`facility.ts`. `buildSettings` resolves values through a deep-merge cascade in
-descending priority — facility-scope DB → global DB → facility defaults → global
-defaults — so a facility value overrides the global one for that facility, while
-the central reader sees only the global value. Use this when a globally-meaningful
-value also needs a per-facility override (e.g. `fhir`, `appointments`,
-`integrations`, `medications`, `templates`). The merge is deep, so the same
-subtree can hold some keys defined globally and others per-facility.
+**Facility overrides.** To let a global value also take a per-facility override,
+declare the subtree in *both* `global.ts` and `facility.ts` — `buildSettings`
+deep-merges the scopes (resolution rule in `specs/administration/settings/`), so
+the same subtree can hold some keys globally and others per-facility (e.g.
+`fhir`, `appointments`, `integrations`, `medications`, `templates`).
 
 ## Reading settings
 

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -49,6 +49,7 @@ export class ReadSettings<Path = SettingPath> {
   // This is what is called on tamanu-web login. This gets only settings relevant to
   // the frontend so only what is needed is sent. No sensitive data is sent.
   // Settings are extracted from the schemas that apply to this reader's context.
+  // spec: SETTINGS#exposure-to-clients
   async getFrontEndSettings() {
     const allSettings = await this.getAll();
     return pick(

--- a/packages/settings/src/reader/buildSettings.ts
+++ b/packages/settings/src/reader/buildSettings.ts
@@ -12,6 +12,7 @@ import { SettingsConfigReader } from './readers/SettingsConfigReader';
  * config value for any key that has no setting yet, so config moving into settings
  * never changes behaviour. They sit below recorded settings and above schema defaults.
  */
+// spec: SETTINGS#scopes-and-resolution
 function getReaderCascade(models: Models, facilityId?: string) {
   return facilityId
     ? [

--- a/specs/administration/settings/overview.md
+++ b/specs/administration/settings/overview.md
@@ -32,6 +32,4 @@ A setting is sent to the web application or the patient portal only when its sch
 
 ## Configuration sources
 
-Everything an operator can tune is a setting. Everything a server must know before settings are available comes from its environment: the database connection, the server's facility identity, cryptographic key material, and network ports.
-
-The environment also carries deployment controls that are not settings, including the primary timezone (`TZ`), the trusted-proxy list (`PROXY_TRUSTED`, defaulting to loopback), the path checked for free disk space (`DISK_PATH`, defaulting to `/tmp`), console logging (`NO_COLOR`, level, timestamps, and destination), the authentication secrets, the canonical host name, and whether database migrations run at startup.
+An operator tunes runtime behaviour through settings. Everything else is an environment variable, because it is either needed before settings can be read (the database connection, cryptographic key material, console logging, and whether migrations run at startup), a property of the environment the process runs in (the primary timezone `TZ`, the trusted-proxy list `PROXY_TRUSTED` defaulting to loopback, the free-disk-space path `DISK_PATH` defaulting to `/tmp`, network ports, the facility identity, and the canonical host name), or a secret held outside the database (the authentication secrets) — none of which a runtime, database-backed setting can be.

--- a/specs/administration/settings/overview.md
+++ b/specs/administration/settings/overview.md
@@ -1,0 +1,37 @@
+---
+id: SETTINGS
+---
+
+# Settings
+
+Runtime configuration lives in settings: named values stored in the database, scoped to where they apply, and edited by administrators in the admin panel. A value that no administrator has set resolves to a default declared in the settings schema. A server takes all of its configuration from settings and environment variables and runs without a configuration file.
+
+## Scopes and resolution
+
+Settings are declared at three scopes: global (applies to every server), central (the central server), and facility (a facility server).
+
+A server resolves a setting through a cascade in descending priority. The central server takes its central value, then the global value, then the schema default. A facility server takes its facility value, then the global value, then the schema default. The global value therefore acts as the default for every server, and a central or facility value overrides it for that server.
+
+A setting subtree may be declared at both the global scope and a more specific scope. Resolution deep-merges the scopes, so a facility can override individual keys while inheriting the rest of the subtree from global, and the central server sees only the global values.
+
+## Editing and when changes take effect
+
+Administrators edit settings in the admin panel, which validates a value against its schema and rejects an invalid one before it is saved.
+
+A saved change applies to subsequent reads without a server restart. A setting marked as requiring a restart is instead read once when the process starts, and a change to it takes effect only after the server restarts.
+
+Resetting a setting removes its stored value at that scope; it then resolves to the inherited or default value, and that reversion applies live like any other change.
+
+## Permissions
+
+Reading and changing settings require the `Setting` permission. A high-risk setting can be changed only by an administrator with full (manage-all) permission, and the editor flags it as high-risk.
+
+## Exposure to clients
+
+A setting is sent to the web application or the patient portal only when its schema marks it as exposed to that client. Secret settings and settings meant only for the server are never sent to any client (see `secret-encryption.md`).
+
+## Configuration sources
+
+Everything an operator can tune is a setting. Everything a server must know before settings are available comes from its environment: the database connection, the server's facility identity, cryptographic key material, and network ports.
+
+The environment also carries deployment controls that are not settings, including the primary timezone (`TZ`), the trusted-proxy list (`PROXY_TRUSTED`, defaulting to loopback), the path checked for free disk space (`DISK_PATH`, defaulting to `/tmp`), console logging (`NO_COLOR`, level, timestamps, and destination), the authentication secrets, the canonical host name, and whether database migrations run at startup.


### PR DESCRIPTION
Splits the settings spec out of #10165 into its own PR.

- `specs/administration/settings/overview.md` (id `SETTINGS`) — the settings/env model: scopes + resolution cascade, editing + live-vs-restart + reset, `Setting`/high-risk permissions, client exposure, and the config-sources boundary (settings/env, no config file). Follows `.agents/docs/spec-format.md`, alongside the existing `require-https` (RHT) and `secret-encryption` (SSEC) specs.
- Trims `llm/project-rules/settings.md` to the how-to-code guidance and cross-references the spec, dropping the overlapping behaviour prose.
- Adds advisory `// spec: SETTINGS` refs at the resolution cascade (`buildSettings`) and frontend exposure (`ReadSettings.getFrontEndSettings`).

The config→settings migration is intentionally not specced — it's transitional (removed post-2.60), and specs are a snapshot of the desired system, not a changelog.