### PR TITLE
fix(mobile): no-issue: skip incomplete conditions when saving program registration

### DIFF
--- a/packages/mobile/App/ui/helpers/programRegistration.spec.ts
+++ b/packages/mobile/App/ui/helpers/programRegistration.spec.ts
@@ -1,0 +1,27 @@
+import { getCompleteRegistrationConditions } from './programRegistration';
+
+describe('getCompleteRegistrationConditions', () => {
+  const complete = { condition: { value: 'condition-a' }, category: { value: 'category-a' } };
+
+  it('keeps rows that have both a condition and a category', () => {
+    expect(getCompleteRegistrationConditions([complete])).toEqual([complete]);
+  });
+
+  it('drops the blank placeholder row left by "Add additional"', () => {
+    // Regression guard: an incomplete row must not be saved, otherwise the submit
+    // loop throws after the registration is saved and re-submitting duplicates it.
+    const incomplete: any[] = [
+      undefined,
+      { condition: { value: 'condition-a' } }, // no category
+      { category: { value: 'category-a' } }, // no condition
+      { condition: { value: '' }, category: { value: 'category-a' } }, // empty condition value
+    ];
+    expect(getCompleteRegistrationConditions([complete, ...incomplete])).toEqual([complete]);
+  });
+
+  it('handles missing/empty condition lists', () => {
+    expect(getCompleteRegistrationConditions(undefined)).toEqual([]);
+    expect(getCompleteRegistrationConditions(null)).toEqual([]);
+    expect(getCompleteRegistrationConditions([])).toEqual([]);
+  });
+});

--- a/packages/mobile/App/ui/helpers/programRegistration.ts
+++ b/packages/mobile/App/ui/helpers/programRegistration.ts
@@ -1,0 +1,17 @@
+interface RegistrationConditionEntry {
+  condition?: { value?: string } | null;
+  category?: { value?: string } | null;
+}
+
+/**
+ * Keep only condition rows that have both a condition and a category selected.
+ *
+ * The "Add additional" button inserts a blank placeholder row that stays empty if
+ * the user backs out of the condition/category picker, and yup's array().of() does
+ * not reject it. Saving those incomplete rows throws on condition.condition.value
+ * after the registration has already been saved, which blocks navigation and, on
+ * re-submit, duplicates the conditions saved before the crash.
+ */
+export const getCompleteRegistrationConditions = <T extends RegistrationConditionEntry>(
+  conditions?: T[] | null,
+): T[] => (conditions ?? []).filter(entry => Boolean(entry?.condition?.value && entry?.category?.value));

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
@@ -17,6 +17,7 @@ import { Form } from '~/ui/components/Forms/Form';
 import { useAuth } from '~/ui/contexts/AuthContext';
 import { IPatientProgramRegistryForm } from '../../../stacks/PatientProgramRegistryForm';
 import { getCurrentDateTimeString } from '~/ui/helpers/date';
+import { getCompleteRegistrationConditions } from '~/ui/helpers/programRegistration';
 import { VisibilityStatus } from '~/visibilityStatuses';
 import { PatientProgramRegistration } from '~/models/PatientProgramRegistration';
 import { useBackendEffect } from '~/ui/hooks/index';
@@ -89,21 +90,17 @@ export const PatientProgramRegistrationDetailsForm = ({ navigation, route }: Bas
       },
     );
 
-    if (formData.conditions) {
-      for (const condition of formData.conditions) {
-        // The "Add additional" button inserts a blank placeholder that stays empty if the user
-        // backs out of the condition/category picker. Skip incomplete rows: without this guard the
-        // loop throws on condition.condition.value after the registration has already been saved,
-        // which blocks navigation and, on re-submit, duplicates the conditions saved so far.
-        if (!condition?.condition?.value || !condition?.category?.value) continue;
-        await PatientProgramRegistrationCondition.createAndSaveOne({
-          date: formData.date,
-          programRegistryCondition: condition.condition.value,
-          programRegistryConditionCategory: condition.category.value,
-          clinician: formData.clinicianId,
-          patientProgramRegistration: newPpr.id,
-        });
-      }
+    // Only save rows with both a condition and a category: the "Add additional" button
+    // can leave an incomplete placeholder that would otherwise throw mid-loop (after the
+    // registration is saved), blocking navigation and duplicating conditions on re-submit.
+    for (const condition of getCompleteRegistrationConditions(formData.conditions)) {
+      await PatientProgramRegistrationCondition.createAndSaveOne({
+        date: formData.date,
+        programRegistryCondition: condition.condition.value,
+        programRegistryConditionCategory: condition.category.value,
+        clinician: formData.clinicianId,
+        patientProgramRegistration: newPpr.id,
+      });
     }
 
     navigation.dispatch(

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
@@ -91,6 +91,11 @@ export const PatientProgramRegistrationDetailsForm = ({ navigation, route }: Bas
 
     if (formData.conditions) {
       for (const condition of formData.conditions) {
+        // The "Add additional" button inserts a blank placeholder that stays empty if the user
+        // backs out of the condition/category picker. Skip incomplete rows: without this guard the
+        // loop throws on condition.condition.value after the registration has already been saved,
+        // which blocks navigation and, on re-submit, duplicates the conditions saved so far.
+        if (!condition?.condition?.value || !condition?.category?.value) continue;
         await PatientProgramRegistrationCondition.createAndSaveOne({
           date: formData.date,
           programRegistryCondition: condition.condition.value,


### PR DESCRIPTION
### Changes

Fixes a high-severity mobile program-registration bug (from the logic-bug audit, #10266).

The "+ Add additional" button in the conditions field inserts an `undefined` placeholder (`addItem(undefined)`), meant to be replaced by the auto-opened condition/category pickers. If the user backs out of the condition picker (its Back button just calls `navigation.goBack()` with no cleanup), the `undefined` entry stays, and yup's `array().of(object(...))` does not reject it. The submit handler saved the registration first (`upsertRegistration`) and then threw on `condition.condition.value`, so navigation never happened — and re-tapping Confirm re-ran the loop and re-created the conditions saved before the crash, producing **duplicate** `PatientProgramRegistrationCondition` records.

- `PatientProgramRegistrationDetailsForm.tsx` — skip condition rows that don't have both a condition and a category, so an incomplete/blank row no longer crashes the loop.

**Testing note (please test carefully):**
- Adding one complete condition still saves.
- Tapping "Add additional" then backing out of the picker and confirming now saves the complete conditions and navigates without a duplicate.
- Editing an existing registration behaves.

A deeper follow-up would stop inserting the `undefined` placeholder and avoid the direct `values.conditions = …` Formik mutation, but this guard fixes the crash and duplicate.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)