### PR TITLE
fix(mobile): no-issue: roll back survey submit on error instead of committing partial data

### DIFF
--- a/packages/mobile/App/models/SurveyResponse.test.ts
+++ b/packages/mobile/App/models/SurveyResponse.test.ts
@@ -1,0 +1,129 @@
+import { Database } from '~/infra/db';
+import { SurveyTypes } from '~/types';
+import {
+  fakePatient,
+  fakeProgramDataElement,
+  fakeSurvey,
+  fakeUser,
+} from '/root/tests/helpers/fake';
+import { writeConfig } from '~/services/config';
+import { SurveyResponse } from './SurveyResponse';
+
+// Regression coverage for the survey submit partial-commit fix.
+//
+// SurveyResponse.submit persists an encounter, a response row and its answers inside a
+// single TypeORM transaction. Previously the try/catch lived INSIDE the transaction
+// callback: when a mid-submit error was caught the callback returned null and resolved
+// normally, so TypeORM committed everything written up to the point of failure. The fix
+// moves the try/catch to wrap the transaction so the error propagates out of the callback,
+// rolling the transaction back, while still returning null to signal failure to the caller.
+//
+// These tests drive a submit that throws partway through (an answer whose code has no
+// matching screen component) and assert that nothing is left persisted.
+describe('SurveyResponse.submit', () => {
+  let patientId: string;
+  let userId: string;
+  let surveyId: string;
+  let dataElement: ReturnType<typeof fakeProgramDataElement>;
+  const orphanCode = 'ORPHAN_CODE_WITH_NO_COMPONENT';
+
+  const clearSubmitTables = async () => {
+    // SQLite deletes row-by-row, so drop FK enforcement while clearing children before parents.
+    await Database.client.query('PRAGMA foreign_keys = OFF;');
+    await Database.models.VitalLog.clear();
+    await Database.models.SurveyResponseAnswer.clear();
+    await Database.models.SurveyResponse.clear();
+    await Database.models.Encounter.clear();
+    await Database.client.query('PRAGMA foreign_keys = ON;');
+  };
+
+  const buildSurveyData = () => ({
+    surveyId,
+    surveyType: SurveyTypes.Programs,
+    encounterReason: 'survey response test',
+    components: [
+      {
+        id: 'survey-screen-component-valid',
+        dataElement,
+        calculation: '',
+      },
+    ],
+  });
+
+  beforeAll(async () => {
+    await Database.connect();
+
+    const facility = await Database.models.Facility.createAndSaveOne({ name: 'Test Facility' });
+    await writeConfig('facilityId', facility.id);
+    await Database.models.Department.createAndSaveOne({ name: 'Test Dept', facility: facility.id });
+    await Database.models.Location.createAndSaveOne({ name: 'Test Loc', facility: facility.id });
+
+    const user = fakeUser();
+    await Database.models.User.insert(user);
+    userId = user.id;
+
+    const patient = fakePatient();
+    await Database.models.Patient.insert(patient);
+    patientId = patient.id;
+
+    const survey = fakeSurvey();
+    await Database.models.Survey.insert(survey);
+    surveyId = survey.id;
+
+    dataElement = fakeProgramDataElement();
+    await Database.models.ProgramDataElement.insert(dataElement);
+  });
+
+  beforeEach(async () => {
+    await clearSubmitTables();
+  });
+
+  it('persists an encounter, response and answer on a successful submit', async () => {
+    const setNote = jest.fn();
+    const result = await SurveyResponse.submit(
+      patientId,
+      userId,
+      buildSurveyData(),
+      { [dataElement.code]: 'A recorded answer' },
+      setNote,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result.id).toBeTruthy();
+    expect(await Database.models.Encounter.count()).toBe(1);
+    expect(await Database.models.SurveyResponse.count()).toBe(1);
+    expect(await Database.models.SurveyResponseAnswer.count()).toBe(1);
+  });
+
+  it('rolls back all writes when an answer errors partway through the submit', async () => {
+    const encountersBefore = await Database.models.Encounter.count();
+    const responsesBefore = await Database.models.SurveyResponse.count();
+    const answersBefore = await Database.models.SurveyResponseAnswer.count();
+
+    const setNote = jest.fn();
+    // The first value maps to a valid component (its answer would be written first), the second
+    // has no matching component so submit throws mid-transaction after a partial write.
+    const result = await SurveyResponse.submit(
+      patientId,
+      userId,
+      buildSurveyData(),
+      {
+        [dataElement.code]: 'A recorded answer',
+        [orphanCode]: 'orphaned value',
+      },
+      setNote,
+    );
+
+    // Failure is reported to the caller as a null result...
+    expect(result).toBeNull();
+    // ...and the reported error is the mid-submit "no screen component" failure, not something else.
+    expect(setNote).toHaveBeenCalledWith(expect.stringContaining('no screen component'));
+
+    // ...and crucially nothing partial is committed: counts are unchanged (all zero here).
+    expect(await Database.models.Encounter.count()).toBe(encountersBefore);
+    expect(await Database.models.SurveyResponse.count()).toBe(responsesBefore);
+    expect(await Database.models.SurveyResponseAnswer.count()).toBe(answersBefore);
+    expect(await Database.models.SurveyResponse.count()).toBe(0);
+    expect(await Database.models.SurveyResponseAnswer.count()).toBe(0);
+  });
+});

