### PR TITLE
fix(facility): no-issue: handle MAR update without doses payload

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Medication.test.js
+++ b/packages/facility-server/__tests__/apiv1/Medication.test.js
@@ -1,6 +1,7 @@
 import config from 'config';
 
 import {
+  ADMINISTRATION_STATUS,
   DRUG_STOCK_STATUSES,
   INVOICE_STATUSES,
   REFERENCE_TYPES,
@@ -799,6 +800,59 @@ describe('Medication', () => {
       expect(found).toBeDefined();
       expect(found.prescription.invoiceItem).toBeDefined();
       expect(found.prescription.invoiceItem.approved).toBe(false);
+    });
+  });
+
+  describe('PUT /api/medication/medication-administration-record/:id', () => {
+    const createMar = async () => {
+      const medication = await models.ReferenceData.create(
+        fake(models.ReferenceData, { type: REFERENCE_TYPES.DRUG }),
+      );
+      const encounter = await models.Encounter.create(
+        fake(models.Encounter, {
+          patientId: patient.id,
+          locationId: location.id,
+          departmentId: department.id,
+          examinerId: app.user.id,
+          endDate: null,
+        }),
+      );
+      const prescription = await models.Prescription.create(
+        fake(models.Prescription, {
+          medicationId: medication.id,
+          prescriberId: app.user.id,
+          startDate: getCurrentDateTimeString(),
+        }),
+      );
+      await models.EncounterPrescription.create(
+        fake(models.EncounterPrescription, {
+          encounterId: encounter.id,
+          prescriptionId: prescription.id,
+        }),
+      );
+      const mar = await models.MedicationAdministrationRecord.create(
+        fake(models.MedicationAdministrationRecord, {
+          prescriptionId: prescription.id,
+          status: ADMINISTRATION_STATUS.GIVEN,
+          recordedByUserId: app.user.id,
+        }),
+      );
+      return mar;
+    };
+
+    it('should update the error flag when no doses are provided', async () => {
+      const mar = await createMar();
+
+      const result = await app.put(`/api/medication/medication-administration-record/${mar.id}`).send({
+        isError: true,
+        errorNotes: 'Recorded against the wrong patient',
+      });
+
+      expect(result).toHaveSucceeded();
+
+      const reloadedMar = await models.MedicationAdministrationRecord.findByPk(mar.id);
+      expect(reloadedMar.isError).toBe(true);
+      expect(reloadedMar.errorNotes).toBe('Recorded against the wrong patient');
     });
   });
 });

--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -1473,7 +1473,7 @@ medication.put(
         await existingMar.save();
       }
 
-      if (doses.length) {
+      if (doses?.length) {
         for (const dose of doses) {
           const givenByUser = await User.findByPk(dose.givenByUserId);
           if (!givenByUser) {


### PR DESCRIPTION
### Changes

The PUT `/api/medication/medication-administration-record/:id` handler in `packages/facility-server/app/routes/apiv1/medication.js` checked `doses.length` directly, but `updateMarSchema` marks `doses` as optional (and the earlier validation at the same handler already used `doses?.length`). A request with only `{ isError, errorNotes }` (valid per the schema) threw a TypeError and 500'd inside the managed transaction, rolling back the medication-error flag update. Fixed by changing the check to `doses?.length`. Added a regression test in `Medication.test.js` that PUTs the endpoint with only `isError`/`errorNotes` and asserts the error flag persists — it 500'd before the fix and passes after.

From the logic-bug audit (#10266), finding F11.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_