### PR TITLE
fix(mobile): no-issue: compute current-encounter day boundary in local time

### DIFF
--- a/packages/mobile/App/models/Encounter.spec.ts
+++ b/packages/mobile/App/models/Encounter.spec.ts
@@ -1,3 +1,5 @@
+import { formatISO9075, subDays } from 'date-fns';
+
 import { Database } from '~/infra/db';
 import { fakeEncounter, fakePatient, fakeUser } from '/root/tests/helpers/fake';
 
@@ -22,6 +24,31 @@ describe('Encounter', () => {
       const result = await Database.models.Encounter.getForPatient(patient.id);
       delete encounter.examiner; // examiner is not eager-loaded from db
       expect(result[0]).toMatchObject(encounter);
+    });
+  });
+
+  describe('getCurrentEncounterForPatient', () => {
+    it('returns an encounter started today and ignores one from a previous day', async () => {
+      const patient = fakePatient();
+      await Database.models.Patient.insert(patient);
+
+      const user = fakeUser();
+      await Database.models.User.insert(user);
+
+      const oldEncounter = fakeEncounter();
+      oldEncounter.startDate = formatISO9075(subDays(new Date(), 5));
+      oldEncounter.patient = patient;
+      oldEncounter.examiner = user;
+      await Database.models.Encounter.insert(oldEncounter);
+
+      const todayEncounter = fakeEncounter();
+      todayEncounter.startDate = formatISO9075(new Date());
+      todayEncounter.patient = patient;
+      todayEncounter.examiner = user;
+      await Database.models.Encounter.insert(todayEncounter);
+
+      const result = await Database.models.Encounter.getCurrentEncounterForPatient(patient.id);
+      expect(result?.id).toBe(todayEncounter.id);
     });
   });
 });

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -136,12 +136,10 @@ export class Encounter extends BaseModel implements IEncounter {
     // The 3 hour offset is a completely arbitrary time we decided would be safe to
     // close the previous days encounters at, rather than midnight.
     const now = new Date();
-    let dayStart = addHours(startOfDay(now), TIME_OFFSET);
+    const cutover = addHours(startOfDay(now), TIME_OFFSET);
     // Before the 3am cutover we are still within the previous day's clinical window, so the
     // boundary is yesterday's cutover — otherwise it would sit in the future and match nothing.
-    if (now < dayStart) {
-      dayStart = subDays(dayStart, 1);
-    }
+    const dayStart = now < cutover ? subDays(cutover, 1) : cutover;
 
     return repo
       .createQueryBuilder('encounter')

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -30,7 +30,7 @@ import { EncounterHistory } from './EncounterHistory';
 import { readConfig } from '~/services/config';
 import { ReferenceData, ReferenceDataRelation } from '~/models/ReferenceData';
 import { SYNC_DIRECTIONS } from './types';
-import { getCurrentDateTimeString } from '~/ui/helpers/date';
+import { getCurrentDateTimeString, toDateTimeString } from '~/ui/helpers/date';
 import { DateTimeStringColumn } from './DateColumns';
 import { Note } from './Note';
 import { EncounterPrescription } from './EncounterPrescription';
@@ -135,13 +135,21 @@ export class Encounter extends BaseModel implements IEncounter {
 
     // The 3 hour offset is a completely arbitrary time we decided would be safe to
     // close the previous days encounters at, rather than midnight.
-    const date = addHours(startOfDay(new Date()), TIME_OFFSET);
+    const now = new Date();
+    let dayStart = addHours(startOfDay(now), TIME_OFFSET);
+    // Before the 3am cutover we are still within the previous day's clinical window, so the
+    // boundary is yesterday's cutover — otherwise it would sit in the future and match nothing.
+    if (now < dayStart) {
+      dayStart = subDays(dayStart, 1);
+    }
 
     return repo
       .createQueryBuilder('encounter')
       .where('patientId = :patientId', { patientId })
-      .andWhere("startDate >= datetime(:date, 'unixepoch')", {
-        date: formatDateForQuery(date),
+      // startDate is stored as a local ISO 9075 string, so compare against a local ISO 9075
+      // boundary directly. datetime(:epoch, 'unixepoch') renders UTC and would be offset.
+      .andWhere('startDate >= :date', {
+        date: toDateTimeString(dayStart),
       })
       .orderBy('startDate', 'DESC')
       .addOrderBy('createdAt', 'DESC')


### PR DESCRIPTION
### Changes

Fixes a high-severity mobile encounter-grouping bug (from the logic-bug audit, #10266).

`getCurrentEncounterForPatient` built the clinical-day boundary as `addHours(startOfDay(now), 3)` and compared with `startDate >= datetime(:epoch, 'unixepoch')`. SQLite renders `unixepoch` as **UTC**, but `startDate` is stored as a **local** ISO 9075 string, so the boundary was offset by the device's UTC offset:

- At UTC+12 (e.g. Fiji), the effective boundary landed on the previous afternoon, so a survey submitted in the morning attached to *yesterday's* encounter — grouping two clinical days' records together.
- At negative UTC offsets the boundary sat in the future, so `getCurrentEncounterForPatient` returned nothing and **every** survey submission created a new encounter.

The boundary was also today's 3am unconditionally, so the whole 00:00–03:00 window pointed to the future regardless of timezone.

- `Encounter.ts` — compute the current clinical-day start (stepping back a day before the 3am cutover) and compare against it as a local ISO 9075 string (`toDateTimeString`), instead of a UTC-rendered epoch.

Unit tests added.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DgeouPJ3UR44Bokc7a1Cn)_