### PR TITLE
fix(web): no-issue: gate encounter panes read-only prop on the delivered name

### DIFF
--- a/packages/web/__tests__/views/patients/panes/ImagingPane.test.jsx
+++ b/packages/web/__tests__/views/patients/panes/ImagingPane.test.jsx
@@ -1,0 +1,68 @@
+/*
+ * Regression test for encounter pane read-only gating.
+ *
+ * EncounterView/PatientView compute a read-only flag (discharged encounter or
+ * deceased patient) and pass it to each pane as `disabled`. The panes previously
+ * destructured a prop named `readonly`, which was never supplied, so their action
+ * buttons stayed enabled. The fix renames the prop to `disabled` so the buttons
+ * disable as intended.
+ *
+ * ImagingPane is the simplest affected pane: its "Print" action is a plain button
+ * with no permission machinery. We stub the heavy table/modals (and the permission
+ * button, which needs an auth context) so we can render just the action row.
+ */
+
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { renderElementWithTranslatedText } from '../../../helpers';
+
+// The permission button needs an auth context; stub it to a plain button that forwards `disabled`.
+vi.mock('@tamanu/ui-components', async () => {
+  const actual = await vi.importActual('@tamanu/ui-components');
+  return {
+    ...actual,
+    ButtonWithPermissionCheck: ({ children, disabled, ['data-testid']: dataTestId }) => (
+      <button type="button" disabled={disabled} data-testid={dataTestId}>
+        {children}
+      </button>
+    ),
+  };
+});
+
+// Stub the data-fetching table and modals so the pane renders without a backend.
+vi.mock('../../../../app/components/ImagingRequestModal', () => ({
+  ImagingRequestModal: () => null,
+}));
+vi.mock('../../../../app/components/ImagingRequestsTable', () => ({
+  ImagingRequestsTable: () => null,
+}));
+vi.mock('../../../../app/components/PatientPrinting', () => ({
+  PrintMultipleImagingRequestsSelectionModal: () => null,
+}));
+
+// eslint-disable-next-line import/first
+import { ImagingPane } from '../../../../app/views/patients/panes/ImagingPane';
+
+const PRINT_BUTTON = 'button-21bg';
+const NEW_REQUEST_BUTTON = 'buttonwithpermissioncheck-14hy';
+
+const renderPane = disabled =>
+  renderElementWithTranslatedText(<ImagingPane encounter={{ id: 'encounter-1' }} disabled={disabled} />);
+
+describe('ImagingPane read-only gating', () => {
+  it('disables the action buttons when disabled is true', () => {
+    renderPane(true);
+
+    expect(screen.getByTestId(PRINT_BUTTON).disabled).toBe(true);
+    expect(screen.getByTestId(NEW_REQUEST_BUTTON).disabled).toBe(true);
+  });
+
+  it('leaves the action buttons enabled when disabled is false', () => {
+    renderPane(false);
+
+    expect(screen.getByTestId(PRINT_BUTTON).disabled).toBe(false);
+    expect(screen.getByTestId(NEW_REQUEST_BUTTON).disabled).toBe(false);
+  });
+});

--- a/packages/web/__tests__/views/patients/panes/ImagingPane.test.jsx
+++ b/packages/web/__tests__/views/patients/panes/ImagingPane.test.jsx
@@ -42,7 +42,6 @@ vi.mock('../../../../app/components/PatientPrinting', () => ({
   PrintMultipleImagingRequestsSelectionModal: () => null,
 }));
 
-// eslint-disable-next-line import/first
 import { ImagingPane } from '../../../../app/views/patients/panes/ImagingPane';
 
 const PRINT_BUTTON = 'button-21bg';

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -93,7 +93,7 @@ const StyledConditionalTooltip = styled(ConditionalTooltip)`
   }
 `;
 
-export const ChartsPane = React.memo(({ patient, encounter }) => {
+export const ChartsPane = React.memo(({ patient, encounter, disabled }) => {
   const api = useApi();
   const queryClient = useQueryClient();
   const { facilityId, ability } = useAuth();
@@ -376,7 +376,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
                     setChartSurveyIdToSubmit(selectedChartTypeId);
                     setModalOpen(true);
                   }}
-                  disabled={!recordButtonEnabled}
+                  disabled={!recordButtonEnabled || disabled}
                   verb="create"
                   subject={subject('Charting', { id: selectedChartTypeId })}
                   data-testid="styledbuttonwithpermissioncheck-ruv4"
@@ -422,9 +422,9 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
 ChartsPane.propTypes = {
   patient: PropTypes.object.isRequired,
   encounter: PropTypes.string.isRequired,
-  readonly: PropTypes.bool,
+  disabled: PropTypes.bool,
 };
 
 ChartsPane.defaultProps = {
-  readonly: false,
+  disabled: false,
 };

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -344,6 +344,7 @@ export const ChartsPane = React.memo(({ patient, encounter, disabled }) => {
                       setChartSurveyIdToSubmit(coreComplexChartSurveyId);
                       setModalOpen(true);
                     }}
+                    disabled={disabled}
                   />
                 </NoteModalActionBlocker>
               ) : null}

