### PR TITLE
fix(mobile): TAM-6959: use lodash groupBy instead of es-toolkit/compat

### DIFF
--- a/packages/mobile/App/services/sync/utils/checkForeignKeys.ts
+++ b/packages/mobile/App/services/sync/utils/checkForeignKeys.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { groupBy } from 'es-toolkit/compat';
+import { groupBy } from 'lodash';
 
 interface ForeignKeyViolation {
   table: string;


### PR DESCRIPTION
### Changes

The mobile release build (`createBundleReleaseJsAndAssets`) fails on release/2.55 for the same reason as on 2.54 (see #10372): `checkForeignKeys.ts` (from the TAM-6959 hotfix) imports `groupBy` from `es-toolkit/compat`, but `es-toolkit` is only declared as a dependency of `packages/utils`, not `packages/mobile`, so Metro can'''t resolve it during the release bundle step.\n\nRather than adding `es-toolkit` as a new dependency to this older release branch, this swaps to `lodash`'''s `groupBy`, which mobile already depends on directly and uses elsewhere. (Note: mobile'''s lodash-to-es-toolkit migration only lands from release/2.60 onwards, so this fix is only needed on 2.55-2.59.)

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->