### PR TITLE
fix(web): no-issue: clear encounter loading state when the fetch fails

### DIFF
--- a/packages/web/__tests__/contexts/Encounter.test.jsx
+++ b/packages/web/__tests__/contexts/Encounter.test.jsx
@@ -1,0 +1,81 @@
+/*
+ * Regression test for the encounter loading state.
+ *
+ * loadEncounter and createEncounter set isLoadingEncounter to true before
+ * fetching, but only cleared it after a successful fetch. If the primary
+ * `encounter/:id` (or `encounter` create) request rejected, the loading flag
+ * was left stuck at true and the encounter view never recovered without a
+ * full page reload.
+ */
+
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi } from 'vitest';
+
+import { createQueryClient } from '../helpers/render';
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+
+vi.mock('../../app/api', async () => {
+  const actual = await vi.importActual('../../app/api');
+  return {
+    ...actual,
+    useApi: () => ({
+      get: mockGet,
+      post: mockPost,
+    }),
+  };
+});
+
+import { EncounterProvider, useEncounter } from '../../app/contexts/Encounter';
+
+const LoadEncounterProbe = () => {
+  const { isLoadingEncounter, loadEncounter, createEncounter } = useEncounter();
+  return (
+    <div>
+      <span data-testid="loading-state">{isLoadingEncounter ? 'loading' : 'idle'}</span>
+      <button type="button" onClick={() => loadEncounter('test-encounter-id').catch(() => {})}>
+        load
+      </button>
+      <button type="button" onClick={() => createEncounter({}).catch(() => {})}>
+        create
+      </button>
+    </div>
+  );
+};
+
+const renderWithProvider = () =>
+  render(
+    <QueryClientProvider client={createQueryClient()}>
+      <EncounterProvider>
+        <LoadEncounterProbe />
+      </EncounterProvider>
+    </QueryClientProvider>,
+  );
+
+describe('EncounterProvider loading state', () => {
+  it('clears isLoadingEncounter after a failed loadEncounter fetch', async () => {
+    mockGet.mockRejectedValueOnce(new Error('network error'));
+    renderWithProvider();
+
+    await userEvent.click(screen.getByText('load'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading-state').textContent).toBe('idle');
+    });
+  });
+
+  it('clears isLoadingEncounter after a failed createEncounter fetch', async () => {
+    mockPost.mockRejectedValueOnce(new Error('network error'));
+    renderWithProvider();
+
+    await userEvent.click(screen.getByText('create'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading-state').textContent).toBe('idle');
+    });
+  });
+});

