### PR TITLE
refactor(invoicing): TAM-6900: break up recalculateBedFee

### DIFF
--- a/packages/database/src/models/Invoice/Invoice.ts
+++ b/packages/database/src/models/Invoice/Invoice.ts
@@ -29,7 +29,11 @@ import {
   getCurrentDateTimeString,
   instantToDateTimeStringInTimezone,
 } from '@tamanu/utils/dateTime';
-import { selectEncounterFeeCode, computeBedFeeChargeInstants } from '@tamanu/utils/invoice';
+import {
+  selectEncounterFeeCode,
+  computeBedFeeChargeInstants,
+  countBedFeeNightsByLocation,
+} from '@tamanu/utils/invoice';
 import type { Prescription } from 'models/Prescription';
 import type { Encounter } from '../Encounter';
 import type { Location } from '../Location';
@@ -504,9 +508,6 @@ export class Invoice extends Model {
       return;
     }
 
-    const { InvoiceItem, InvoiceProduct, ChangeLog } = this.sequelize.models;
-    const locationSourceType = this.sequelize.models.Location.name;
-
     const chargeInstants = computeBedFeeChargeInstants({
       startDateTime: encounter.startDate,
       endDateTime: encounter.endDate || getCurrentDateTimeString(),
@@ -515,27 +516,35 @@ export class Invoice extends Model {
       facilityTimeZone: (await settings.get('facilityTimeZone')) as string | null,
     });
 
-    // Reconstruct the location at each instant from the audit changelog (logs.changes) — the
-    // source of truth for encounter history. Each row is a full encounter snapshot, so its
-    // location_id is the location as of that write. `record_updated_at` (a timestamptz) is the
-    // write clock; rendered in the primary timezone it dates each ward move to when it happened,
-    // since moves are recorded as they occur. The exception is the admission itself: encounters
-    // are often recorded after the patient arrived, so the earliest row takes effect from
-    // encounter.startDate (the same anchor as the charge instants) rather than its data-entry
-    // time — otherwise backdated admission nights would fall back to the current location and be
-    // billed to a ward the patient later moved to. migrationContext is excluded so rows backfilled
-    // by data migrations (which may lack location_id) don't shadow real writes.
+    const locationHistory = await this.loadEncounterLocationHistory(encounter, primaryTimeZone);
+    const nightsByLocation = countBedFeeNightsByLocation(
+      chargeInstants,
+      locationHistory,
+      encounter.locationId ?? null,
+    );
+    await this.reconcileBedFeeLines(invoice, nightsByLocation);
+  }
+
+  /**
+   * The encounter's location timeline from the audit changelog. The admission (first) row anchors
+   * to startDate, not its write time, so backdated admission nights bill to the correct ward.
+   */
+  private static async loadEncounterLocationHistory(
+    encounter: Encounter,
+    primaryTimeZone: string,
+  ): Promise<{ date: string; locationId: string | null }[]> {
+    const { ChangeLog } = this.sequelize.models;
     const changelogRows = await ChangeLog.findAll({
       where: {
         tableSchema: 'public',
         tableName: 'encounters',
         recordId: encounter.id,
-        migrationContext: null,
+        migrationContext: null, // exclude migration-backfilled rows; they may lack a location
       },
       order: [['recordUpdatedAt', 'ASC']],
       attributes: ['recordUpdatedAt', 'recordData'],
     });
-    const locationHistory = changelogRows.map((row, index) => ({
+    return changelogRows.map((row, index) => ({
       date:
         index === 0
           ? encounter.startDate
@@ -543,28 +552,19 @@ export class Invoice extends Model {
       // recordData is a JSONB encounter snapshot (typed as string on the model, object at runtime).
       locationId: (row.recordData as unknown as Record<string, any>)?.location_id ?? null,
     }));
-    const locationIdAtInstant = (instant: string): string | null => {
-      let locationId: string | null | undefined;
-      for (const change of locationHistory) {
-        if (change.date! > instant) break; // ascending history — no later row can precede this instant
-        locationId = change.locationId;
-      }
-      return locationId ?? encounter.locationId ?? null;
-    };
+  }
 
-    // Count qualifying nights per location — the rate follows the location occupied at each instant.
-    const nightsByLocation = new Map<string, number>();
-    for (const instant of chargeInstants) {
-      const locationId = locationIdAtInstant(instant);
-      if (!locationId) {
-        continue;
-      }
-      nightsByLocation.set(locationId, (nightsByLocation.get(locationId) ?? 0) + 1);
-    }
+  /**
+   * Reconcile per-location lines to the night counts: departed locations are zeroed (kept
+   * revivable, not soft-deleted — that's a cashier action); locations with no product are skipped.
+   */
+  private static async reconcileBedFeeLines(
+    invoice: Invoice,
+    nightsByLocation: Map<string, number>,
+  ) {
+    const { InvoiceItem, InvoiceProduct } = this.sequelize.models;
+    const locationSourceType = this.sequelize.models.Location.name;
 
-    // Zero out existing bed-fee lines for locations that no longer qualify (not a soft-delete —
-    // that's reserved for cashier removals, and the line must stay revivable if the patient
-    // returns to the location). Quantity-0 lines are cleaned off the invoice at finalisation.
     const existingItems = await InvoiceItem.findAll({
       where: { invoiceId: invoice.id, sourceRecordType: locationSourceType },
     });

--- a/packages/utils/__test__/bedFee.test.ts
+++ b/packages/utils/__test__/bedFee.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeBedFeeChargeInstants } from '../src';
+import { computeBedFeeChargeInstants, countBedFeeNightsByLocation } from '../src';
 
 const base = {
   overnightChargeTime: '02:00',
@@ -69,5 +69,57 @@ describe('computeBedFeeChargeInstants', () => {
       endDateTime: '2024-06-17 16:00:00',
     });
     expect(instants).toEqual(['2024-06-17 15:00:00']);
+  });
+});
+
+describe('countBedFeeNightsByLocation', () => {
+  const nights = (map: Map<string, number>) => Object.fromEntries(map);
+
+  it('attributes every night to the current location when there is no change history', () => {
+    const result = countBedFeeNightsByLocation(
+      ['2024-06-17 02:00:00', '2024-06-18 02:00:00'],
+      [],
+      'loc-current',
+    );
+    expect(nights(result)).toEqual({ 'loc-current': 2 });
+  });
+
+  it('attributes each night to the location occupied at that instant across a mid-stay move', () => {
+    const result = countBedFeeNightsByLocation(
+      ['2024-06-17 02:00:00', '2024-06-18 02:00:00', '2024-06-19 02:00:00'],
+      [
+        { date: '2024-06-16 18:00:00', locationId: 'loc-a' },
+        { date: '2024-06-17 12:00:00', locationId: 'loc-b' },
+      ],
+      'loc-b',
+    );
+    // 17th check precedes the move → loc-a; 18th + 19th → loc-b.
+    expect(nights(result)).toEqual({ 'loc-a': 1, 'loc-b': 2 });
+  });
+
+  it('follows a move that precedes every instant (early ward move)', () => {
+    const result = countBedFeeNightsByLocation(
+      ['2024-06-16 14:00:00'],
+      [
+        { date: '2024-06-16 09:00:00', locationId: 'loc-a' },
+        { date: '2024-06-16 11:00:00', locationId: 'loc-b' },
+      ],
+      'loc-b',
+    );
+    expect(nights(result)).toEqual({ 'loc-b': 1 });
+  });
+
+  it('skips instants that resolve to no location', () => {
+    const result = countBedFeeNightsByLocation(['2024-06-17 02:00:00'], [], null);
+    expect(nights(result)).toEqual({});
+  });
+
+  it('returns an empty tally when there are no charge instants', () => {
+    const result = countBedFeeNightsByLocation(
+      [],
+      [{ date: '2024-06-16 18:00:00', locationId: 'loc-a' }],
+      'loc-a',
+    );
+    expect(nights(result)).toEqual({});
   });
 });

--- a/packages/utils/src/invoice/bedFee.ts
+++ b/packages/utils/src/invoice/bedFee.ts
@@ -63,3 +63,38 @@ export const computeBedFeeChargeInstants = ({
   // so the night follows the patient's current location — an early ward move is reflected at once.
   return instants.length > 0 ? instants : [endDateTime];
 };
+
+export interface BedFeeLocationChange {
+  /** Effective time of the location change, a primary-tz ISO 9075 string. */
+  date: string;
+  locationId: string | null;
+}
+
+/**
+ * Tally bed-fee nights per location: each charge instant is attributed to the location occupied
+ * then (latest change at or before it), else the current location. Inputs are ascending ISO 9075.
+ */
+export const countBedFeeNightsByLocation = (
+  chargeInstants: string[],
+  locationChanges: BedFeeLocationChange[],
+  currentLocationId: string | null,
+): Map<string, number> => {
+  const locationIdAtInstant = (instant: string): string | null => {
+    let locationId: string | null | undefined;
+    for (const change of locationChanges) {
+      if (change.date > instant) break; // ascending — no later change can precede this instant
+      locationId = change.locationId;
+    }
+    return locationId ?? currentLocationId ?? null;
+  };
+
+  const nightsByLocation = new Map<string, number>();
+  for (const instant of chargeInstants) {
+    const locationId = locationIdAtInstant(instant);
+    if (!locationId) {
+      continue;
+    }
+    nightsByLocation.set(locationId, (nightsByLocation.get(locationId) ?? 0) + 1);
+  }
+  return nightsByLocation;
+};


### PR DESCRIPTION
### Changes

Structural refactor of `Invoice.recalculateBedFee` for maintainability — **no behaviour change**.

It was one ~115-line method doing three things at once: reconstructing the location timeline, counting nights per location, and reconciling the invoice lines. Split into a thin orchestrator plus focused pieces:

- **`countBedFeeNightsByLocation`** — the pure night-counting logic (attribute each charge instant to the location occupied then, with the current-location fallback) extracted to `@tamanu/utils/invoice`, next to `computeBedFeeChargeInstants`, with its own unit tests.
- **`loadEncounterLocationHistory`** — the `logs.changes` query + timeline mapping (incl. the admission-row startDate anchor).
- **`reconcileBedFeeLines`** — the zero-out of departed locations + per-location upsert (resurrection guard, placeholder skip).

`recalculateBedFee` is now a ~15-line orchestrator: guard → charge instants → load history → count → reconcile.

Per review feedback, N+1 batching was deliberately left out (only a handful of locations per encounter). Verified by the existing BedFee model + charger suites (behaviour preserved) and 5 new unit tests for the extracted counter; lint clean; no new type errors.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->