### PR TITLE
fix(web): no-issue: stop TimeWithUnitField mutating shared time unit options

### DIFF
--- a/packages/web/__tests__/components/Field/TimeWithUnitField.test.jsx
+++ b/packages/web/__tests__/components/Field/TimeWithUnitField.test.jsx
@@ -1,0 +1,65 @@
+/*
+ * Regression test for TimeWithUnitInput.
+ *
+ * TIME_UNIT_OPTIONS is a shared array imported from @tamanu/constants. The component used to
+ * call TIME_UNIT_OPTIONS.sort(...) directly, mutating the shared array in place (descending in
+ * the mount effect, ascending in render) instead of sorting a copy. Because the default unit is
+ * read from TIME_UNIT_OPTIONS[0], once a valued instance had mounted and left the shared array
+ * mutated, a later empty instance could default to the wrong unit instead of minutes.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { TIME_UNIT_OPTIONS } from '@tamanu/constants';
+import { SettingsContext } from '@tamanu/ui-components';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+import { TimeWithUnitInput } from '../../../app/components/Field/TimeWithUnitField';
+
+const renderTimeWithUnitInput = (props) =>
+  renderElementWithTranslatedText(
+    <SettingsContext.Provider value={{ getSetting: () => false }}>
+      <TimeWithUnitInput onChange={() => {}} {...props} />
+    </SettingsContext.Provider>,
+  );
+
+describe('TimeWithUnitInput', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not mutate the shared TIME_UNIT_OPTIONS array when mounting with a value', () => {
+    const originalOrder = TIME_UNIT_OPTIONS.map((option) => option.unit);
+    const sortSpy = vi.spyOn(Array.prototype, 'sort');
+
+    renderTimeWithUnitInput({
+      name: 'timeToDeath',
+      value: 60 * 24 * 365 * 2,
+      label: 'Time',
+    });
+
+    // Sorting is fine as long as it's never done directly on the shared constant.
+    const sortedTheSharedArrayInPlace = sortSpy.mock.instances.some(
+      (instance) => instance === TIME_UNIT_OPTIONS,
+    );
+    expect(sortedTheSharedArrayInPlace).toBe(false);
+    expect(TIME_UNIT_OPTIONS.map((option) => option.unit)).toEqual(originalOrder);
+  });
+
+  it('renders the unit options select without mutating the shared TIME_UNIT_OPTIONS array', () => {
+    const originalOrder = TIME_UNIT_OPTIONS.map((option) => option.unit);
+    const sortSpy = vi.spyOn(Array.prototype, 'sort');
+
+    renderTimeWithUnitInput({
+      name: 'timeBetweenOnsetAndDeath',
+      value: 0,
+      label: 'Time empty',
+    });
+
+    const sortedTheSharedArrayInPlace = sortSpy.mock.instances.some(
+      (instance) => instance === TIME_UNIT_OPTIONS,
+    );
+    expect(sortedTheSharedArrayInPlace).toBe(false);
+    expect(TIME_UNIT_OPTIONS.map((option) => option.unit)).toEqual(originalOrder);
+  });
+});

--- a/packages/web/app/components/Field/TimeWithUnitField.jsx
+++ b/packages/web/app/components/Field/TimeWithUnitField.jsx
@@ -55,7 +55,7 @@ export const TimeWithUnitInput = ({
       return;
     }
 
-    const multiple = TIME_UNIT_OPTIONS.sort((a, b) => b.minutes - a.minutes).find(
+    const multiple = [...TIME_UNIT_OPTIONS].sort((a, b) => b.minutes - a.minutes).find(
       (o) => valueInMinutes % o.minutes === 0,
     );
     setUnit(multiple.unit);
@@ -100,7 +100,7 @@ export const TimeWithUnitInput = ({
           data-testid="mainfield-r4oz"
         />
         <Select select onChange={onUnitChange} value={unit} data-testid="select-f39x">
-          {TIME_UNIT_OPTIONS.sort((a, b) => a.minutes - b.minutes).map((option) => (
+          {[...TIME_UNIT_OPTIONS].sort((a, b) => a.minutes - b.minutes).map((option) => (
             <MenuItem
               key={option.unit}
               value={option.unit}


### PR DESCRIPTION
### Changes

`packages/web/app/components/Field/TimeWithUnitField.jsx` called `TIME_UNIT_OPTIONS.sort(...)` directly on the shared `TIME_UNIT_OPTIONS` array imported from `@tamanu/constants`, mutating it in place (descending in the mount effect, ascending in render). Since the component's default unit is read from `TIME_UNIT_OPTIONS[0]`, once a valued instance had mounted and left the array reordered, a later empty instance could default to the wrong unit instead of minutes (e.g. the DeathForm "time between onset and death" field defaulting to years, so entering `30` recorded 30 years).

Fix: sort copies of the array (`[...TIME_UNIT_OPTIONS].sort(...)`) instead of the shared reference.

Added a regression test (`packages/web/__tests__/components/Field/TimeWithUnitField.test.jsx`) that spies on `Array.prototype.sort` to assert the shared `TIME_UNIT_OPTIONS` array is never sorted in place when the component mounts, with and without a value. Both cases failed before the fix (the sort spy detected the shared array as the sort target) and pass after it.

From the logic-bug audit (#10266), finding W9.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_