### PR TITLE
fix(central): no-issue: use payload exp for absoluteExpiration token refresh

### DIFF
--- a/packages/central-server/__tests__/auth/refresh.test.js
+++ b/packages/central-server/__tests__/auth/refresh.test.js
@@ -204,6 +204,45 @@ describe('Auth', () => {
       expect(refreshResponse).toHaveRequestError();
     });
 
+    describe('with absoluteExpiration enabled', () => {
+      let originalAbsoluteExpiration;
+
+      beforeAll(() => {
+        originalAbsoluteExpiration = config.auth.refreshToken.absoluteExpiration;
+        config.auth.refreshToken.absoluteExpiration = true;
+      });
+
+      afterAll(() => {
+        config.auth.refreshToken.absoluteExpiration = originalAbsoluteExpiration;
+      });
+
+      it('Should succeed and keep the original absolute expiry on the rotated refresh token', async () => {
+        const loginResponse = await baseApp.post('/api/login').send({
+          email: TEST_EMAIL,
+          password: TEST_PASSWORD,
+          deviceId: TEST_DEVICE_ID,
+        });
+
+        expect(loginResponse).toHaveSucceeded();
+        const { refreshToken } = loginResponse.body;
+        const oldRefreshTokenContents = jose.decodeJwt(refreshToken);
+
+        const refreshResponse = await withDateUnsafelyFaked(new Date(Date.now() + 10000), () =>
+          baseApp.post('/api/refresh').send({
+            refreshToken,
+            deviceId: TEST_DEVICE_ID,
+          }),
+        );
+
+        expect(refreshResponse).toHaveSucceeded();
+        expect(refreshResponse.body).toHaveProperty('refreshToken');
+
+        const newRefreshTokenContents = jose.decodeJwt(refreshResponse.body.refreshToken);
+
+        expect(newRefreshTokenContents.exp).toEqual(oldRefreshTokenContents.exp);
+      });
+    });
+
     it('Should fail if refresh token requested from deactivated user', async () => {
       const freshUser = await store.models.User.create(
         fake(store.models.User, {

--- a/packages/central-server/app/auth/refresh.js
+++ b/packages/central-server/app/auth/refresh.js
@@ -103,15 +103,14 @@ export const refresh = asyncHandler(async (req, res) => {
     {
       userId: user.id,
       refreshId: newRefreshId,
-      // If absolute expiration pass through the exp from the old token
-      ...(absoluteExpiration && { exp: contents.exp }),
     },
     refreshSecret,
     {
       audience: JWT_TOKEN_TYPES.REFRESH,
       issuer: canonicalHostName,
       jwtid: `${refreshTokenJwtId}`,
-      ...(!absoluteExpiration && { expiresIn: refreshTokenDuration }),
+      // If absolute expiration pass through the exp from the old token, otherwise use the configured duration
+      expiresIn: absoluteExpiration ? contents.payload.exp : refreshTokenDuration,
     },
   );
   // Extract expiry as set by jose.SignJWT


### PR DESCRIPTION
### Changes

`app/auth/refresh.js` read `contents.exp` when rotating a refresh token with `auth.refreshToken.absoluteExpiration` enabled, but the JWT payload lives at `contents.payload` — so `contents.exp` was always `undefined`. The `expiresIn` option was also always omitted from `buildToken` in this branch, so `jose`'s `setExpirationTime` always threw, meaning every `/refresh` call 500'd whenever `absoluteExpiration` was enabled.

Fixed by reading the original expiry from `contents.payload.exp` and passing it through as `expiresIn` (jose treats a numeric `expiresIn` as an absolute epoch), so the rotated refresh token keeps the original absolute expiry.

Added a regression test in `__tests__/auth/refresh.test.js` that enables `absoluteExpiration`, logs in, refreshes, and asserts the refresh succeeds and the new refresh token's `exp` matches the original — this test fails with a 500 before the fix.

From the logic-bug audit (#10266), finding C5.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_