### PR TITLE
fix(web): no-issue: control table pagination and ignore stale fetch responses

### DIFF
--- a/packages/web/__tests__/components/Table/DataFetchingTable.stale.test.jsx
+++ b/packages/web/__tests__/components/Table/DataFetchingTable.stale.test.jsx
@@ -53,7 +53,6 @@ vi.mock('../../../app/contexts/Settings', async () => {
   };
 });
 
-// eslint-disable-next-line import/first
 import { DataFetchingTable } from '../../../app/components/Table/DataFetchingTable';
 
 const columns = [{ key: 'name', title: 'Name' }];

--- a/packages/web/__tests__/components/Table/DataFetchingTable.stale.test.jsx
+++ b/packages/web/__tests__/components/Table/DataFetchingTable.stale.test.jsx
@@ -1,0 +1,99 @@
+/*
+ * Regression test for DataFetchingTable's out-of-order response guard.
+ *
+ * Each fetch is tagged with an incrementing id. If a newer fetch has started by
+ * the time an earlier one resolves, the earlier (stale) response must be
+ * discarded so it cannot overwrite the current results. Previously a slow
+ * earlier request (e.g. search "smi") could resolve after a newer one
+ * ("smith") and clobber the correct rows.
+ */
+
+import * as React from 'react';
+import { act, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+
+// Capture a resolver for every api.get call so responses can be resolved out of order.
+// `useApi` must return a STABLE object: `api` is a dependency of the fetch effect, so a fresh
+// object each render would re-trigger the fetch on every state change.
+const { fetchResolvers, stableApi } = vi.hoisted(() => {
+  const resolvers = [];
+  return {
+    fetchResolvers: resolvers,
+    stableApi: { get: () => new Promise(resolve => resolvers.push(resolve)) },
+  };
+});
+vi.mock('../../../app/api', async () => {
+  const actual = await vi.importActual('../../../app/api');
+  return {
+    ...actual,
+    useApi: () => stableApi,
+  };
+});
+
+vi.mock('@tamanu/ui-components', async () => {
+  const actual = await vi.importActual('@tamanu/ui-components');
+  return {
+    ...actual,
+    useDateTime: () => ({
+      getCurrentDateTime: () => '2023-06-12 10:00',
+      getCurrentDate: () => '2023-06-12',
+    }),
+  };
+});
+
+// getSetting is used for the auto-refresh feature flag and per-field hidden flags; leaving
+// everything unset keeps auto-refresh off and all columns visible.
+vi.mock('../../../app/contexts/Settings', async () => {
+  const actual = await vi.importActual('../../../app/contexts/Settings');
+  return {
+    ...actual,
+    useSettings: () => ({ getSetting: () => undefined }),
+  };
+});
+
+// eslint-disable-next-line import/first
+import { DataFetchingTable } from '../../../app/components/Table/DataFetchingTable';
+
+const columns = [{ key: 'name', title: 'Name' }];
+
+const renderTable = fetchOptions =>
+  renderElementWithTranslatedText(
+    <DataFetchingTable endpoint="patient" columns={columns} fetchOptions={fetchOptions} />,
+  );
+
+describe('DataFetchingTable stale response handling', () => {
+  beforeEach(() => {
+    fetchResolvers.length = 0;
+  });
+
+  it('ignores an earlier response that resolves after a newer fetch', async () => {
+    // Mount triggers the first fetch (search "smi").
+    const { rerender } = renderTable({ search: 'smi' });
+
+    // Change the search, triggering a second, newer fetch (search "smith").
+    rerender(
+      <DataFetchingTable endpoint="patient" columns={columns} fetchOptions={{ search: 'smith' }} />,
+    );
+
+    // Two fetches should be in flight.
+    await waitFor(() => expect(fetchResolvers.length).toBe(2));
+    const [resolveStale, resolveNewer] = fetchResolvers;
+
+    // The newer request resolves first with the correct rows.
+    await act(async () => {
+      resolveNewer({ data: [{ id: 'newer', name: 'Smith Result' }], count: 1 });
+    });
+
+    expect(screen.queryByText('Smith Result')).not.toBeNull();
+
+    // The older ("smi") request resolves later; its stale rows must be discarded.
+    await act(async () => {
+      resolveStale({ data: [{ id: 'stale', name: 'Smi Result' }], count: 1 });
+    });
+
+    expect(screen.queryByText('Smi Result')).toBeNull();
+    expect(screen.queryByText('Smith Result')).not.toBeNull();
+  });
+});

--- a/packages/web/__tests__/components/Table/DataFetchingTable.stale.test.jsx
+++ b/packages/web/__tests__/components/Table/DataFetchingTable.stale.test.jsx
@@ -21,7 +21,12 @@ const { fetchResolvers, stableApi } = vi.hoisted(() => {
   const resolvers = [];
   return {
     fetchResolvers: resolvers,
-    stableApi: { get: () => new Promise(resolve => resolvers.push(resolve)) },
+    stableApi: {
+      get: () =>
+        new Promise(resolve => {
+          resolvers.push(resolve);
+        }),
+    },
   };
 });
 vi.mock('../../../app/api', async () => {

--- a/packages/web/__tests__/components/Table/Paginator.test.jsx
+++ b/packages/web/__tests__/components/Table/Paginator.test.jsx
@@ -1,0 +1,76 @@
+/*
+ * Regression test for Paginator.
+ *
+ * The MUI Pagination must be controlled by the `page` prop. Previously it was
+ * rendered without a page prop and tracked the current page in its own internal
+ * state, so when the parent reset the page (filter/sort/rows-per-page change or
+ * refresh) the control kept showing the stale page and its number buttons were
+ * computed around the wrong page.
+ */
+
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+import { Paginator } from '../../../app/components/Table/Paginator';
+
+const renderPaginator = pageIndex =>
+  renderElementWithTranslatedText(
+    <table>
+      <tbody>
+        <tr>
+          <Paginator
+            page={pageIndex}
+            colSpan={1}
+            count={100}
+            rowsPerPage={10}
+            onPageChange={() => {}}
+            onRowsPerPageChange={() => {}}
+            rowsPerPageOptions={[10, 25, 50]}
+          />
+        </tr>
+      </tbody>
+    </table>,
+  );
+
+const selectedPageLabel = () => document.querySelector('.Mui-selected')?.textContent;
+
+describe('Paginator', () => {
+  it('reflects the controlled page prop as the active page', () => {
+    // pageIndex 5 → human page 6, which is far from the uncontrolled default (page 1).
+    renderPaginator(5);
+
+    // The button for page 6 must be rendered and marked as the selected page. Without the
+    // controlled `page` prop the MUI control stays on its internal page 1 and never renders a
+    // page-6 button in its item window.
+    expect(screen.queryByText('6')).not.toBeNull();
+    expect(selectedPageLabel()).toBe('6');
+  });
+
+  it('updates the active page when the page prop changes', () => {
+    const { rerender } = renderPaginator(0);
+    expect(selectedPageLabel()).toBe('1');
+
+    rerender(
+      <table>
+        <tbody>
+          <tr>
+            <Paginator
+              page={4}
+              colSpan={1}
+              count={100}
+              rowsPerPage={10}
+              onPageChange={() => {}}
+              onRowsPerPageChange={() => {}}
+              rowsPerPageOptions={[10, 25, 50]}
+            />
+          </tr>
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.queryByText('5')).not.toBeNull();
+    expect(selectedPageLabel()).toBe('5');
+  });
+});

--- a/packages/web/app/components/Table/DataFetchingTable.jsx
+++ b/packages/web/app/components/Table/DataFetchingTable.jsx
@@ -58,6 +58,9 @@ export const DataFetchingTable = memo(
     const [isNotificationMuted, setIsNotificationMuted] = useState(false);
 
     const tableRef = useRef(null);
+    // Incremented on every fetch so out-of-order responses (e.g. a slow search resolving after a
+    // newer one) can be discarded instead of overwriting the current results.
+    const latestFetchId = useRef(0);
     const api = useApi();
 
     const { getSetting } = useSettings();
@@ -220,6 +223,9 @@ export const DataFetchingTable = memo(
       if (shouldLoadMoreData) setIsLoadingMoreData(true);
       const loadingDelay = !shouldLoadMoreData && loadingIndicatorDelay();
 
+      latestFetchId.current += 1;
+      const thisFetchId = latestFetchId.current;
+
       (async () => {
         try {
           if (!endpoint) {
@@ -230,10 +236,16 @@ export const DataFetchingTable = memo(
 
           if (loadingDelay) clearTimeout(loadingDelay); // Clear the loading indicator timeout if data fetched before 1 second passes (stops flash from short loading time)
 
+          // A newer fetch has started since this one; ignore this stale response so it can't
+          // overwrite the current page/sort/filter results.
+          if (thisFetchId !== latestFetchId.current) return;
+
           const transformedData = transformData(data, count); // Transform the data before updating the table rows
           updateTableWithData(transformedData, count, rest); // Set the data for table rows and update the previous fetch state
         } catch (error) {
           clearTimeout(loadingDelay);
+          // Don't surface an error from a stale request over the current results.
+          if (thisFetchId !== latestFetchId.current) return;
           clearLoadingIndicators();
           // eslint-disable-next-line no-console
           console.error(error);

--- a/packages/web/app/components/Table/Paginator.jsx
+++ b/packages/web/app/components/Table/Paginator.jsx
@@ -170,6 +170,7 @@ export const Paginator = React.memo(
           <StyledPagination
             size="small"
             count={numberOfPages}
+            page={selectedPageNumber}
             variant="outlined"
             onChange={onPageChange}
             renderItem={item => {


### PR DESCRIPTION
### Changes

Fixes two high-severity `DataFetchingTable`/`Paginator` correctness bugs (from the logic-bug audit, #10266). **Risky — shared table component used everywhere; please regression-test broadly.**

**1. Uncontrolled pagination (Paginator).** The MUI `Pagination` was rendered without a `page` prop, so it tracked the current page in its own internal state. But the table treats page as controlled and resets it to 0 on sort/filter/rows-per-page changes and manual refresh. Those resets never reached MUI's internal state, so after a reset the next/previous chevrons computed their target from the stale internal page and jumped to the wrong (often empty) page; the page-number buttons/ellipses were also laid out around the stale page. Fix: pass `page={selectedPageNumber}` (the mapping in `Table.handleChangePage` already converts MUI's 1-indexed page back to the table's 0-indexed page).

**2. No stale-response guard (DataFetchingTable).** The fetch effect re-ran on every `page`/`sorting`/`fetchOptions` change but applied whichever response resolved **last**, with no cancellation or ordering check. Typing "smith" then a slower "smi" could leave the table showing "smi" results — the wrong record set in a clinical list — with no corrective refetch. Fix: tag each fetch with an incrementing id and discard a response (or error) when a newer fetch has started.

- `Paginator.jsx` — `page={selectedPageNumber}`.
- `DataFetchingTable.jsx` — `latestFetchId` ref; ignore stale success/error responses.

**Testing note (please test carefully — this component backs nearly every list):**
- Page to page 4, apply a filter → should show page 1 of results; next/prev should move correctly.
- Change rows-per-page and sort columns → page resets and navigation stays consistent.
- Rapidly change a search term / sort / page and confirm the displayed data always matches the final query.
- Lazy-loading tables and the auto-refresh/notification path still behave.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DgeouPJ3UR44Bokc7a1Cn)_