### PR TITLE
fix(invoicing): TAM-6901: convert inpatient-bundled medication qty to dispensing units

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37796,6 +37796,7 @@
       "devDependencies": {
         "@casl/ability": "^6.8.0",
         "@tamanu/build-tooling": "*",
+        "@tamanu/fake-data": "*",
         "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.13",
         "@types/jsonpath": "^0.2.4",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@casl/ability": "^6.8.0",
     "@tamanu/build-tooling": "*",
+    "@tamanu/fake-data": "*",
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.13",
     "@types/jsonpath": "^0.2.4",

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -366,10 +366,15 @@ export class Prescription extends Model {
       ))
     ) {
       const admissionStart = await getAdmissionStartDate(this.sequelize.models, encounter.id);
+      // Convert the pre-admission dosing-unit total to dispensing units (ceil once), the
+      // same way marQty is derived above, so the invoice quantity is in dispensing units.
+      const unitConversion = Number(prescription.unitConversion) || 1;
       administeredQty = admissionStart
-        ? doses
-            .filter((d: any) => d.givenTime && d.givenTime < admissionStart)
-            .reduce((sum: number, d: any) => sum + Number(d.doseAmount || 0), 0)
+        ? Math.ceil(
+            doses
+              .filter((d: any) => d.givenTime && d.givenTime < admissionStart)
+              .reduce((sum: number, d: any) => sum + Number(d.doseAmount || 0), 0) / unitConversion,
+          )
         : 0;
     }
 

