### PR TITLE
feat: no-issue: support BIND_ADDRESS env var for server and frontend listeners

### DIFF
--- a/packages/central-server/app/subCommands/startApi.js
+++ b/packages/central-server/app/subCommands/startApi.js
@@ -2,6 +2,7 @@ import config from 'config';
 import { Command } from 'commander';
 
 import { log } from '@tamanu/shared/services/logging';
+import { listenForBindAddresses } from '@tamanu/shared/utils/bindAddress';
 import { performTimeZoneChecks } from '@tamanu/shared/utils/timeZoneCheck';
 import { syncDatabaseServerVersion } from '@tamanu/database';
 import { resolveDbConfig } from '@tamanu/database/services/connectionConfig';
@@ -26,7 +27,7 @@ export const startApi = async ({ skipMigrationCheck }) => {
     serverVersion: version,
   });
 
-  const { server } = await createApp(context);
+  const { express, server } = await createApp(context);
 
   await performTimeZoneChecks({
     sequelize: store.sequelize,
@@ -48,13 +49,7 @@ export const startApi = async ({ skipMigrationCheck }) => {
     );
   }
 
-  let { port } = config;
-  if (+process.env.PORT) {
-    port = +process.env.PORT;
-  }
-  server.listen(port, () => {
-    log.info(`Server is running on port ${port}!`);
-  });
+  listenForBindAddresses({ server, app: express, fallbackPort: config.port });
 
   context.onClose(() => server.close());
 

--- a/packages/facility-server/app/subCommands/startAll.js
+++ b/packages/facility-server/app/subCommands/startAll.js
@@ -2,6 +2,7 @@ import config from 'config';
 import { Command } from 'commander';
 
 import { log } from '@tamanu/shared/services/logging';
+import { listenForBindAddresses } from '@tamanu/shared/utils/bindAddress';
 import { DEVICE_TYPES, JOB_TOPICS } from '@tamanu/constants';
 
 import { checkConfig } from '../checkConfig';
@@ -28,15 +29,9 @@ async function startApiSyncAndTasks(context) {
   context.syncConnection = new FacilitySyncConnection();
   const isConfigured = await setupSyncRuntime(context);
 
-  const { server } = await createApiApp(context);
+  const { express, server } = await createApiApp(context);
 
-  let { port } = config;
-  if (+process.env.PORT) {
-    port = +process.env.PORT;
-  }
-  server.listen(port, () => {
-    log.info(`API Server is running on port ${port}!`);
-  });
+  listenForBindAddresses({ server, app: express, fallbackPort: config.port, label: 'API Server' });
 
   const { server: syncServer } = await createSyncApp(context);
 

--- a/packages/facility-server/app/subCommands/startApp.js
+++ b/packages/facility-server/app/subCommands/startApp.js
@@ -2,6 +2,7 @@ import config from 'config';
 import { Command } from 'commander';
 
 import { log } from '@tamanu/shared/services/logging';
+import { listenForBindAddresses } from '@tamanu/shared/utils/bindAddress';
 import { performTimeZoneChecks } from '@tamanu/shared/utils/timeZoneCheck';
 import { DEVICE_TYPES } from '@tamanu/constants';
 
@@ -80,14 +81,14 @@ const startApp =
       await setupSyncRuntime(context);
     }
 
-    let server, port;
+    let server, express, port;
     switch (appType) {
       case APP_TYPES.API:
-        ({ server } = await createApiApp(context));
+        ({ express, server } = await createApiApp(context));
         ({ port } = config);
         break;
       case APP_TYPES.SYNC: {
-        ({ server } = await createSyncApp(context));
+        ({ express, server } = await createSyncApp(context));
         ({ port } = config.sync.syncApiConnection);
 
         // start SyncTask as part of sync app so that it is in the same process with tamanu-sync process
@@ -116,12 +117,7 @@ const startApp =
         throw new Error(`Unknown app type: ${appType}`);
     }
 
-    if (+process.env.PORT) {
-      port = +process.env.PORT;
-    }
-    server.listen(port, () => {
-      log.info(`Server is running on port ${port}!`);
-    });
+    listenForBindAddresses({ server, app: express, fallbackPort: port });
     process.once('SIGTERM', () => {
       log.info('Received SIGTERM, closing HTTP server');
       cancelConfigPoll();

--- a/packages/patient-portal/Caddyfile.docker
+++ b/packages/patient-portal/Caddyfile.docker
@@ -1,4 +1,6 @@
-:3000 {
+# BIND_ADDRESS is a comma-separated list of host:port listeners (IPv4 or
+# bracketed IPv6, e.g. "127.0.0.1:3000,[::1]:3000"); defaults to :3000.
+{$BIND_ADDRESS::3000} {
 	root * /app
 	log {
 		output stderr

--- a/packages/shared/__tests__/utils/bindAddress.test.js
+++ b/packages/shared/__tests__/utils/bindAddress.test.js
@@ -1,0 +1,72 @@
+import { parseBindAddress, resolveBindAddresses } from '../../src/utils/bindAddress';
+
+describe('parseBindAddress', () => {
+  it('parses a bare port', () => {
+    expect(parseBindAddress('3000')).toEqual({ host: undefined, port: 3000 });
+  });
+
+  it('parses a bare port with a leading colon', () => {
+    expect(parseBindAddress(':3000')).toEqual({ host: undefined, port: 3000 });
+  });
+
+  it('parses an IPv4 host and port', () => {
+    expect(parseBindAddress('127.0.0.1:8080')).toEqual({ host: '127.0.0.1', port: 8080 });
+  });
+
+  it('parses a bracketed IPv6 host and port', () => {
+    expect(parseBindAddress('[::1]:8080')).toEqual({ host: '::1', port: 8080 });
+    expect(parseBindAddress('[2001:db8::1]:443')).toEqual({ host: '2001:db8::1', port: 443 });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseBindAddress('  127.0.0.1:8080  ')).toEqual({ host: '127.0.0.1', port: 8080 });
+  });
+
+  it('throws on a non-numeric port', () => {
+    expect(() => parseBindAddress('127.0.0.1:abc')).toThrow();
+  });
+
+  it('throws on a malformed bracketed IPv6 address', () => {
+    expect(() => parseBindAddress('[::1:8080')).toThrow(); // missing closing bracket
+    expect(() => parseBindAddress('[::1]8080')).toThrow(); // missing colon after bracket
+  });
+});
+
+describe('resolveBindAddresses', () => {
+  const { BIND_ADDRESS, PORT } = process.env;
+
+  afterEach(() => {
+    if (BIND_ADDRESS === undefined) delete process.env.BIND_ADDRESS;
+    else process.env.BIND_ADDRESS = BIND_ADDRESS;
+    if (PORT === undefined) delete process.env.PORT;
+    else process.env.PORT = PORT;
+  });
+
+  it('falls back to the config port when neither env var is set', () => {
+    delete process.env.BIND_ADDRESS;
+    delete process.env.PORT;
+    expect(resolveBindAddresses(4000)).toEqual([{ host: undefined, port: 4000 }]);
+  });
+
+  it('uses PORT over the fallback', () => {
+    delete process.env.BIND_ADDRESS;
+    process.env.PORT = '5000';
+    expect(resolveBindAddresses(4000)).toEqual([{ host: undefined, port: 5000 }]);
+  });
+
+  it('uses BIND_ADDRESS over PORT and the fallback', () => {
+    process.env.BIND_ADDRESS = '127.0.0.1:9000';
+    process.env.PORT = '5000';
+    expect(resolveBindAddresses(4000)).toEqual([{ host: '127.0.0.1', port: 9000 }]);
+  });
+
+  it('parses a comma-separated list of listeners', () => {
+    process.env.BIND_ADDRESS = '127.0.0.1:9000, [::1]:9000 ,:9001';
+    delete process.env.PORT;
+    expect(resolveBindAddresses(4000)).toEqual([
+      { host: '127.0.0.1', port: 9000 },
+      { host: '::1', port: 9000 },
+      { host: undefined, port: 9001 },
+    ]);
+  });
+});

--- a/packages/shared/__tests__/utils/bindAddress.test.js
+++ b/packages/shared/__tests__/utils/bindAddress.test.js
@@ -26,6 +26,13 @@ describe('parseBindAddress', () => {
     expect(() => parseBindAddress('127.0.0.1:abc')).toThrow();
   });
 
+  it('throws on an empty or out-of-range port', () => {
+    expect(() => parseBindAddress('127.0.0.1:')).toThrow(); // Number('') === 0, would bind ephemeral
+    expect(() => parseBindAddress('[::1]:')).toThrow();
+    expect(() => parseBindAddress(':0')).toThrow();
+    expect(() => parseBindAddress(':70000')).toThrow();
+  });
+
   it('throws on a malformed bracketed IPv6 address', () => {
     expect(() => parseBindAddress('[::1:8080')).toThrow(); // missing closing bracket
     expect(() => parseBindAddress('[::1]8080')).toThrow(); // missing colon after bracket
@@ -58,6 +65,12 @@ describe('resolveBindAddresses', () => {
     process.env.BIND_ADDRESS = '127.0.0.1:9000';
     process.env.PORT = '5000';
     expect(resolveBindAddresses(4000)).toEqual([{ host: '127.0.0.1', port: 9000 }]);
+  });
+
+  it('throws when BIND_ADDRESS is set but has no valid segments', () => {
+    process.env.BIND_ADDRESS = ' , ';
+    delete process.env.PORT;
+    expect(() => resolveBindAddresses(4000)).toThrow();
   });
 
   it('parses a comma-separated list of listeners', () => {

--- a/packages/shared/src/utils/bindAddress.js
+++ b/packages/shared/src/utils/bindAddress.js
@@ -20,21 +20,25 @@ export function parseBindAddress(address) {
       throw new Error(`Invalid IPv6 bind address: ${address}`);
     }
     const host = trimmed.slice(1, closingBracket);
-    const port = Number(trimmed.slice(closingBracket + 2));
-    if (!Number.isInteger(port)) {
-      throw new Error(`Invalid port in bind address: ${address}`);
-    }
-    return { host, port };
+    return { host, port: parsePort(trimmed.slice(closingBracket + 2), address) };
   }
 
   // host:port (IPv4 or empty host) — split on the last colon so a bare `:3000` works
   const lastColon = trimmed.lastIndexOf(':');
   const host = lastColon === -1 ? '' : trimmed.slice(0, lastColon);
-  const port = Number(lastColon === -1 ? trimmed : trimmed.slice(lastColon + 1));
-  if (!Number.isInteger(port)) {
+  const port = parsePort(lastColon === -1 ? trimmed : trimmed.slice(lastColon + 1), address);
+  return { host: host || undefined, port };
+}
+
+// Reject anything that isn't a whole port number in 1–65535. In particular
+// `Number('')` is 0, so an empty port (e.g. `127.0.0.1:`) must be caught here
+// rather than silently binding an OS-assigned ephemeral port.
+function parsePort(portString, address) {
+  const port = Number(portString);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error(`Invalid port in bind address: ${address}`);
   }
-  return { host: host || undefined, port };
+  return port;
 }
 
 /**
@@ -47,11 +51,15 @@ export function parseBindAddress(address) {
 export function resolveBindAddresses(fallbackPort) {
   const bindAddress = process.env.BIND_ADDRESS?.trim();
   if (bindAddress) {
-    return bindAddress
+    const addresses = bindAddress
       .split(',')
       .map(entry => entry.trim())
       .filter(Boolean)
       .map(parseBindAddress);
+    if (addresses.length === 0) {
+      throw new Error(`BIND_ADDRESS is set but contains no valid addresses: "${process.env.BIND_ADDRESS}"`);
+    }
+    return addresses;
   }
 
   const port = +process.env.PORT || fallbackPort;

--- a/packages/shared/src/utils/bindAddress.js
+++ b/packages/shared/src/utils/bindAddress.js
@@ -1,0 +1,88 @@
+import { createServer } from 'node:http';
+
+import { log } from '../services/logging';
+
+/**
+ * Parse a single listen address into `{ host, port }`.
+ *
+ * Accepts:
+ *  - a bare port: `3000` or `:3000` (host left undefined → all interfaces)
+ *  - IPv4 host and port: `127.0.0.1:3000`
+ *  - bracketed IPv6 host and port: `[::1]:3000`, `[2001:db8::1]:443`
+ */
+export function parseBindAddress(address) {
+  const trimmed = address.trim();
+
+  // Bracketed IPv6, e.g. [::1]:3000
+  if (trimmed.startsWith('[')) {
+    const closingBracket = trimmed.indexOf(']');
+    if (closingBracket === -1 || trimmed[closingBracket + 1] !== ':') {
+      throw new Error(`Invalid IPv6 bind address: ${address}`);
+    }
+    const host = trimmed.slice(1, closingBracket);
+    const port = Number(trimmed.slice(closingBracket + 2));
+    if (!Number.isInteger(port)) {
+      throw new Error(`Invalid port in bind address: ${address}`);
+    }
+    return { host, port };
+  }
+
+  // host:port (IPv4 or empty host) — split on the last colon so a bare `:3000` works
+  const lastColon = trimmed.lastIndexOf(':');
+  const host = lastColon === -1 ? '' : trimmed.slice(0, lastColon);
+  const port = Number(lastColon === -1 ? trimmed : trimmed.slice(lastColon + 1));
+  if (!Number.isInteger(port)) {
+    throw new Error(`Invalid port in bind address: ${address}`);
+  }
+  return { host: host || undefined, port };
+}
+
+/**
+ * Resolve the set of addresses a server should listen on.
+ *
+ * `BIND_ADDRESS` (a comma-separated list of `host:port` listeners, IPv4 or
+ * bracketed IPv6) takes precedence over `PORT`, which in turn overrides the
+ * given fallback port from config.
+ */
+export function resolveBindAddresses(fallbackPort) {
+  const bindAddress = process.env.BIND_ADDRESS?.trim();
+  if (bindAddress) {
+    return bindAddress
+      .split(',')
+      .map(entry => entry.trim())
+      .filter(Boolean)
+      .map(parseBindAddress);
+  }
+
+  const port = +process.env.PORT || fallbackPort;
+  return [{ host: undefined, port }];
+}
+
+function formatBindAddress({ host, port }) {
+  if (!host) return `port ${port}`;
+  return host.includes(':') ? `[${host}]:${port}` : `${host}:${port}`;
+}
+
+/**
+ * Listen on every address resolved from `BIND_ADDRESS` / `PORT` / `fallbackPort`.
+ *
+ * The primary http server is reused for the first address; any additional
+ * addresses get their own http server sharing the same request handler. Closing
+ * the primary server also closes the extras, so existing shutdown logic that
+ * only tracks the primary server keeps working.
+ *
+ * @returns {import('node:http').Server[]} every server now listening
+ */
+export function listenForBindAddresses({ server, app, fallbackPort, label = 'Server' }) {
+  const addresses = resolveBindAddresses(fallbackPort);
+  return addresses.map(({ host, port }, index) => {
+    const target = index === 0 ? server : createServer(app);
+    if (index !== 0) {
+      server.on('close', () => target.close());
+    }
+    target.listen(port, host, () => {
+      log.info(`${label} is running on ${formatBindAddress({ host, port })}!`);
+    });
+    return target;
+  });
+}

--- a/packages/web/Caddyfile.docker
+++ b/packages/web/Caddyfile.docker
@@ -1,4 +1,6 @@
-:3000 {
+# BIND_ADDRESS is a comma-separated list of host:port listeners (IPv4 or
+# bracketed IPv6, e.g. "127.0.0.1:3000,[::1]:3000"); defaults to :3000.
+{$BIND_ADDRESS::3000} {
 	root * /app
 	log {
 		output stderr


### PR DESCRIPTION
### Changes

Adds the ability to bind the servers and the frontend Caddy builds to addresses supplied via a `BIND_ADDRESS` environment variable, taking precedence over `PORT`.

`BIND_ADDRESS` holds a full `host:port` (IPv4 or bracketed IPv6, e.g. `[::1]:3000`) and accepts a **comma-separated list** for multiple listeners.

**Servers** — new shared helper `@tamanu/shared/utils/bindAddress`:
- `resolveBindAddresses(fallbackPort)` applies precedence `BIND_ADDRESS` → `PORT` → configured port.
- `listenForBindAddresses(...)` listens on every resolved address: it reuses the existing primary http server for the first address and spins up extra `http.createServer(app)` listeners (sharing the same Express handler) for any additional addresses. Closing the primary server cascades to the extras, so existing shutdown logic is unchanged. (Websockets remain on the primary listener.)
- Wired into `central-server` `startApi`, and `facility-server` `startApp` (API + sync) and `startAll` (API), replacing the duplicated `+process.env.PORT` blocks. The combined `startAll` sync server keeps its config-only port, matching prior behaviour where `PORT` never applied to it.

**Frontend Caddy builds** — the Caddyfiles read `BIND_ADDRESS` directly in the site address (`{$BIND_ADDRESS::3000}`). Caddy supports comma-separated listeners natively, and this works identically for the Linux container image and the Windows VHDX bundle, both of which invoke `caddy run --config Caddyfile` directly (so a shell entrypoint wouldn't run on the Windows path). Defaults to `:3000`, matching the previous hardcoded value. Caddy can't nest one env var inside another's default, and the static frontend never consumed `PORT` (only the node servers do), so there is no `PORT` for it to override — `PORT` precedence is implemented where `PORT` is actually used (the servers).

**Tests** — `packages/shared/__tests__/utils/bindAddress.test.js` covers parsing (bare port, IPv4, bracketed IPv6, malformed) and the `BIND_ADDRESS`/`PORT`/fallback precedence.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [x] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01RWZcx77iL8ABzbq6nq9jJT)_