### PR TITLE
fix(database): no-issue: compute survey result from final answers on server submit

### DIFF
--- a/packages/central-server/__tests__/models/SurveyResponse.test.js
+++ b/packages/central-server/__tests__/models/SurveyResponse.test.js
@@ -233,6 +233,49 @@ describe('SurveyResponse.createWithAnswers', () => {
     });
   });
 
+  it('computes result from calculated answers when the client does not precompute them', async () => {
+    const survey = await createDummySurvey(models);
+    const numberElement = await models.ProgramDataElement.create({
+      ...fake(models.ProgramDataElement),
+      code: 'testNumber',
+      type: PROGRAM_DATA_ELEMENT_TYPES.NUMBER,
+    });
+    await models.SurveyScreenComponent.create({
+      ...fake(models.SurveyScreenComponent),
+      dataElementId: numberElement.id,
+      surveyId: survey.id,
+    });
+    const resultElement = await models.ProgramDataElement.create({
+      ...fake(models.ProgramDataElement),
+      code: 'testResult',
+      type: PROGRAM_DATA_ELEMENT_TYPES.RESULT,
+    });
+    await models.SurveyScreenComponent.create({
+      ...fake(models.SurveyScreenComponent),
+      dataElementId: resultElement.id,
+      surveyId: survey.id,
+      calculation: 'testNumber * 2',
+    });
+
+    await models.SurveyResponse.sequelize.transaction(() =>
+      models.SurveyResponse.createWithAnswers({
+        patientId,
+        encounterId,
+        surveyId: survey.id,
+        answers: {
+          [numberElement.id]: 40,
+        },
+      }),
+    );
+
+    expect(await models.SurveyResponse.findOne()).toMatchObject({
+      surveyId: survey.id,
+      encounterId,
+      result: 80,
+      resultText: '80%',
+    });
+  });
+
   it('creates patient data from actions', async () => {
     const survey = await createDummySurvey(models);
     const { dataElement } = await createDummyDataElement(models, survey, {

--- a/packages/database/src/models/SurveyResponse.ts
+++ b/packages/database/src/models/SurveyResponse.ts
@@ -415,7 +415,7 @@ export class SurveyResponse extends Model {
       answers: finalAnswers,
       ...responseData,
     });
-    const { result, resultText } = getResultValue(questions, answers, {
+    const { result, resultText } = getResultValue(questions, finalAnswers, {
       encounterType: encounter.encounterType,
     });
     const record = await SurveyResponse.create({


### PR DESCRIPTION
### Changes

`SurveyResponse.createWithAnswers` (packages/database/src/models/SurveyResponse.ts) built `finalAnswers` (raw answers merged with `runCalculations` output) but then called `getResultValue` with the raw answers. Result/Calculated question values only exist in the calculated answers, so when the client had not precomputed them (patient portal submission, admin import) the stored `result`/`resultText` came out as 0/empty. The fix passes `finalAnswers` to `getResultValue`, matching the mobile equivalent (`SurveyResponse.submit`) which the code is marked to keep in sync with. Adds a regression test in `packages/central-server/__tests__/models/SurveyResponse.test.js` that submits a survey with a Result component without precomputed calculated answers and asserts the stored result — it failed (result 0, resultText fell back to the component detail) before the fix and passes after.

From the logic-bug audit (#10266), finding D2.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_