### PR TITLE
fix(web): no-issue: render report load-failure message without [object Object]

### DIFF
--- a/packages/web/__tests__/views/reports/reportGeneratorFormLoadFailure.test.jsx
+++ b/packages/web/__tests__/views/reports/reportGeneratorFormLoadFailure.test.jsx
@@ -1,0 +1,78 @@
+/*
+ * Regression test for the report-list load-failure message in
+ * packages/web/app/views/reports/ReportGeneratorForm.jsx.
+ *
+ * When `api.get('reports')` fails, the error message was built by interpolating
+ * a <TranslatedText> React element directly into a template literal, so the
+ * user saw "[object Object] - <error message>" instead of the intended
+ * explanation.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+
+vi.mock('../../../app/contexts/Auth', () => ({
+  useAuth: () => ({
+    currentUser: { email: 'clinician@example.com' },
+    facilityId: 'facility-1',
+  }),
+}));
+
+vi.mock('../../../app/contexts/Localisation', () => ({
+  useLocalisation: () => ({
+    getLocalisation: () => ({ id: 'country-1', name: 'Testland' }),
+  }),
+}));
+
+const { stubApi } = vi.hoisted(() => ({
+  stubApi: {
+    get: vi.fn(async url => {
+      if (url === 'reports') {
+        throw new Error('Network unavailable');
+      }
+      return [];
+    }),
+  },
+}));
+
+vi.mock('@tamanu/ui-components', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useApi: () => stubApi,
+    useDateTime: () => ({
+      primaryTimeZone: 'Pacific/Auckland',
+      facilityTimeZone: undefined,
+      getCurrentDate: () => '2026-07-13',
+    }),
+  };
+});
+
+vi.mock('../../../app/components', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // The real DateField mounts a MUI X date picker, which needs a
+    // LocalizationProvider we have no reason to set up for this test; stub it
+    // out so the form can render without it.
+    DateField: () => <div data-testid="datefield-stub" />,
+  };
+});
+
+import { ReportGeneratorForm } from '../../../app/views/reports/ReportGeneratorForm';
+
+describe('ReportGeneratorForm load failure message', () => {
+  it('renders the explanatory text without "[object Object]"', async () => {
+    renderElementWithTranslatedText(<ReportGeneratorForm />);
+
+    const alert = await screen.findByTestId('alert-us27');
+
+    await waitFor(() => expect(alert.textContent).toContain('Unable to load available reports'));
+
+    expect(alert.textContent).not.toContain('[object Object]');
+    expect(alert.textContent).toContain('Network unavailable');
+  });
+});

--- a/packages/web/__tests__/views/reports/reportGeneratorFormLoadFailure.test.jsx
+++ b/packages/web/__tests__/views/reports/reportGeneratorFormLoadFailure.test.jsx
@@ -10,9 +10,12 @@
 
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from 'styled-components';
 
-import { renderElementWithTranslatedText } from '../../helpers';
+import { createQueryClient, createStubTheme, renderElementWithTranslatedText } from '../../helpers';
+import { TranslationProvider } from '../../../app/contexts/Translation';
 
 vi.mock('../../../app/contexts/Auth', () => ({
   useAuth: () => ({
@@ -74,5 +77,55 @@ describe('ReportGeneratorForm load failure message', () => {
 
     expect(alert.textContent).not.toContain('[object Object]');
     expect(alert.textContent).toContain('Network unavailable');
+  });
+
+  it('clears a previous load-failure alert once the reports fetch is re-run and succeeds', async () => {
+    // The reports-fetch effect depends on `getTranslation`, so it re-runs whenever
+    // that reference changes (e.g. once translations finish loading). Simulate
+    // that by swapping the translation context's `getTranslation` identity
+    // between renders, driven by a mutable holder the wrapper re-reads on
+    // every render pass.
+    const makeTranslationContext = () => ({
+      getTranslation: (_stringId, fallback) => fallback,
+      updateStoredLanguage: () => {},
+      storedLanguage: 'aa',
+      translations: {},
+    });
+    const translationContextHolder = { current: makeTranslationContext() };
+
+    const Wrapper = ({ children }) => (
+      <QueryClientProvider client={createQueryClient()}>
+        <ThemeProvider theme={createStubTheme()}>
+          <TranslationProvider value={translationContextHolder.current}>
+            {children}
+          </TranslationProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    );
+
+    let reportsFetchCount = 0;
+    stubApi.get.mockImplementation(async url => {
+      if (url === 'reports') {
+        reportsFetchCount += 1;
+        if (reportsFetchCount === 1) {
+          throw new Error('Network unavailable');
+        }
+        return [{ id: 'report-1', name: 'Test report' }];
+      }
+      return [];
+    });
+
+    const { rerender } = render(<ReportGeneratorForm />, { wrapper: Wrapper });
+
+    const alert = await screen.findByTestId('alert-us27');
+    await waitFor(() => expect(alert.textContent).toContain('Network unavailable'));
+
+    // Simulate translations finishing loading and force a re-render so the
+    // effect picks up the new `getTranslation` reference and re-fetches.
+    translationContextHolder.current = makeTranslationContext();
+    rerender(<ReportGeneratorForm />);
+
+    await waitFor(() => expect(reportsFetchCount).toBe(2));
+    await waitFor(() => expect(screen.queryByTestId('alert-us27')).toBeNull());
   });
 });

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -220,17 +220,14 @@ export const ReportGeneratorForm = () => {
         setAvailableReports(reports);
       } catch (error) {
         setRequestError(
-          `${(
-            <TranslatedText
-              stringId="report.generate.requestError.loadFailure"
-              fallback="Unable to load available reports"
-              data-testid="translatedtext-jzpc"
-            />
+          `${getTranslation(
+            'report.generate.requestError.loadFailure',
+            'Unable to load available reports',
           )} - ${error.message}`,
         );
       }
     })();
-  }, [api]);
+  }, [api, getTranslation]);
 
   const submitRequestReport = async formValues => {
     const { reportId, emails, timezone, ...filterValues } = formValues;

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -218,6 +218,7 @@ export const ReportGeneratorForm = () => {
       try {
         const reports = await api.get('reports');
         setAvailableReports(reports);
+        setRequestError(null);
       } catch (error) {
         setRequestError(
           `${getTranslation(


### PR DESCRIPTION
### Changes

`ReportGeneratorForm.jsx` interpolated a `<TranslatedText>` React element directly into a template literal when the report list failed to load (`api.get('reports')` throwing), so users saw "[object Object] - <error message>" in the error alert instead of a readable explanation.

Fix: resolve the string via `getTranslation()` (already used elsewhere in this component) before interpolating it, instead of interpolating the JSX element.

Added a regression test (`packages/web/__tests__/views/reports/reportGeneratorFormLoadFailure.test.jsx`) that renders `ReportGeneratorForm` with a mocked failing `reports` fetch and asserts the alert text contains "Unable to load available reports" and does not contain "[object Object]". Confirmed it fails against the pre-fix code (alert showed `Error: [object Object] - Network unavailable`) and passes after the fix.

From the logic-bug audit (#10266), finding W13.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_