### PR TITLE
fix(central): no-issue: include digit 9 in patient-portal one-time codes

### DIFF
--- a/packages/central-server/__tests__/patientPortalApi/randomSixDigitCode.test.js
+++ b/packages/central-server/__tests__/patientPortalApi/randomSixDigitCode.test.js
@@ -1,0 +1,15 @@
+import { randomSixDigitCode } from '../../app/patientPortalApi/auth/PortalOneTimeTokenService';
+
+describe('randomSixDigitCode', () => {
+  it('generates six-digit codes that use the full 0-9 digit range', () => {
+    const sampleSize = 2000;
+    const codes = Array.from({ length: sampleSize }, () => randomSixDigitCode());
+
+    for (const code of codes) {
+      expect(code).toMatch(/^[0-9]{6}$/);
+    }
+
+    const digitsSeen = new Set(codes.join(''));
+    expect(digitsSeen.has('9')).toBe(true);
+  });
+});

--- a/packages/central-server/app/patientPortalApi/auth/PortalOneTimeTokenService.js
+++ b/packages/central-server/app/patientPortalApi/auth/PortalOneTimeTokenService.js
@@ -7,9 +7,9 @@ import { InvalidCredentialError, InvalidTokenError } from '@tamanu/errors';
 
 const DEFAULT_SALT_ROUNDS = 10;
 
-function randomSixDigitCode() {
+export function randomSixDigitCode() {
   // returns a zero-padded 6 digit string using crypto.randomInt for better security
-  return Array.from({ length: 6 }, () => randomInt(0, 9)).join('');
+  return Array.from({ length: 6 }, () => randomInt(0, 10)).join('');
 }
 
 function randomRegisterCode() {


### PR DESCRIPTION
### Changes

`randomSixDigitCode()` in `packages/central-server/app/patientPortalApi/auth/PortalOneTimeTokenService.js` generated patient-portal one-time login/verification codes using `crypto.randomInt(0, 9)`. Since `randomInt`'s upper bound is exclusive, every digit position could only ever be 0-8, so the digit "9" never appeared — shrinking the effective keyspace by roughly 47%. The fix changes the bound to `randomInt(0, 10)` so all ten digits are possible.

Added a regression test (`packages/central-server/__tests__/patientPortalApi/randomSixDigitCode.test.js`) that generates 2000 codes and asserts each matches `/^[0-9]{6}$/` and that the digit "9" appears at least once across the sample. This test failed against the unfixed code (digit "9" never observed in 2000 codes) and passes after the fix.

From the logic-bug audit (#10266), finding C6.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_