### PR TITLE
fix(web): no-issue: spread empty filter state in location bookings context

### DIFF
--- a/packages/web/__tests__/contexts/LocationBookings.test.jsx
+++ b/packages/web/__tests__/contexts/LocationBookings.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../app/views/scheduling/locationBookings/utils', () => ({
+  scrollToBeginning: vi.fn(),
+  scrollToCell: vi.fn(),
+  scrollToThisWeek: vi.fn(),
+}));
+
+vi.mock('../../app/api/queries', () => ({
+  useUserPreferencesQuery: () => ({ data: undefined }),
+}));
+
+vi.mock('../../app/utils/useUrlSearchParams', () => ({
+  useUrlSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@tamanu/ui-components', async () => {
+  const actual = await vi.importActual('@tamanu/ui-components');
+  return {
+    ...actual,
+    useDateTime: () => ({ getCurrentDate: () => '2024-04-12' }),
+  };
+});
+
+import {
+  LOCATION_BOOKINGS_EMPTY_FILTER_STATE,
+  LocationBookingsContextProvider,
+  useLocationBookingsContext,
+} from '../../app/contexts/LocationBookings';
+
+const ShowFilters = () => {
+  const { filters } = useLocationBookingsContext();
+  return <span data-testid="filters">{JSON.stringify(filters)}</span>;
+};
+
+describe('LocationBookingsContextProvider', () => {
+  it('initialises filters to the empty filter state with no extra keys', () => {
+    render(
+      <LocationBookingsContextProvider>
+        <ShowFilters />
+      </LocationBookingsContextProvider>,
+    );
+
+    const filters = JSON.parse(screen.getByTestId('filters').textContent);
+    expect(filters).toStrictEqual(LOCATION_BOOKINGS_EMPTY_FILTER_STATE);
+  });
+});

--- a/packages/web/app/contexts/LocationBookings.jsx
+++ b/packages/web/app/contexts/LocationBookings.jsx
@@ -26,7 +26,7 @@ export const LocationBookingsContextProvider = ({ children }) => {
   const clinicianId = queryParams.get('clinicianId');
   const { data: userPreferences } = useUserPreferencesQuery();
   const [filters, setFilters] = useState({
-    LOCATION_BOOKINGS_EMPTY_FILTER_STATE,
+    ...LOCATION_BOOKINGS_EMPTY_FILTER_STATE,
   });
 
   useEffect(() => {


### PR DESCRIPTION
### Changes

`LocationBookingsContextProvider` (`packages/web/app/contexts/LocationBookings.jsx`) initialised its `filters` state with object shorthand — `useState({ LOCATION_BOOKINGS_EMPTY_FILTER_STATE })` — instead of spreading the constant. This meant the initial filter state was `{ LOCATION_BOOKINGS_EMPTY_FILTER_STATE: {...} }`: a bogus key wrapping the whole constant, while the real filter keys (`locationGroupIds`, `clinicianId`, `bookingTypeId`, `patientNameOrId`) were all undefined. Fixed by spreading the constant: `useState({ ...LOCATION_BOOKINGS_EMPTY_FILTER_STATE })`.

Added a regression test (`packages/web/__tests__/contexts/LocationBookings.test.jsx`) that renders the provider and asserts the initial filters deep-equal `LOCATION_BOOKINGS_EMPTY_FILTER_STATE` with no extra key. It failed before the fix (bogus key present, real keys missing) and passes after.

From the logic-bug audit (#10266), finding W10.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_