### PR TITLE
fix(migrations): TAM-6977: Remove settings seeds on facility

### DIFF
--- a/packages/database/src/migrations/000_baseline.ts
+++ b/packages/database/src/migrations/000_baseline.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import config from 'config';
 import type { QueryInterface } from 'sequelize';
+import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 
 const BASELINE_SQL_PATH = path.join(import.meta.dirname, '000_baseline.sql');
 const FROZEN_MIGRATIONS_PATH = path.join(import.meta.dirname, '000_baseline_frozen_migrations.json');
@@ -47,6 +49,15 @@ export async function up(query: QueryInterface): Promise<void> {
 
   // Reset on the Sequelize (CLS-bound) connection too.
   await query.sequelize.query('RESET search_path');
+
+  // The baseline snapshot seeds global settings, but the frozen migrations it
+  // replaces only inserted them on central (guarded by serverFacilityId(s)).
+  // Settings are PULL_FROM_CENTRAL: a facility server must not author its own
+  // rows, or the first sync pull collides with central's copies (different ids,
+  // same key/scope) on settings_alive_key_unique_without_facility_idx.
+  if (selectFacilityIds(config)) {
+    await query.sequelize.query('DELETE FROM settings');
+  }
 
   // Mark frozen migrations as applied so Umzug skips them.
   const frozenMigrations: string[] = JSON.parse(readFileSync(FROZEN_MIGRATIONS_PATH, 'utf-8'));


### PR DESCRIPTION
### Changes

This is an issue that only happens on fresh new facilities. Settings are not meant to originate from facility and initial seed migration adds them where they should've been discarded. Going with this approach is the most easy to avoid modifying the DB dump file.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._
