### PR TITLE
fix(web): no-issue: double slash in API requests (2.53 backport)

### DIFF
--- a/packages/web/app/components/ReminderContact/ContactDetails.jsx
+++ b/packages/web/app/components/ReminderContact/ContactDetails.jsx
@@ -362,7 +362,7 @@ export const ContactDetails = ({
       )}
       <StyledContactListTable
         columns={columns}
-        endpoint={`/patient/${patient.id}/reminderContacts`}
+        endpoint={`patient/${patient.id}/reminderContacts`}
         disablePagination
         initialSort={{ orderBy: 'name', order: 'asc' }}
         allowExport={false}

--- a/packages/web/app/views/patients/panes/PatientMedicationPane.jsx
+++ b/packages/web/app/views/patients/panes/PatientMedicationPane.jsx
@@ -677,7 +677,7 @@ export const PatientMedicationPane = ({ patient }) => {
           </ButtonGroup>
         </TableTitle>
         <StyledDataFetchingTable
-          endpoint={`/patient/${patient.id}/ongoing-prescriptions`}
+          endpoint={`patient/${patient.id}/ongoing-prescriptions`}
           fetchOptions={{ facilityId }}
           columns={ONGOING_MEDICATION_COLUMNS(getTranslation, getEnumTranslation)}
           rowStyle={rowStyle}
@@ -709,7 +709,7 @@ export const PatientMedicationPane = ({ patient }) => {
           </TableTitle>
           <StyledDataFetchingTable
             $compact
-            endpoint={`/patient/${patient.id}/dispensed-medications`}
+            endpoint={`patient/${patient.id}/dispensed-medications`}
             columns={DISPENSED_MEDICATION_COLUMNS(
               getTranslation,
               getEnumTranslation,


### PR DESCRIPTION
### Changes

Backport of #10367 to release\/2.53 (three endpoint leading-slash fixes; see #10391 for the 2.57 equivalent). Minimal cherry-pick — the original commit's import refactors don't apply to release branches.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->