### PR TITLE
fix(web): no-issue: clear dependent report parameter when its category changes

### DIFF
--- a/packages/web/__tests__/views/reports/reportDependentParam.test.jsx
+++ b/packages/web/__tests__/views/reports/reportDependentParam.test.jsx
@@ -1,0 +1,119 @@
+/*
+ * Regression tests for the report generator's dependent parameter fields
+ * (LabTestTypeField, VaccineField).
+ *
+ * These fields depend on a paired "category" parameter. When the category
+ * changes, the previously selected value must be cleared from Formik state so a
+ * report is never generated with a value from one category and a different
+ * category. The clearing must NOT wipe a value that was restored on mount (e.g.
+ * from saved report parameters); that is guarded with a ref that remembers the
+ * initial category.
+ */
+
+import * as React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { Formik } from 'formik';
+import { describe, it, expect, vi } from 'vitest';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+
+// Both fields fetch their options through `useApi`. Stub it so the fields can
+// render without a real backend; the clearing behaviour under test does not
+// depend on the fetched options. Other `app/api` exports are preserved.
+vi.mock('../../../app/api', async () => {
+  const actual = await vi.importActual('../../../app/api');
+  return {
+    ...actual,
+    useApi: () => ({
+      get: vi.fn(async url => {
+        if (typeof url === 'string' && url.startsWith('labTestType')) {
+          return { data: [] };
+        }
+        return [];
+      }),
+    }),
+  };
+});
+
+// eslint-disable-next-line import/first
+import { LabTestTypeField } from '../../../app/views/reports/LabTestTypeField';
+// eslint-disable-next-line import/first
+import { VaccineField } from '../../../app/views/reports/VaccineField';
+
+const renderInFormik = (element, initialValues) =>
+  renderElementWithTranslatedText(
+    <Formik initialValues={initialValues} onSubmit={() => {}}>
+      {({ values }) => (
+        <>
+          {element}
+          <div data-testid="formik-values">{JSON.stringify(values)}</div>
+        </>
+      )}
+    </Formik>,
+  );
+
+const readValues = () => JSON.parse(screen.getByTestId('formik-values').textContent);
+
+describe('LabTestTypeField dependent parameter clearing', () => {
+  it('does not clear a preset value on initial mount', async () => {
+    renderInFormik(<LabTestTypeField parameterValues={{ labTestCategoryId: 'category-1' }} />, {
+      labTestTypeIds: ['test-a', 'test-b'],
+    });
+
+    // Give any mount effects a chance to run before asserting the value survived.
+    await waitFor(() => expect(readValues().labTestTypeIds).toEqual(['test-a', 'test-b']));
+  });
+
+  it('clears the selection when the category changes', async () => {
+    const { rerender } = renderInFormik(
+      <LabTestTypeField parameterValues={{ labTestCategoryId: 'category-1' }} />,
+      { labTestTypeIds: ['test-a', 'test-b'] },
+    );
+
+    expect(readValues().labTestTypeIds).toEqual(['test-a', 'test-b']);
+
+    rerender(
+      <Formik initialValues={{ labTestTypeIds: ['test-a', 'test-b'] }} onSubmit={() => {}}>
+        {({ values }) => (
+          <>
+            <LabTestTypeField parameterValues={{ labTestCategoryId: 'category-2' }} />
+            <div data-testid="formik-values">{JSON.stringify(values)}</div>
+          </>
+        )}
+      </Formik>,
+    );
+
+    await waitFor(() => expect(readValues().labTestTypeIds).toEqual([]));
+  });
+});
+
+describe('VaccineField dependent parameter clearing', () => {
+  it('does not clear a preset value on initial mount', async () => {
+    renderInFormik(<VaccineField parameterValues={{ category: 'category-1' }} />, {
+      vaccine: 'vaccine-a',
+    });
+
+    await waitFor(() => expect(readValues().vaccine).toBe('vaccine-a'));
+  });
+
+  it('clears the selection when the category changes', async () => {
+    const { rerender } = renderInFormik(<VaccineField parameterValues={{ category: 'category-1' }} />, {
+      vaccine: 'vaccine-a',
+    });
+
+    expect(readValues().vaccine).toBe('vaccine-a');
+
+    rerender(
+      <Formik initialValues={{ vaccine: 'vaccine-a' }} onSubmit={() => {}}>
+        {({ values }) => (
+          <>
+            <VaccineField parameterValues={{ category: 'category-2' }} />
+            <div data-testid="formik-values">{JSON.stringify(values)}</div>
+          </>
+        )}
+      </Formik>,
+    );
+
+    await waitFor(() => expect(readValues().vaccine).toBeUndefined());
+  });
+});

