### PR TITLE
fix(facility): no-issue: return after early empty responses in route handlers

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Patient.relations.test.js
+++ b/packages/facility-server/__tests__/apiv1/Patient.relations.test.js
@@ -333,8 +333,14 @@ describe('Patient relations', () => {
       permissionApp = await baseApp.asNewRole(permissions);
 
       const patient = await models.Patient.create(await createDummyPatient(models));
+      const findAllSpy = jest.spyOn(models.Referral, 'findAll');
+
       const response = await permissionApp.get(`/api/patient/${patient.id}/referrals`);
+
+      expect(response).toHaveSucceeded();
       expect(response.body).toEqual({ count: 0, data: [] });
+      expect(findAllSpy).not.toHaveBeenCalled();
+      findAllSpy.mockRestore();
     });
 
     it('should return list of referrals', async () => {

--- a/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
@@ -1177,6 +1177,23 @@ describe('PatientProgramRegistration', () => {
         expect(latestEntry).toHaveProperty('clinicalStatusId', clinicalStatus2.id);
         expect(latestEntry).toHaveProperty('registrationDate', TEST_DATE_LATE);
       });
+
+      it('should return an empty history when the patient has no registration', async () => {
+        const patient = await models.Patient.create(fake(models.Patient));
+        const programRegistry = await createProgramRegistry();
+
+        const permissions = [
+          ['read', 'ProgramRegistry', programRegistry.id],
+          ['read', 'Patient'],
+          ['list', 'PatientProgramRegistration'],
+        ];
+        const appWithPermissions = await ctx.baseApp.asNewRole(permissions);
+        const result = await appWithPermissions.get(
+          `/api/patient/${patient.id}/programRegistration/${programRegistry.id}/history`,
+        );
+        expect(result).toHaveSucceeded();
+        expect(result.body).toEqual({ count: 0, data: [] });
+      });
     });
 
     describe('GET /programRegistration/:programRegistrationId/condition', () => {

--- a/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
@@ -553,6 +553,24 @@ describe('PatientVaccine', () => {
     });
   });
 
+  describe('Administered vaccine circumstances', () => {
+    it('should return an empty list when the vaccine has no circumstances', async () => {
+      const vaccine = await recordAdministeredVaccine(patient, scheduled1, {
+        circumstanceIds: [],
+      });
+      const findAllSpy = jest.spyOn(models.ReferenceData, 'findAll');
+
+      const result = await app.get(
+        `/api/patient/${patient.id}/administeredVaccine/${vaccine.id}/circumstances`,
+      );
+
+      expect(result).toHaveSucceeded();
+      expect(result.body).toEqual({ count: 0, data: [] });
+      expect(findAllSpy).not.toHaveBeenCalled();
+      findAllSpy.mockRestore();
+    });
+  });
+
   describe('Administered vaccines table', () => {
     let readPatient = null;
     let vaccineOld;

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -670,6 +670,7 @@ encounterRelations.get(
         data: [],
         count: 0,
       });
+      return;
     }
 
     const { count, data } = await runPaginatedQuery(

--- a/packages/facility-server/app/routes/apiv1/patient/patientProgramRegistration/patientProgramRegistration.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientProgramRegistration/patientProgramRegistration.js
@@ -340,6 +340,7 @@ patientProgramRegistration.get(
         count: 0,
         data: [],
       });
+      return;
     }
 
     const changes = await ChangeLog.findAll({

--- a/packages/facility-server/app/routes/apiv1/patient/patientRelations.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientRelations.js
@@ -229,6 +229,7 @@ patientRelations.get(
         data: [],
         count: 0,
       });
+      return;
     }
 
     const patientReferrals = await models.Referral.findAll({
@@ -322,6 +323,7 @@ patientRelations.get(
         data: [],
         count: 0,
       });
+      return;
     }
 
     const { count, data } = await runPaginatedQuery(

--- a/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
@@ -412,8 +412,10 @@ patientVaccineRoutes.get(
     if (
       !Array.isArray(administeredVaccine.circumstanceIds) ||
       administeredVaccine.circumstanceIds.length === 0
-    )
+    ) {
       res.send({ count: 0, data: [] });
+      return;
+    }
     const results = await models.ReferenceData.findAll({
       where: {
         id: administeredVaccine.circumstanceIds,


### PR DESCRIPTION
### Changes

Five route handlers sent an empty result on an early-exit path but were missing `return`, so execution fell through to a second query and a second `res.send`: `app/routes/apiv1/encounter.js` (`programResponses`), `app/routes/apiv1/patient/patientRelations.js` (`referrals` and `programResponses`), `app/routes/apiv1/patient/patientProgramRegistration/patientProgramRegistration.js` (registration `history`), and `app/routes/apiv1/patient/patientVaccine.js` (administered vaccine `circumstances`). In the program-registration history handler this also went on to dereference `registration.id` on a `null` registration.

Fix: added `return` after each early `res.send`. Added regression tests: a program-registration history request for a patient with no registration, plus empty-path cases for administered vaccine circumstances and patient referrals that assert the follow-up query is no longer executed. The added assertions (spying on the follow-up `findAll` calls) failed before the fix — confirming the redundant, unreachable-after-fix query was actually running — and pass after it.

From the logic-bug audit (#10266), finding F10.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_