### PR TITLE
fix(central): no-issue: await report-failure email and pass body as text

### DIFF
--- a/packages/central-server/__tests__/report/ReportRunner.test.js
+++ b/packages/central-server/__tests__/report/ReportRunner.test.js
@@ -1,0 +1,55 @@
+import { ReportRunner } from '../../app/report/ReportRunner';
+
+jest.mock('../../app/services/mailConfig', () => ({
+  getDefaultFromAddress: jest.fn(() => 'no-reply@tamanu.example'),
+}));
+
+describe('ReportRunner', () => {
+  describe('sendErrorToEmail', () => {
+    const buildRunner = emailService => {
+      const runner = new ReportRunner(
+        'test-report',
+        {},
+        { email: ['recipient@tamanu.example'] },
+        {},
+        {},
+        emailService,
+        'user-1',
+        'csv',
+        { duration: '0s', ifRunAtLeast: '0s' },
+      );
+      runner.getRequestedByUser = jest.fn().mockResolvedValue({ email: 'user@tamanu.example' });
+      runner.getReportName = jest.fn().mockResolvedValue('test-report-name');
+      return runner;
+    };
+
+    it('awaits the email send and passes the failure body as "text"', async () => {
+      let sendEmailSettled = false;
+
+      const emailService = {
+        sendEmail: jest.fn().mockImplementation(
+          () =>
+            new Promise(resolve => {
+              setImmediate(() => {
+                sendEmailSettled = true;
+                resolve({ status: 'Sent' });
+              });
+            }),
+        ),
+      };
+
+      const runner = buildRunner(emailService);
+
+      await runner.sendErrorToEmail(new Error('report blew up'));
+
+      // If sendErrorToEmail failed to await emailService.sendEmail, this would still be false
+      // here, since the microtask queued by setImmediate would not yet have run.
+      expect(sendEmailSettled).toBe(true);
+      expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+      const [emailArgs] = emailService.sendEmail.mock.calls[0];
+      expect(emailArgs).not.toHaveProperty('message');
+      expect(emailArgs.text).toContain('test-report-name');
+      expect(emailArgs.text).toContain('report blew up');
+    });
+  });
+});

--- a/packages/central-server/app/report/ReportRunner.js
+++ b/packages/central-server/app/report/ReportRunner.js
@@ -285,11 +285,11 @@ export class ReportRunner {
     try {
       const user = await this.getRequestedByUser();
       const reportName = await this.getReportName();
-      this.emailService.sendEmail({
+      await this.emailService.sendEmail({
         from: getDefaultFromAddress(),
         to: user.email,
         subject: 'Failed to generate report',
-        message: `Report requested: ${reportName} failed to generate with error: ${e.message}`,
+        text: `Report requested: ${reportName} failed to generate with error: ${e.message}`,
       });
     } catch (e2) {
       this.log.error('Issue sending error to email', {


### PR DESCRIPTION
### Changes

`sendErrorToEmail` in `packages/central-server/app/report/ReportRunner.js` called `this.emailService.sendEmail` without awaiting it, so the spawned child process could exit before the failure email was sent, and any send errors were uncatchable. It also passed the body under a `message` key instead of `text`, which nodemailer expects, so the failure body was silently dropped. Fix: await the call and rename `message` to `text`, matching `sendReportToEmail` in the same file. Added a regression test (`packages/central-server/__tests__/report/ReportRunner.test.js`) with a mocked `emailService` that asserts `sendEmail` is awaited and called with a `text` property containing the failure body; it failed before the fix (assertion that the send had settled by the time `sendErrorToEmail` returned failed) and passes after.

From the logic-bug audit (#10266), finding C9.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_