--- a/packages/web/__tests__/views/reports/reportDependentParam.test.jsx
+++ b/packages/web/__tests__/views/reports/reportDependentParam.test.jsx
@@ -40,7 +40,7 @@ import { VaccineField } from '../../../app/views/reports/VaccineField';
 
 const renderInFormik = (element, initialValues) =>
   renderElementWithTranslatedText(
-    <Formik initialValues={initialValues} onSubmit={() => {}}>
+    <Formik initialValues={initialValues} initialStatus={{}} onSubmit={() => {}}>
       {({ values }) => (
         <>
           {element}
@@ -71,7 +71,11 @@ describe('LabTestTypeField dependent parameter clearing', () => {
     expect(readValues().labTestTypeIds).toEqual(['test-a', 'test-b']);
 
     rerender(
-      <Formik initialValues={{ labTestTypeIds: ['test-a', 'test-b'] }} onSubmit={() => {}}>
+      <Formik
+        initialValues={{ labTestTypeIds: ['test-a', 'test-b'] }}
+        initialStatus={{}}
+        onSubmit={() => {}}
+      >
         {({ values }) => (
           <>
             <LabTestTypeField parameterValues={{ labTestCategoryId: 'category-2' }} />

--- a/packages/web/__tests__/views/reports/reportDependentParam.test.jsx
+++ b/packages/web/__tests__/views/reports/reportDependentParam.test.jsx
@@ -35,9 +35,7 @@ vi.mock('../../../app/api', async () => {
   };
 });
 
-// eslint-disable-next-line import/first
 import { LabTestTypeField } from '../../../app/views/reports/LabTestTypeField';
-// eslint-disable-next-line import/first
 import { VaccineField } from '../../../app/views/reports/VaccineField';
 
 const renderInFormik = (element, initialValues) =>

--- a/packages/web/app/views/reports/LabTestTypeField.jsx
+++ b/packages/web/app/views/reports/LabTestTypeField.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { useFormikContext } from 'formik';
 import { useQuery } from '@tanstack/react-query';
 import { getReferenceDataStringId } from '@tamanu/shared/utils/translation';
 import { useApi } from '../../api';
@@ -22,6 +23,18 @@ export const LabTestTypeField = ({ name = 'labTestTypeIds', label, required, par
   const { labTestCategoryId: category } = parameterValues;
   const { data } = useLabTestTypes(category);
   const { getTranslation } = useTranslation();
+  const { setFieldValue } = useFormikContext();
+  const previousCategory = useRef(category);
+
+  useEffect(() => {
+    if (previousCategory.current !== category) {
+      previousCategory.current = category;
+      // Clear the previous selection when the category changes: the control only recomputes its
+      // displayed chips, so without this the old category's test-type ids stay in form state and
+      // are submitted with the new category.
+      setFieldValue(name, []);
+    }
+  }, [category, name, setFieldValue]);
 
   if (!category) {
     return null;

--- a/packages/web/app/views/reports/VaccineField.jsx
+++ b/packages/web/app/views/reports/VaccineField.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useFormikContext } from 'formik';
 import { uniqBy } from 'es-toolkit/compat';
 import {
   SelectField,
@@ -12,9 +13,21 @@ import { Field } from '../../components';
 export const VaccineField = ({ name = 'vaccine', required, label, parameterValues }) => {
   const api = useApi();
   const { category } = parameterValues;
+  const { setFieldValue } = useFormikContext();
+  const previousCategory = useRef(category);
   const [vaccines, setVaccines] = useState([]);
   const [error, setError] = useState(null);
   const [isErrorDialogVisible, setIsErrorDialogVisible] = useState(false);
+
+  useEffect(() => {
+    if (previousCategory.current !== category) {
+      previousCategory.current = category;
+      // Clear the previous selection when the category changes: the select only blanks its
+      // displayed label, so without this the old category's vaccine stays in form state and is
+      // submitted with the new category.
+      setFieldValue(name, undefined);
+    }
+  }, [category, name, setFieldValue]);
 
   useEffect(() => {
     if (!category) {


### PR DESCRIPTION
### Changes

Fixes a high-severity report-parameter bug (from the logic-bug audit, #10266).

The report generator's `LabTestTypeField` (paired with `labTestCategoryId`) and `VaccineField` (paired with `category`) never cleared their selection when the parent category parameter changed. `MultiselectField` / `SelectField` only recompute their displayed options/label from the new category, so the previous category's selected test-type ids / vaccine stayed in Formik state and were submitted alongside the new category — generating a report with contradictory (and often empty) parameters, with the field appearing blank.

- `LabTestTypeField.jsx` / `VaccineField.jsx` — clear the dependent field's value when the category changes, using a ref to the previous category so a restored initial value isn't wiped on mount.

Unit test added.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DgeouPJ3UR44Bokc7a1Cn)_