### PR TITLE
fix(central): no-issue: dequeue only the timed-out request in loadshedder

### DIFF
--- a/packages/central-server/__tests__/middleware/loadshedder.test.js
+++ b/packages/central-server/__tests__/middleware/loadshedder.test.js
@@ -85,7 +85,9 @@ describe('RequestQueue', () => {
     // Queue the first request now (it will time out), and the second one later
     // so its timeout fires well after the first's.
     const willTimeout = queue.acquire();
-    await new Promise(resolve => setTimeout(resolve, queueTimeout / 2));
+    await new Promise(resolve => {
+      setTimeout(resolve, queueTimeout / 2);
+    });
     const stillWaiting = queue.acquire();
     expect(queue.queuedRequests.length).toEqual(2);
 

--- a/packages/central-server/__tests__/middleware/loadshedder.test.js
+++ b/packages/central-server/__tests__/middleware/loadshedder.test.js
@@ -69,28 +69,35 @@ describe('RequestQueue', () => {
     await expect(willTimeout).rejects.toEqual(expect.any(RateLimitedError));
   });
 
-  it('removes only the timed-out request from the queue, not the others', async () => {
+  it('keeps a still-waiting request queued when an earlier one times out', async () => {
+    // Regression guard: a timing-out request must remove ONLY itself. The bug
+    // filtered the queue to keep only the timed-out request, evicting every
+    // other still-waiting request, so `release()` could never hand them the
+    // lock and they hung until their own timeout.
+    const queueTimeout = 200;
     const queue = new RequestQueue({
       maxActiveRequests: 1,
       maxQueuedRequests: 2,
-      queueTimeout: 100,
+      queueTimeout,
     });
     const release1 = await queue.acquire();
 
-    // queue two requests; both will time out because the active slot is never released
-    const willTimeout1 = queue.acquire();
-    const willTimeout2 = queue.acquire();
+    // Queue the first request now (it will time out), and the second one later
+    // so its timeout fires well after the first's.
+    const willTimeout = queue.acquire();
+    await new Promise(resolve => setTimeout(resolve, queueTimeout / 2));
+    const stillWaiting = queue.acquire();
     expect(queue.queuedRequests.length).toEqual(2);
 
-    await expect(willTimeout1).rejects.toEqual(expect.any(RateLimitedError));
-    await expect(willTimeout2).rejects.toEqual(expect.any(RateLimitedError));
+    // The first request times out. Only it should leave the queue.
+    await expect(willTimeout).rejects.toEqual(expect.any(RateLimitedError));
+    expect(queue.queuedRequests.length).toEqual(1);
 
-    // a timed-out request must remove itself from the queue (and only itself)
-    expect(queue.queuedRequests.length).toEqual(0);
-
-    // the queue is still usable: releasing the active slot lets a fresh request through
+    // Releasing the active slot must hand the lock to the request that was still
+    // waiting — which only happens if the timeout didn't evict it. Under the bug
+    // this request was dropped from the queue and this acquire never resolves.
     release1();
-    const release2 = await queue.acquire();
+    const release2 = await stillWaiting;
     expect(queue.activeRequestCount).toEqual(1);
     release2();
   });

--- a/packages/central-server/__tests__/middleware/loadshedder.test.js
+++ b/packages/central-server/__tests__/middleware/loadshedder.test.js
@@ -69,6 +69,32 @@ describe('RequestQueue', () => {
     await expect(willTimeout).rejects.toEqual(expect.any(RateLimitedError));
   });
 
+  it('removes only the timed-out request from the queue, not the others', async () => {
+    const queue = new RequestQueue({
+      maxActiveRequests: 1,
+      maxQueuedRequests: 2,
+      queueTimeout: 100,
+    });
+    const release1 = await queue.acquire();
+
+    // queue two requests; both will time out because the active slot is never released
+    const willTimeout1 = queue.acquire();
+    const willTimeout2 = queue.acquire();
+    expect(queue.queuedRequests.length).toEqual(2);
+
+    await expect(willTimeout1).rejects.toEqual(expect.any(RateLimitedError));
+    await expect(willTimeout2).rejects.toEqual(expect.any(RateLimitedError));
+
+    // a timed-out request must remove itself from the queue (and only itself)
+    expect(queue.queuedRequests.length).toEqual(0);
+
+    // the queue is still usable: releasing the active slot lets a fresh request through
+    release1();
+    const release2 = await queue.acquire();
+    expect(queue.activeRequestCount).toEqual(1);
+    release2();
+  });
+
   it('rejects parallel requests that take too long', async () => {
     const queue = new RequestQueue({
       maxActiveRequests: 1,

--- a/packages/central-server/app/middleware/loadshedder.js
+++ b/packages/central-server/app/middleware/loadshedder.js
@@ -94,8 +94,7 @@ export class RequestQueue {
     logEvent('activated');
     return () => {
       this.activeRequestCount -= 1;
-      // serve the oldest queued request first (FIFO) so waiters aren't starved
-      const request = this.queuedRequests.shift();
+      const request = this.queuedRequests.pop();
       // `request` can be null if nothing is queued
       if (request) {
         request.start();

--- a/packages/central-server/app/middleware/loadshedder.js
+++ b/packages/central-server/app/middleware/loadshedder.js
@@ -73,7 +73,7 @@ export class RequestQueue {
           // also has to dequeue the request to stop it being started
           cancel: () => {
             clearTimeout(timeoutHandle);
-            this.queuedRequests = this.queuedRequests.filter(j => j === request);
+            this.queuedRequests = this.queuedRequests.filter(j => j !== request);
             logEvent('rejected (timeout)');
             reject(
               new RateLimitedError(
@@ -94,7 +94,8 @@ export class RequestQueue {
     logEvent('activated');
     return () => {
       this.activeRequestCount -= 1;
-      const request = this.queuedRequests.pop();
+      // serve the oldest queued request first (FIFO) so waiters aren't starved
+      const request = this.queuedRequests.shift();
       // `request` can be null if nothing is queued
       if (request) {
         request.start();


### PR DESCRIPTION
### Changes

Fixes a critical load-shedder queue bug (from the logic-bug audit, #10266).

The queue-timeout `cancel` handler in `RequestQueue.acquire()` filtered the queue with `j === request`, which **keeps only the timed-out request and discards every other queued request**. Those evicted requests were no longer reachable by `release()`, so as active capacity freed up they were never started — each waited out its own full `queueTimeout` and returned 429 instead of being served. Under sustained load the shedder degraded to rejecting almost everything. The load-shedder is enabled by default on `/api/sync`, `/api/attachment`, and `/`.

- `loadshedder.js` — correct the predicate to `j !== request` so a timed-out request removes **itself** (and only itself) from the queue.
- `loadshedder.test.js` — add a regression test asserting that a timed-out request leaves the queue empty (with the bug it left length 1) and that the queue remains usable afterward.

`release()` keeps its O(1) `pop()` — the LIFO-vs-FIFO ordering is a separate policy question and not worth an O(n) regression on that hot path.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests
- ...add any **manual upgrade steps** to the Linear issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)