--- a/packages/facility-server/__tests__/apiv1/InpatientFeeInclusions.test.js
+++ b/packages/facility-server/__tests__/apiv1/InpatientFeeInclusions.test.js
@@ -30,6 +30,7 @@ describe('Inpatient fee inclusions', () => {
   let location;
   let labPanel;
   let drug;
+  let drugWithConversion;
 
   const createEncounterWithInvoice = async encounterType => {
     const encounter = await models.Encounter.create({
@@ -162,6 +163,27 @@ describe('Inpatient fee inclusions', () => {
       }),
     );
 
+    // Drug product whose dosing unit differs from its dispensing unit (e.g. mg dosed, 5mg
+    // tablets dispensed): unitConversion 5 is snapshotted onto prescriptions from ReferenceDrug.
+    drugWithConversion = await models.ReferenceData.create(
+      fake(models.ReferenceData, { type: REFERENCE_TYPES.DRUG, code: 'INC-EXC-DRUG-CONV' }),
+    );
+    await models.ReferenceDrug.create(
+      fake(models.ReferenceDrug, {
+        referenceDataId: drugWithConversion.id,
+        dosingUnit: 'mg',
+        dispensingUnit: 'tablet',
+        unitConversion: 5,
+      }),
+    );
+    const drugWithConversionProduct = await models.InvoiceProduct.create(
+      fake(models.InvoiceProduct, {
+        category: INVOICE_ITEMS_CATEGORIES.DRUG,
+        sourceRecordType: INVOICE_ITEMS_CATEGORIES_MODELS[INVOICE_ITEMS_CATEGORIES.DRUG],
+        sourceRecordId: drugWithConversion.id,
+      }),
+    );
+
     // Imaging product
     const [imagingType] = await models.ReferenceData.findOrCreate({
       where: { type: REFERENCE_TYPES.IMAGING_TYPE, code: IMAGING_TYPES.CT_SCAN },
@@ -185,7 +207,7 @@ describe('Inpatient fee inclusions', () => {
         rules: { facilityId: facility.id },
       }),
     );
-    for (const product of [panelProduct, drugProduct, imagingProduct]) {
+    for (const product of [panelProduct, drugProduct, imagingProduct, drugWithConversionProduct]) {
       await models.InvoicePriceListItem.create(
         fake(models.InvoicePriceListItem, {
           invoiceProductId: product.id,
@@ -312,6 +334,55 @@ describe('Inpatient fee inclusions', () => {
     const items = result.body.items ?? [];
     expect(items).toHaveLength(1);
     // Pre-admission dose (3) billed; post-admission dose (4) bundled into the admission fee.
+    expect(items[0].quantity).toBe(3);
+  });
+
+  it('converts the pre-admission dosing total to dispensing units when medications are bundled', async () => {
+    // Drug with unitConversion 5 — doses are in mg, dispensing unit is 5mg tablets.
+    // Emergency encounter (started 30 days ago via the helper).
+    const encounter = await createEncounterWithInvoice(ENCOUNTER_TYPES.EMERGENCY);
+    const { body: prescription } = await app
+      .post(`/api/medication/encounterPrescription/${encounter.id}`)
+      .send({
+        medicationId: drugWithConversion.id,
+        prescriberId: user.id,
+        doseAmount: 1,
+        units: 'mg',
+        frequency: ADMINISTRATION_FREQUENCIES.IMMEDIATELY,
+        route: 'dermal',
+        date: '2025-01-01',
+        startDate: getCurrentDateTimeString(),
+      });
+    // Doses administered during the ED phase (before admission) totalling 12mg — should stay
+    // billed, but converted to dispensing units: Math.ceil(12 / 5) = 3 tablets.
+    await app.post('/api/medication/medication-administration-record/given').send({
+      prescriptionId: prescription.id,
+      dose: { doseAmount: 6, givenTime: toDateTimeString(sub(new Date(), { days: 22 })) },
+      dueAt: toDateTimeString(sub(new Date(), { days: 22 })),
+    });
+    await app.post('/api/medication/medication-administration-record/given').send({
+      prescriptionId: prescription.id,
+      dose: { doseAmount: 6, givenTime: toDateTimeString(sub(new Date(), { days: 20 })) },
+      dueAt: toDateTimeString(sub(new Date(), { days: 20 })),
+    });
+    // Admit the encounter in place, effective 15 days ago.
+    await encounter.update({
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      submittedTime: toDateTimeString(sub(new Date(), { days: 15 })),
+    });
+    // Dose administered after admission — should be bundled (excluded).
+    await app.post('/api/medication/medication-administration-record/given').send({
+      prescriptionId: prescription.id,
+      dose: { doseAmount: 8, givenTime: toDateTimeString(sub(new Date(), { days: 10 })) },
+      dueAt: toDateTimeString(sub(new Date(), { days: 10 })),
+    });
+
+    const result = await app.get(`/api/encounter/${encounter.id}/invoice`);
+    expect(result).toHaveSucceeded();
+    const items = result.body.items ?? [];
+    expect(items).toHaveLength(1);
+    // Pre-admission total is 12mg → Math.ceil(12 / 5) = 3 dispensing units, NOT the raw dosing
+    // total of 12; post-admission dose (8mg) bundled into the admission fee.
     expect(items[0].quantity).toBe(3);
   });
 });


### PR DESCRIPTION
### Changes

Fixes a high-severity medication-invoicing overcharge (from the logic-bug audit, #10266).

In `Prescription.recalculateAndApplyInvoiceQuantity`, the normal path converts administered dose totals from dosing units to dispensing units:

```ts
marQty = Math.ceil(totalDosingAmount / unitConversion);
```

But the inpatient-fee-bundled branch (which re-computes the billable quantity as only the pre-admission doses) summed raw `doseAmount` values with **no `unitConversion` division and no ceil**. The result was in dosing units (e.g. mg) while the invoice item quantity is defined in dispensing units (e.g. tablets), and it was then added to `totalSentQty` (dispensing units) and written to the invoice item.

Example: a facility bundling medication into the admission fee; a drug with `unitConversion = 250` (mg/tablet) given as two 250 mg pre-admission doses should bill `ceil(500 / 250) = 2` tablets, but the invoice quantity became `500` — a 250× overcharge.

- `Prescription.ts` — apply the same `Math.ceil(sum / unitConversion)` conversion in the bundled branch as the normal path.

The existing `EncounterInvoice.test.js` only exercises `unitConversion = 1` for the bundled case, which masks this; a bundled case with `unitConversion != 1` has been added.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)