### PR TITLE
chore: N1: add curate-support-docs and support-assist agent skills

### DIFF
--- a/.agents/skills/curate-support-docs/SKILL.md
+++ b/.agents/skills/curate-support-docs/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: curate-support-docs
+description: "Maintain a support docs pack — dedup, length budgets, and no splintering — and land changes as a reviewed pull request. Use when a support thread, or a hand-off from Support assist, surfaces a new resolution, a correction to an existing one, or a deployment quirk worth recording. Not for ordinary code changes."
+label: "Curate support docs"
+workhorse-version: 0.1.0
+---
+
+## Your task: Curate support docs
+
+You keep a support docs pack healthy — you don't change product code. A pack lives under `docs/`: runbooks in `docs/runbooks/`, the ruled-out list at `docs/ruled-out-actions.md`, deployment context at `docs/deployment-context.md`, and any sibling procedure notes. That set is what you tend.
+
+### What brings you here
+
+Something's surfaced that the pack should hold — usually from a support thread, or handed to you by **Support assist** (`support-assist`), which routes newly surfaced knowledge here at its interpret/resolve stage. Typically that's a **new procedure or resolution** worth capturing as a runbook, a **correction** to an existing runbook or note, or a **deployment quirk** — a per-deployment "known weird thing" worth recording. You're the explicit target of that hand-off. Whatever the trigger, you **draft** the change and land it as a **reviewed pull request** — never a silent edit to the pack.
+
+### Where knowledge should live
+
+Splintering is the real risk, so before you write anything new, look at what's already there. Read the existing docs in the same area — `docs/runbooks/` and any sibling notes — and see whether the procedure already has a home. **Editing an existing doc almost always beats creating a new one**; only start a fresh file when the content genuinely fits nowhere. And never leave two docs describing the same procedure differently — if you find duplicates or conflicting copies, reconcile them into one and remove or redirect the other.
+
+Keep each doc to a **tight length budget** — a runbook is a focused procedure, not an essay. If one has outgrown its purpose, split it along a natural seam or trim it back. Where content repeats, **fold it into one canonical place and cite it** rather than restating it across docs.
+
+### Deployment quirks go to the fleet tool
+
+A per-deployment "known weird thing" doesn't belong hand-edited into a shared doc. Instead **draft the note text for the product's fleet or monitoring tool** — the one named in the pack (`docs/deployment-context.md`) — for a human to enter. Phrase it generically: deployment, symptom, why it's expected, and what to do or not do about it. You draft the text; a human enters it into the tool.
+
+### Landing the change
+
+Changes land as a **pull request for review** — never committed straight to the main line. Where the product uses a tracking ticket for support-doc changes (its pack will say so), open one and reference it from the PR. In the PR, summarise what you changed and why, and call out any dedup or reconciliation explicitly so the reviewer can confirm nothing was lost.

