### PR TITLE
fix(web): no-issue: stop imaging request save creating a blank result each time

### DIFF
--- a/packages/web/__tests__/views/imagingResultSubmit.test.js
+++ b/packages/web/__tests__/views/imagingResultSubmit.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+// Focused regression test for the result-submit guard in
+// packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx.
+//
+// The guard is inline (non-exported), so this test mirrors the EXACT predicate
+// from the fixed source. `newResult.completedAt` is pre-seeded with the current
+// time, so it cannot indicate whether the user actually entered a result; the
+// server creates an ImagingResult whenever completedAt is truthy. The fix only
+// attaches newResult when a clinician (completedById) or a description was
+// entered, so re-saving a completed request no longer appends a blank result.
+const hasEnteredResult = newResult => Boolean(newResult?.completedById || newResult?.description);
+
+describe('imaging request newResult submit guard', () => {
+  it('attaches the result when a completed-by clinician is set', () => {
+    expect(hasEnteredResult({ completedById: 'user-123', completedAt: '2026-07-12 09:00:00' })).toBe(
+      true,
+    );
+  });
+
+  it('attaches the result when a description is set', () => {
+    expect(
+      hasEnteredResult({ description: 'Fracture visible', completedAt: '2026-07-12 09:00:00' }),
+    ).toBe(true);
+  });
+
+  it('does NOT attach the result when only completedAt is present', () => {
+    // This is the bug: completedAt is always pre-filled, so a bare save would
+    // otherwise append an empty result row.
+    expect(hasEnteredResult({ completedAt: '2026-07-12 09:00:00' })).toBe(false);
+  });
+
+  it('does NOT attach the result for an empty or missing newResult', () => {
+    expect(hasEnteredResult({})).toBe(false);
+    expect(hasEnteredResult(undefined)).toBe(false);
+    expect(hasEnteredResult({ completedById: '', description: '' })).toBe(false);
+  });
+});

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -271,13 +271,18 @@ const ImagingRequestInfoPane = React.memo(({ imagingRequest, onSubmit }) => {
 
   const isCancelled = imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.CANCELLED;
   const getCanAddResult = values => values.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED;
+  // completedAt is pre-filled with the current time, so it can't tell us whether the user actually
+  // entered a result. Only submit newResult when they've filled in a clinician or a description,
+  // otherwise every save of a completed request would append a blank result row.
+  const hasEnteredResult = newResult =>
+    Boolean(newResult?.completedById || newResult?.description);
 
   return (
     <Form
       // Only submit specific fields for update
       onSubmit={async values => {
         const updatedValues = pick(values, 'status', 'completedById', 'locationGroupId');
-        if (getCanAddResult(values)) {
+        if (getCanAddResult(values) && hasEnteredResult(values.newResult)) {
           updatedValues.newResult = values.newResult;
         }
 


### PR DESCRIPTION
### Changes

Fixes a high-severity imaging bug (from the logic-bug audit, #10266).

`ImagingRequestInfoPane` seeded `initialValues.newResult.completedAt` with the current time unconditionally, and the submit handler attached `newResult` whenever `values.status === COMPLETED`. The facility server creates an `ImagingResult` whenever `newResult?.completedAt` is truthy, so every save of a completed request — even just changing the Facility area, or clicking Save with no changes — appended a second, empty result row (blank completed-by and description, a misleading page-load completion time). Each further save added another.

- `ImagingRequestView.jsx` — only submit `newResult` when the user has actually entered a completed-by clinician or a description (`completedAt` is pre-filled, so it can't signal intent).

Unit test added.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DgeouPJ3UR44Bokc7a1Cn)_