--- a/packages/web/app/views/patients/panes/EncounterMedicationPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterMedicationPane.jsx
@@ -73,7 +73,7 @@ const TableContainer = styled.div`
   border-radius: 3px;
 `;
 
-export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
+export const EncounterMedicationPane = React.memo(({ encounter, disabled }) => {
   const { ability, facilityId } = useAuth();
   const queryClient = useQueryClient();
   const { getSetting } = useSettings();
@@ -202,7 +202,7 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
                       'medication.action.addOngoingMedications',
                       'Add existing ongoing medication to encounter',
                     )}
-                    disabled={readonly}
+                    disabled={disabled}
                     onClick={() => setMedicationImportModalOpen(true)}
                   >
                     <ThemedTooltip
@@ -230,7 +230,7 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
                           'Print prescription',
                         )}
                         onClick={() => setPrintMedicationModalOpen(true)}
-                        disabled={readonly}
+                        disabled={disabled}
                         color="primary"
                         data-testid="styledtextbutton-hbja"
                       >
@@ -256,7 +256,7 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
                             'Send to pharmacy',
                           )}
                           onClick={() => setPharmacyOrderModalOpen(true)}
-                          disabled={readonly}
+                          disabled={disabled}
                           color="primary"
                           data-testid="styledtextbutton-uhgj"
                         >
