### PR TITLE
fix(shared): no-issue: de-duplicate programRegistry suggester, allow re-registration

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -7,6 +7,7 @@ import {
   REFERENCE_TYPES,
   INVOICE_ITEMS_CATEGORIES,
   INVOICE_ITEMS_CATEGORIES_MODELS,
+  REGISTRATION_STATUSES,
 } from '@tamanu/constants';
 import {
   buildDiagnosis,
@@ -1300,5 +1301,58 @@ describe('Suggestions', () => {
     expect(body).toBeInstanceOf(Array);
     expect(body.length).toBeGreaterThan(0);
     expect(body[0]).toHaveProperty('id', childSubdivision.id);
+  });
+
+  describe('Program registry suggester', () => {
+    // Unique prefix so the `q` filter only matches the registries seeded here, keeping the
+    // result set deterministic regardless of other registries in the shared test database.
+    const namePrefix = 'ZZSuggesterDedupe';
+
+    const createProgramRegistry = async name => {
+      const program = await models.Program.create(fake(models.Program));
+      return models.ProgramRegistry.create(
+        fake(models.ProgramRegistry, { programId: program.id, name }),
+      );
+    };
+
+    it('should only exclude registries the patient is actively registered in', async () => {
+      // Regression: a patient removed from a registry (inactive) or recorded-in-error should be
+      // suggested again for re-registration. Only currently active registrations are excluded.
+      const patient = await models.Patient.create(fake(models.Patient));
+
+      const activeRegistry = await createProgramRegistry(`${namePrefix} Active`);
+      const inactiveRegistry = await createProgramRegistry(`${namePrefix} Inactive`);
+      const unregisteredRegistry = await createProgramRegistry(`${namePrefix} None`);
+
+      await models.PatientProgramRegistration.create(
+        fake(models.PatientProgramRegistration, {
+          patientId: patient.id,
+          programRegistryId: activeRegistry.id,
+          clinicianId: userApp.user.id,
+          registrationStatus: REGISTRATION_STATUSES.ACTIVE,
+        }),
+      );
+      await models.PatientProgramRegistration.create(
+        fake(models.PatientProgramRegistration, {
+          patientId: patient.id,
+          programRegistryId: inactiveRegistry.id,
+          clinicianId: userApp.user.id,
+          registrationStatus: REGISTRATION_STATUSES.INACTIVE,
+        }),
+      );
+
+      const result = await userApp
+        .get('/api/suggestions/programRegistry')
+        .query({ patientId: patient.id, q: namePrefix });
+      expect(result).toHaveSucceeded();
+
+      const { body } = result;
+      expect(body).toBeInstanceOf(Array);
+      const suggestedIds = body.map(({ id }) => id);
+      expect(suggestedIds).not.toContain(activeRegistry.id);
+      expect(suggestedIds).toEqual(
+        expect.arrayContaining([inactiveRegistry.id, unregisteredRegistry.id]),
+      );
+    });
   });
 });

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -1064,60 +1064,8 @@ createSuggester(
 
     return {
       ...baseWhere,
-      // Only suggest program registries this patient isn't already part of
-      id: {
-        [Op.notIn]: Sequelize.literal(
-          `(
-          SELECT DISTINCT(pr.id)
-          FROM program_registries pr
-          INNER JOIN patient_program_registrations ppr
-          ON ppr.program_registry_id = pr.id
-          WHERE
-            ppr.patient_id = $patient_id
-          AND
-            ppr.registration_status != '${REGISTRATION_STATUSES.RECORDED_IN_ERROR}'
-        )`,
-        ),
-      },
-    };
-  },
-  {
-    extraReplacementsBuilder: query => ({
-      patient_id: query.patientId,
-    }),
-  },
-);
-
-createNameSuggester(
-  'programRegistryClinicalStatus',
-  'ProgramRegistryClinicalStatus',
-  ({ endpoint, modelName, query: { programRegistryId } }) => ({
-    ...DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
-    ...(programRegistryId ? { programRegistryId } : {}),
-  }),
-);
-
-createNameSuggester(
-  'programRegistryCondition',
-  'ProgramRegistryCondition',
-  ({ endpoint, modelName, query: { programRegistryId } }) => ({
-    ...DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
-    ...(programRegistryId ? { programRegistryId } : {}),
-  }),
-);
-
-createNameSuggester(
-  'programRegistry',
-  'ProgramRegistry',
-  ({ endpoint, modelName, query }) => {
-    const baseWhere = DEFAULT_WHERE_BUILDER({ endpoint, modelName });
-    if (!query.patientId) {
-      return baseWhere;
-    }
-
-    return {
-      ...baseWhere,
-      // Only suggest program registries this patient isn't already part of
+      // Only exclude registries the patient is currently actively registered in. A patient who
+      // was removed (inactive) or recorded-in-error can be suggested again for re-registration.
       id: {
         [Op.notIn]: Sequelize.literal(
           `(
@@ -1139,6 +1087,15 @@ createNameSuggester(
       patient_id: query.patientId,
     }),
   },
+);
+
+createNameSuggester(
+  'programRegistryCondition',
+  'ProgramRegistryCondition',
+  ({ endpoint, modelName, query: { programRegistryId } }) => ({
+    ...DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
+    ...(programRegistryId ? { programRegistryId } : {}),
+  }),
 );
 
 createNameSuggester('labTestPanel', 'LabTestPanel', ({ endpoint, modelName, req }) => {


### PR DESCRIPTION
### Changes

Resolves S1 from the logic-bug audit (#10266), per the product decision to **allow re-registering patients who were removed from a registry**.

The `programRegistry` suggester in `suggestions.js` was registered **twice with contradictory filters**. Express serves only the first-registered route, so the second definition was dead code — an intended behaviour change that never took effect. The live version excluded every registry in which the patient had any registration with status `!= recordedInError` (i.e. both `active` **and** removed `inactive` registrations blocked the registry), so a patient previously **removed** from a registry could not be re-registered via the "Add patient to program registry" form.

Adopting the behaviour from the shadowed block:

- Change the live suggester's predicate to exclude only registries the patient is **currently `active`** in, so removed (`inactive`) or `recorded-in-error` patients can be suggested again for re-registration.
- Delete the dead duplicate `programRegistry` registration.
- Drop the duplicated `programRegistryClinicalStatus` registration (it was registered identically twice — harmless but confirms the copy-paste/bad-merge origin).

Kept the live `createSuggester` implementation so all other behaviour (search, mapper) is unchanged; only the filter predicate changed.

No existing test pinned either behaviour (`Suggestions.test.js`, `ProgramRegistry.test.js`); worth adding one asserting that a registry the patient is `active` in is excluded, while one they were removed from is suggested.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)