### PR TITLE
fix(web): no-issue: sort related conditions ascending in program registry table

### DIFF
--- a/packages/web/__tests__/views/programRegistry/ProgramRegistryTable.test.jsx
+++ b/packages/web/__tests__/views/programRegistry/ProgramRegistryTable.test.jsx
@@ -1,0 +1,28 @@
+/*
+ * Regression test for ProgramRegistryTable's related conditions cell.
+ *
+ * The conditions cell must sort condition names ascending (A-Z), matching the
+ * ascending sort used for the same data on the patient program registry
+ * detail page. A swapped localeCompare comparator would sort descending
+ * instead, so in a line-clamped cell the wrong (i.e. last-alphabetically)
+ * conditions end up truncated from view.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { ConditionsCell } from '../../../app/views/programRegistry/ProgramRegistryTable';
+
+describe('ConditionsCell', () => {
+  it('sorts related condition names ascending (A-Z)', () => {
+    const conditions = [
+      { id: 'condition-zebra', name: 'Zebra condition' },
+      { id: 'condition-apple', name: 'Apple condition' },
+      { id: 'condition-mango', name: 'Mango condition' },
+    ];
+    const getTranslation = (_stringId, fallback) => fallback;
+
+    const result = ConditionsCell({ conditions, getTranslation });
+
+    expect(result).toBe('Apple condition, Mango condition, Zebra condition');
+  });
+});

--- a/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
@@ -21,13 +21,13 @@ import { TranslatedText } from '../../components/Translation';
 import { useTranslation } from '../../contexts/Translation.jsx';
 import { NoteModalActionBlocker } from '../../components/NoteModalActionBlocker';
 
-const ConditionsCell = ({ conditions, getTranslation }) => {
+export const ConditionsCell = ({ conditions, getTranslation }) => {
   return conditions
     ?.map(condition => {
       const { id, name } = condition;
       return getTranslation(getReferenceDataStringId(id, 'programRegistryCondition'), name);
     })
-    .sort((a, b) => b.localeCompare(a))
+    .sort((a, b) => a.localeCompare(b))
     .join(', ');
 };
 


### PR DESCRIPTION
### Changes

The related conditions cell in `packages/web/app/views/programRegistry/ProgramRegistryTable.jsx` sorted condition names descending (`b.localeCompare(a)`) instead of ascending, contradicting the ascending sort used for the same data on the patient program registry detail page. Since the cell is line-clamped, this caused the wrong (last-alphabetically) conditions to be truncated from view. Fixed the comparator to `a.localeCompare(b)`.

Added a regression test (`packages/web/__tests__/views/programRegistry/ProgramRegistryTable.test.jsx`) exercising the exported `ConditionsCell` accessor with unordered condition names, asserting ascending output; this test failed against the unfixed comparator and passes after the fix.

From the logic-bug audit (#10266), finding W19.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_