--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -172,13 +172,17 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
     values: object,
     setNote: (note: string) => void = () => null,
   ): Promise<SurveyResponse> {
-    return getConnection().transaction(async () => {
-      const { surveyId, encounterReason, components, ...otherData } = surveyData;
+    const { surveyId, encounterReason, components, ...otherData } = surveyData;
 
-      const survey = await Survey.findOne({ where: { id: surveyId } });
-      if (!survey) throw new Error(`Survey with id ${surveyId} not found`);
+    const survey = await Survey.findOne({ where: { id: surveyId } });
+    if (!survey) throw new Error(`Survey with id ${surveyId} not found`);
 
-      try {
+    // The try/catch must wrap the transaction, not sit inside its callback: a catch
+    // inside the callback that returns normally makes TypeORM COMMIT the partial
+    // writes. Letting the error propagate out of the callback rolls the transaction
+    // back, then we report the failure to the caller as a null result.
+    try {
+      return await getConnection().transaction(async () => {
         setNote('Creating encounter...');
         const encounter = await Encounter.getOrCreateCurrentEncounter(patientId, userId, {
           startDate: getCurrentDateTimeString(),
@@ -268,11 +272,11 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
         setNote('Done');
 
         return responseRecord;
-      } catch (e) {
-        setNote(`Error: ${e.message} (${JSON.stringify(e)})`);
-        return null;
-      }
-    });
+      });
+    } catch (e) {
+      setNote(`Error: ${e.message} (${JSON.stringify(e)})`);
+      return null;
+    }
   }
 
   static async getForPatient(patientId: string, surveyId?: string): Promise<SurveyResponse[]> {


### PR DESCRIPTION
### Changes

Fixes a critical mobile data-integrity bug (from the logic-bug audit, #10266).

`SurveyResponse.submit` wrapped its work in a `try/catch` placed **inside** the TypeORM `getConnection().transaction(async () => { … })` callback. On any mid-submit error the callback caught it and returned `null`, so the callback resolved normally and TypeORM **committed** everything written so far — the encounter, the `SurveyResponse` row, a subset of answers, and vital logs. This is the exact opposite of the in-code intent ("better to fail entirely than save partial data"). The UI treats the `null` return as a failure and the clinician resubmits → duplicate/partial survey responses on the device that then sync to central.

Fix: move the `try/catch` to wrap the transaction. An error now propagates out of the callback so the transaction **rolls back**, and the outer catch still returns `null` to preserve the caller's `if (!response) return` contract. The survey-not-found check stays before the transaction so its behaviour (throw) is unchanged.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)