### PR TITLE
fix(facility): no-issue: return imaging area note content in update response

### DIFF
--- a/packages/facility-server/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/facility-server/__tests__/apiv1/ImagingRequests.test.js
@@ -199,6 +199,33 @@ describe('Imaging requests', () => {
       expect(result.body.note).toEqual('test-note');
       expect(result.body.areaNote).toEqual('test-area-note');
     });
+
+    it('should return updated areaNote content when updating an existing imaging request', async () => {
+      const createdImagingRequest = await models.ImagingRequest.create({
+        encounterId: encounter.id,
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+      });
+
+      await models.Note.createForRecord(
+        createdImagingRequest.id,
+        NOTE_RECORD_TYPES.IMAGING_REQUEST,
+        NOTE_TYPES.AREA_TO_BE_IMAGED,
+        'original-area-note',
+        app.user.id,
+      );
+
+      const result = await app.put(`/api/imagingRequest/${createdImagingRequest.id}`).send({
+        areaNote: 'updated-area-note',
+      });
+
+      expect(result).toHaveSucceeded();
+      expect(result.body.areaNote).toEqual('updated-area-note');
+
+      const getResult = await app.get(`/api/imagingRequest/${createdImagingRequest.id}`);
+      expect(getResult).toHaveSucceeded();
+      expect(getResult.body.areaNote).toEqual('updated-area-note');
+    });
   });
 
   describe('Area listing', () => {

--- a/packages/facility-server/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/facility-server/__tests__/apiv1/ImagingRequests.test.js
@@ -226,6 +226,25 @@ describe('Imaging requests', () => {
       expect(getResult).toHaveSucceeded();
       expect(getResult.body.areaNote).toEqual('updated-area-note');
     });
+
+    it('should return created areaNote content when updating an imaging request with no existing area note', async () => {
+      const createdImagingRequest = await models.ImagingRequest.create({
+        encounterId: encounter.id,
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+      });
+
+      const result = await app.put(`/api/imagingRequest/${createdImagingRequest.id}`).send({
+        areaNote: 'new-area-note',
+      });
+
+      expect(result).toHaveSucceeded();
+      expect(result.body.areaNote).toEqual('new-area-note');
+
+      const getResult = await app.get(`/api/imagingRequest/${createdImagingRequest.id}`);
+      expect(getResult).toHaveSucceeded();
+      expect(getResult.body.areaNote).toEqual('new-area-note');
+    });
   });
 
   describe('Area listing', () => {

--- a/packages/facility-server/app/routes/apiv1/imaging.js
+++ b/packages/facility-server/app/routes/apiv1/imaging.js
@@ -219,7 +219,7 @@ imagingRequest.put(
     if (areaNote) {
       if (areaNoteObject) {
         await areaNoteObject.update({ content: areaNote });
-        notes.areaNote = areaNote.content || '';
+        notes.areaNote = areaNote;
       } else {
         const noteObject = await imagingRequestObject.createNote({
           noteTypeId: NOTE_TYPES.AREA_TO_BE_IMAGED,


### PR DESCRIPTION
### Changes

In `packages/facility-server/app/routes/apiv1/imaging.js`, the PUT `/api/imagingRequest/:id` handler updated the area-to-be-imaged note correctly with `areaNoteObject.update({ content: areaNote })`, but then built the response with `areaNote.content` — `areaNote` is the plain string from the request body, so `.content` is always `undefined` and the response `areaNote` was always empty (the sibling `otherNote` branch already read `otherNote.content` correctly). Fix: use the submitted string directly for the response value. Added a regression test in `__tests__/apiv1/ImagingRequests.test.js` that updates an imaging request's area note and asserts the response and a follow-up GET both carry the submitted text; it failed before the fix (`Expected: "updated-area-note", Received: ""`) and passes after. From the logic-bug audit (#10266), finding F9.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_