### PR TITLE
fix(mobile): no-issue: enforce mandatory village using the villageId field key

### DIFF
--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/patientDetailsValidationSchema.test.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/patientDetailsValidationSchema.test.tsx
@@ -1,0 +1,33 @@
+import '~/ui/helpers/yupMethods';
+import { getPatientDetailsValidation } from './patientDetailsValidationSchema';
+
+const basePayload = {
+  firstName: 'Test',
+  lastName: 'Patient',
+  dateOfBirth: new Date('2000-01-01'),
+  sex: 'female',
+};
+
+describe('getPatientDetailsValidation', () => {
+  it('rejects a payload missing villageId when fields.villageId.requiredPatientData is true', async () => {
+    const getSetting = jest.fn(key => {
+      if (key === 'fields.villageId.requiredPatientData') return true;
+      return false;
+    });
+    const schema = getPatientDetailsValidation(getSetting);
+
+    await expect(schema.validate(basePayload)).rejects.toThrow();
+  });
+
+  it('accepts a payload including villageId when fields.villageId.requiredPatientData is true', async () => {
+    const getSetting = jest.fn(key => {
+      if (key === 'fields.villageId.requiredPatientData') return true;
+      return false;
+    });
+    const schema = getPatientDetailsValidation(getSetting);
+
+    await expect(
+      schema.validate({ ...basePayload, villageId: 'village-1' }),
+    ).resolves.toBeTruthy();
+  });
+});

--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/patientDetailsValidationSchema.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/patientDetailsValidationSchema.tsx
@@ -68,9 +68,9 @@ export const getPatientDetailsValidation = (getSetting: <T>(key: string) => T) =
       .translatedLabel(
         <TranslatedText stringId="general.localisedField.sex.label" fallback="Sex" />,
       ),
-    village: requiredWhenConfiguredMandatory(
+    villageId: requiredWhenConfiguredMandatory(
       getSetting,
-      'village',
+      'villageId',
       Yup.string().translatedLabel(
         <TranslatedText stringId="general.localisedField.villageId.label" fallback="Village" />,
       ),


### PR DESCRIPTION
### Changes

The mobile patient details validation schema (`patientDetailsValidationSchema.tsx`) used the setting path `fields.village.requiredPatientData` and payload key `village` to decide whether the village field was mandatory, but the actual form field/column and the settings schema both use `villageId`. Since the settings lookup for `fields.village.requiredPatientData` always returned `undefined`, the required check never fired even though the UI label (which reads `fields.villageId`) correctly showed a required asterisk.

Fix: use `villageId` for both the schema key and the setting path, matching the existing `religionId` pattern a few lines below.

Added a regression test (`patientDetailsValidationSchema.test.tsx`) covering `getPatientDetailsValidation`: with `fields.villageId.requiredPatientData` set to `true`, the schema now rejects a payload missing `villageId` and accepts one with it. The rejection test failed before the fix (the promise resolved instead of rejecting) and passes after it.

From the logic-bug audit (#10266), finding M12.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_