### PR TITLE
perf(labs): no-issue: exclude sensitive labs with NOT EXISTS anti-join in worklist query

### DIFF
--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -144,12 +144,21 @@ labRequest.get(
   '/',
   asyncHandler(async (req, res) => {
     const {
-      models: { LabRequest },
+      models: { LabRequest, LabTestType },
       query,
       settings,
     } = req;
     req.checkPermission('list', 'LabRequest');
     const canListSensitive = req.ability.can('list', 'SensitiveLabRequest');
+    // With no sensitive test types (most deployments) the anti-join below is vacuous, so skip
+    // it. paranoid: false mirrors the raw filter, which doesn't exclude soft-deleted types.
+    const mustExcludeSensitive =
+      !canListSensitive &&
+      (await LabTestType.findOne({
+        where: { isSensitive: true },
+        attributes: ['id'],
+        paranoid: false,
+      })) !== null;
 
     const {
       order = 'ASC',
@@ -235,7 +244,7 @@ labRequest.get(
       ),
       makeDeletedAtIsNullFilter('encounter'),
       makeFilter(
-        !canListSensitive,
+        mustExcludeSensitive,
         `NOT EXISTS (
           SELECT 1
           FROM lab_tests

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -304,8 +304,11 @@ labRequest.get(
         ${whereClauses && `WHERE ${whereClauses}`}
     `;
 
+    // MATERIALIZED is load-bearing: without it Postgres inlines this single-reference CTE and
+    // re-evaluates the whole-table sensitive-lab scan once per matched row (measured ~2.5s / 11
+    // rows on a prod worklist). Forcing a single computation keeps it to one scan.
     const queryCte = `
-      WITH sensitive_labs AS (
+      WITH sensitive_labs AS MATERIALIZED (
         SELECT lab_requests.id as id, TRUE as is_sensitive
         FROM lab_requests
         INNER JOIN lab_tests

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -234,7 +234,18 @@ labRequest.get(
         },
       ),
       makeDeletedAtIsNullFilter('encounter'),
-      makeFilter(!canListSensitive, 'sensitive_labs.is_sensitive IS NULL', () => {}),
+      makeFilter(
+        !canListSensitive,
+        `NOT EXISTS (
+          SELECT 1
+          FROM lab_tests
+          INNER JOIN lab_test_types
+            ON (lab_test_types.id = lab_tests.lab_test_type_id)
+          WHERE lab_tests.lab_request_id = lab_requests.id
+            AND lab_test_types.is_sensitive IS TRUE
+        )`,
+        () => {},
+      ),
     ].filter(f => f);
 
     const { whereClauses, filterReplacements } = getWhereClausesAndReplacementsFromFilters(
@@ -270,8 +281,6 @@ labRequest.get(
           ON (examiner.id = encounter.examiner_id)
         LEFT JOIN users AS requester
           ON (requester.id = lab_requests.requested_by_id)
-        LEFT JOIN sensitive_labs
-          ON (sensitive_labs.id = lab_requests.id)
         ${
           isInvoicingEnabled
             ? `
@@ -304,22 +313,8 @@ labRequest.get(
         ${whereClauses && `WHERE ${whereClauses}`}
     `;
 
-    const queryCte = `
-      WITH sensitive_labs AS MATERIALIZED (
-        SELECT lab_requests.id as id, TRUE as is_sensitive
-        FROM lab_requests
-        INNER JOIN lab_tests
-          ON (lab_requests.id = lab_tests.lab_request_id)
-        INNER JOIN lab_test_types
-          ON (lab_test_types.id = lab_tests.lab_test_type_id)
-        WHERE lab_test_types.is_sensitive IS TRUE
-        GROUP BY lab_requests.id
-      )
-    `;
-
     const countResult = await req.db.query(
       `
-      ${queryCte}
       SELECT COUNT(1) AS count ${from}
       `,
       { replacements: filterReplacements, type: QueryTypes.SELECT },
@@ -360,7 +355,6 @@ labRequest.get(
 
     const result = await req.db.query(
       `
-        ${queryCte}
         SELECT
           lab_requests.*,
           ${isInvoicingEnabled ? `lab_approval.approved AS approved,` : ''}

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -304,9 +304,6 @@ labRequest.get(
         ${whereClauses && `WHERE ${whereClauses}`}
     `;
 
-    // MATERIALIZED is load-bearing: without it Postgres inlines this single-reference CTE and
-    // re-evaluates the whole-table sensitive-lab scan once per matched row (measured ~2.5s / 11
-    // rows on a prod worklist). Forcing a single computation keeps it to one scan.
     const queryCte = `
       WITH sensitive_labs AS MATERIALIZED (
         SELECT lab_requests.id as id, TRUE as is_sensitive


### PR DESCRIPTION
### Changes

The lab worklist (`GET /api/labRequest`) is intermittently very slow on production facilities — measured on Palau BNH: bimodal at p50 24ms / p90 92ms but **p99 10.7s, max 10.9s**. Load is ruled out (every other endpoint is p99 ~448ms across 53k requests on the same box).

`EXPLAIN (ANALYZE, BUFFERS)` of the worklist count query pinned the cause: **the `sensitive_labs` CTE**. It is a single-reference CTE, so Postgres inlines it and pushes it into a nested loop, **re-evaluating the whole-table `lab_requests ⋈ lab_tests ⋈ lab_test_types` sensitive-lab scan once per matched row** (`Group … loops=11`, 318,707 buffers = 97% of the query; the `lab_requests` scan itself is only ~20ms / 7,542 buffers). 234ms × 11 ≈ 2.57s.

Fix (first pass): mark the CTE `MATERIALIZED` so it is computed **once** per query instead of per matched row (~2.5s → 32ms validated on the affected facility).

Fix (final): drop the CTE and its `LEFT JOIN` entirely and express the exclusion as a per-row `NOT EXISTS` anti-join inside the existing `makeFilter(!canListSensitive, …)`. This subsumes both follow-ups from the first pass: privileged users (`canListSensitive`) get **no sensitive machinery at all** (the filter is simply not added), and non-privileged users get an index probe on `lab_tests_lab_request_id` per candidate row instead of any whole-table `lab_tests` scan. Semantics are unchanged — a request is excluded when any of its tests has a sensitive type — and covered by the existing `should exclude sensitive lab requests` test.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
**Validated on the affected facility (Palau BNH) with `EXPLAIN (ANALYZE, BUFFERS)` of the count query — cost of the sensitive-labs exclusion:**

| | Inlined CTE (before) | `MATERIALIZED` (first pass) | `NOT EXISTS` (this PR) |
|---|---|---|---|
| Sensitive-side cost | ~234 ms **per matched row** (318,707 buffers) | ~234 ms once per query | **0.26 ms / 63 buffers** |

The anti-join plan is a `Parallel Hash Right Anti Join`: the sensitive `lab_test_types` set is hashed first (empty on this facility), so the `lab_tests` probe short-circuits after reading a single row — the 587k-row `lab_tests` table is never scanned. The remaining query time is the base worklist scan (`lab_requests` + encounter lookups), unrelated to the sensitive filter.
