### PR TITLE
fix(scripts): no-issue: read web replica counts from web options in deploy helper

### DIFF
--- a/packages/scripts/src/ghaCdHelpers.mjs
+++ b/packages/scripts/src/ghaCdHelpers.mjs
@@ -305,12 +305,12 @@ export function configMap(deployName, imageTag, options, { appVersion } = {}) {
       centralApiReplicas: options.centralapis,
       centralDbReplicas: options.centraldbs,
       centralTasksReplicas: options.centraltasks,
-      centralWebReplicas: options.centraldbs,
+      centralWebReplicas: options.centralwebs,
 
       facilityApiReplicas: options.facilityapis,
       facilityDbReplicas: options.facilitydbs,
       facilityTasksReplicas: options.facilitytasks,
-      facilityWebReplicas: options.facilitydbs,
+      facilityWebReplicas: options.facilitywebs,
 
       patientPortalReplicas: options.patientportals,
 

--- a/packages/scripts/tests/ghaCdHelpers.test.mjs
+++ b/packages/scripts/tests/ghaCdHelpers.test.mjs
@@ -1,5 +1,5 @@
 import test from 'tape';
-import { parseDeployConfig, stackName } from '../src/ghaCdHelpers.mjs';
+import { configMap, parseDeployConfig, stackName } from '../src/ghaCdHelpers.mjs';
 
 function withoutOptions({ ...deploy }) {
   delete deploy.options;
@@ -95,5 +95,29 @@ test('normalise a complex branch name', (t) => {
   t.equal(
     stackName('refs/heads/fix/refs/heads/§ING interpretèd 🌌'),
     'fix-refs-heads-ing-interpret-d',
+  );
+});
+
+test('configMap reads web replica counts from web options, not db options', (t) => {
+  t.plan(2);
+
+  const options = {
+    centralwebs: 4,
+    centraldbs: 2,
+    facilitywebs: 5,
+    facilitydbs: 3,
+  };
+
+  const config = configMap('ci-k8s-deploy', 'latest', options);
+
+  t.equal(
+    config['tamanu-on-k8s:centralWebReplicas'].value,
+    options.centralwebs,
+    'centralWebReplicas should come from centralwebs, not centraldbs',
+  );
+  t.equal(
+    config['tamanu-on-k8s:facilityWebReplicas'].value,
+    options.facilitywebs,
+    'facilityWebReplicas should come from facilitywebs, not facilitydbs',
   );
 });


### PR DESCRIPTION
### Changes

Fixes a copy-paste defect in the deploy helper (from the logic-bug audit, #10266, finding SC1). In `packages/scripts/src/ghaCdHelpers.mjs`, the web replica counts were read from the DB replica options (`centralWebReplicas: options.centraldbs`, `facilityWebReplicas: options.facilitydbs`), so the `centralwebs`/`facilitywebs` deploy-line options were defined but never consumed and web replica counts silently tracked DB counts. The two property reads now use `options.centralwebs` / `options.facilitywebs`.

A regression test was added to `packages/scripts/tests/ghaCdHelpers.test.mjs` asserting that distinct web and DB replica options produce distinct replica counts; it failed before the fix (web replicas mirrored the DB values) and passes after.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)