### PR TITLE
fix(central): no-issue: read lab-test publisher limit from task config

### DIFF
--- a/packages/central-server/__tests__/tasks/automaticLabTestPublisher.test.js
+++ b/packages/central-server/__tests__/tasks/automaticLabTestPublisher.test.js
@@ -8,6 +8,7 @@ import { AutomaticLabTestResultPublisher } from '../../app/tasks/AutomaticLabTes
 const testConfig = {
   enabled: true,
   schedule: '0 0 0 0 0',
+  limit: 300,
   results: {
     'labTestType-RATPositive': {
       labTestMethodId: 'labTestMethod-RAT',
@@ -167,6 +168,27 @@ describe('Lab test publisher', () => {
       'status',
       LAB_REQUEST_STATUSES.RECEPTION_PENDING,
     );
+  });
+
+  it('Should read the limit from the task config', async () => {
+    expect(publisher).toHaveProperty('limit', testConfig.limit);
+  });
+
+  it('Should only publish up to the configured limit', async () => {
+    const limitedPublisher = new AutomaticLabTestResultPublisher(ctx, { ...testConfig, limit: 1 });
+
+    const { labTest: labTestA } = await makeLabRequest('labTestType-RATPositive');
+    const { labTest: labTestB } = await makeLabRequest('labTestType-RATNegative');
+
+    await limitedPublisher.run();
+    expect(limitedPublisher).toHaveProperty('lastRunCount', 1);
+
+    const updatedLabTestA = await models.LabTest.findByPk(labTestA.id);
+    const updatedLabTestB = await models.LabTest.findByPk(labTestB.id);
+    const publishedCount = [updatedLabTestA, updatedLabTestB].filter(
+      labTest => labTest.result !== '',
+    ).length;
+    expect(publishedCount).toBe(1);
   });
 
   it('Should error with an invalid method', async () => {

--- a/packages/central-server/app/tasks/AutomaticLabTestResultPublisher.js
+++ b/packages/central-server/app/tasks/AutomaticLabTestResultPublisher.js
@@ -10,11 +10,11 @@ export class AutomaticLabTestResultPublisher extends ScheduledTask {
   }
 
   constructor(context, overrideConfig = null) {
-    const { schedule, results, jitterTime, enabled } =
+    const { schedule, results, jitterTime, enabled, limit } =
       overrideConfig || config.schedules.automaticLabTestResultPublisher;
     super(schedule, log, jitterTime, enabled);
     this.results = results;
-    this.limit = config.limit;
+    this.limit = limit;
     this.models = context.store.models;
     this.lastRunCount = 0;
   }


### PR DESCRIPTION
### Changes

`AutomaticLabTestResultPublisher` (`packages/central-server/app/tasks/AutomaticLabTestResultPublisher.js`) read `this.limit` from the top-level imported `config` module, which has no `limit` key, instead of the task-specific config object destructured in the constructor. `this.limit` was always `undefined`, so the publish query ran with no cap. Fix: destructure `limit` from the same `schedules.automaticLabTestResultPublisher` config object already used for `results`, `schedule`, `jitterTime`, and `enabled`.

Added a regression test in `__tests__/tasks/automaticLabTestPublisher.test.js` asserting the constructed task has the configured limit, and that with `limit: 1` and two publishable results only one is published per run. Both new tests failed before the fix (`limit` was `undefined`; `lastRunCount` was `2` instead of `1`) and pass after it.

From the logic-bug audit (#10266), finding C3.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_