### PR TITLE
fix(utils): no-issue: parse repeat date as local time for ordinal weekday

### DIFF
--- a/packages/utils/__test__/appointmentScheduling.test.ts
+++ b/packages/utils/__test__/appointmentScheduling.test.ts
@@ -1,0 +1,18 @@
+// Set before any date-fns/appointmentScheduling imports: date-fns reads the runtime TZ, and a
+// date-only string parsed via `new Date(...)` is UTC midnight, which lands on the previous local
+// day in a UTC-negative timezone.
+process.env.TZ = 'America/Santiago';
+
+import { describe, test, expect } from 'vitest';
+import { REPEAT_FREQUENCY } from '@tamanu/constants';
+import { getNextFrequencyDate } from '../src/appointmentScheduling';
+
+describe('getNextFrequencyDate', () => {
+  test('keeps the same ordinal weekday position for monthly repeats in a UTC-negative timezone', () => {
+    // 2024-03-08 is the 2nd Friday of March 2024, so the next monthly repeat should land on the
+    // 2nd Friday of April 2024, which is 2024-04-12.
+    const nextDate = getNextFrequencyDate('2024-03-08', 1, REPEAT_FREQUENCY.MONTHLY);
+
+    expect(nextDate).toBe('2024-04-12');
+  });
+});

--- a/packages/utils/src/appointmentScheduling.ts
+++ b/packages/utils/src/appointmentScheduling.ts
@@ -51,7 +51,7 @@ export const getNextFrequencyDate = (
   repeatUnit: keyof typeof REPEAT_FREQUENCY,
 ) => {
   const dayOfWeek = format(parseISO(date), 'iiiiii').toUpperCase();
-  const nthWeekday = getWeekdayOrdinalPosition(new Date(date));
+  const nthWeekday = getWeekdayOrdinalPosition(parseISO(date));
 
   const incrementedDate = add(parseISO(date), {
     [REPEAT_FREQUENCY_UNIT_PLURAL_LABELS[repeatUnit]]: repeatFrequency,


### PR DESCRIPTION
### Changes

`getNextFrequencyDate` in `packages/utils/src/appointmentScheduling.ts` computed the monthly ordinal weekday position using `new Date(date)`, which parses a date-only string as UTC midnight. In any UTC-negative timezone this lands on the local previous day, so the ordinal weekday used to place the next repeat is off by one — monthly repeating appointments land on the wrong week. The fix uses `parseISO(date)` instead, matching the neighbouring `dayOfWeek` calculation which already parsed correctly. Added a regression test (`packages/utils/__test__/appointmentScheduling.test.ts`) that sets `process.env.TZ = "America/Santiago"` and asserts the monthly-ordinal next date lands on the correct week; it failed (returning the wrong week) before the fix and passes after.

From the logic-bug audit (#10266), finding U1.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_