### PR TITLE
fix(mobile): no-issue: record per-field sync ticks on patient additional data insert

### DIFF
--- a/packages/mobile/App/models/PatientAdditionalData.spec.ts
+++ b/packages/mobile/App/models/PatientAdditionalData.spec.ts
@@ -12,11 +12,18 @@ const FACILITY_ID = 'facility-pad-spec';
 beforeAll(async () => {
   mockedReadConfig.mockReturnValue(Promise.resolve(FACILITY_ID));
   await Database.connect();
-  await Database.models.Facility.createAndSaveOne({
-    id: FACILITY_ID,
-    code: FACILITY_ID,
-    name: 'PAD spec facility',
-  });
+  // findOrCreate: the mobile test suite runs against a fresh sqlite file per
+  // run (see TEST_CONNECTION_CONFIG in App/infra/db/index.ts), so this fixed
+  // id never collides in practice, but guard against it anyway as cheap
+  // insurance in case that ever changes.
+  const existingFacility = await Database.models.Facility.findOne({ where: { id: FACILITY_ID } });
+  if (!existingFacility) {
+    await Database.models.Facility.createAndSaveOne({
+      id: FACILITY_ID,
+      code: FACILITY_ID,
+      name: 'PAD spec facility',
+    });
+  }
 });
 
 describe('PatientAdditionalData', () => {
@@ -37,6 +44,9 @@ describe('PatientAdditionalData', () => {
         place_of_birth: expect.any(Number),
         primary_contact_number: expect.any(Number),
       });
+      // fields not provided on insert should not appear in updatedAtByField
+      expect(updatedAtByField).not.toHaveProperty('secondary_contact_number');
+      expect(updatedAtByField).not.toHaveProperty('blood_type');
     });
 
     it('records insert field ticks in the same form as update field ticks', async () => {

--- a/packages/mobile/App/models/PatientAdditionalData.spec.ts
+++ b/packages/mobile/App/models/PatientAdditionalData.spec.ts
@@ -1,0 +1,62 @@
+import { mocked } from 'jest-mock';
+
+import { Database } from '~/infra/db';
+import { fakePatient } from '/root/tests/helpers/fake';
+import { readConfig } from '~/services/config';
+jest.mock('~/services/config');
+const mockedReadConfig = mocked(readConfig);
+jest.setTimeout(60000); // can be slow to create/delete records
+
+const FACILITY_ID = 'facility-pad-spec';
+
+beforeAll(async () => {
+  mockedReadConfig.mockReturnValue(Promise.resolve(FACILITY_ID));
+  await Database.connect();
+  await Database.models.Facility.createAndSaveOne({
+    id: FACILITY_ID,
+    code: FACILITY_ID,
+    name: 'PAD spec facility',
+  });
+});
+
+describe('PatientAdditionalData', () => {
+  describe('setUpdatedAtByField', () => {
+    it('records per-field sync ticks for fields populated on insert', async () => {
+      const patient = fakePatient();
+      await Database.models.Patient.insert(patient);
+
+      await Database.models.PatientAdditionalData.createAndSaveOne({
+        patient: patient.id,
+        placeOfBirth: 'Suva',
+        primaryContactNumber: '1234567',
+      });
+
+      const saved = await Database.models.PatientAdditionalData.getForPatient(patient.id);
+      const updatedAtByField = JSON.parse(saved.updatedAtByField ?? 'null');
+      expect(updatedAtByField).toMatchObject({
+        place_of_birth: expect.any(Number),
+        primary_contact_number: expect.any(Number),
+      });
+    });
+
+    it('records insert field ticks in the same form as update field ticks', async () => {
+      const patient = fakePatient();
+      await Database.models.Patient.insert(patient);
+
+      const created = await Database.models.PatientAdditionalData.createAndSaveOne({
+        patient: patient.id,
+        placeOfBirth: 'Nadi',
+      });
+      await Database.models.PatientAdditionalData.updateValues(created.id, {
+        primaryContactNumber: '7654321',
+      });
+
+      const saved = await Database.models.PatientAdditionalData.getForPatient(patient.id);
+      const updatedAtByField = JSON.parse(saved.updatedAtByField ?? 'null');
+      expect(updatedAtByField).toMatchObject({
+        place_of_birth: expect.any(Number),
+        primary_contact_number: expect.any(Number),
+      });
+    });
+  });
+});

--- a/packages/mobile/App/models/PatientAdditionalData.ts
+++ b/packages/mobile/App/models/PatientAdditionalData.ts
@@ -186,7 +186,7 @@ export class PatientAdditionalData extends BaseModel implements IPatientAddition
     // e.g. from a central record syncing down to this device
     if (!oldPatientAdditionalData) {
       includedColumns.forEach((camelCaseKey) => {
-        if (this[snakeCase(camelCaseKey)] !== undefined) {
+        if (this[camelCaseKey] !== undefined) {
           newUpdatedAtByField[snakeCase(camelCaseKey)] = syncTick;
         }
       });


### PR DESCRIPTION
### Changes

The insert branch of `setUpdatedAtByField` in `packages/mobile/App/models/PatientAdditionalData.ts` checked `this[snakeCase(camelCaseKey)]`, but entity properties are camelCase, so the check was always undefined and no per-field sync ticks were recorded on insert — a PAD created with initial values synced up without `updatedAtByField`, so central's field-level merge against a concurrent edit could lose the mobile-entered values. The fix checks `this[camelCaseKey]`, mirroring the (correct) update branch. Adds a mobile jest model regression test (`PatientAdditionalData.spec.ts`) asserting that per-field ticks are recorded for fields populated on insert and match the form produced by an update; both cases failed before the fix. From the logic-bug audit (#10266), finding M7.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_