### PR TITLE
fix(web): no-issue: scope date selector arrow keys to the day strip

### DIFF
--- a/packages/web/__tests__/views/scheduling/DateSelector.test.jsx
+++ b/packages/web/__tests__/views/scheduling/DateSelector.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthContext, DateTimeProvider, SettingsContext } from '@tamanu/ui-components';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+import { DateSelector } from '../../../app/views/scheduling/outpatientBookings/DateSelector';
+
+// Regression test for packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx.
+//
+// handleOnKeyDown was bound to the outer Wrapper, which also contains the
+// editable month input, so ArrowLeft/ArrowRight typed into that input bubbled
+// up and mutated the selected date instead of moving the cursor in the input.
+// The fix scopes the handler to the day strip only.
+
+vi.mock('../../../app/components', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // Replace the MUI month/year picker with a plain text input so we can
+    // focus it and dispatch key events without pulling in date pickers.
+    MonthPicker: props => <input onChange={() => {}} value="" {...props} />,
+  };
+});
+
+const renderDateSelector = (value, onChange) =>
+  renderElementWithTranslatedText(
+    <AuthContext.Provider value={{ primaryTimeZone: 'Pacific/Auckland' }}>
+      <SettingsContext.Provider value={{ getSetting: () => undefined }}>
+        <DateTimeProvider>
+          <DateSelector value={value} onChange={onChange} />
+        </DateTimeProvider>
+      </SettingsContext.Provider>
+    </AuthContext.Provider>,
+  );
+
+describe('DateSelector keyboard navigation scope', () => {
+  it('does not change the selected date when arrow keys are pressed in the month input', async () => {
+    const user = userEvent.setup();
+    const selectedDate = new Date(2024, 3, 15); // 15 Apr 2024
+    const onChange = vi.fn();
+
+    renderDateSelector(selectedDate, onChange);
+
+    const monthInput = screen.getByTestId('styledmonthpicker-3pmc');
+    monthInput.focus();
+    await user.keyboard('{ArrowLeft}');
+    await user.keyboard('{ArrowRight}');
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('navigates and focuses adjacent days without throwing at the first day', async () => {
+    const user = userEvent.setup();
+    const selectedDate = new Date(2024, 3, 15); // 15 Apr 2024
+    const onChange = vi.fn();
+
+    const { rerender } = renderDateSelector(selectedDate, onChange);
+
+    const firstDay = new Date(2024, 3, 1);
+    const firstDayButton = screen.getByTestId(/daywrapper-2vbq-.*-1$/);
+    firstDayButton.focus();
+
+    await expect(
+      user.keyboard('{ArrowLeft}'),
+    ).resolves.not.toThrow();
+
+    // Re-render with the first day selected, mirroring parent state update.
+    rerender(
+      <AuthContext.Provider value={{ primaryTimeZone: 'Pacific/Auckland' }}>
+        <SettingsContext.Provider value={{ getSetting: () => undefined }}>
+          <DateTimeProvider>
+            <DateSelector value={firstDay} onChange={onChange} />
+          </DateTimeProvider>
+        </SettingsContext.Provider>
+      </AuthContext.Provider>,
+    );
+
+    const secondDayButton = screen.getByTestId(/daywrapper-2vbq-.*-2$/);
+    secondDayButton.focus();
+
+    await user.keyboard('{ArrowRight}');
+
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
@@ -184,18 +184,18 @@ export const DateSelector = ({ value, onChange }) => {
     if (e.key === 'ArrowLeft') {
       if (isSameDay(value, viewedDays[0])) return;
       handleChange(subDays(value, 1));
-      e.target.previousElementSibling.focus();
+      e.target.previousElementSibling?.focus();
     }
 
     if (e.key === 'ArrowRight') {
       if (isSameDay(value, viewedDays.at(-1))) return;
       handleChange(addDays(value, 1));
-      e.target.nextElementSibling.focus();
+      e.target.nextElementSibling?.focus();
     }
   };
 
   return (
-    <Wrapper onKeyDown={handleOnKeyDown} data-testid="wrapper-up3h">
+    <Wrapper data-testid="wrapper-up3h">
       <StyledMonthPicker
         key={value.valueOf()}
         value={viewedDays[0]}
@@ -209,7 +209,7 @@ export const DateSelector = ({ value, onChange }) => {
         <StepperButton onClick={handleDecrement} data-testid="stepperbutton-s2jx">
           <ArrowBackIos data-testid="arrowbackios-jjro" />
         </StepperButton>
-        <DaysWrapper data-testid="dayswrapper-f31b">
+        <DaysWrapper onKeyDown={handleOnKeyDown} data-testid="dayswrapper-f31b">
           {viewedDays.map(date => (
             <DayButton
               aria-pressed={isSameDay(date, value)}


### PR DESCRIPTION
### Changes

`DateSelector.jsx`'s `handleOnKeyDown` was bound to the outer `Wrapper`, which also contains the editable month input and stepper buttons. ArrowLeft/ArrowRight events bubbling up from those children mutated the selected date, and `e.target.previousElementSibling`/`nextElementSibling.focus()` threw when there was no sibling (first/last day). Fix: the handler is now bound to the day-strip wrapper only, and the sibling focus calls are null-guarded. Added a vitest + user-event regression test confirming arrow keys inside the month input no longer change the selected date, and that navigating from the first day no longer throws; the test failed before the fix (assertion failure on the month-input case, uncaught `TypeError: Cannot read properties of null (reading 'focus')` on the day-strip case) and passes after it.

From the logic-bug audit (#10266), finding W22.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_