### PR TITLE
fix(mobile): no-issue: raise auth error for unknown email in offline login

### DIFF
--- a/packages/mobile/App/services/auth/AuthService.test.ts
+++ b/packages/mobile/App/services/auth/AuthService.test.ts
@@ -1,6 +1,8 @@
 import { CentralServerConnection } from '../sync';
 import { AuthService } from './AuthService';
 import { MODELS_MAP } from '~/models/modelsMap';
+import { readConfig } from '~/services/config';
+import { AuthenticationError, invalidUserCredentialsMessage } from '../error';
 
 jest.mock('../sync/CentralServerConnection', () => ({
   CentralServerConnection: jest.fn().mockImplementation(() => ({
@@ -12,6 +14,11 @@ jest.mock('../sync/CentralServerConnection', () => ({
     clearToken: jest.fn(),
     clearRefreshToken: jest.fn(),
   })),
+}));
+
+jest.mock('~/services/config', () => ({
+  readConfig: jest.fn(),
+  writeConfig: jest.fn(),
 }));
 
 describe('AuthService', () => {
@@ -39,6 +46,21 @@ describe('AuthService', () => {
       authService.endSession();
       expect(centralServerConnection.clearToken).toHaveBeenCalled();
       expect(centralServerConnection.clearRefreshToken).toHaveBeenCalled();
+    });
+  });
+
+  describe('localSignIn', () => {
+    it('should raise an authentication error when no user matches the given email', async () => {
+      (readConfig as jest.Mock).mockResolvedValue('test-facility-id');
+      const models = { ...MODELS_MAP, User: { findOne: jest.fn().mockResolvedValue(null) } };
+      authService = new AuthService(models, centralServerConnection);
+
+      await expect(
+        authService.localSignIn(
+          { email: 'unknown@example.com', password: 'password' },
+          jest.fn(),
+        ),
+      ).rejects.toThrow(new AuthenticationError(invalidUserCredentialsMessage));
     });
   });
 });

--- a/packages/mobile/App/services/auth/AuthService.ts
+++ b/packages/mobile/App/services/auth/AuthService.ts
@@ -84,13 +84,17 @@ export class AuthService {
       },
     });
 
+    if (!user) {
+      throw new AuthenticationError(invalidUserCredentialsMessage);
+    }
+
     if (!user.password) {
       throw new AuthenticationError(
         'You need to first login when connected to internet to use your account offline.',
       );
     }
 
-    if (!user || !(await compare(password, user.password))) {
+    if (!(await compare(password, user.password))) {
       throw new AuthenticationError(invalidUserCredentialsMessage);
     }
 


### PR DESCRIPTION
### Changes

`localSignIn` in `packages/mobile/App/services/auth/AuthService.ts` dereferenced `user.password` before checking whether the `User.findOne` lookup had actually returned a user, so an unknown or misspelled email crashed with a raw `TypeError: Cannot read properties of null (reading 'password')` instead of raising the intended `AuthenticationError` with the invalid-credentials message. The fix reorders the checks so the `!user` case is handled first.

Added a regression test in `AuthService.test.ts` covering `localSignIn` with an email that matches no user; it rejects with the `AuthenticationError`/invalid-credentials message rather than a `TypeError`. Confirmed the test fails with the `TypeError` before the fix and passes after.

From the logic-bug audit (#10266), finding M5.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_