### PR TITLE
fix(web): no-issue: escape regex metacharacters in translation search

### DIFF
--- a/packages/web/__tests__/views/translationSearchRegex.test.js
+++ b/packages/web/__tests__/views/translationSearchRegex.test.js
@@ -14,7 +14,7 @@ const matchesSearch = (stringId, searchValue) => {
 
 describe('translation search regex escaping', () => {
   it('does not throw when the search value contains an unbalanced "("', () => {
-    // Pre-fix: `new RegExp('(?:^|\\.)report(status')` throws a SyntaxError.
+    // Regression test: `new RegExp('(?:^|\\.)report(status')` would throw a SyntaxError
     expect(() => matchesSearch('report.status', 'report(status')).not.toThrow();
     expect(matchesSearch('report.status', 'report(status')).toBe(false);
   });

--- a/packages/web/__tests__/views/translationSearchRegex.test.js
+++ b/packages/web/__tests__/views/translationSearchRegex.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+// Focused regression test for the translation search predicate in
+// packages/web/app/views/administration/translation/TranslationForm.jsx.
+//
+// The predicate is inline (non-exported) inside a useMemo, so this test mirrors
+// the EXACT expression from the fixed source: it escapes every regex
+// metacharacter in the raw search value before building the RegExp, then
+// matches stringIds from the start or after a "." delimiter.
+//
+// Pre-fix the code did `searchValue.replace('.', '\\.')`, which:
+//   - only escaped the first ".", and no other metacharacters, so a stray "("
+//     or "[" threw "Invalid regular expression" during render; and
+//   - left additional dots unescaped, so "." acted as a wildcard.
+const matchesSearch = (stringId, searchValue) => {
+  const escapedSearch = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return Boolean(stringId.match(new RegExp(`(?:^|\\.)${escapedSearch}`, 'i')));
+};
+
+describe('translation search regex escaping', () => {
+  it('does not throw when the search value contains an unbalanced "("', () => {
+    // Pre-fix: `new RegExp('(?:^|\\.)report(status')` throws a SyntaxError.
+    expect(() => matchesSearch('report.status', 'report(status')).not.toThrow();
+    expect(matchesSearch('report.status', 'report(status')).toBe(false);
+  });
+
+  it('does not throw for other unescaped metacharacters like "[" and "*"', () => {
+    expect(() => matchesSearch('general.action.save', 'save[')).not.toThrow();
+    expect(() => matchesSearch('general.action.save', 'save*')).not.toThrow();
+  });
+
+  it('treats "." as a literal delimiter, not a wildcard', () => {
+    // "action.save" should match the literal segment "action.save"...
+    expect(matchesSearch('general.action.save', 'action.save')).toBe(true);
+    // ...but must NOT match when the "." stands in for an arbitrary character
+    // (pre-fix the unescaped "." would wildcard-match "actionXsave").
+    expect(matchesSearch('general.actionXsave.thing', 'action.save')).toBe(false);
+  });
+
+  it('still matches from the start of the stringId or after a "." delimiter', () => {
+    expect(matchesSearch('general.action.save', 'general')).toBe(true);
+    expect(matchesSearch('general.action.save', 'action')).toBe(true);
+    // "ction" is mid-segment, so it should not match.
+    expect(matchesSearch('general.action.save', 'ction')).toBe(false);
+  });
+});

--- a/packages/web/__tests__/views/translationSearchRegex.test.js
+++ b/packages/web/__tests__/views/translationSearchRegex.test.js
@@ -7,11 +7,6 @@ import { describe, expect, it } from 'vitest';
 // the EXACT expression from the fixed source: it escapes every regex
 // metacharacter in the raw search value before building the RegExp, then
 // matches stringIds from the start or after a "." delimiter.
-//
-// Pre-fix the code did `searchValue.replace('.', '\\.')`, which:
-//   - only escaped the first ".", and no other metacharacters, so a stray "("
-//     or "[" threw "Invalid regular expression" during render; and
-//   - left additional dots unescaped, so "." acted as a wildcard.
 const matchesSearch = (stringId, searchValue) => {
   const escapedSearch = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return Boolean(stringId.match(new RegExp(`(?:^|\\.)${escapedSearch}`, 'i')));

--- a/packages/web/app/views/administration/translation/TranslationForm.jsx
+++ b/packages/web/app/views/administration/translation/TranslationForm.jsx
@@ -265,9 +265,12 @@ export const FormContents = ({ data, languageNames, isSubmitting, submitForm, di
       : data.filter(row => !row.stringId.startsWith(REFERENCE_DATA_TRANSLATION_PREFIX));
 
     if (searchValue) {
+      // Escape every regex metacharacter so the user's raw input can't throw a SyntaxError
+      // (e.g. an unbalanced "(" or "[") or act as a wildcard (e.g. stray ".").
+      const escapedSearch = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       return includedTranslations.filter(row =>
         // Search from start of stringId or after a . delimiter
-        row.stringId.match(new RegExp(`(?:^|\\.)${searchValue.replace('.', '\\.')}`, 'i')),
+        row.stringId.match(new RegExp(`(?:^|\\.)${escapedSearch}`, 'i')),
       );
     }
     return includedTranslations;


### PR DESCRIPTION
### Changes

Fixes a high-severity admin-panel crash (from the logic-bug audit, #10266).

The Translation editor's search box built a `RegExp` directly from raw user input, escaping only the first `.` (`String.replace` with a string pattern replaces a single occurrence). Any other metacharacter passed through, so typing an unbalanced `(` or `[` threw a `SyntaxError` inside the `useMemo` during render — which propagated to the app-level ErrorBoundary and replaced the whole Translation view with an error screen, losing unsaved translation edits. Stray extra dots also acted as wildcards, producing false-positive matches.

- `TranslationForm.jsx` — escape all regex metacharacters in the search term before building the pattern (the `(?:^|\.)` segment-boundary anchor and case-insensitivity are preserved).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)