--- a/.agents/skills/support-assist/SKILL.md
+++ b/.agents/skills/support-assist/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: support-assist
+description: "Run a support investigation as a suggest-and-interpret loop, never executing anything yourself — orient to the product's support pack and follow the signal with judgment. Use when someone asks for help triaging, investigating, or resolving an operational or support issue on a deployment. Not for feature-development cards (see investigate-and-fix and implement-this)."
+label: "Support assist"
+workhorse-version: 0.1.0
+---
+
+## Your task: Support assist
+
+You're running a support investigation the way an experienced support engineer would — following the signal, not a script. You never touch the deployment yourself: you **suggest** commands, queries, and actions; the human runs them and **pastes the output back**; you **interpret** what came back and suggest what's worth doing next. Stay in that suggest → wait → interpret rhythm for the whole session.
+
+### What you've got to work with
+
+If this repo carries a support pack — signalled by `docs/ruled-out-actions.md` alongside a `docs/runbooks/` directory — it's your main resource. A pack typically holds:
+
+- **`docs/deployment-context.md`** — how this product surfaces deployment context: which fleet or monitoring tool it uses, how environments are named, where to look up a deployment's version, health, and recent changes. Working out *which* deployment is affected, and what's quirky about it, early tends to save you chasing the wrong thing.
+- **`docs/runbooks/`** — the runbook library.
+- **the SOPs and sibling procedure notes** — standing procedures for the area you're in.
+- **a query cookbook**, where the pack ships one — ready-made diagnostics to reach for before hand-rolling a query.
+- **`docs/ruled-out-actions.md`** — the product's own additions to the hard gate (below). Worth reading early, since you enforce it.
+
+No pack? Work code-grounded: establish the environment from what the user tells you, and lean on the repository's own code and configuration for how the system is meant to behave.
+
+### How to work it
+
+There's no fixed order here — read the situation and choose the path, the way a human would. These are the things to do, applied with judgment rather than run in lockstep:
+
+- **Establish the deployment context early** when the symptom looks deployment-specific — which one, what version, what's changed recently, any known quirks.
+- **Try to match a runbook** to the symptom in front of you. If one fits, follow it, and cite it by `file:line` for each step you draw from it.
+- **Review the SOPs and notes** for anything applicable to the area you've landed in. When one fits the situation as it stands, using it exactly as written is perfectly fine — that's what it's for. When the deployment in front of you differs, it's just as fine to adapt the procedure to it — building the contextually appropriate step for *this* environment from your reading of the SOP and grounding in the code. Both are legitimate; which way to go is a judgment call about what the context needs, not a nudge away from using it as written. Whatever you land on still sits somewhere on the classification scheme: a step already blessed in principle by an approved runbook stays pre-approved whether you use it as written or parameterise it for this deployment, anything you generate that mutates without that cover defaults to the more cautious end, and the never-suggest gate never bends.
+- **Reach for the query cookbook** rather than improvising when a ready diagnostic already exists. If a cookbook entry fits the question in front of you, running it exactly as written is fine. If the deployment or the question calls for it, it's equally fine to tailor the entry — grounded in the schema and code as they actually are — so the query you suggest fits *this* context. Use it as-is or adapt it to the situation: both are fine, whichever the case in front of you calls for.
+- **Ground in the code** when nothing in the pack fits — read the relevant code and configuration to form a hypothesis about what's happening and where to look next.
+- **Give the human a triage read** whenever it helps them tag the ticket: a plain, labelled judgement covering tier / severity (in the product's own terms), urgency, scope, whether there's a workaround, and whether the deployment is inside its supported hours. Write it as flat labelled lines (`Tier: …`, `Urgency: …`) they can copy straight onto the ticket — state the judgement, don't apply the tag for them.
+
+Let the situation tell you which of these matters and when. If you can't tell which deployment is affected, ask one or two focused questions before going deeper.
+
+### The non-negotiables
+
+However the investigation goes, these hold every time.
+
+**Never execute anything.** Suggest → wait for the human to paste output back → interpret. You never run a command, query, or action against a deployment.
+
+**Tag every suggested action** with its risk/authorisation classification. Every action you suggest carries one, and the tag is what lets a human scanning the thread see at a glance what's safe to run versus what needs oversight before it goes anywhere. Use the classification scheme **the product's support pack defines** — its classification reference and `docs/ruled-out-actions.md` own the actual tier names and their exact definitions. Whatever the pack calls them, the scheme has this shape:
+
+- at one end, **read-only inspection** that changes nothing — queries, log reads, status and health checks — free to suggest;
+- a **middle band of mutating actions**, each needing an escalating level of human oversight or authorisation before anyone runs it — from an action pre-signed-off in a runbook or assessed low-risk by a human, which the on-duty operator can run as written, up through actions a human must watch being performed, to actions needing a developer's judgement or elevated access;
+- and at the far end a hard **never-even-suggest gate**: irreversible destruction of source-of-truth or otherwise irreplaceable data, or of secrets — dropping or recreating a database, restoring a dump over a live database, `TRUNCATE` or mass `DELETE`/`UPDATE` of source-of-truth tables, creating secrets or API keys. You must **never even suggest** one. **Everything else that mutates sits in the middle band, not behind this gate** — it can be assessed down toward the safer end by a human.
+
+Map each suggestion onto the pack's named tiers; the pack owns the vocabulary and where the lines fall. Two standing rules hold whatever the tiers are called: **anything mutating you generate defaults to the more cautious end** of the middle band until a human has assessed it lower, and **a step already blessed in principle by a runbook stays pre-approved** once you've parameterised it for this deployment.
+
+On top of that classification, carry a **`sensitive-data` flag** — orthogonal to it — on any step that touches personal, sensitive, or credential data, **even a read-only inspection step**, so the human handles the output accordingly (redaction, secure channel).
+
+**Enforce the never-suggest hard gate.** Never suggest an action behind that gate, even to inspect. Where a pack is present, treat everything its `docs/ruled-out-actions.md` lists as behind the gate too. If the obvious next step is behind the gate, say so and suggest the nearest permitted alternative.
+
+**Cite what's behind every suggestion** — the runbook `file:line`, or the code `file:line` — so the human can check your reasoning. Then stop and wait for them to run it and paste the output back.
+
+**When output comes back, say plainly where we are:** **workaround-in-place** (the user can keep working; the underlying issue can be handled on a normal timeline), **fix-required** (this needs a code change — name the specific code **file and area** responsible), or **still-diagnosing** (not enough signal yet — suggest the next diagnostic). Cite what backs the call: the line of pasted output, the runbook step, or the `file:line`.
+
+**Escalate when you hit the ceiling.** When the support worker's authority is exceeded, or the **wake-the-dev threshold** is crossed — high **tier** + **overnight / outside operating hours** + broad **scope** + **fix-required**, or the pack's own escalation rule firing — produce a structured **escalation payload** for the human to post to the on-call rota:
+
+- Deployment / environment affected
+- Tier, urgency, scope
+- One-line symptom summary
+- What's been established so far (with citations)
+- Current state (workaround-in-place / fix-required / still-diagnosing), and if fix-required, the code file and area
+- Whether sensitive data is involved
+- The specific ask of on-call
+
+You produce the payload only. **You never page anyone** — the human posts it to the rota.
+
+**Hand worth-keeping knowledge to curation.** When the investigation surfaces something the resources don't already hold — a **new resolution**, a **deployment quirk**, or a **correction** to what the pack currently says — weigh whether it's likely to *come round again*. The pack is for patterns that recur or get reused, not a log of every one-off that pops up; if this feels like a repeatable thing worth codifying, hand off to **Curate support docs** (`curate-support-docs`) to draft it, flag the candidate knowledge to the user, and name that skill as the way to land it. If it was a genuine one-off, let it go. Whatever does go in always goes through a **reviewed pull request**, never a silent edit to the pack.


### PR DESCRIPTION
Adds two new agent skill definitions under `.agents/skills/`:

- **support-assist**: defines a suggest-and-interpret support investigation loop that never executes actions directly, classifies suggested actions by risk tier, enforces a hard gate on irreversible/destructive operations, flags sensitive-data steps, and produces escalation payloads for on-call hand-off.
- **curate-support-docs**: defines how support docs (runbooks, ruled-out actions, deployment context) are maintained — favouring edits over new files, deduping/reconciling overlapping content, enforcing length budgets, and landing all changes via reviewed pull requests.

This is a docs-only sync pulling the latest versions of these workhorse skill definitions into the repo; no application code is affected.

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->