### PR TITLE
fix(invoicing): TAM-6900: bill ward moves immediately, not just on the nightly charger

### DIFF
--- a/packages/database/src/models/Invoice/Invoice.ts
+++ b/packages/database/src/models/Invoice/Invoice.ts
@@ -528,6 +528,11 @@ export class Invoice extends Model {
   /**
    * The encounter's location timeline from the audit changelog. The admission (first) row anchors
    * to startDate, not its write time, so backdated admission nights bill to the correct ward.
+   *
+   * The changelog trigger is deferred to commit, so when this runs in the same transaction as an
+   * encounter update (e.g. a ward move via the encounter route) that update's row isn't written
+   * yet. Append the encounter's live current location as the latest point so a just-made move is
+   * billed immediately, matching what the nightly charger later derives from the committed row.
    */
   private static async loadEncounterLocationHistory(
     encounter: Encounter,
@@ -544,7 +549,7 @@ export class Invoice extends Model {
       order: [['recordUpdatedAt', 'ASC']],
       attributes: ['recordUpdatedAt', 'recordData'],
     });
-    return changelogRows.map((row, index) => ({
+    const history = changelogRows.map((row, index) => ({
       date:
         index === 0
           ? encounter.startDate
@@ -552,6 +557,10 @@ export class Invoice extends Model {
       // recordData is a JSONB encounter snapshot (typed as string on the model, object at runtime).
       locationId: (row.recordData as unknown as Record<string, any>)?.location_id ?? null,
     }));
+    if (encounter.locationId) {
+      history.push({ date: getCurrentDateTimeString(), locationId: encounter.locationId });
+    }
+    return history;
   }
 
   /**

--- a/packages/facility-server/__tests__/apiv1/BedFee.test.js
+++ b/packages/facility-server/__tests__/apiv1/BedFee.test.js
@@ -2,7 +2,7 @@ import { createDummyEncounter, createDummyPatient } from '@tamanu/database/demoD
 import { fake, fakeUser } from '@tamanu/fake-data/fake';
 import config from 'config';
 import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
-import { storedDateTimeToEpochMilliseconds } from '@tamanu/utils/dateTime';
+import { getCurrentDateTimeString, storedDateTimeToEpochMilliseconds } from '@tamanu/utils/dateTime';
 import { ReadSettings } from '@tamanu/settings';
 import {
   ENCOUNTER_TYPES,
@@ -194,6 +194,52 @@ describe('Bed fee (Invoice.recalculateBedFee)', () => {
     expect(items).toHaveLength(2);
     expect(nightsByProduct[bedProduct.id]).toBe(1);
     expect(nightsByProduct[bedProductB.id]).toBe(2);
+  });
+
+  it('bills a ward move recomputed in the same transaction, before the changelog trigger fires', async () => {
+    // The audit changelog trigger is deferred to commit, so a recompute run in the same transaction
+    // as a ward move (as the encounter route does) can't see that move's changelog row yet. The
+    // recompute must still bill the new location — from the encounter's live location, not the
+    // stale changelog — rather than waiting for the next nightly charger.
+    const locationB = await models.Location.create(
+      fake(models.Location, { facilityId: facility.id, code: 'BED-LOC-MOVE-TXN' }),
+    );
+    const bedProductB = await models.InvoiceProduct.create(
+      fake(models.InvoiceProduct, {
+        category: INVOICE_ITEMS_CATEGORIES.BED_FEE,
+        sourceRecordType: INVOICE_ITEMS_CATEGORIES_MODELS[INVOICE_ITEMS_CATEGORIES.BED_FEE],
+        sourceRecordId: locationB.id,
+      }),
+    );
+
+    // Admitted to bed A and still admitted (endDate null) — committed, so its changelog row exists.
+    const startDate = getCurrentDateTimeString();
+    const encounter = await models.Encounter.create({
+      ...(await createDummyEncounter(models)),
+      patientId: patient.id,
+      locationId: bedLocation.id,
+      departmentId: department.id,
+      examinerId: user.id,
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate,
+      endDate: null,
+    });
+    const invoice = await models.Invoice.create({
+      encounterId: encounter.id,
+      displayId: `INV-${encounter.id.slice(0, 8)}`,
+      date: startDate,
+      status: INVOICE_STATUSES.IN_PROGRESS,
+    });
+
+    await models.Invoice.sequelize.transaction(async () => {
+      await encounter.update({ locationId: locationB.id });
+      await models.Invoice.recalculateBedFee(encounter, settings, primaryTimeZone);
+    });
+
+    const items = await models.InvoiceItem.findAll({ where: { invoiceId: invoice.id } });
+    const nightsByProduct = Object.fromEntries(items.map(item => [item.productId, item.quantity]));
+    expect(nightsByProduct[bedProductB.id]).toBe(1); // the just-made move is billed immediately
+    expect(nightsByProduct[bedProduct.id] ?? 0).toBe(0); // bed A no longer qualifies
   });
 
   it('bills the admission ward for backdated-admission nights recorded before a later ward move', async () => {


### PR DESCRIPTION
### Changes

**Problem:** moving a patient to a different bed didn't update the bed fee on the invoice until the nightly `BedFeeCharger` ran. `recalculateBedFee` rebuilds location history from `logs.changes`, but that table is written by a **deferred constraint trigger** that only fires at commit. The encounter route recomputes the bed fee in the *same transaction* as the ward move, so the move's changelog row isn't visible yet and the recompute misses it.

**Fix:** append the encounter's live current location as the latest point of the reconstructed timeline, so a just-made move is billed immediately — consistent with what the charger later derives from the committed row. Attribution only; night counts are unchanged, and past crossed checks still resolve from committed history.

Adds a regression test that moves the location and recomputes within one transaction (no manual changelog manipulation) — it fails before this change and passes after. Found during TAM-6900 QA ("patient move lag").

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->