### PR TITLE
fix(web): no-issue: handle missing normal range and zero minimum in lab tests table

### DIFF
--- a/packages/web/__tests__/views/patients/PatientLabTestsTable.test.jsx
+++ b/packages/web/__tests__/views/patients/PatientLabTestsTable.test.jsx
@@ -37,6 +37,7 @@ vi.mock('../../../app/views/patients/LabTestResultModal', () => ({
 vi.mock('../../../app/components/Table', () => ({
   Table: ({ columns, data }) => {
     const normalRangeColumn = columns.find(column => column.key === 'normalRange');
+    expect(normalRangeColumn).toBeDefined();
     return (
       <div>
         {data.map((row, index) => (
@@ -96,5 +97,23 @@ describe('PatientLabTestsTable normal range column', () => {
     renderTable({ sex: 'male' }, labTests);
 
     expect(screen.getByTestId('normal-range-cell-0').textContent).toBe('0–5');
+  });
+
+  it('renders the no-range fallback when the range has a min but no max', () => {
+    const labTests = [
+      {
+        testType: 'Test C',
+        testTypeId: 'test-type-3',
+        testCategory: 'Category A',
+        unit: 'mg',
+        rangeText: null,
+        normalRanges: { male: { min: 5, max: null } },
+        results: {},
+      },
+    ];
+
+    renderTable({ sex: 'male' }, labTests);
+
+    expect(screen.getByTestId('normal-range-cell-0').textContent).toBe('—');
   });
 });

--- a/packages/web/__tests__/views/patients/PatientLabTestsTable.test.jsx
+++ b/packages/web/__tests__/views/patients/PatientLabTestsTable.test.jsx
@@ -1,0 +1,100 @@
+/*
+ * Regression test for the "Normal range" column of PatientLabTestsTable.
+ *
+ * The column accessor read `row.normalRanges[patient?.sex]` directly. The
+ * server only ever builds "male"/"female" keys, so a patient with sex
+ * "other" produced `undefined`, and accessing `range.min` on it threw a
+ * TypeError (rendered as an error cell by the table's per-cell error
+ * boundary). Separately, the accessor used a truthiness check on
+ * `range.min`, so a legitimate range of `{ min: 0, max: ... }` was treated
+ * as absent and rendered the no-range fallback instead of "0–...".
+ *
+ * We stub the heavy Table component to invoke only the "normalRange"
+ * column's accessor, so we can exercise the accessor logic in isolation.
+ */
+
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+
+vi.mock('@tamanu/ui-components', async () => {
+  const actual = await vi.importActual('@tamanu/ui-components');
+  return {
+    ...actual,
+    useDateTime: () => ({
+      formatShort: () => '',
+      formatTimeWithSeconds: () => '',
+    }),
+  };
+});
+
+vi.mock('../../../app/views/patients/LabTestResultModal', () => ({
+  LabTestResultModal: () => null,
+}));
+
+vi.mock('../../../app/components/Table', () => ({
+  Table: ({ columns, data }) => {
+    const normalRangeColumn = columns.find(column => column.key === 'normalRange');
+    return (
+      <div>
+        {data.map((row, index) => (
+          <div key={row.testType} data-testid={`normal-range-cell-${index}`}>
+            {normalRangeColumn.accessor(row)}
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+import { PatientLabTestsTable } from '../../../app/views/patients/PatientLabTestsTable';
+
+const renderTable = (patient, labTests) =>
+  renderElementWithTranslatedText(
+    <PatientLabTestsTable
+      patient={patient}
+      labTests={labTests}
+      count={labTests.length}
+      isLoading={false}
+      searchParameters={{}}
+    />,
+  );
+
+describe('PatientLabTestsTable normal range column', () => {
+  it('renders the no-range fallback for a patient with sex "other" instead of throwing', () => {
+    const labTests = [
+      {
+        testType: 'Test A',
+        testTypeId: 'test-type-1',
+        testCategory: 'Category A',
+        unit: 'mg',
+        rangeText: null,
+        normalRanges: { male: { min: 1, max: 5 }, female: { min: 2, max: 6 } },
+        results: {},
+      },
+    ];
+
+    expect(() => renderTable({ sex: 'other' }, labTests)).not.toThrow();
+    expect(screen.getByTestId('normal-range-cell-0').textContent).toBe('—');
+  });
+
+  it('renders a normal range with a zero minimum instead of the no-range fallback', () => {
+    const labTests = [
+      {
+        testType: 'Test B',
+        testTypeId: 'test-type-2',
+        testCategory: 'Category A',
+        unit: 'mg',
+        rangeText: null,
+        normalRanges: { male: { min: 0, max: 5 } },
+        results: {},
+      },
+    ];
+
+    renderTable({ sex: 'male' }, labTests);
+
+    expect(screen.getByTestId('normal-range-cell-0').textContent).toBe('0–5');
+  });
+});

--- a/packages/web/app/views/patients/PatientLabTestsTable.jsx
+++ b/packages/web/app/views/patients/PatientLabTestsTable.jsx
@@ -185,7 +185,9 @@ export const PatientLabTestsTable = React.memo(
         accessor: row => {
           const range = row.normalRanges[patient?.sex];
           const value =
-            range?.min != null ? `${range.min}–${range.max}` : (row.rangeText ?? '—');
+            range?.min != null && range?.max != null
+              ? `${range.min}–${range.max}`
+              : (row.rangeText ?? '—');
           return <CategoryCell data-testid="categorycell-1fi2">{value}</CategoryCell>;
         },
         sortable: false,

--- a/packages/web/app/views/patients/PatientLabTestsTable.jsx
+++ b/packages/web/app/views/patients/PatientLabTestsTable.jsx
@@ -184,7 +184,8 @@ export const PatientLabTestsTable = React.memo(
         ),
         accessor: row => {
           const range = row.normalRanges[patient?.sex];
-          const value = range.min ? `${range.min}–${range.max}` : (row.rangeText ?? '—');
+          const value =
+            range?.min != null ? `${range.min}–${range.max}` : (row.rangeText ?? '—');
           return <CategoryCell data-testid="categorycell-1fi2">{value}</CategoryCell>;
         },
         sortable: false,


### PR DESCRIPTION
### Changes

The "Normal range" column accessor in `packages/web/app/views/patients/PatientLabTestsTable.jsx` looked up `row.normalRanges[patient?.sex]`, but the server only ever builds `male`/`female` keys, so a patient with sex "other" produced `undefined` and `range.min` threw a `TypeError` (caught per-cell by the table's error boundary, rendering an error cell on every row). Separately, the accessor used a truthy check on `range.min`, so a legitimate range of `{ min: 0, max: ... }` was treated as absent and rendered the no-range fallback instead of the actual range.

Fix: guard for a missing range and use a `!= null` check on `min`/`max`, matching the existing idiom used by the date-cell accessor lower in the same file.

Added a regression test (`packages/web/__tests__/views/patients/PatientLabTestsTable.test.jsx`) covering both cases — sex "other" renders the fallback without crashing, and a `{ min: 0, max: 5 }` range renders as "0–5". Confirmed both cases failed before the fix (TypeError thrown, and "—" rendered instead of "0–5") and pass after.

From the logic-bug audit (#10266), finding W3.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_