### PR TITLE
fix(web): no-issue: clear sample fields when lab collection time is cleared

### DIFF
--- a/packages/web/__tests__/views/labRequest/SampleDetailsField.test.jsx
+++ b/packages/web/__tests__/views/labRequest/SampleDetailsField.test.jsx
@@ -54,7 +54,6 @@ vi.mock('../../../app/contexts/Settings', async () => {
   };
 });
 
-// eslint-disable-next-line import/first
 import {
   SampleDetailsField,
   SAMPLE_DETAILS_FIELD_PREFIX,

--- a/packages/web/__tests__/views/labRequest/SampleDetailsField.test.jsx
+++ b/packages/web/__tests__/views/labRequest/SampleDetailsField.test.jsx
@@ -81,6 +81,7 @@ const renderSampleDetails = () =>
         [SPECIMEN_TYPE_FIELD]: 'specimen-type-1',
         [SITE_FIELD]: 'site-1',
       }}
+      initialStatus={{}}
       onSubmit={() => {}}
     >
       {({ values }) => (

--- a/packages/web/__tests__/views/labRequest/SampleDetailsField.test.jsx
+++ b/packages/web/__tests__/views/labRequest/SampleDetailsField.test.jsx
@@ -1,0 +1,121 @@
+/*
+ * Regression test for SampleDetailsField.
+ *
+ * Clearing the "Date & time collected" field abandons the whole sample entry
+ * (removeSample deletes it from the submitted sampleDetails). The sibling Formik
+ * fields (collectedBy, specimenType, site) must also be reset to undefined so
+ * their stale values aren't validated (e.g. mandatory specimen type) and aren't
+ * submitted while the sample no longer exists.
+ */
+
+import * as React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { Formik } from 'formik';
+import { describe, it, expect, vi } from 'vitest';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+
+// The real "Date & time collected" input is a heavy MUI date picker. Replace it
+// (and the sibling autocompletes) with light stubs so we can drive the clear
+// handler directly; the reset logic under test lives in SampleDetailsField, not
+// in these field widgets.
+vi.mock('../../../app/components/Field', async () => {
+  const actual = await vi.importActual('../../../app/components/Field');
+  return {
+    ...actual,
+    DateTimeField: props => (
+      <button
+        type="button"
+        data-testid="clear-collection-time"
+        onClick={() => props.onChange({ target: { value: '', name: props.field?.name } })}
+      />
+    ),
+    AutocompleteField: props => <div data-testid={`autocomplete-${props.field?.name}`} />,
+  };
+});
+
+// SampleDetailsField reads getCurrentDateTime from useDateTime; provide a stub so
+// it does not need a full DateTime provider.
+vi.mock('@tamanu/ui-components', async () => {
+  const actual = await vi.importActual('@tamanu/ui-components');
+  return {
+    ...actual,
+    useDateTime: () => ({ getCurrentDateTime: () => '2023-06-12 10:00' }),
+  };
+});
+
+// getSetting resolves the mandatory-specimen-type feature flag.
+vi.mock('../../../app/contexts/Settings', async () => {
+  const actual = await vi.importActual('../../../app/contexts/Settings');
+  return {
+    ...actual,
+    useSettings: () => ({ getSetting: () => true }),
+  };
+});
+
+// eslint-disable-next-line import/first
+import {
+  SampleDetailsField,
+  SAMPLE_DETAILS_FIELD_PREFIX,
+} from '../../../app/views/labRequest/SampleDetailsField';
+
+const IDENTIFIER = 'category-1';
+const COLLECTED_BY_FIELD = `${SAMPLE_DETAILS_FIELD_PREFIX}collectedBy-${IDENTIFIER}`;
+const SPECIMEN_TYPE_FIELD = `${SAMPLE_DETAILS_FIELD_PREFIX}specimenType-${IDENTIFIER}`;
+const SITE_FIELD = `${SAMPLE_DETAILS_FIELD_PREFIX}labSampleSiteSuggester-${IDENTIFIER}`;
+const SAMPLE_TIME_FIELD = `${SAMPLE_DETAILS_FIELD_PREFIX}sampleTime-${IDENTIFIER}`;
+
+const noopSuggester = {
+  fetchSuggestions: async () => [],
+  fetchCurrentOption: async () => undefined,
+};
+
+const readValues = () => JSON.parse(screen.getByTestId('formik-values').textContent);
+
+const renderSampleDetails = () =>
+  renderElementWithTranslatedText(
+    <Formik
+      initialValues={{
+        [SAMPLE_TIME_FIELD]: '2023-06-12 09:00',
+        [COLLECTED_BY_FIELD]: 'practitioner-1',
+        [SPECIMEN_TYPE_FIELD]: 'specimen-type-1',
+        [SITE_FIELD]: 'site-1',
+      }}
+      onSubmit={() => {}}
+    >
+      {({ values }) => (
+        <>
+          <SampleDetailsField
+            initialSamples={[{ categoryId: IDENTIFIER, categoryName: 'Category One' }]}
+            practitionerSuggester={noopSuggester}
+            specimenTypeSuggester={noopSuggester}
+            labSampleSiteSuggester={noopSuggester}
+            onSampleChange={() => {}}
+          />
+          <div data-testid="formik-values">{JSON.stringify(values)}</div>
+        </>
+      )}
+    </Formik>,
+  );
+
+describe('SampleDetailsField', () => {
+  it('resets collectedBy, specimenType and site when the collection time is cleared', async () => {
+    const user = userEvent.setup();
+    renderSampleDetails();
+
+    // Sanity check: the sample fields start populated.
+    expect(readValues()[COLLECTED_BY_FIELD]).toBe('practitioner-1');
+    expect(readValues()[SPECIMEN_TYPE_FIELD]).toBe('specimen-type-1');
+    expect(readValues()[SITE_FIELD]).toBe('site-1');
+
+    await user.click(screen.getByTestId('clear-collection-time'));
+
+    await waitFor(() => {
+      const values = readValues();
+      expect(values[COLLECTED_BY_FIELD]).toBeUndefined();
+      expect(values[SPECIMEN_TYPE_FIELD]).toBeUndefined();
+      expect(values[SITE_FIELD]).toBeUndefined();
+    });
+  });
+});

--- a/packages/web/app/views/labRequest/SampleDetailsField.jsx
+++ b/packages/web/app/views/labRequest/SampleDetailsField.jsx
@@ -1,6 +1,7 @@
 import { Colors } from '../../constants/styles';
 import { Typography } from '@material-ui/core';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useFormikContext } from 'formik';
 import styled from 'styled-components';
 import { Heading4 } from '../../components';
 import { useDateTime } from '@tamanu/ui-components';
@@ -72,6 +73,7 @@ export const SampleDetailsField = ({
 }) => {
   const { getCurrentDateTime } = useDateTime();
   const { getSetting } = useSettings();
+  const { setFieldValue } = useFormikContext();
   const mandateSpecimenType = getSetting(SETTING_KEYS.FEATURE_MANDATE_SPECIMEN_TYPE);
 
   const HEADERS = [
@@ -195,7 +197,16 @@ export const SampleDetailsField = ({
                 if (value) {
                   setValue(identifier, 'sampleTime', value);
                 } else {
+                  // Clearing the collection time abandons the whole sample. Also reset the sibling
+                  // Formik fields so their stale values aren't validated (e.g. mandatory specimen
+                  // type) or left displayed while the submitted sampleDetails no longer has them.
                   removeSample(identifier);
+                  setFieldValue(`${SAMPLE_DETAILS_FIELD_PREFIX}collectedBy-${identifier}`, undefined);
+                  setFieldValue(`${SAMPLE_DETAILS_FIELD_PREFIX}specimenType-${identifier}`, undefined);
+                  setFieldValue(
+                    `${SAMPLE_DETAILS_FIELD_PREFIX}labSampleSiteSuggester-${identifier}`,
+                    undefined,
+                  );
                 }
               }}
               data-testid="styledfield-ratc"
@@ -250,6 +261,7 @@ export const SampleDetailsField = ({
       samples,
       removeSample,
       setValue,
+      setFieldValue,
       hasPanels,
       getCurrentDateTime,
     ],

--- a/packages/web/app/views/labRequest/SampleDetailsField.jsx
+++ b/packages/web/app/views/labRequest/SampleDetailsField.jsx
@@ -218,7 +218,7 @@ export const SampleDetailsField = ({
               disabled={!isSampleCollected}
               component={AutocompleteField}
               suggester={practitionerSuggester}
-              value={samples[identifier]?.collectedBy}
+              value={samples[identifier]?.collectedBy ?? ''}
               onChange={({ target: { value } }) => {
                 setValue(identifier, 'collectedById', value);
               }}
@@ -231,7 +231,7 @@ export const SampleDetailsField = ({
               disabled={!isSampleCollected}
               component={AutocompleteField}
               suggester={specimenTypeSuggester}
-              value={samples[identifier]?.specimenType}
+              value={samples[identifier]?.specimenType ?? ''}
               onChange={({ target: { value } }) => {
                 setValue(identifier, 'specimenTypeId', value);
               }}
@@ -244,7 +244,7 @@ export const SampleDetailsField = ({
               disabled={!isSampleCollected}
               component={AutocompleteField}
               suggester={labSampleSiteSuggester}
-              value={samples[identifier]?.labSampleSite}
+              value={samples[identifier]?.labSampleSite ?? ''}
               onChange={({ target: { value } }) => {
                 setValue(identifier, 'labSampleSiteId', value);
               }}


### PR DESCRIPTION
### Changes

Fixes a high-severity lab-request validation bypass (from the logic-bug audit, #10266).

Clearing "Date & time collected" in `SampleDetailsField` calls `removeSample(identifier)`, which deletes the whole sample entry (`collectedById`, `specimenTypeId`, `labSampleSiteId`) from the `samples` state that becomes the submitted `sampleDetails`. But the sibling Formik field values (and the autocompletes' displayed text) were **not** reset — they just disabled while still showing the old selections. The `mandateSpecimenType` rule checks the *Formik* specimen-type value (still populated), so it passed, while the created lab request had no specimen type, collector, or site (`specimenAttached=false`).

- `SampleDetailsField.jsx` — when the collection time is cleared, also reset the `collectedBy`, `specimenType`, and `labSampleSite` Formik fields for that sample, so validation and the submitted payload stay consistent.

Unit test added.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DgeouPJ3UR44Bokc7a1Cn)_