### PR TITLE
refactor(invoicing): TAM-6900: read bed-fee location history from logs

### DIFF
--- a/packages/database/src/models/Invoice/Invoice.ts
+++ b/packages/database/src/models/Invoice/Invoice.ts
@@ -25,7 +25,7 @@ import type { LabTest } from 'models/LabTest';
 import type { ImagingRequestArea } from 'models/ImagingRequestArea';
 import type { ReadSettings } from '@tamanu/settings';
 import { generateInvoiceDisplayId } from '@tamanu/utils/generateInvoiceDisplayId';
-import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
+import { getCurrentDateTimeString, toDateTimeString } from '@tamanu/utils/dateTime';
 import { selectEncounterFeeCode, computeBedFeeChargeInstants } from '@tamanu/utils/invoice';
 import type { Prescription } from 'models/Prescription';
 import type { Encounter } from '../Encounter';
@@ -501,7 +501,7 @@ export class Invoice extends Model {
       return;
     }
 
-    const { InvoiceItem, InvoiceProduct, EncounterHistory } = this.sequelize.models;
+    const { InvoiceItem, InvoiceProduct, ChangeLog } = this.sequelize.models;
     const locationSourceType = this.sequelize.models.Location.name;
 
     const chargeInstants = computeBedFeeChargeInstants({
@@ -512,18 +512,25 @@ export class Invoice extends Model {
       facilityTimeZone: (await settings.get('facilityTimeZone')) as string | null,
     });
 
-    // Load the encounter's location history once and resolve each instant in memory — the history
-    // is small (one row per ward move), so this avoids a query per night. Dates are ISO 9075
-    // strings, so string ordering is chronological.
-    const locationHistory = await EncounterHistory.findAll({
-      where: { encounterId: encounter.id },
-      order: [['date', 'ASC']],
-      attributes: ['date', 'locationId'],
+    // Reconstruct the location at each instant from the audit changelog (logs.changes) — the
+    // source of truth for encounter history. Each row is a full encounter snapshot, so its
+    // location_id is the location as of that write. `record_updated_at` (a timestamptz) is
+    // normalised to a primary-tz ISO 9075 string to compare against the charge instants, which
+    // are chronological as strings. History is small (a handful of rows per encounter).
+    const changelogRows = await ChangeLog.findAll({
+      where: { tableSchema: 'public', tableName: 'encounters', recordId: encounter.id },
+      order: [['recordUpdatedAt', 'ASC']],
+      attributes: ['recordUpdatedAt', 'recordData'],
     });
+    const locationHistory = changelogRows.map(row => ({
+      date: toDateTimeString(row.recordUpdatedAt),
+      // recordData is a JSONB encounter snapshot (typed as string on the model, object at runtime).
+      locationId: (row.recordData as unknown as Record<string, any>)?.location_id ?? null,
+    }));
     const locationIdAtInstant = (instant: string): string | null => {
       let locationId: string | null | undefined;
       for (const change of locationHistory) {
-        if (change.date > instant) break; // ascending history — no later row can precede this instant
+        if (change.date! > instant) break; // ascending history — no later row can precede this instant
         locationId = change.locationId;
       }
       return locationId ?? encounter.locationId ?? null;

--- a/packages/facility-server/__tests__/apiv1/BedFee.test.js
+++ b/packages/facility-server/__tests__/apiv1/BedFee.test.js
@@ -48,6 +48,29 @@ describe('Bed fee (Invoice.recalculateBedFee)', () => {
     return models.InvoiceItem.findAll({ where: { invoiceId: invoice.id } });
   };
 
+  // recalculateBedFee reconstructs location history from the audit changelog (logs.changes).
+  // These helpers stand in for the encounter writes that would populate it: clear the rows the
+  // always-on trigger wrote when the encounter was created, then record a location as of a given
+  // (write-)time, so a test controls the timeline the same way it used to with EncounterHistory.
+  const clearEncounterChangelog = encounterId =>
+    ctx.sequelize.query('DELETE FROM logs.changes WHERE record_id = :id', {
+      replacements: { id: encounterId },
+    });
+  const recordLocationAt = (encounterId, locationId, at) =>
+    models.ChangeLog.create({
+      tableOid: 0,
+      tableSchema: 'public',
+      tableName: 'encounters',
+      loggedAt: at,
+      updatedByUserId: user.id,
+      recordId: encounterId,
+      recordCreatedAt: at,
+      recordUpdatedAt: at,
+      recordData: { location_id: locationId },
+      deviceId: 'test',
+      version: 'test',
+    });
+
   beforeAll(async () => {
     ctx = await createTestContext();
     models = ctx.models;
@@ -157,26 +180,9 @@ describe('Bed fee (Invoice.recalculateBedFee)', () => {
     });
 
     // Location history: bed A from admission, moved to bed B mid-day on the 17th.
-    await models.EncounterHistory.create(
-      fake(models.EncounterHistory, {
-        encounterId: encounter.id,
-        locationId: bedLocation.id,
-        departmentId: department.id,
-        examinerId: user.id,
-        encounterType: ENCOUNTER_TYPES.ADMISSION,
-        date: '2024-06-16 18:00:00',
-      }),
-    );
-    await models.EncounterHistory.create(
-      fake(models.EncounterHistory, {
-        encounterId: encounter.id,
-        locationId: locationB.id,
-        departmentId: department.id,
-        examinerId: user.id,
-        encounterType: ENCOUNTER_TYPES.ADMISSION,
-        date: '2024-06-17 12:00:00',
-      }),
-    );
+    await clearEncounterChangelog(encounter.id);
+    await recordLocationAt(encounter.id, bedLocation.id, '2024-06-16 18:00:00');
+    await recordLocationAt(encounter.id, locationB.id, '2024-06-17 12:00:00');
 
     await models.Invoice.recalculateBedFee(encounter, settings, primaryTimeZone);
     const items = await models.InvoiceItem.findAll({ where: { invoiceId: invoice.id } });
@@ -219,26 +225,9 @@ describe('Bed fee (Invoice.recalculateBedFee)', () => {
     });
 
     // Bed A from admission, moved to bed B at 11:00 — both before the next 02:00 check.
-    await models.EncounterHistory.create(
-      fake(models.EncounterHistory, {
-        encounterId: encounter.id,
-        locationId: bedLocation.id,
-        departmentId: department.id,
-        examinerId: user.id,
-        encounterType: ENCOUNTER_TYPES.ADMISSION,
-        date: '2024-06-16 09:00:00',
-      }),
-    );
-    await models.EncounterHistory.create(
-      fake(models.EncounterHistory, {
-        encounterId: encounter.id,
-        locationId: locationB.id,
-        departmentId: department.id,
-        examinerId: user.id,
-        encounterType: ENCOUNTER_TYPES.ADMISSION,
-        date: '2024-06-16 11:00:00',
-      }),
-    );
+    await clearEncounterChangelog(encounter.id);
+    await recordLocationAt(encounter.id, bedLocation.id, '2024-06-16 09:00:00');
+    await recordLocationAt(encounter.id, locationB.id, '2024-06-16 11:00:00');
 
     await models.Invoice.recalculateBedFee(encounter, settings, primaryTimeZone);
     const items = await models.InvoiceItem.findAll({ where: { invoiceId: invoice.id } });
@@ -275,18 +264,9 @@ describe('Bed fee (Invoice.recalculateBedFee)', () => {
       date: '2024-06-16 09:00:00',
       status: INVOICE_STATUSES.IN_PROGRESS,
     });
-    const addHistory = (locationId, date) =>
-      models.EncounterHistory.create(
-        fake(models.EncounterHistory, {
-          encounterId: encounter.id,
-          locationId,
-          departmentId: department.id,
-          examinerId: user.id,
-          encounterType: ENCOUNTER_TYPES.ADMISSION,
-          date,
-        }),
-      );
+    const addHistory = (locationId, date) => recordLocationAt(encounter.id, locationId, date);
 
+    await clearEncounterChangelog(encounter.id);
     // Admitted to bed A; same-day stay → minimum-one-night charged to A.
     await addHistory(bedLocation.id, '2024-06-16 09:00:00');
     await models.Invoice.recalculateBedFee(encounter, settings, primaryTimeZone);


### PR DESCRIPTION
…s.changes

encounter_history is being deprecated as a queryable feature-data source. Its only use in the epic is Invoice.recalculateBedFee, which reconstructs the location occupied at each overnight-check instant to attribute per-night bed fees. Switch that reader to the audit changelog (logs.changes) instead.

logs.changes exists on every server (created in 000_baseline.sql) and is now always-on (audit.changes.enabled was retired), so the facility BedFeeCharger can read its own local changelog — no dual-writer, no deterministic ids, no central move. Each row is a full encounter snapshot, so location_id is read straight from record_data; record_updated_at is normalised to a primary-tz ISO 9075 string for the existing instant comparison.

Note: logs.changes timestamps a change by write time, not the clinical submittedTime that encounter_history.date carried — identical for changes recorded in real time, differing only for backdated data entry (accepted).

The core encounter_history writers are untouched (out of scope). Bed-fee tests now drive history via logs.changes rows instead of EncounterHistory.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
