### PR TITLE
fix(shared): no-issue: preserve supplied timezone when parsing fhir datetimes

### DIFF
--- a/packages/shared/__tests__/utils/fhir/datetime.test.js
+++ b/packages/shared/__tests__/utils/fhir/datetime.test.js
@@ -1,0 +1,22 @@
+import __cjs_date_fns_tz from 'date-fns-tz';
+
+import { dateParts } from '../../../src/utils/fhir/datetime';
+
+const { getTimezoneOffset } = __cjs_date_fns_tz;
+
+describe('dateParts', () => {
+  it('preserves the supplied timezone when the datetime string has no explicit offset', () => {
+    // Pacific/Kiritimati has a fixed +14:00 offset with no daylight saving,
+    // so the expected tz is deterministic regardless of the date used.
+    const withTz = 'Pacific/Kiritimati';
+    const combinedDate = new Date('2024-01-15T10:00:00');
+    const str = '2024-01-15T10:00:00';
+    const form = "yyyy-MM-dd'T'HH:mm:ss";
+
+    const result = dateParts(combinedDate, withTz, str, form);
+
+    const expectedOffsetSeconds = getTimezoneOffset(withTz, result.plain) / 1000;
+    expect(expectedOffsetSeconds).toBe(14 * 3600);
+    expect(result.tz).toBe('+14:00');
+  });
+});

--- a/packages/shared/src/utils/fhir/datetime.js
+++ b/packages/shared/src/utils/fhir/datetime.js
@@ -40,7 +40,7 @@ function normalizeTz(tz, date) {
   return offsetSuffix;
 }
 
-function dateParts(combinedDate, withTz, str, form) {
+export function dateParts(combinedDate, withTz, str, form) {
   let date = combinedDate;
   let tz = null;
   if (form.endsWith('X') && str.endsWith('Z')) {
@@ -54,7 +54,7 @@ function dateParts(combinedDate, withTz, str, form) {
   } else if (withTz) {
     // no timezone in the format, use provided timezone
     date = zonedTimeToUtc(combinedDate, withTz);
-    tz = normalizeTz(tz, date);
+    tz = normalizeTz(withTz, date);
   }
   // else: no timezone in the format, using system timezone to parse and no tz in the output
 


### PR DESCRIPTION
### Changes

In `packages/shared/src/utils/fhir/datetime.js`, `dateParts()` computed the timezone offset with `normalizeTz(tz, date)`, but `tz` was still `null` at that point (it's only set in the earlier branches that handle formats with an explicit offset in the string). As a result, parsing a datetime string with no explicit offset while passing a `withTz` timezone always produced the wrong `tz` value instead of the supplied timezone's offset.

Fix: pass `withTz` instead of the still-null local `tz` variable.

Added a regression test in `packages/shared/__tests__/utils/fhir/datetime.test.js` (exporting `dateParts` for direct testing) that parses a no-offset datetime string with an explicit `withTz` and asserts the resulting `tz` equals the supplied timezone's offset. This test failed before the fix (got `+00:00` instead of the expected `+14:00`) and passes after.

From the logic-bug audit (#10266), finding S3.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_