### PR TITLE
fix(facility): no-issue: parameterise facilityId in patient location queries

### DIFF
--- a/packages/facility-server/__tests__/apiv1/PatientLocations.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientLocations.test.js
@@ -305,6 +305,37 @@ describe('PatientLocations', () => {
     });
   });
 
+  it('should treat a facilityId containing a single quote as data, not SQL (parameterised query)', async () => {
+    // Regression: facilityId was previously interpolated directly into the SQL string, so a
+    // value containing a single quote produced a syntax error (500). It must now be bound as a
+    // parameter, so a malicious-looking facilityId is treated as data and simply matches no
+    // locations (empty/zero result) rather than erroring.
+    const maliciousFacilityId = "x'orinjection";
+
+    const occupancyResponse = await app.get(
+      `/api/patient/locations/occupancy?facilityId=${encodeURIComponent(maliciousFacilityId)}`,
+    );
+    expect(occupancyResponse).toHaveSucceeded();
+    expect(occupancyResponse.body.data).toEqual(0);
+
+    const statsResponse = await app.get(
+      `/api/patient/locations/stats?facilityId=${encodeURIComponent(maliciousFacilityId)}`,
+    );
+    expect(statsResponse).toHaveSucceeded();
+    expect(statsResponse.body.data).toEqual({
+      availableLocationCount: 0,
+      reservedLocationCount: 0,
+      occupiedLocationCount: 0,
+    });
+
+    // Contrast: a real facilityId still returns a valid numeric result shape.
+    const validStatsResponse = await app.get(
+      `/api/patient/locations/stats?facilityId=${facilityId}`,
+    );
+    expect(validStatsResponse).toHaveSucceeded();
+    expect(typeof validStatsResponse.body.data.occupiedLocationCount).toBe('number');
+  });
+
   it('should hide historical and merged locations', async () => {
     // Arrange
     const { Location } = models;

--- a/packages/facility-server/app/routes/apiv1/patient/patientLocations.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientLocations.js
@@ -4,7 +4,7 @@ import { QueryTypes } from 'sequelize';
 import { camelCaseProperties } from '@tamanu/utils/camelCaseProperties';
 import { LOCATION_AVAILABILITY_STATUS, VISIBILITY_STATUSES } from '@tamanu/constants';
 
-const patientsLocationSelect = (planned, encountersWhereAndClauses, facilityId) => `
+const patientsLocationSelect = (planned, encountersWhereAndClauses) => `
   SELECT
   	locations.id,
   	COUNT(open_encounters)
@@ -17,7 +17,7 @@ const patientsLocationSelect = (planned, encountersWhereAndClauses, facilityId) 
     ${encountersWhereAndClauses ? `AND ${encountersWhereAndClauses}` : ''}
   ) open_encounters
   ON locations.id = open_encounters.${planned ? 'planned_' : ''}location_id
-  WHERE locations.facility_id = '${facilityId}'
+  WHERE locations.facility_id = $facilityId
   AND locations.max_occupancy = 1
   AND locations.deleted_at IS NULL
   GROUP BY locations.id
@@ -36,11 +36,14 @@ patientLocations.get(
         SELECT
           (SUM(max_1_occupancy_locations.count) / COUNT(max_1_occupancy_locations) * 100)::float AS occupancy
         FROM (
-          ${patientsLocationSelect(false, `encounters.encounter_type = 'admission'`, facilityId)}
+          ${patientsLocationSelect(false, `encounters.encounter_type = 'admission'`)}
         ) max_1_occupancy_locations
       `,
       {
         type: QueryTypes.SELECT,
+        bind: {
+          facilityId,
+        },
       },
     );
 
@@ -155,11 +158,14 @@ patientLocations.get(
           SUM(sign(max_1_occupancy_locations.count)) AS occupied_location_count,
           COUNT(max_1_occupancy_locations) - SUM(sign(max_1_occupancy_locations.count)) AS available_location_count
         FROM (
-          ${patientsLocationSelect(undefined, undefined, facilityId)}
+          ${patientsLocationSelect(undefined, undefined)}
         ) max_1_occupancy_locations
       `,
       {
         type: QueryTypes.SELECT,
+        bind: {
+          facilityId,
+        },
       },
     );
 
@@ -168,11 +174,14 @@ patientLocations.get(
         SELECT
           SUM(sign(max_1_occupancy_locations.count)) AS reserved_location_count
         FROM (
-          ${patientsLocationSelect(true, undefined, facilityId)}
+          ${patientsLocationSelect(true, undefined)}
         ) max_1_occupancy_locations
       `,
       {
         type: QueryTypes.SELECT,
+        bind: {
+          facilityId,
+        },
       },
     );
 


### PR DESCRIPTION
### Changes

Fixes a critical SQL injection (from the logic-bug audit, #10266).

`patientsLocationSelect` in `patient/patientLocations.js` interpolated the `facilityId` request query parameter straight into the SQL string:

```js
WHERE locations.facility_id = '${facilityId}'
```

This is a genuine injection path reachable by any authenticated user (e.g. `?facilityId=x'; …`), used by the `/locations/occupancy` and `/locations/stats` endpoints. It also violates the project's "parameterised queries only" rule.

- Replace the interpolation with a `$facilityId` bind placeholder and pass `bind: { facilityId }` at each of the three query call sites — matching the sibling `/locations/alos` and `/locations/readmissions` endpoints in the same file, which already use binds.
- Drop the now-unused `facilityId` argument from the `patientsLocationSelect` helper.

No behavioural change for legitimate input; the query results are identical.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)