### PR TITLE
fix(mobile): no-issue: filter report totals by device in where clause

### DIFF
--- a/packages/mobile/App/models/Encounter.spec.ts
+++ b/packages/mobile/App/models/Encounter.spec.ts
@@ -1,7 +1,14 @@
 import { formatISO9075, subDays } from 'date-fns';
 
+// getTotalEncountersAndResponses filters by the current device's id, so this test
+// stubs it to a fixed, synchronous value it can assert against.
+jest.mock('react-native-device-info', () => ({
+  ...jest.requireActual('react-native-device-info/jest/react-native-device-info-mock'),
+  getUniqueId: () => 'own-device-id',
+}));
+
 import { Database } from '~/infra/db';
-import { fakeEncounter, fakePatient, fakeUser } from '/root/tests/helpers/fake';
+import { fakeEncounter, fakePatient, fakeSurvey, fakeUser } from '/root/tests/helpers/fake';
 
 beforeAll(async () => {
   await Database.connect();
@@ -49,6 +56,39 @@ describe('Encounter', () => {
 
       const result = await Database.models.Encounter.getCurrentEncounterForPatient(patient.id);
       expect(result?.id).toBe(todayEncounter.id);
+    });
+  });
+
+  describe('getTotalEncountersAndResponses', () => {
+    it('only counts encounters from the current device', async () => {
+      const ownDeviceId = 'own-device-id';
+
+      const user = fakeUser();
+      await Database.models.User.insert(user);
+
+      const ownDevicePatient = fakePatient();
+      await Database.models.Patient.insert(ownDevicePatient);
+
+      const ownDeviceEncounter = fakeEncounter();
+      ownDeviceEncounter.deviceId = ownDeviceId;
+      ownDeviceEncounter.patient = ownDevicePatient;
+      ownDeviceEncounter.examiner = user;
+      await Database.models.Encounter.insert(ownDeviceEncounter);
+
+      const otherDevicePatient = fakePatient();
+      await Database.models.Patient.insert(otherDevicePatient);
+
+      const otherDeviceEncounter = fakeEncounter();
+      otherDeviceEncounter.deviceId = 'some-other-device';
+      otherDeviceEncounter.patient = otherDevicePatient;
+      otherDeviceEncounter.examiner = user;
+      await Database.models.Encounter.insert(otherDeviceEncounter);
+
+      const survey = fakeSurvey();
+      const result = await Database.models.Encounter.getTotalEncountersAndResponses(survey.id);
+
+      const totalEncounters = result.reduce((sum, row) => sum + Number(row.totalEncounters), 0);
+      expect(totalEncounters).toBe(1);
     });
   });
 });

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -293,8 +293,8 @@ export class Encounter extends BaseModel implements IEncounter {
       .where("encounter.startDate >= datetime(:date, 'unixepoch')", {
         date: formatDateForQuery(date),
       })
+      .andWhere('encounter.deviceId = :deviceId', { deviceId: getUniqueId() })
       .groupBy('date(encounter.startDate)')
-      .having('encounter.deviceId = :deviceId', { deviceId: getUniqueId() })
       .orderBy('encounterDate', 'ASC');
 
     return query.getRawMany();


### PR DESCRIPTION
### Changes

`getTotalEncountersAndResponses` in `packages/mobile/App/models/Encounter.ts` grouped encounters by `date(encounter.startDate)` and then filtered by device using `.having('encounter.deviceId = :deviceId', ...)`. Because `deviceId` is a non-aggregated column, SQLite's HAVING resolves it to an arbitrary row within each date group, so per-day totals could mix encounters from all devices together instead of scoping to the current device.

Fix: move the `deviceId` predicate to `.andWhere`, matching the sibling queries in the same file that already filter this way.

Added a regression test in `Encounter.spec.ts` that creates same-day encounters for two different device ids and asserts the totals only include the current device's encounters. The test failed before the fix (expected 1, received 0 — the buggy query dropped the whole day's group) and passes after it.

From the logic-bug audit (#10266), finding M4.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_