### PR TITLE
fix(web): no-issue: clear stale frequency when switching task templates

### DIFF
--- a/packages/web/__tests__/forms/TaskForm.test.jsx
+++ b/packages/web/__tests__/forms/TaskForm.test.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { REFERENCE_TYPES } from '@tamanu/constants';
+
+import { renderElementWithTranslatedText } from '../helpers';
+import { TaskForm } from '../../app/forms/TaskForm';
+
+// Regression test for the stale-frequency bug in packages/web/app/forms/TaskForm.jsx
+// handleTaskChange (logic-bug audit, finding W17, PR #10266).
+//
+// Selecting a task template that has a frequency, then switching to a template
+// with no frequency, previously left the old frequencyValue in place (only
+// frequencyUnit was cleared), because handleTaskChange only ever set
+// frequencyValue when the new template had one and never cleared it otherwise.
+// The fix explicitly clears frequencyValue when the selected template has none.
+
+const { nextAutocompleteTargetRef } = vi.hoisted(() => ({
+  nextAutocompleteTargetRef: { current: null },
+}));
+
+vi.mock('../../app/components/Field', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // Stub out the autocomplete so we can trigger `onChange` with a synthetic
+    // task-template selection without driving the real react-autosuggest widget.
+    AutocompleteField: ({ onChange, field, ['data-testid']: testId }) => (
+      <button
+        type="button"
+        data-testid={testId}
+        onClick={() => onChange({ target: { ...nextAutocompleteTargetRef.current, name: field.name } })}
+      >
+        select
+      </button>
+    ),
+    CheckField: ({ field }) => <input type="checkbox" checked={Boolean(field?.value)} readOnly />,
+    DateTimeField: ({ field }) => <input value={field?.value ?? ''} readOnly />,
+    SuggesterSelectField: () => null,
+    NumberField: ({ field, ['data-testid']: testId }) => (
+      <input data-testid={`${testId}-input`} value={field?.value ?? ''} readOnly />
+    ),
+  };
+});
+
+vi.mock('@tamanu/ui-components', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useDateTime: () => ({
+      getCurrentDateTime: () => '2026-07-13 00:00:00',
+    }),
+    TranslatedSelectField: ({ field }) => <div>{field?.value ?? ''}</div>,
+    TextField: ({ field }) => <textarea value={field?.value ?? ''} readOnly />,
+  };
+});
+
+vi.mock('../../app/api', () => ({
+  useSuggester: () => ({}),
+}));
+
+vi.mock('../../app/api/mutations/useTaskMutation', () => ({
+  useCreateTasks: () => ({ mutate: vi.fn(), isLoading: false }),
+}));
+
+vi.mock('../../app/contexts/Encounter', () => ({
+  useEncounter: () => ({ encounter: { id: 'encounter-1' } }),
+}));
+
+vi.mock('../../app/contexts/Auth', () => ({
+  useAuth: () => ({ ability: { can: () => true }, currentUser: { id: 'user-1' } }),
+}));
+
+const frequencyTaskTemplate = {
+  type: REFERENCE_TYPES.TASK_TEMPLATE,
+  label: 'Repeating task',
+  value: 'task-template-frequency',
+  taskTemplate: {
+    designations: [],
+    highPriority: false,
+    frequencyValue: 2,
+    frequencyUnit: 'day',
+  },
+};
+
+const onceOffTaskTemplate = {
+  type: REFERENCE_TYPES.TASK_TEMPLATE,
+  label: 'Once-off task',
+  value: 'task-template-once-off',
+  taskTemplate: {
+    designations: [],
+    highPriority: false,
+  },
+};
+
+const renderTaskForm = () =>
+  renderElementWithTranslatedText(
+    <TaskForm onClose={() => {}} refreshTaskTable={() => {}} />,
+  );
+
+describe('TaskForm handleTaskChange', () => {
+  beforeEach(() => {
+    nextAutocompleteTargetRef.current = null;
+  });
+
+  it('clears a stale frequency value when switching to a once-off template', () => {
+    renderTaskForm();
+
+    nextAutocompleteTargetRef.current = frequencyTaskTemplate;
+    fireEvent.click(screen.getByTestId('field-hp09'));
+
+    expect(screen.getByTestId('field-7vdy-input').value).toBe('2');
+
+    nextAutocompleteTargetRef.current = onceOffTaskTemplate;
+    fireEvent.click(screen.getByTestId('field-hp09'));
+
+    expect(screen.getByTestId('field-7vdy-input').value).toBe('');
+  });
+});

--- a/packages/web/app/forms/TaskForm.jsx
+++ b/packages/web/app/forms/TaskForm.jsx
@@ -173,7 +173,9 @@ export const TaskForm = React.memo(({ onClose, refreshTaskTable }) => {
         designations?.map(item => item.designationId),
       );
       setFieldValue('highPriority', highPriority);
-      frequencyValue ? setFieldValue('frequencyValue', Number(frequencyValue)) : null;
+      frequencyValue
+        ? setFieldValue('frequencyValue', Number(frequencyValue))
+        : setFieldValue('frequencyValue', '');
       setFieldValue('frequencyUnit', frequencyUnit);
     }
   };


### PR DESCRIPTION
### Changes

`TaskForm.handleTaskChange` only set `frequencyValue` when the newly selected task template had one (`frequencyValue ? setFieldValue(...) : null`), and never cleared it otherwise. Switching from a task template with a frequency to a once-off template left the stale `frequencyValue` in place while `frequencyUnit` was cleared, blocking submission on a required `frequencyUnit` the user never set. Fixed by explicitly clearing `frequencyValue` when the selected template has no frequency (`packages/web/app/forms/TaskForm.jsx`).

Added a regression test (`packages/web/__tests__/forms/TaskForm.test.jsx`) that selects a frequency template then a once-off template and asserts the frequency value is cleared; it failed before the fix (`expected '2' to be ''`) and passes after.

From the logic-bug audit (#10266), finding W17.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_