@@ -285,7 +285,7 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
           <ButtonGroup>
             {canAccessMar && (
               <StyledButton
-                disabled={readonly}
+                disabled={disabled}
                 variant="outlined"
                 color="primary"
                 onClick={handleNavigateToMar}
@@ -309,7 +309,7 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
                 >
                   <StyledButtonWithPermissionCheck
                     onClick={handleNewPrescription}
-                    disabled={readonly || medicationSetsLoading || isEncounterDischarged}
+                    disabled={disabled || medicationSetsLoading || isEncounterDischarged}
                     verb="create"
                     noun="Medication"
                     data-testid="styledbuttonwithpermissioncheck-cagj"

--- a/packages/web/app/views/patients/panes/ImagingPane.jsx
+++ b/packages/web/app/views/patients/panes/ImagingPane.jsx
@@ -10,7 +10,7 @@ import { PrintMultipleImagingRequestsSelectionModal } from '../../../components/
 import { TabPane } from '../components';
 import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
-export const ImagingPane = React.memo(({ encounter, readonly }) => {
+export const ImagingPane = React.memo(({ encounter, disabled }) => {
   const [newRequestModalOpen, setNewRequestModalOpen] = useState(false);
   const [printRequestsModalOpen, setPrintRequestsModalOpen] = useState(false);
 
@@ -33,7 +33,7 @@ export const ImagingPane = React.memo(({ encounter, readonly }) => {
         <NoteModalActionBlocker>
           <Button
             onClick={() => setPrintRequestsModalOpen(true)}
-            disabled={readonly}
+            disabled={disabled}
             variant="outlined"
             color="primary"
             data-testid="button-21bg"
@@ -48,7 +48,7 @@ export const ImagingPane = React.memo(({ encounter, readonly }) => {
         <NoteModalActionBlocker>
           <ButtonWithPermissionCheck
             onClick={() => setNewRequestModalOpen(true)}
-            disabled={readonly}
+            disabled={disabled}
             verb="create"
             noun="ImagingRequest"
             data-testid="buttonwithpermissioncheck-14hy"

--- a/packages/web/app/views/patients/panes/LabsPane.jsx
+++ b/packages/web/app/views/patients/panes/LabsPane.jsx
@@ -10,7 +10,7 @@ import { PrintMultipleLabRequestsSelectionModal } from '../../../components/Pati
 import { TabPane } from '../components';
 import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
-export const LabsPane = React.memo(({ encounter, readonly }) => {
+export const LabsPane = React.memo(({ encounter, disabled }) => {
   const [newRequestModalOpen, setNewRequestModalOpen] = useState(false);
   const [printRequestsModalOpen, setPrintRequestsModalOpen] = useState(false);
 
@@ -32,7 +32,7 @@ export const LabsPane = React.memo(({ encounter, readonly }) => {
         <NoteModalActionBlocker>
           <ButtonWithPermissionCheck
             onClick={() => setPrintRequestsModalOpen(true)}
-            disabled={readonly}
+            disabled={disabled}
             verb="read"
             noun="LabRequest"
             variant="outlined"
@@ -50,7 +50,7 @@ export const LabsPane = React.memo(({ encounter, readonly }) => {
         <NoteModalActionBlocker>
           <ButtonWithPermissionCheck
             onClick={() => setNewRequestModalOpen(true)}
-            disabled={readonly}
+            disabled={disabled}
             verb="create"
             noun="LabRequest"
             size="small"

--- a/packages/web/app/views/patients/panes/NotesPane.jsx
+++ b/packages/web/app/views/patients/panes/NotesPane.jsx
@@ -17,7 +17,7 @@ const StyledAutocompleteInput = styled(AutocompleteInput)`
   width: 200px;
 `;
 
-export const NotesPane = React.memo(({ encounter, readonly }) => {
+export const NotesPane = React.memo(({ encounter, disabled }) => {
   const { noteTypeId, setNoteTypeId } = useEncounterNotesQuery();
   const { loadEncounter } = useEncounter();
   const { openNoteModal, updateNoteModalProps } = useNoteModal();
@@ -54,7 +54,7 @@ export const NotesPane = React.memo(({ encounter, readonly }) => {
         <NoteModalActionBlocker>
           <ButtonWithPermissionCheck
             onClick={handleOpenNewNote}
-            disabled={readonly}
+            disabled={disabled}
             verb="create"
             noun="EncounterNote"
             data-testid="buttonwithpermissioncheck-qbou"

--- a/packages/web/app/views/patients/panes/ProcedurePane.jsx
+++ b/packages/web/app/views/patients/panes/ProcedurePane.jsx
@@ -8,7 +8,7 @@ import { TabPane } from '../components';
 import { TranslatedText } from '../../../components/Translation/TranslatedText';
 import { NoteModalActionBlocker } from '../../../components/NoteModalActionBlocker';
 
-export const ProcedurePane = React.memo(({ encounter, readonly }) => {
+export const ProcedurePane = React.memo(({ encounter, disabled }) => {
   const [editedProcedure, setEditedProcedure] = useState(null);
   const { loadEncounter } = useEncounter();
 
@@ -34,7 +34,7 @@ export const ProcedurePane = React.memo(({ encounter, readonly }) => {
         <NoteModalActionBlocker>
           <ButtonWithPermissionCheck
             onClick={onCreateNewProcedure}
-            disabled={readonly}
+            disabled={disabled}
             verb="create"
             noun="Procedure"
             data-testid="buttonwithpermissioncheck-h58o"

--- a/packages/web/app/views/patients/panes/VaccinesPane.jsx
+++ b/packages/web/app/views/patients/panes/VaccinesPane.jsx
@@ -36,7 +36,7 @@ const TableWrapper = styled.div`
   }
 `;
 
-export const VaccinesPane = React.memo(({ patient, readonly }) => {
+export const VaccinesPane = React.memo(({ patient, disabled }) => {
   const { getSetting } = useSettings();
   const [hideUpcomingVaccines, setHideUpcomingVaccines] = useState(
     getSetting('features.hideUpcomingVaccines'),
@@ -154,7 +154,7 @@ export const VaccinesPane = React.memo(({ patient, readonly }) => {
               verb="create"
               noun="PatientVaccine"
               onClick={() => setIsAdministerModalOpen(true)}
-              disabled={readonly}
+              disabled={disabled}
               data-testid="buttonwithpermissioncheck-zmgl"
             >
               <TranslatedText

--- a/packages/web/app/views/patients/panes/VitalsPane.jsx
+++ b/packages/web/app/views/patients/panes/VitalsPane.jsx
@@ -10,7 +10,7 @@ import { VitalChartDataProvider } from '../../../contexts/VitalChartData';
 import { VitalChartsModal } from '../../../components/VitalChartsModal';
 import { useAuth } from '../../../contexts/Auth';
 
-export const VitalsPane = React.memo(({ patient, encounter, readonly }) => {
+export const VitalsPane = React.memo(({ patient, encounter, disabled }) => {
   const { facilityId } = useAuth();
   const queryClient = useQueryClient();
   const { getCurrentDateTime } = useDateTime();
@@ -61,7 +61,7 @@ export const VitalsPane = React.memo(({ patient, encounter, readonly }) => {
           <NoteModalActionBlocker>
             <Button
               onClick={() => setModalOpen(true)}
-              disabled={readonly}
+              disabled={disabled}
               data-testid="button-mk5r"
             >
               <TranslatedText


### PR DESCRIPTION
### Changes

Fixes a high-severity read-only gating bug (from the logic-bug audit, #10266).

`EncounterView` and `PatientView` compute a read-only flag (`encounter?.endDate || !!patient.dateOfDeath`) and pass it into the tab machinery as `disabled`. `TabDisplay` / `TabDisplayDraggable` forward it verbatim (`...tabProps` → `render(tabProps)`), so each pane receives a prop named **`disabled`**. But these panes destructured a prop named **`readonly`**, which was never supplied — so it was always `undefined` and the panes' action buttons ("Record vitals", "New lab request", "New imaging request", "New note", "New procedure", "Record vaccine", medication actions) stayed **enabled on discharged encounters and deceased patients**. `SummaryPane` already reads `disabled` and worked correctly, confirming the delivered prop name.

- Rename the prop to `disabled` in `VitalsPane`, `LabsPane`, `ImagingPane`, `NotesPane`, `ProcedurePane`, `EncounterMedicationPane`, and `VaccinesPane`.
- `ChartsPane` declared `readonly` in propTypes/defaultProps but never consumed it; wire the delivered `disabled` into its Record button (`disabled={!recordButtonEnabled || disabled}`) and rename the propType.

No source-side changes needed — the views already pass `disabled`.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)