### PR TITLE
fix(sync): handle empty page in incoming pull

### DIFF
--- a/packages/facility-server/__tests__/sync/pullIncomingChanges.test.js
+++ b/packages/facility-server/__tests__/sync/pullIncomingChanges.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { pullIncomingChanges } from '../../app/sync/pullIncomingChanges';
+
+describe('pullIncomingChanges', () => {
+  it('completes cleanly when the central server returns an empty page', async () => {
+    // central server reports records to pull, but the pull query returns an empty page
+    // (reachable when totalToPull diverges from the dependency-ordered pull query)
+    const centralServer = {
+      initiatePull: jest.fn().mockResolvedValue({ totalToPull: 10, pullUntil: 42 }),
+      pull: jest.fn().mockResolvedValue([]),
+    };
+    const sequelize = {};
+
+    const result = await pullIncomingChanges(centralServer, sequelize, 'sessionId', 1);
+
+    expect(centralServer.pull).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ totalPulled: 10, pullUntil: 42 });
+  });
+});

--- a/packages/facility-server/app/sync/pullIncomingChanges.js
+++ b/packages/facility-server/app/sync/pullIncomingChanges.js
@@ -37,15 +37,15 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
       fromId,
       limit,
     });
-    const { id, sortOrder } = records[records.length - 1];
-    fromId = btoa(JSON.stringify({ sortOrder, id }));
-    totalPulled += records.length;
-    const pullTime = Date.now() - startTime;
-
     if (!records.length) {
       log.debug(`FacilitySyncManager.pull.noMoreChanges`);
       break;
     }
+
+    const { id, sortOrder } = records[records.length - 1];
+    fromId = btoa(JSON.stringify({ sortOrder, id }));
+    totalPulled += records.length;
+    const pullTime = Date.now() - startTime;
 
     log.info('FacilitySyncManager.savingChangesToSnapshot', { count: records.length });
 


### PR DESCRIPTION
### Changes

In `packages/facility-server/app/sync/pullIncomingChanges.js`, the pull loop destructured `records[records.length - 1]` before the `if (!records.length) break` guard, so an empty page from the central server threw a TypeError and failed the whole sync session — the "no more changes" break was unreachable. Empty final pages are reachable when the central server's `totalToPull` diverges from the dependency-ordered pull query. The fix moves the empty-page break above the destructure. Added a regression unit test (`__tests__/sync/pullIncomingChanges.test.js`) that stubs the central server connection to return an empty page and asserts the pull completes cleanly; it failed with the TypeError before the fix and passes after.

From the logic-bug audit (#10266), finding F8.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_