--- a/packages/web/__tests__/contexts/Encounter.test.jsx
+++ b/packages/web/__tests__/contexts/Encounter.test.jsx
@@ -1,12 +1,4 @@
-/*
- * Regression test for the encounter loading state.
- *
- * loadEncounter and createEncounter set isLoadingEncounter to true before
- * fetching, but only cleared it after a successful fetch. If the primary
- * `encounter/:id` (or `encounter` create) request rejected, the loading flag
- * was left stuck at true and the encounter view never recovered without a
- * full page reload.
- */
+// Regression test for the encounter loading state (W11).
 
 import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -70,6 +62,18 @@ describe('EncounterProvider loading state', () => {
 
   it('clears isLoadingEncounter after a failed createEncounter fetch', async () => {
     mockPost.mockRejectedValueOnce(new Error('network error'));
+    renderWithProvider();
+
+    await userEvent.click(screen.getByText('create'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading-state').textContent).toBe('idle');
+    });
+  });
+
+  it('clears isLoadingEncounter when the post succeeds but the follow-up load fails', async () => {
+    mockPost.mockResolvedValueOnce({ id: 'test-encounter-id' });
+    mockGet.mockRejectedValueOnce(new Error('network error'));
     renderWithProvider();
 
     await userEvent.click(screen.getByText('create'));

--- a/packages/web/app/contexts/Encounter.jsx
+++ b/packages/web/app/contexts/Encounter.jsx
@@ -61,26 +61,29 @@ export const EncounterProvider = ({ children }) => {
       if (shouldUpdateLoading) {
         setIsLoadingEncounter(true);
       }
-      const data = await api.get(`encounter/${encounterId}`);
-      const { data: diagnoses } = await getDataOrDefaultOnError(
-        () => api.get(`encounter/${encounterId}/diagnoses`),
-        { data: [] },
-      );
-      const { data: procedures } = await getDataOrDefaultOnError(
-        () => api.get(`encounter/${encounterId}/procedures`),
-        { data: [] },
-      );
-      const { data: medications } = await getDataOrDefaultOnError(
-        () => api.get(`encounter/${encounterId}/medications`),
-        { data: [] },
-      );
-      const { data: triages } = await getDataOrDefaultOnError(
-        () => api.get(`encounter/${encounterId}/triages`),
-        { data: [] },
-      );
-      setEncounterData({ ...data, diagnoses, procedures, medications, triages });
-      if (shouldUpdateLoading) {
-        setIsLoadingEncounter(false);
+      try {
+        const data = await api.get(`encounter/${encounterId}`);
+        const { data: diagnoses } = await getDataOrDefaultOnError(
+          () => api.get(`encounter/${encounterId}/diagnoses`),
+          { data: [] },
+        );
+        const { data: procedures } = await getDataOrDefaultOnError(
+          () => api.get(`encounter/${encounterId}/procedures`),
+          { data: [] },
+        );
+        const { data: medications } = await getDataOrDefaultOnError(
+          () => api.get(`encounter/${encounterId}/medications`),
+          { data: [] },
+        );
+        const { data: triages } = await getDataOrDefaultOnError(
+          () => api.get(`encounter/${encounterId}/triages`),
+          { data: [] },
+        );
+        setEncounterData({ ...data, diagnoses, procedures, medications, triages });
+      } finally {
+        if (shouldUpdateLoading) {
+          setIsLoadingEncounter(false);
+        }
       }
     },
     [api],
@@ -95,11 +98,14 @@ export const EncounterProvider = ({ children }) => {
   // create, fetch and set encounter then navigate to encounter view.
   const createEncounter = async data => {
     setIsLoadingEncounter(true);
-    const createdEncounter = await api.post('encounter', data);
-    invalidateAiPatientSummary(createdEncounter);
-    await loadEncounter(createdEncounter.id);
-    setIsLoadingEncounter(false);
-    return createdEncounter;
+    try {
+      const createdEncounter = await api.post('encounter', data);
+      invalidateAiPatientSummary(createdEncounter);
+      await loadEncounter(createdEncounter.id);
+      return createdEncounter;
+    } finally {
+      setIsLoadingEncounter(false);
+    }
   };
 
   return (

--- a/packages/web/app/contexts/Encounter.jsx
+++ b/packages/web/app/contexts/Encounter.jsx
@@ -101,7 +101,9 @@ export const EncounterProvider = ({ children }) => {
     try {
       const createdEncounter = await api.post('encounter', data);
       invalidateAiPatientSummary(createdEncounter);
-      await loadEncounter(createdEncounter.id);
+      // createEncounter already owns isLoadingEncounter via its own try/finally,
+      // so tell loadEncounter not to touch it too.
+      await loadEncounter(createdEncounter.id, false);
       return createdEncounter;
     } finally {
       setIsLoadingEncounter(false);


### PR DESCRIPTION
### Changes

In `packages/web/app/contexts/Encounter.jsx`, `loadEncounter` and `createEncounter` set `isLoadingEncounter` to `true` before fetching but only cleared it after the primary fetch (`encounter/:id` or the `encounter` POST) succeeded. If that fetch rejected, `isLoadingEncounter` was left stuck at `true` and the encounter view stayed on the loading state until a full page reload.

Fix: wrap both primary fetches in `try/finally` so the loading flag always clears, without changing the existing error-propagation behaviour for callers.

Added a regression test (`packages/web/__tests__/contexts/Encounter.test.jsx`) that mocks a rejecting `api.get`/`api.post` and asserts `isLoadingEncounter` returns to `false` after the failed load/create. Both cases failed before the fix (loading state stuck at `true`) and pass after it.

From the logic-bug audit (#10266), finding W11.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_