### PR TITLE
fix(adminPanel): TAM-6891: allow reference data suggester search by id

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -1180,6 +1180,25 @@ describe('Suggestions', () => {
     expect(body[0]).toHaveProperty('id', invoiceProduct.id);
   });
 
+  it('should also match on record id when searchById is passed', async () => {
+    const product = await models.InvoiceProduct.create({
+      id: 'invoiceProduct-drug-RX00343',
+      name: 'Paracetamol tablet',
+      category: INVOICE_ITEMS_CATEGORIES.OTHER,
+      visibilityStatus: 'current',
+    });
+
+    const withFlag = await userApp.get(
+      '/api/suggestions/invoiceProduct?q=RX00343&searchById=true',
+    );
+    expect(withFlag).toHaveSucceeded();
+    expect(withFlag.body.map(({ id }) => id)).toContain(product.id);
+
+    const withoutFlag = await userApp.get('/api/suggestions/invoiceProduct?q=RX00343');
+    expect(withoutFlag).toHaveSucceeded();
+    expect(withoutFlag.body.map(({ id }) => id)).not.toContain(product.id);
+  });
+
   it('should only return non-hidden invoice products', async () => {
     await models.InvoiceProduct.truncate({ cascade: true });
 

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -272,8 +272,20 @@ const getTranslationWhereLiteral = (endpoint, modelName, searchColumn) => {
   );
 };
 
-const DEFAULT_WHERE_BUILDER = ({ endpoint, modelName, searchColumn = 'name', skipVisibilityFilter = false }) => ({
-  [Op.or]: [getTranslationWhereLiteral(endpoint, modelName, searchColumn)],
+// searchById=true additionally matches the search term against the record id — used by the
+// admin panel reference data manage screen, where the raw ids are displayed and searched on.
+const DEFAULT_WHERE_BUILDER = ({
+  endpoint,
+  modelName,
+  searchColumn = 'name',
+  skipVisibilityFilter = false,
+  search,
+  query,
+}) => ({
+  [Op.or]: [
+    getTranslationWhereLiteral(endpoint, modelName, searchColumn),
+    ...(query?.searchById === 'true' && search ? [{ id: { [Op.iLike]: search } }] : []),
+  ],
   ...(!skipVisibilityFilter && VISIBILITY_CRITERIA),
 });
 
@@ -462,11 +474,11 @@ REFERENCE_TYPE_VALUES.forEach(typeName => {
   createSuggester(
     typeName,
     'ReferenceData',
-    ({ endpoint, modelName, req, search }) => {
+    ({ endpoint, modelName, req, search, query }) => {
       const { parentId } = req.query;
 
       const baseWhere = {
-        ...DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
+        ...DEFAULT_WHERE_BUILDER({ endpoint, modelName, search, query }),
         type: typeName,
       };
 
@@ -767,9 +779,9 @@ createSuggester(
 createSuggester(
   'invoiceProduct',
   'InvoiceProduct',
-  ({ endpoint, modelName, query }) => {
+  ({ endpoint, modelName, query, search }) => {
     if (!query.priceListId) {
-      return DEFAULT_WHERE_BUILDER({ endpoint, modelName });
+      return DEFAULT_WHERE_BUILDER({ endpoint, modelName, search, query });
     }
 
     return {

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/SearchField.jsx
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/SearchField.jsx
@@ -27,7 +27,10 @@ const CentredCheckContainer = styled.div`
 `;
 
 const AvailableFacilitiesSearchField = () => {
-  const suggester = useSuggester('facility', { ...SUGGESTER_OPTIONS, baseQueryParameters: { noLimit: true } });
+  const suggester = useSuggester('facility', {
+    ...SUGGESTER_OPTIONS,
+    baseQueryParameters: { ...SUGGESTER_OPTIONS.baseQueryParameters, noLimit: true },
+  });
   return (
     <Field
       name="availableFacilities"

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/constants.js
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/constants.js
@@ -12,4 +12,7 @@ export const DATA_TYPE_OPTIONS = [...MANAGEABLE_REFERENCE_DATA_TYPES].sort().map
 export const REQUIRED_FIELDS = new Set(['id', 'code', 'name']);
 
 export const SUGGESTER_FORMATTER = ({ name, id }) => ({ label: `${name} (${id})`, value: id });
-export const SUGGESTER_OPTIONS = { formatter: SUGGESTER_FORMATTER };
+export const SUGGESTER_OPTIONS = {
+  formatter: SUGGESTER_FORMATTER,
+  baseQueryParameters: { searchById: true },
+};


### PR DESCRIPTION
### Changes

The `invoiceProductId` (and other FK) search fields on the admin panel reference data manage screen are suggesters, which search by name only — pasting an id finds nothing, even though the dropdown labels and the table both show raw ids (TAM-6891, reported by Les for Invoice Price List Item).

This adds an opt-in `searchById=true` query param to the shared suggester service: the default where builder additionally matches the search term against the record id (same pattern as the patient suggester matching `displayId`). Only the admin manage tab passes the flag (via its shared `SUGGESTER_OPTIONS`), so every suggester field on that screen — search bar and add\/edit forms — now matches on name or id, while clinical suggesters are unchanged. Selected values still filter the table by exact id as before.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->