### PR TITLE
chore(database): no-issue: declare fake-data devDependency used by tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37796,6 +37796,7 @@
       "devDependencies": {
         "@casl/ability": "^6.8.0",
         "@tamanu/build-tooling": "*",
+        "@tamanu/fake-data": "*",
         "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.13",
         "@types/jsonpath": "^0.2.4",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@casl/ability": "^6.8.0",
     "@tamanu/build-tooling": "*",
+    "@tamanu/fake-data": "*",
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.13",
     "@types/jsonpath": "^0.2.4",


### PR DESCRIPTION
### Changes

Four `@tamanu/database` test files (`sortInDependencyOrder`, `sync/migrations`, `sync/saveChangesForModel`, `utils/audit/extractChangelogFromSnapshotRecords`) import `@tamanu/fake-data/fake`, but the package never declares `@tamanu/fake-data` as a dependency. CI's workspace-scoped install (`npm install --workspace=@tamanu/database`) therefore only resolves it by luck of the restored node_modules cache — on `release/2.60` the same gap made the whole database test job fail with `ERR_MODULE_NOT_FOUND` (fixed there via #10276, from the #10266 audit). This declares the devDependency on `main` so the resolution is guaranteed rather than incidental, per the project rule of adding dependencies to the package they're used in.

The matching lockfile entry was added by hand (single line) to avoid unrelated lockfile churn from a newer npm version.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavJTM9ksL7wevJ9epyAQu)_