### PR TITLE
fix(facility): no-issue: exclude cancelled bookings from reschedule conflict check

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -325,6 +325,58 @@ describe('Appointments', () => {
       });
     });
 
+    describe('reschedule conflict checking', () => {
+      afterEach(async () => {
+        await models.Appointment.truncate();
+      });
+
+      it('should allow rescheduling into a slot freed by a cancelled booking', async () => {
+        const cancelledBookingResult = await makeBooking(
+          '2024-10-03 12:00:00',
+          '2024-10-03 12:30:00',
+        );
+        expect(cancelledBookingResult).toHaveSucceeded();
+        const cancelResult = await userApp
+          .put(`/api/appointments/locationBooking/${cancelledBookingResult.body.id}?skipConflictCheck=true`)
+          .send({
+            status: APPOINTMENT_STATUSES.CANCELLED,
+          });
+        expect(cancelResult).toHaveSucceeded();
+
+        const otherBookingResult = await makeBooking(
+          '2024-10-03 14:00:00',
+          '2024-10-03 14:30:00',
+        );
+        expect(otherBookingResult).toHaveSucceeded();
+
+        const result = await userApp
+          .put(`/api/appointments/locationBooking/${otherBookingResult.body.id}`)
+          .send({
+            startTime: '2024-10-03 12:00:00',
+            endTime: '2024-10-03 12:30:00',
+            locationId,
+          });
+        expect(result).toHaveSucceeded();
+      });
+
+      it('should reject rescheduling into a slot still occupied by an active booking', async () => {
+        await makeBooking('2024-10-03 12:00:00', '2024-10-03 12:30:00');
+        const otherBookingResult = await makeBooking(
+          '2024-10-03 14:00:00',
+          '2024-10-03 14:30:00',
+        );
+
+        const result = await userApp
+          .put(`/api/appointments/locationBooking/${otherBookingResult.body.id}`)
+          .send({
+            startTime: '2024-10-03 12:00:00',
+            endTime: '2024-10-03 12:30:00',
+            locationId,
+          });
+        expect(result.status).toBe(409);
+      });
+    });
+
     describe('booking confirmation emails', () => {
       const TEST_EMAIL = 'booking@test.com';
 

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -599,6 +599,9 @@ appointments.put(
                   id: { [Op.ne]: id },
                 },
                 { locationId },
+                {
+                  status: { [Op.not]: APPOINTMENT_STATUSES.CANCELLED },
+                },
                 timeQueryWhereClause,
               ],
             },


### PR DESCRIPTION
### Changes

The `PUT /locationBooking/:id` reschedule overlap check in `packages/facility-server/app/routes/apiv1/appointments.js` was missing the `status: { [Op.not]: APPOINTMENT_STATUSES.CANCELLED }` filter that the `POST /locationBooking` create handler already applies. As a result, rescheduling a booking into a slot freed by a cancelled booking incorrectly matched the cancelled row and threw a 409 `EditConflictError`, even though creating a brand-new booking in that same slot succeeds.

Fix: add the same status filter to the update handler's conflict query.

Regression test added in `packages/facility-server/__tests__/apiv1/Appointments.test.js` (`reschedule conflict checking` describe block): creates a booking, cancels it, creates a second booking elsewhere, then reschedules the second booking into the first booking's freed slot. This failed with a 409 before the fix and passes after. A companion test asserts that rescheduling into a slot still occupied by an active booking still correctly returns 409.

From the logic-bug audit (#10266), finding F2.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_