### PR TITLE
fix(invoicing): no-issue: run invoice and payment writes inside their transaction

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Invoice.test.js
+++ b/packages/facility-server/__tests__/apiv1/Invoice.test.js
@@ -343,4 +343,38 @@ describe('Invoice API', () => {
       expect(finalised.priceFinal).toBe('2');
     });
   });
+
+  describe('PUT /:id (update) transaction handling', () => {
+    it('should roll back item deletions when a later write in the update fails', async () => {
+      const encounter = await createEncounter();
+      const procedureType = await createProcedureType();
+      const invoiceProduct = await createInvoiceProduct(procedureType);
+      const invoice = await createInvoice(encounter.id, { displayId: 'INV-ROLLBACK-001' });
+      const existingItem = await createInvoiceItem(
+        invoice.id,
+        invoiceProduct.id,
+        procedureType.id,
+      );
+
+      // The replacement item list omits the existing item (so it is destroyed first) and adds an
+      // item whose productId violates the invoice_items -> invoice_products foreign key, forcing
+      // the upsert to fail mid-transaction. The whole update must roll back, leaving the original
+      // item intact rather than permanently deleting it.
+      const result = await app.put(`/api/invoices/${invoice.id}`).send({
+        items: [
+          {
+            orderDate: '2024-01-01',
+            orderedByUserId: user.id,
+            productId: 'nonexistent-invoice-product',
+            quantity: 1,
+          },
+        ],
+      });
+      expect(result).not.toHaveSucceeded();
+
+      const itemsAfter = await models.InvoiceItem.findAll({ where: { invoiceId: invoice.id } });
+      expect(itemsAfter).toHaveLength(1);
+      expect(itemsAfter[0].id).toBe(existingItem.id);
+    });
+  });
 });

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -256,72 +256,54 @@ invoiceRoute.put(
     const { data, error } = await updateInvoiceSchema.safeParseAsync(req.body);
     if (error) throw new ValidationError(error.message);
 
-    const transaction = await req.db.transaction();
-
-    try {
+    // Managed transaction: CLS binds it to every Sequelize call inside the callback, so
+    // the destroy/update calls actually run in the transaction and roll back together on error.
+    await req.db.transaction(async () => {
       if (!data.discount) {
         //remove any existing discount if discount info is not provided
-        await req.models.InvoiceDiscount.destroy({ where: { invoiceId } }, { transaction });
+        await req.models.InvoiceDiscount.destroy({ where: { invoiceId } });
       }
       //if discount info is provided, update or create discount
       else {
         //remove any existing discount if discount id is not matching
-        await req.models.InvoiceDiscount.destroy(
-          { where: { invoiceId, id: { [Op.ne]: data.discount.id } } },
-          { transaction },
-        );
+        await req.models.InvoiceDiscount.destroy({
+          where: { invoiceId, id: { [Op.ne]: data.discount.id } },
+        });
         //update or create discount
-        await req.models.InvoiceDiscount.upsert(
-          {
-            ...data.discount,
-            invoiceId,
-            appliedByUserId: req.user.id,
-            appliedTime: getCurrentPrimaryTimeZoneDateTimeString(),
-          },
-          { transaction },
-        );
+        await req.models.InvoiceDiscount.upsert({
+          ...data.discount,
+          invoiceId,
+          appliedByUserId: req.user.id,
+          appliedTime: getCurrentPrimaryTimeZoneDateTimeString(),
+        });
       }
 
       //remove any existing item if item ids are not matching
-      await req.models.InvoiceItem.destroy(
-        { where: { invoiceId, id: { [Op.notIn]: data.items.map(item => item.id) } } },
-        { transaction },
-      );
+      await req.models.InvoiceItem.destroy({
+        where: { invoiceId, id: { [Op.notIn]: data.items.map(item => item.id) } },
+      });
 
       for (const item of data.items) {
         const { discount: itemDiscount, ...itemData } = item;
         //update or create item
-        await req.models.InvoiceItem.upsert({ ...itemData, invoiceId }, { transaction });
+        await req.models.InvoiceItem.upsert({ ...itemData, invoiceId });
 
         //remove any existing discount if discount info is not provided
         if (!itemDiscount) {
-          await req.models.InvoiceItemDiscount.destroy(
-            { where: { invoiceItemId: item.id } },
-            { transaction },
-          );
+          await req.models.InvoiceItemDiscount.destroy({ where: { invoiceItemId: item.id } });
         } else {
           //remove any existing discount if discount id is not matching
-          await req.models.InvoiceItemDiscount.destroy(
-            {
-              where: {
-                invoiceItemId: item.id,
-                id: { [Op.ne]: itemDiscount.id },
-              },
+          await req.models.InvoiceItemDiscount.destroy({
+            where: {
+              invoiceItemId: item.id,
+              id: { [Op.ne]: itemDiscount.id },
             },
-            { transaction },
-          );
+          });
           //update or create discount
-          await req.models.InvoiceItemDiscount.upsert(
-            { ...itemDiscount, invoiceItemId: item.id },
-            { transaction },
-          );
+          await req.models.InvoiceItemDiscount.upsert({ ...itemDiscount, invoiceItemId: item.id });
         }
       }
-      await transaction.commit();
-    } catch (error) {
-      await transaction.rollback();
-      throw error;
-    }
+    });
 
     // Recalculate patientPaymentStatus now that items/discount may have changed.
     // Payments can be recorded on in-progress invoices, so the status may be stale

--- a/packages/facility-server/app/routes/apiv1/invoice/patientPayment.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/patientPayment.js
@@ -80,10 +80,10 @@ const handleCreatePatientPayment = asyncHandler(async (req, res) => {
     throw new ForbiddenError('Amount of payment is higher than the owing total');
   }
 
-  const transaction = await req.db.transaction();
-
-  try {
-    const payment = await req.models.InvoicePayment.create(
+  // Managed transaction: CLS binds it to every Sequelize call inside the callback, so all
+  // writes run in the transaction and roll back together on error.
+  const payment = await req.db.transaction(async () => {
+    const createdPayment = await req.models.InvoicePayment.create(
       {
         invoiceId,
         date: data.date,
@@ -91,16 +91,13 @@ const handleCreatePatientPayment = asyncHandler(async (req, res) => {
         amount: data.amount,
         updatedByUserId: req.user.id ?? null,
       },
-      { returning: true, transaction },
+      { returning: true },
     );
-    await req.models.InvoicePatientPayment.create(
-      {
-        invoicePaymentId: payment.id,
-        methodId: data.methodId,
-        chequeNumber: data.chequeNumber,
-      },
-      { transaction },
-    );
+    await req.models.InvoicePatientPayment.create({
+      invoicePaymentId: createdPayment.id,
+      methodId: data.methodId,
+      chequeNumber: data.chequeNumber,
+    });
 
     //Update the overall patient payment status to invoice
     await req.models.Invoice.update(
@@ -114,14 +111,10 @@ const handleCreatePatientPayment = asyncHandler(async (req, res) => {
         ),
       },
       { where: { id: invoiceId } },
-      { transaction },
     );
-    await transaction.commit();
-    res.json(payment);
-  } catch (error) {
-    await transaction.rollback();
-    throw error;
-  }
+    return createdPayment;
+  });
+  res.json(payment);
 });
 
 const handleUpdatePatientPayment = asyncHandler(async (req, res) => {
@@ -148,9 +141,9 @@ const handleUpdatePatientPayment = asyncHandler(async (req, res) => {
   )
     throw new ForbiddenError('Amount of payment is higher than the invoice total');
 
-  const transaction = await req.db.transaction();
-
-  try {
+  // Managed transaction: CLS binds it to every Sequelize call inside the callback, so all
+  // writes run in the transaction and roll back together on error.
+  await req.db.transaction(async () => {
     await req.models.InvoicePayment.update(
       {
         date: data.date,
@@ -158,8 +151,7 @@ const handleUpdatePatientPayment = asyncHandler(async (req, res) => {
         amount: data.amount,
         updatedByUserId: req.user.id ?? null,
       },
-      { where: { id: paymentId } },
-      { transaction, returning: true },
+      { where: { id: paymentId }, returning: true },
     );
     await req.models.InvoicePatientPayment.update(
       {
@@ -167,7 +159,6 @@ const handleUpdatePatientPayment = asyncHandler(async (req, res) => {
         chequeNumber: data.chequeNumber,
       },
       { where: { invoicePaymentId: paymentId } },
-      { transaction },
     );
 
     //Update the overall patient payment status to invoice
@@ -183,14 +174,9 @@ const handleUpdatePatientPayment = asyncHandler(async (req, res) => {
         ),
       },
       { where: { id: invoiceId } },
-      { transaction },
     );
-    await transaction.commit();
-    res.json(payment);
-  } catch (error) {
-    await transaction.rollback();
-    throw error;
-  }
+  });
+  res.json(payment);
 });
 
 const handleGetPatientPayments = asyncHandler(async (req, res) => {

--- a/packages/facility-server/app/routes/apiv1/invoice/patientPayment.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/patientPayment.js
@@ -151,7 +151,7 @@ const handleUpdatePatientPayment = asyncHandler(async (req, res) => {
         amount: data.amount,
         updatedByUserId: req.user.id ?? null,
       },
-      { where: { id: paymentId }, returning: true },
+      { where: { id: paymentId } },
     );
     await req.models.InvoicePatientPayment.update(
       {


### PR DESCRIPTION
### Changes

Fixes two high-severity invoicing data-loss bugs (from the logic-bug audit, #10266).

The invoice update handler (`invoices.js` PUT `/:id`) and both patient-payment handlers (`patientPayment.js` create + update) opened an **unmanaged** transaction (`req.db.transaction()`, which CLS does not auto-bind) and then passed `{ transaction }` as an **extra argument** to `Model.destroy` / `Model.update`:

```js
await req.models.InvoiceItem.destroy({ where: { … } }, { transaction }); // 2nd arg ignored
await req.models.Invoice.update(values, { where: { … } }, { transaction }); // 3rd arg ignored
```

`Model.destroy(options)` and `Model.update(values, options)` take a single options object, so the transaction was silently ignored and those statements committed immediately in autocommit — outside the transaction. On a later failure `transaction.rollback()` restored nothing, so a partial invoice edit could permanently delete invoice items/discounts, and a failed payment edit could leave payment records inconsistent, while the client saw a 500.

Convert these three handlers to **managed transactions** (`req.db.transaction(async () => { … })`), per the project's transaction conventions. CLS binds the transaction to every Sequelize call inside the callback, so all writes now run in the transaction and roll back together on error; the ignored `{ transaction }` arguments are removed, and the payment handlers return the payment from the transaction and respond after it commits.

The sibling finalise handler in `invoices.js` already passed the transaction correctly via `save({ transaction })` / `create(values, { transaction })`, so it's left unchanged.

- `invoice/invoices.js` — PUT `/:id` update handler → managed transaction.
- `invoice/patientPayment.js` — create + update handlers → managed transactions.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)