### PR TITLE
fix(web): no-issue: validate only visible chart form questions

### DIFF
--- a/packages/web/__tests__/forms/ChartForm.test.jsx
+++ b/packages/web/__tests__/forms/ChartForm.test.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { PROGRAM_DATA_ELEMENT_TYPES, VISIBILITY_STATUSES } from '@tamanu/constants';
+
+import { ChartForm } from '../../app/forms/ChartForm';
+
+// Regression test for the validation schema construction in
+// packages/web/app/forms/ChartForm.jsx.
+//
+// The validation schema was previously built from every survey component while
+// the screen only renders components with a visibilityStatus of current. A
+// mandatory question retired to historical status stayed .required() but was
+// never rendered, so the form could not be submitted and the error was
+// attached to a field that does not exist on screen. The schema must be built
+// from the visible components only, as VitalsForm does.
+
+const captured = vi.hoisted(() => ({ validationSchema: null }));
+
+const { mockUseSurveyQuery, mockUsePatientAdditionalDataQuery } = vi.hoisted(() => ({
+  mockUseSurveyQuery: vi.fn(),
+  mockUsePatientAdditionalDataQuery: vi.fn(),
+}));
+
+vi.mock('@tamanu/ui-components', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useDateTime: () => ({ getCurrentDateTime: () => '2026-07-12 00:00:00' }),
+    // Capture the validation schema instead of mounting the whole form body.
+    Form: props => {
+      captured.validationSchema = props.validationSchema;
+      return <div data-testid="chart-form-body" />;
+    },
+  };
+});
+
+vi.mock('../../app/contexts/Auth', () => ({
+  useAuth: () => ({ currentUser: { id: 'user-1' }, ability: { can: () => true } }),
+}));
+
+vi.mock('../../app/contexts/Encounter.jsx', () => ({
+  useEncounter: () => ({ encounter: { encounterType: 'admission' } }),
+}));
+
+vi.mock('../../app/contexts/Translation', () => ({
+  useTranslation: () => ({ getTranslation: (stringId, fallback) => fallback }),
+}));
+
+vi.mock('../../app/api/queries/useSurveyQuery', () => ({
+  useSurveyQuery: (...args) => mockUseSurveyQuery(...args),
+}));
+
+vi.mock('../../app/api/queries', () => ({
+  usePatientAdditionalDataQuery: (...args) => mockUsePatientAdditionalDataQuery(...args),
+}));
+
+vi.mock('../../app/api', () => ({
+  combineQueries: queries => ({
+    data: queries.map(query => query.data),
+    isLoading: queries.some(query => query.isLoading),
+    isError: queries.some(query => query.isError),
+    error: null,
+  }),
+}));
+
+vi.mock('../../app/components/Surveys/getComponentForQuestionType.jsx', () => ({
+  getComponentForQuestionType: () => () => null,
+}));
+
+const makeComponent = ({ id, visibilityStatus }) => ({
+  id: `component-${id}`,
+  dataElementId: id,
+  dataElement: { id, type: PROGRAM_DATA_ELEMENT_TYPES.TEXT, defaultText: `Question ${id}` },
+  validationCriteria: JSON.stringify({ mandatory: true }),
+  config: '',
+  text: `Question ${id}`,
+  visibilityStatus,
+  screenIndex: 0,
+  componentIndex: 0,
+});
+
+const chartSurveyData = {
+  id: 'chart-survey-1',
+  components: [
+    makeComponent({ id: 'pde-visible', visibilityStatus: VISIBILITY_STATUSES.CURRENT }),
+    makeComponent({ id: 'pde-historical', visibilityStatus: VISIBILITY_STATUSES.HISTORICAL }),
+  ],
+};
+
+const renderChartForm = () =>
+  render(
+    <ChartForm
+      patient={{ id: 'patient-1' }}
+      onSubmit={() => {}}
+      onClose={() => {}}
+      chartSurveyId="chart-survey-1"
+    />,
+  );
+
+describe('ChartForm validation schema', () => {
+  beforeEach(() => {
+    captured.validationSchema = null;
+    mockUseSurveyQuery.mockReturnValue({
+      data: chartSurveyData,
+      isLoading: false,
+      isError: false,
+    });
+    mockUsePatientAdditionalDataQuery.mockReturnValue({
+      data: {},
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it('does not require answers for mandatory questions retired to historical status', () => {
+    renderChartForm();
+
+    expect(captured.validationSchema.isValidSync({ 'pde-visible': 'answered' })).toBe(true);
+  });
+
+  it('still requires answers for visible mandatory questions', () => {
+    renderChartForm();
+
+    expect(captured.validationSchema.isValidSync({})).toBe(false);
+  });
+});

--- a/packages/web/app/forms/ChartForm.jsx
+++ b/packages/web/app/forms/ChartForm.jsx
@@ -88,10 +88,13 @@ export const ChartForm = React.memo(
       editedObject,
       getCurrentDateTime,
     ]);
-    const validationSchema = useMemo(() => getValidationSchema(chartSurveyData, getTranslation), [
-      chartSurveyData,
-      getTranslation,
-    ]);
+    const validationSchema = useMemo(
+      () =>
+        getValidationSchema({ components: visibleComponents }, getTranslation, {
+          encounterType: encounter?.encounterType,
+        }),
+      [visibleComponents, encounter?.encounterType, getTranslation],
+    );
 
     if (isLoading) {
       return <ModalLoader data-testid="modalloader-wncd" />;


### PR DESCRIPTION
### Changes

`packages/web/app/forms/ChartForm.jsx` built its validation schema from every survey component while the screen only renders components with a `current` visibility status, so a mandatory question retired to `historical` status stayed `.required()` but was never rendered — the form became unsubmittable with the error attached to a non-existent field. The fix builds the schema from the visible components only and passes the `{ encounterType }` argument, mirroring how VitalsForm does it. Added a regression test (`packages/web/__tests__/forms/ChartForm.test.jsx`) that renders ChartForm with a mandatory historical component and asserts the form validates with only visible fields filled — it failed before the fix and passes after. From the logic-bug audit (#10266), finding W16.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_