### PR TITLE
fix(central): no-issue: batch repeating-task generation with where filter and offset

### DIFF
--- a/packages/central-server/__tests__/tasks/GenerateRepeatingTasks.test.js
+++ b/packages/central-server/__tests__/tasks/GenerateRepeatingTasks.test.js
@@ -114,6 +114,31 @@ describe('GenerateRepeatingTasks', () => {
       });
     });
 
+    it('should process every parent even when tasks leave the filter mid-run', async () => {
+      // Create 6 repeating parent tasks (batch size is 2, so 3 batches)
+      const parentTasks = [];
+      for (let i = 0; i < 6; i++) {
+        parentTasks.push(await createTask());
+      }
+
+      // Simulate an incoming sync setting endTime on already-processed parents
+      // between pages — with keyset pagination no unprocessed parent is skipped
+      models.Task.generateRepeatingTasks.mockImplementation(async tasks => {
+        await models.Task.update(
+          { endTime: toDateTimeString(new Date()) },
+          { where: { id: tasks.map(({ id }) => id) } },
+        );
+      });
+
+      await task.run();
+
+      const processedTaskIds = getProcessedTaskIds();
+      expect(processedTaskIds).toHaveLength(6);
+      parentTasks.forEach(parentTask => {
+        expect(processedTaskIds).toContain(parentTask.id);
+      });
+    });
+
     it('should only count repeating parent tasks when batching', async () => {
       // 2 repeating parent tasks fit in a single batch of 2
       const repeatingTasks = [await createTask(), await createTask()];

--- a/packages/central-server/__tests__/tasks/GenerateRepeatingTasks.test.js
+++ b/packages/central-server/__tests__/tasks/GenerateRepeatingTasks.test.js
@@ -1,0 +1,133 @@
+import { fake, fakeUser } from '@tamanu/fake-data/fake';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
+import { addDays } from 'date-fns';
+import { TASK_STATUSES } from '@tamanu/constants';
+
+import { createTestContext } from '../utilities';
+import { GenerateRepeatingTasks } from '../../app/tasks/GenerateRepeatingTasks';
+
+// Mock config for the task
+jest.mock('config', () => ({
+  ...jest.requireActual('config'),
+  schedules: {
+    ...jest.requireActual('config').schedules,
+    generateRepeatingTasks: {
+      schedule: '0 1 * * *',
+      batchSize: 2,
+      batchSleepAsyncDurationInMilliseconds: 10,
+      enabled: true,
+      jitterTime: 0,
+    },
+  },
+}));
+
+// Mock sleepAsync to speed up tests
+jest.mock('@tamanu/utils/sleepAsync', () => ({
+  sleepAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('GenerateRepeatingTasks', () => {
+  let ctx;
+  let models;
+  let task;
+  let examiner;
+  let patient;
+  let facility;
+  let department;
+  let location;
+  let encounter;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+    examiner = await models.User.create(fakeUser());
+    patient = await models.Patient.create(fake(models.Patient));
+    facility = await models.Facility.create(fake(models.Facility));
+    department = await models.Department.create(
+      fake(models.Department, { facilityId: facility.id }),
+    );
+    location = await models.Location.create(fake(models.Location, { facilityId: facility.id }));
+    encounter = await models.Encounter.create(
+      fake(models.Encounter, {
+        patientId: patient.id,
+        examinerId: examiner.id,
+        departmentId: department.id,
+        locationId: location.id,
+        endDate: null,
+      }),
+    );
+  });
+
+  beforeEach(async () => {
+    // Clear any existing data
+    await models.Task.destroy({ where: {}, force: true });
+
+    // Reset mocks
+    jest.clearAllMocks();
+    jest.spyOn(models.Task, 'generateRepeatingTasks').mockImplementation(async () => {});
+
+    task = new GenerateRepeatingTasks(ctx);
+  });
+
+  afterAll(async () => {
+    await ctx.close();
+  });
+
+  const createTask = async (overrides = {}) => {
+    return await models.Task.create(
+      fake(models.Task, {
+        encounterId: encounter.id,
+        requestedByUserId: examiner.id,
+        status: TASK_STATUSES.TODO,
+        dueTime: toDateTimeString(addDays(new Date(), 1)),
+        endTime: null,
+        parentTaskId: null,
+        frequencyValue: 1,
+        frequencyUnit: 'day',
+        ...overrides,
+      }),
+    );
+  };
+
+  const getProcessedTaskIds = () => {
+    return models.Task.generateRepeatingTasks.mock.calls.flatMap(([tasks]) =>
+      tasks.map(processedTask => processedTask.id),
+    );
+  };
+
+  describe('batching logic', () => {
+    it('should generate child tasks for every repeating parent task across batches', async () => {
+      // Create 5 repeating parent tasks (batch size is 2, so should create 3 batches)
+      const parentTasks = [];
+      for (let i = 0; i < 5; i++) {
+        parentTasks.push(await createTask());
+      }
+
+      await task.run();
+
+      expect(models.Task.generateRepeatingTasks).toHaveBeenCalledTimes(3);
+
+      const processedTaskIds = getProcessedTaskIds();
+      expect(processedTaskIds).toHaveLength(5);
+      parentTasks.forEach(parentTask => {
+        expect(processedTaskIds).toContain(parentTask.id);
+      });
+    });
+
+    it('should only count repeating parent tasks when batching', async () => {
+      // 2 repeating parent tasks fit in a single batch of 2
+      const repeatingTasks = [await createTask(), await createTask()];
+      // Non-repeating and child tasks should not inflate the batch count
+      await createTask({ frequencyValue: null, frequencyUnit: null });
+      await createTask({ frequencyValue: null, frequencyUnit: null });
+      await createTask({ parentTaskId: repeatingTasks[0].id });
+
+      await task.run();
+
+      expect(models.Task.generateRepeatingTasks).toHaveBeenCalledTimes(1);
+
+      const processedTaskIds = getProcessedTaskIds();
+      expect(processedTaskIds.sort()).toEqual(repeatingTasks.map(({ id }) => id).sort());
+    });
+  });
+});

--- a/packages/central-server/app/tasks/GenerateRepeatingTasks.js
+++ b/packages/central-server/app/tasks/GenerateRepeatingTasks.js
@@ -113,14 +113,14 @@ export class GenerateRepeatingTasks extends ScheduledTask {
   async generateChildTasks() {
     const { Task } = this.models;
 
-    const toProcess = await Task.count({
-      where: {
-        endTime: null,
-        frequencyValue: { [Op.not]: null },
-        frequencyUnit: { [Op.not]: null },
-        parentTaskId: null,
-      },
-    });
+    const repeatingParentTaskWhere = {
+      endTime: null,
+      frequencyValue: { [Op.not]: null },
+      frequencyUnit: { [Op.not]: null },
+      parentTaskId: null,
+    };
+
+    const toProcess = await Task.count({ where: repeatingParentTaskWhere });
     if (toProcess === 0) return;
 
     const { batchSize, batchSleepAsyncDurationInMilliseconds } = this.config;
@@ -131,31 +131,37 @@ export class GenerateRepeatingTasks extends ScheduledTask {
       );
     }
 
-    const batchCount = Math.ceil(toProcess / batchSize);
-
+    // recordCount is informational only — the loop below runs until it gets a
+    // short page, so tasks changed mid-run can't cause rows to be skipped
     log.info('Running batched generating repeating tasks', {
       recordCount: toProcess,
-      batchCount,
       batchSize,
     });
 
-    for (let i = 0; i < batchCount; i++) {
+    // Keyset pagination: paging by last seen id rather than offset so that
+    // rows leaving the filter between pages can't shift later pages
+    let lastSeenId = null;
+    let isLastPage = false;
+    while (!isLastPage) {
       const tasks = await Task.findAll({
         where: {
-          endTime: null,
-          frequencyValue: { [Op.not]: null },
-          frequencyUnit: { [Op.not]: null },
-          parentTaskId: null,
+          ...repeatingParentTaskWhere,
+          ...(lastSeenId !== null && { id: { [Op.gt]: lastSeenId } }),
         },
         include: ['designations'],
-        offset: i * batchSize,
         limit: batchSize,
         order: [['id', 'ASC']],
       });
+      if (tasks.length === 0) return;
+
+      lastSeenId = tasks[tasks.length - 1].id;
+      isLastPage = tasks.length < batchSize;
 
       await Task.generateRepeatingTasks(tasks);
 
-      await sleepAsync(batchSleepAsyncDurationInMilliseconds);
+      if (!isLastPage) {
+        await sleepAsync(batchSleepAsyncDurationInMilliseconds);
+      }
     }
   }
 }

--- a/packages/central-server/app/tasks/GenerateRepeatingTasks.js
+++ b/packages/central-server/app/tasks/GenerateRepeatingTasks.js
@@ -114,10 +114,12 @@ export class GenerateRepeatingTasks extends ScheduledTask {
     const { Task } = this.models;
 
     const toProcess = await Task.count({
-      endTime: null,
-      frequencyValue: { [Op.not]: null },
-      frequencyUnit: { [Op.not]: null },
-      parentTaskId: null,
+      where: {
+        endTime: null,
+        frequencyValue: { [Op.not]: null },
+        frequencyUnit: { [Op.not]: null },
+        parentTaskId: null,
+      },
     });
     if (toProcess === 0) return;
 
@@ -146,7 +148,9 @@ export class GenerateRepeatingTasks extends ScheduledTask {
           parentTaskId: null,
         },
         include: ['designations'],
+        offset: i * batchSize,
         limit: batchSize,
+        order: [['id', 'ASC']],
       });
 
       await Task.generateRepeatingTasks(tasks);


### PR DESCRIPTION
### Changes

In `packages/central-server/app/tasks/GenerateRepeatingTasks.js`, the `Task.count` call passed its filter at the top level instead of under `where:`, so it counted every task in the table, and the batch loop called `findAll` with no `offset` and no `order`, so every iteration refetched the same first batch — repeating parent tasks beyond the first `batchSize` never had child tasks generated. The fix moves the filter under `where:` and adds `offset: i * batchSize` plus a stable `order: [['id', 'ASC']]`, matching the sibling `GenerateMedicationAdministrationRecords` task. Adds a regression test (`__tests__/tasks/GenerateRepeatingTasks.test.js`) that creates more repeating parents than the batch size and asserts every parent is processed exactly once and that non-repeating/child tasks don't inflate the batch count — both assertions failed before the fix. From the logic-bug audit (#10266), finding C2.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_