### PR TITLE
fix(web): no-issue: exclude triage-only certainty options outside triage

### DIFF
--- a/packages/web/__tests__/forms/DiagnosisForm.test.jsx
+++ b/packages/web/__tests__/forms/DiagnosisForm.test.jsx
@@ -38,4 +38,37 @@ describe('shouldIncludeCertaintyOption', () => {
       shouldIncludeCertaintyOption({ value: DIAGNOSIS_CERTAINTY.DISPROVEN }, false, true),
     ).toBe(true);
   });
+
+  it('keeps the EMERGENCY option when editing a diagnosis that already has it set, even on a non-triage encounter', () => {
+    expect(
+      shouldIncludeCertaintyOption(
+        { value: DIAGNOSIS_CERTAINTY.EMERGENCY },
+        false,
+        true,
+        DIAGNOSIS_CERTAINTY.EMERGENCY,
+      ),
+    ).toBe(true);
+  });
+
+  it('still excludes EMERGENCY for a new diagnosis on a non-triage encounter, even if a currentCertainty is passed', () => {
+    expect(
+      shouldIncludeCertaintyOption(
+        { value: DIAGNOSIS_CERTAINTY.EMERGENCY },
+        false,
+        false,
+        DIAGNOSIS_CERTAINTY.EMERGENCY,
+      ),
+    ).toBe(false);
+  });
+
+  it('excludes EMERGENCY when editing a diagnosis whose current certainty is not EMERGENCY, on a non-triage encounter', () => {
+    expect(
+      shouldIncludeCertaintyOption(
+        { value: DIAGNOSIS_CERTAINTY.EMERGENCY },
+        false,
+        true,
+        DIAGNOSIS_CERTAINTY.SUSPECTED,
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/web/__tests__/forms/DiagnosisForm.test.jsx
+++ b/packages/web/__tests__/forms/DiagnosisForm.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { DIAGNOSIS_CERTAINTY } from '@tamanu/constants';
+
+import { shouldIncludeCertaintyOption } from '../../app/forms/DiagnosisForm';
+
+// Regression test for the certainty option filter in
+// packages/web/app/forms/DiagnosisForm.jsx.
+//
+// The triage-only "ED Diagnosis" (EMERGENCY) option was never excluded when
+// isTriage was false, so it fell through to the final `!EDIT_ONLY.includes(...)`
+// check (which is true for EMERGENCY) and was offered/saveable on ordinary
+// encounters, contradicting the adjacent comment.
+
+describe('shouldIncludeCertaintyOption', () => {
+  it('excludes the triage-only EMERGENCY option when not triaging', () => {
+    expect(
+      shouldIncludeCertaintyOption({ value: DIAGNOSIS_CERTAINTY.EMERGENCY }, false, false),
+    ).toBe(false);
+  });
+
+  it('includes the triage-only EMERGENCY option when triaging', () => {
+    expect(
+      shouldIncludeCertaintyOption({ value: DIAGNOSIS_CERTAINTY.EMERGENCY }, true, false),
+    ).toBe(true);
+  });
+
+  it('excludes EDIT_ONLY options when not editing, regardless of triage', () => {
+    expect(
+      shouldIncludeCertaintyOption({ value: DIAGNOSIS_CERTAINTY.DISPROVEN }, false, false),
+    ).toBe(false);
+    expect(
+      shouldIncludeCertaintyOption({ value: DIAGNOSIS_CERTAINTY.ERROR }, true, false),
+    ).toBe(false);
+  });
+
+  it('includes EDIT_ONLY options when editing', () => {
+    expect(
+      shouldIncludeCertaintyOption({ value: DIAGNOSIS_CERTAINTY.DISPROVEN }, false, true),
+    ).toBe(true);
+  });
+});

--- a/packages/web/app/forms/DiagnosisForm.jsx
+++ b/packages/web/app/forms/DiagnosisForm.jsx
@@ -23,9 +23,10 @@ import { useAuth } from '../contexts/Auth';
 const TRIAGE_ONLY = [DIAGNOSIS_CERTAINTY.EMERGENCY];
 const EDIT_ONLY = [DIAGNOSIS_CERTAINTY.DISPROVEN, DIAGNOSIS_CERTAINTY.ERROR];
 
-const shouldIncludeCertaintyOption = (option, isTriage, isEdit) => {
+export const shouldIncludeCertaintyOption = (option, isTriage, isEdit) => {
   if (isTriage && TRIAGE_ONLY.includes(option.value)) return true;
   if (isEdit && EDIT_ONLY.includes(option.value)) return true;
+  if (!isTriage && TRIAGE_ONLY.includes(option.value)) return false;
   return !EDIT_ONLY.includes(option.value);
 };
 

--- a/packages/web/app/forms/DiagnosisForm.jsx
+++ b/packages/web/app/forms/DiagnosisForm.jsx
@@ -23,9 +23,14 @@ import { useAuth } from '../contexts/Auth';
 const TRIAGE_ONLY = [DIAGNOSIS_CERTAINTY.EMERGENCY];
 const EDIT_ONLY = [DIAGNOSIS_CERTAINTY.DISPROVEN, DIAGNOSIS_CERTAINTY.ERROR];
 
-export const shouldIncludeCertaintyOption = (option, isTriage, isEdit) => {
+export const shouldIncludeCertaintyOption = (option, isTriage, isEdit, currentCertainty) => {
   if (isTriage && TRIAGE_ONLY.includes(option.value)) return true;
   if (isEdit && EDIT_ONLY.includes(option.value)) return true;
+  // keep the diagnosis' existing ED certainty selectable when editing, even if the
+  // encounter is no longer a triage (e.g. it has since moved to Emergency short stay)
+  if (isEdit && TRIAGE_ONLY.includes(option.value) && option.value === currentCertainty) {
+    return true;
+  }
   if (!isTriage && TRIAGE_ONLY.includes(option.value)) return false;
   return !EDIT_ONLY.includes(option.value);
 };
@@ -36,7 +41,7 @@ export const DiagnosisForm = React.memo(
     // don't show the "ED Diagnosis" option if we're just on a regular encounter
     // (unless we're editing a diagnosis with ED certainty already set)
     const certaintyOptions = DIAGNOSIS_CERTAINTY_VALUES.filter(value =>
-      shouldIncludeCertaintyOption({ value }, isTriage, isEdit),
+      shouldIncludeCertaintyOption({ value }, isTriage, isEdit, diagnosis?.certainty),
     );
     const defaultCertainty = certaintyOptions[0].value;
     const hasDiagnosis = Boolean(diagnosis?.id);
@@ -132,7 +137,9 @@ export const DiagnosisForm = React.memo(
               component={TranslatedSelectField}
               enumValues={DIAGNOSIS_CERTAINTY_LABELS}
               transformOptions={options =>
-                options.filter(option => shouldIncludeCertaintyOption(option, isTriage, isEdit))
+                options.filter(option =>
+                  shouldIncludeCertaintyOption(option, isTriage, isEdit, diagnosis?.certainty),
+                )
               }
               required
               data-testid="field-a9rl"


### PR DESCRIPTION
### Changes

`shouldIncludeCertaintyOption` in `packages/web/app/forms/DiagnosisForm.jsx` never excluded the triage-only (`EMERGENCY`) certainty option when `isTriage` was false — it fell through to `!EDIT_ONLY.includes(...)`, which is true for `EMERGENCY`, so "ED Diagnosis" was offered and saveable on ordinary (non-triage) encounters, contradicting the adjacent comment. Fixed by also excluding `TRIAGE_ONLY` values when not triaging. Added a regression test (`packages/web/__tests__/forms/DiagnosisForm.test.jsx`) covering the predicate for triage/non-triage and edit/non-edit combinations; it failed before the fix (EMERGENCY included when `isTriage=false`) and passes after.

From the logic-bug audit (#10266), finding W12.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_