### PR TITLE
fix(facility): no-issue: stop vaccine creation after a 400 validation response

### DIFF
--- a/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
@@ -475,6 +475,44 @@ describe('PatientVaccine', () => {
       );
     });
 
+    it('Should reject and create no record when scheduledVaccineId is missing for a non-OTHER category', async () => {
+      const freshPatient = await models.Patient.create(await createDummyPatient(models));
+      const countBefore = await models.AdministeredVaccine.count();
+
+      const result = await app.post(`/api/patient/${freshPatient.id}/administeredVaccine`).send({
+        status: VACCINE_STATUS.GIVEN,
+        category: VACCINE_CATEGORIES.ROUTINE,
+        recorderId: clinician.id,
+        date: new Date(),
+        givenBy: 'Clinician',
+        facilityId,
+      });
+
+      expect(result).toHaveStatus(400);
+
+      // The 400 must short-circuit the handler: no AdministeredVaccine (and no encounter) is created
+      const countAfter = await models.AdministeredVaccine.count();
+      expect(countAfter).toEqual(countBefore);
+    });
+
+    it('Should reject and create no record when status is missing', async () => {
+      const freshPatient = await models.Patient.create(await createDummyPatient(models));
+      const countBefore = await models.AdministeredVaccine.count();
+
+      const result = await app.post(`/api/patient/${freshPatient.id}/administeredVaccine`).send({
+        scheduledVaccineId: scheduled1.id,
+        recorderId: clinician.id,
+        date: new Date(),
+        givenBy: 'Clinician',
+        facilityId,
+      });
+
+      expect(result).toHaveStatus(400);
+
+      const countAfter = await models.AdministeredVaccine.count();
+      expect(countAfter).toEqual(countBefore);
+    });
+
     it('Should update reason for encounter with correct description when vaccine is recorded in error', async () => {
       const result = await app.get(`/api/patient/${patient.id}/administeredVaccines`);
       const vaccineId = result.body.data[0].id;

--- a/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
@@ -332,6 +332,23 @@ describe('PatientVaccine', () => {
       expect(vaccine.givenBy).toEqual(country.name);
     });
 
+    it('rejects a non-OTHER vaccine with no scheduledVaccineId and creates no record', async () => {
+      const countBefore = await models.AdministeredVaccine.count();
+      const result = await app.post(`/api/patient/${patient.id}/administeredVaccine`).send({
+        status: VACCINE_RECORDING_TYPES.GIVEN,
+        category: VACCINE_CATEGORIES.ROUTINE,
+        recorderId: clinician.id,
+        patientId: patient.id,
+        date: new Date(),
+        facilityId,
+        // scheduledVaccineId deliberately omitted
+      });
+      expect(result).toHaveStatus(400);
+      // The handler must return after the 400 — no AdministeredVaccine should be persisted.
+      const countAfter = await models.AdministeredVaccine.count();
+      expect(countAfter).toEqual(countBefore);
+    });
+
     it('Should record vaccine with correct values when category is Other', async () => {
       const VACCINE_BRAND = 'Test Vaccine Brand';
       const VACCINE_NAME = 'Test Vaccine Name';

--- a/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
@@ -224,10 +224,12 @@ patientVaccineRoutes.post(
     // Require scheduledVaccineId if vaccine category is not OTHER
     if (req.body.category !== VACCINE_CATEGORIES.OTHER && !req.body.scheduledVaccineId) {
       res.status(400).send({ error: { message: 'scheduledVaccineId is required' } });
+      return;
     }
 
     if (!req.body.status) {
       res.status(400).send({ error: { message: 'status is required' } });
+      return;
     }
 
     const { models } = req;


### PR DESCRIPTION
### Changes

Fixes a high-severity vaccine-recording bug (from the logic-bug audit, #10266).

In `POST /:id/administeredVaccine`, the two validation failures (`scheduledVaccineId` required, `status` required) called `res.status(400).send(...)` **without returning**. Execution continued to create the (possibly auto-discharged) encounter and the `AdministeredVaccine` record, then crashed with `ERR_HTTP_HEADERS_SENT` on the final response. The client was told the request was rejected while a phantom vaccine record (with a null `scheduledVaccineId`) was persisted.

- `patientVaccine.js` — `return` after each 400 response.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DgeouPJ3UR44Bokc7a1Cn)_