### PR TITLE
fix(settings): no-issue: stop settings cascade mutating schema defaults

### DIFF
--- a/packages/settings/__tests__/buildSettings.test.js
+++ b/packages/settings/__tests__/buildSettings.test.js
@@ -1,0 +1,43 @@
+import { SETTINGS_SCOPES } from '@tamanu/constants';
+
+import { buildSettings } from '../src/reader/buildSettings';
+import { globalDefaults } from '../src';
+
+// A stub Setting model returning canned values per scope, mimicking Setting.get(key, facilityId, scope)
+const makeModels = valuesByScope => ({
+  Setting: {
+    get: async (_key, _facilityId, scope) => valuesByScope[scope] ?? {},
+  },
+});
+
+describe('buildSettings cascade', () => {
+  it('does not mutate the shared schema default singletons', async () => {
+    const before = JSON.parse(JSON.stringify(globalDefaults));
+    const models = makeModels({
+      [SETTINGS_SCOPES.FACILITY]: { injectedByFacility: 'should-not-persist' },
+    });
+
+    await buildSettings(models, 'facility-1');
+
+    expect(globalDefaults).toEqual(before);
+    expect(globalDefaults).not.toHaveProperty('injectedByFacility');
+  });
+
+  it('does not leak one facility’s DB overrides into another facility', async () => {
+    const facilityOneValue = 'facility-1-only-value';
+    const facilityOne = await buildSettings(
+      makeModels({ [SETTINGS_SCOPES.FACILITY]: { injectedKey: facilityOneValue } }),
+      'facility-1',
+    );
+    expect(facilityOne.injectedKey).toEqual(facilityOneValue);
+
+    // facility-2 has no stored settings, so it must fall back to defaults, never facility-1's value
+    const facilityTwo = await buildSettings(makeModels({}), 'facility-2');
+    expect(facilityTwo.injectedKey).toBeUndefined();
+  });
+
+  it('returns a fresh object rather than the globalDefaults singleton', async () => {
+    const settings = await buildSettings(makeModels({}), 'facility-1');
+    expect(settings).not.toBe(globalDefaults);
+  });
+});

--- a/packages/settings/src/reader/buildSettings.ts
+++ b/packages/settings/src/reader/buildSettings.ts
@@ -28,7 +28,12 @@ export async function buildSettings(models: Models, facilityId?: string) {
   for (const reader of readers) {
     const value = await reader.getSettings();
     if (value) {
+      // Merge into a fresh object: mergeWith mutates its first argument, and the
+      // JSON readers return the shared schema-default singletons (facilityDefaults /
+      // globalDefaults). Passing `value` as the destination would pollute those
+      // singletons across requests and facilities.
       settings = mergeWith(
+        {},
         value,
         settings, // Prioritise previous value
         (_, settingValue) => (isArray(settingValue) ? settingValue : undefined), // Replace, don’t merge arrays


### PR DESCRIPTION
### Changes

Fixes a critical settings-cascade bug (from the logic-bug audit, #10266).

`buildSettings` merged each reader's value into the accumulator with `mergeWith(value, settings, …)`, but es-toolkit/compat `mergeWith` **mutates and returns its first argument**, and `SettingsJSONReader.getSettings()` returns the module-level schema-default singletons (`facilityDefaults` / `globalDefaults`) **by reference**. So every `buildSettings` call deep-merged all DB-stored settings *into the shared defaults*, and the returned object was the mutated `globalDefaults` singleton. Consequences:

- Deleting/reverting a setting in the admin panel had no effect until process restart (the old value lived on inside the polluted defaults).
- On a multi-facility server, facility A's facility-scoped overrides baked into the defaults and were then served to facility B.
- Cached per-facility settings objects all aliased the same mutated singleton.

Fix: merge into a fresh `{}` accumulator so the singletons are only ever read as merge *sources*, never used as the mutable destination. Semantics and priority order are unchanged.

- `buildSettings.ts` — `mergeWith({}, value, settings, …)`.
- `__tests__/buildSettings.test.js` — regression tests: the `globalDefaults` singleton isn't mutated, one facility's DB overrides don't leak into another, and the returned object isn't the singleton reference.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)