### PR TITLE
fix(invoicing): TAM-6900: resolve admission bed-fee settings from the bed's facility

### DIFF
--- a/packages/facility-server/__tests__/apiv1/BedFeeAdmissionFacility.test.js
+++ b/packages/facility-server/__tests__/apiv1/BedFeeAdmissionFacility.test.js
@@ -1,0 +1,112 @@
+import config from 'config';
+import { createDummyPatient } from '@tamanu/database/demoData/patients';
+import { fake, fakeUser } from '@tamanu/fake-data/fake';
+import {
+  ENCOUNTER_TYPES,
+  INVOICE_ITEMS_CATEGORIES,
+  INVOICE_ITEMS_CATEGORIES_MODELS,
+  SETTINGS_SCOPES,
+} from '@tamanu/constants';
+import { settingsCache } from '@tamanu/settings';
+import { createTestContext } from '../utilities';
+
+// A bed fee belongs to the bed's facility, so its overnight-check time (and timezone/rate) must be
+// resolved from that facility — the same as the nightly BedFeeCharger and the PUT recompute. The
+// admission (POST create) recompute previously read the settings from the *encounter's* facility,
+// so admitting "at facility A" into a bed at facility B computed the admission night with A's
+// settings until a later recompute corrected it. This regression pins the admission recompute to
+// the bed's facility.
+//
+// Needs two server-configured facilities so req.settings resolves a reader for each: A is where the
+// encounter is created, B is where the bed physically lives.
+const serverFacilityIds = config.serverFacilityId
+  ? [config.serverFacilityId]
+  : config.serverFacilityIds ?? [];
+const [encounterFacilityId, bedFacilityId] = serverFacilityIds;
+const describeOrSkip = bedFacilityId ? describe : describe.skip;
+
+describeOrSkip('Bed fee — admission uses the bed facility settings', () => {
+  let ctx;
+  let models;
+  let app;
+  let user;
+  let bedLocation;
+  let bedProduct;
+  let department;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    user = await models.User.create({ ...fakeUser(), role: 'practitioner' });
+    app = await ctx.baseApp.asUser(user);
+
+    const [encounterFacility] = await models.Facility.findOrCreate({
+      where: { id: encounterFacilityId },
+      defaults: fake(models.Facility, { id: encounterFacilityId, name: 'Encounter facility' }),
+    });
+    await models.Facility.findOrCreate({
+      where: { id: bedFacilityId },
+      defaults: fake(models.Facility, { id: bedFacilityId, name: 'Bed facility' }),
+    });
+
+    department = await models.Department.create(
+      fake(models.Department, { facilityId: encounterFacility.id, code: 'BEDFEE-XFAC-DEPT' }),
+    );
+    // The bed physically belongs to the *other* facility.
+    bedLocation = await models.Location.create(
+      fake(models.Location, { facilityId: bedFacilityId, code: 'BEDFEE-XFAC-BED' }),
+    );
+    bedProduct = await models.InvoiceProduct.create(
+      fake(models.InvoiceProduct, {
+        category: INVOICE_ITEMS_CATEGORIES.BED_FEE,
+        sourceRecordType: INVOICE_ITEMS_CATEGORIES_MODELS[INVOICE_ITEMS_CATEGORIES.BED_FEE],
+        sourceRecordId: bedLocation.id,
+      }),
+    );
+
+    await models.Setting.set('features.invoicing.enabled', true);
+    // Different overnight-check times per facility so the same stay yields a different night count:
+    // over 2024-06-18 10:00 → 2024-06-20 12:00, an 11:00 check crosses 3 nights and a 09:00 check 2.
+    await models.Setting.set(
+      'invoicing.bedFee.overnightChargeTime',
+      '11:00',
+      SETTINGS_SCOPES.FACILITY,
+      encounterFacilityId,
+    );
+    await models.Setting.set(
+      'invoicing.bedFee.overnightChargeTime',
+      '09:00',
+      SETTINGS_SCOPES.FACILITY,
+      bedFacilityId,
+    );
+    settingsCache.reset();
+  });
+
+  afterAll(async () => {
+    await models.Setting.set('features.invoicing.enabled', false);
+    settingsCache.reset();
+    await ctx.close();
+  });
+
+  it('bills the admission night with the bed facility overnight-check time, not the encounter facility', async () => {
+    const patient = await models.Patient.create(await createDummyPatient(models));
+    const result = await app.post('/api/encounter').send({
+      facilityId: encounterFacilityId, // admitted "at" facility A...
+      patientId: patient.id,
+      examinerId: user.id,
+      locationId: bedLocation.id, // ...into a bed that belongs to facility B
+      departmentId: department.id,
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2024-06-18 10:00:00',
+      endDate: '2024-06-20 12:00:00',
+    });
+    expect(result).toHaveSucceeded();
+
+    const invoiceResult = await app.get(`/api/encounter/${result.body.id}/invoice`);
+    expect(invoiceResult).toHaveSucceeded();
+    const bedLine = invoiceResult.body.items.find(item => item.productId === bedProduct.id);
+    expect(bedLine).toBeDefined();
+    // Bed facility B's 09:00 check → 2 nights; the encounter facility A's 11:00 check would give 3.
+    expect(bedLine.quantity).toBe(2);
+  });
+});

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -103,11 +103,20 @@ encounter.post(
           getPrimaryTimeZone(config),
         );
         // Charge the admission night immediately; the nightly BedFeeCharger accrues later nights.
-        await models.Invoice.recalculateBedFee(
-          encounterObject,
-          req.settings[facilityId],
-          getPrimaryTimeZone(config),
-        );
+        // The bed fee belongs to the bed's facility (its timezone, overnight-check time and rate),
+        // which may differ from the encounter's — so resolve settings from the location, matching
+        // the charger and the PUT recompute below.
+        const location = await models.Location.findByPk(encounterObject.locationId, {
+          attributes: ['facilityId'],
+        });
+        const facilitySettings = location && req.settings[location.facilityId];
+        if (facilitySettings) {
+          await models.Invoice.recalculateBedFee(
+            encounterObject,
+            facilitySettings,
+            getPrimaryTimeZone(config),
+          );
+        }
       }
 
       if (data.dietIds) {


### PR DESCRIPTION
### Changes

**Problem:** the admission (POST create) bed-fee recompute resolved its settings from the *encounter's* facility (`req.settings[body.facilityId]`), while the nightly `BedFeeCharger` and the discharge/move (PUT) recompute both resolve them from the *bed's* facility (`req.settings[location.facilityId]`). A bed fee belongs to a physical bed, which belongs to one facility — its timezone, overnight-check time and rate come from that facility. So admitting "at facility A" into a bed that belongs to facility B computed the admission night with A's settings, then a later recompute (discharge/move/charger) switched to B's — the confusing 2->3 flip seen during QA.

**Fix:** in the POST create handler, resolve `recalculateBedFee`'s settings from the bed's `location.facilityId` (guarded like the PUT handler), consistent with the charger and discharge/move paths. Invoice creation and the *encounter* fee correctly stay on the encounter's facility — only the **bed** fee follows the bed.

**Test:** `BedFeeAdmissionFacility.test.js` admits via the POST route at facility A into a priced bed at facility B, where B has a different `invoicing.bedFee.overnightChargeTime` (09:00 vs A's 11:00) so the same stay yields a different night count. It asserts the admission bed-fee line uses B's count (2), not A's (3). Verified it fails on the unfixed code (received 3) and passes with the fix (2). Affected suites green: BedFee, BedFeeCharger, EncounterFee, EncounterFeeEndToEnd, and the new test (28 tests).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->