### PR TITLE
fix(facility): no-issue: enforce sensitive-lab permission for panel requests

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Labs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Labs.test.js
@@ -220,6 +220,54 @@ describe('Labs', () => {
     expect(createdLogs[0].status).toBe(LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED);
   });
 
+  describe('sensitive test type via panel', () => {
+    // `app` uses the practitioner role, which does NOT hold `create SensitiveLabRequest`.
+    const createPanelWithTestType = async ({ isSensitive }) => {
+      const { id: labTestCategoryId } = await models.ReferenceData.create({
+        type: 'labTestCategory',
+        name: `Category ${chance.guid()}`,
+        code: chance.guid(),
+      });
+      const labTestType = await models.LabTestType.create({
+        ...fake(models.LabTestType),
+        labTestCategoryId,
+        isSensitive,
+        availableFacilities: null,
+      });
+      const panel = await models.LabTestPanel.create({
+        name: `Panel ${chance.guid()}`,
+        code: chance.guid(),
+      });
+      await models.LabTestPanelLabTestTypes.create({
+        labTestPanelId: panel.id,
+        labTestTypeId: labTestType.id,
+      });
+      return panel;
+    };
+
+    const postPanelLabRequest = async panel => {
+      const encounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        patientId,
+      });
+      return app
+        .post('/api/labRequest')
+        .send({ panelIds: [panel.id], encounterId: encounter.id });
+    };
+
+    it('forbids a panel containing a sensitive test type without SensitiveLabRequest permission', async () => {
+      const panel = await createPanelWithTestType({ isSensitive: true });
+      const response = await postPanelLabRequest(panel);
+      expect(response).toBeForbidden();
+    });
+
+    it('allows a panel with only non-sensitive test types', async () => {
+      const panel = await createPanelWithTestType({ isSensitive: false });
+      const response = await postPanelLabRequest(panel);
+      expect(response).toHaveSucceeded();
+    });
+  });
+
   it('should record samples for panels', async () => {
     const labTestPanel = await models.LabTestPanel.create({
       name: 'Demo test panel',

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -113,7 +113,22 @@ labRequest.post(
     const hasSensitiveTestType = await models.LabTestType.findOne({
       where: { id: labTestTypeIds, isSensitive: true },
     });
-    if (hasSensitiveTestType) {
+
+    // Panel requests resolve their test types server-side (see createPanelLabRequests), so the
+    // supplied labTestTypeIds don't cover them. Check the panels' tests for sensitivity too,
+    // otherwise a panel containing a sensitive test would bypass the SensitiveLabRequest check.
+    let panelHasSensitiveTestType = false;
+    if (panelIds?.length) {
+      const panels = await models.LabTestPanel.findAll({
+        where: { id: panelIds },
+        include: [{ model: models.LabTestType, as: 'labTestTypes', attributes: ['isSensitive'] }],
+      });
+      panelHasSensitiveTestType = panels.some(panel =>
+        panel.labTestTypes?.some(testType => testType.isSensitive),
+      );
+    }
+
+    if (hasSensitiveTestType || panelHasSensitiveTestType) {
       req.checkPermission('create', 'SensitiveLabRequest');
     }
 


### PR DESCRIPTION
### Changes

Fixes a high-severity permission-bypass (from the logic-bug audit, #10266).

The `POST /labRequest` sensitive-test check queried only the explicitly supplied `labTestTypeIds` (which defaults to `[]`):

```js
const hasSensitiveTestType = await models.LabTestType.findOne({
  where: { id: labTestTypeIds, isSensitive: true },
});
```

Panel requests resolve their actual test types server-side from `panel.labTestTypes` (in `createPanelLabRequests`), so `req.checkPermission('create', 'SensitiveLabRequest')` was skipped entirely for panels. A user without the `create SensitiveLabRequest` permission could post `{ panelIds: [...], labTestTypeIds: [] }` for a panel containing a sensitive test type and create sensitive lab requests — which they then can't even see in the list (they appear as ghost requests). Every other lab route (read/list/write) gates sensitive tests correctly.

- `labs.js` — when `panelIds` are supplied, load the panels' test types and include them in the sensitivity check, using the same `as: 'labTestTypes'` include shape `createPanelLabRequests` uses.

Unit tests added.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DgeouPJ3UR44Bokc7a1Cn)_