### PR TITLE
fix(mobile): store real timestamp for incoming sync tombstones

### DIFF
--- a/packages/mobile/App/services/sync/utils/buildFromSyncRecord.spec.ts
+++ b/packages/mobile/App/services/sync/utils/buildFromSyncRecord.spec.ts
@@ -1,0 +1,53 @@
+import { buildFromSyncRecord } from './buildFromSyncRecord';
+import { BaseModel } from '../../../models/BaseModel';
+import { SyncRecord } from '../types';
+
+const makeMockModel = (columnNames: string[]): typeof BaseModel =>
+  ({
+    excludedSyncColumns: [],
+    getRepository: () => ({
+      metadata: {
+        ownColumns: columnNames.map(propertyName => ({ propertyName })),
+        relationIds: [],
+        ownRelations: [],
+      },
+    }),
+  }) as any;
+
+describe('buildFromSyncRecord', () => {
+  const model = makeMockModel(['id', 'name']);
+
+  it('stores a real current datetime string when the record is deleted', () => {
+    const records: SyncRecord[] = [
+      {
+        recordId: 'record_id',
+        isDeleted: true,
+        data: { id: 'record_id', name: 'Test' },
+      } as SyncRecord,
+    ];
+
+    const before = new Date();
+    const [built] = buildFromSyncRecord(model, records);
+    const after = new Date();
+
+    expect(built.deletedAt).not.toBe("datetime('now')");
+    expect(built.deletedAt).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    const deletedAt = new Date((built.deletedAt as string).replace(' ', 'T'));
+    expect(deletedAt.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);
+    expect(deletedAt.getTime()).toBeLessThanOrEqual(after.getTime() + 1000);
+  });
+
+  it('stores null when the record is not deleted', () => {
+    const records: SyncRecord[] = [
+      {
+        recordId: 'record_id',
+        isDeleted: false,
+        data: { id: 'record_id', name: 'Test' },
+      } as SyncRecord,
+    ];
+
+    const [built] = buildFromSyncRecord(model, records);
+
+    expect(built.deletedAt).toBeNull();
+  });
+});

--- a/packages/mobile/App/services/sync/utils/buildFromSyncRecord.ts
+++ b/packages/mobile/App/services/sync/utils/buildFromSyncRecord.ts
@@ -3,6 +3,7 @@ import { pick } from 'es-toolkit/compat';
 import { DataToPersist, SyncRecord } from '../types';
 import { BaseModel } from '../../../models/BaseModel';
 import { extractIncludedColumns } from './extractIncludedColumns';
+import { getCurrentDateTimeString } from '~/ui/helpers/date';
 
 export const buildFromSyncRecord = (
   model: typeof BaseModel,
@@ -12,7 +13,7 @@ export const buildFromSyncRecord = (
   // Skip field mapping for raw insert - keep original field names
   return records.map(record => {
     const data = pick(record.data, includedColumns);
-    data.deletedAt = record.isDeleted ? "datetime('now')" : null;
+    data.deletedAt = record.isDeleted ? getCurrentDateTimeString() : null;
     return data as DataToPersist;
   });
 };


### PR DESCRIPTION
### Changes

`buildFromSyncRecord` (packages/mobile/App/services/sync/utils/buildFromSyncRecord.ts) set `deletedAt` to the string `"datetime('now')"`, which is bound as a query parameter, so SQLite stored the 15-character literal text instead of a timestamp — `deletedAt IS NULL` filtering still worked, but the column held garbage for any parse, compare, or display. The fix stores a real local ISO 9075 current datetime string using the existing `getCurrentDateTimeString` helper. Adds a regression test (`buildFromSyncRecord.spec.ts`) asserting a deleted record yields a `yyyy-MM-dd HH:mm:ss` timestamp approximately now (and not the literal string) and a non-deleted record yields null; it failed before the fix. From the logic-bug audit (#10266), finding M6.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_