### PR TITLE
test(invoicing): TAM-6900: add invoice finalisation e2e journey

### DIFF
--- a/packages/e2e-tests/pages/patients/InvoicePage/panes/InvoicePane.ts
+++ b/packages/e2e-tests/pages/patients/InvoicePage/panes/InvoicePane.ts
@@ -9,11 +9,15 @@ export class InvoicePane {
   readonly page: Page;
   readonly pane: Locator;
   readonly invoiceTotal: Locator;
+  readonly status: Locator;
+  readonly finaliseButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.pane = this.page.getByTestId('encounterinvoicingpane-sci0');
     this.invoiceTotal = this.page.getByTestId('invoice-summary-invoiceTotal');
+    this.status = this.page.getByTestId('statuslabel-yazt');
+    this.finaliseButton = this.page.getByTestId('button-yicz');
   }
 
   async waitForLoad(): Promise<void> {
@@ -27,5 +31,19 @@ export class InvoicePane {
 
   async expectItemVisible(name: string | RegExp): Promise<void> {
     await expect(this.itemByName(name)).toBeVisible();
+  }
+
+  async expectStatus(label: string | RegExp): Promise<void> {
+    await expect(this.status).toContainText(label);
+  }
+
+  // Finalise the invoice: the Finalise button only shows once the encounter is discharged, and it
+  // opens a confirm modal. Finalisation is one-way.
+  async finalise(): Promise<void> {
+    await this.finaliseButton.click();
+    const modal = this.page.getByTestId('modal-j1bi');
+    await modal.waitFor({ state: 'visible' });
+    await modal.getByRole('button', { name: 'Finalise' }).click();
+    await modal.waitFor({ state: 'hidden' });
   }
 }

--- a/packages/e2e-tests/pages/patients/InvoicePage/panes/InvoicePane.ts
+++ b/packages/e2e-tests/pages/patients/InvoicePage/panes/InvoicePane.ts
@@ -38,10 +38,10 @@ export class InvoicePane {
   }
 
   // Finalise the invoice: the Finalise button only shows once the encounter is discharged, and it
-  // opens a confirm modal. Finalisation is one-way. Clicking the confirm button auto-waits for the
-  // modal; the finalised state is asserted by the caller (expectStatus), so we don't wait on close.
+  // opens a confirm modal. Finalisation is one-way. The confirm button (only one on-screen while
+  // the modal is open) auto-waits; the finalised state is asserted by the caller (expectStatus).
   async finalise(): Promise<void> {
     await this.finaliseButton.click();
-    await this.page.getByTestId('modal-j1bi').getByTestId('confirmbutton-tok1').click();
+    await this.page.getByTestId('confirmbutton-tok1').click();
   }
 }

--- a/packages/e2e-tests/pages/patients/InvoicePage/panes/InvoicePane.ts
+++ b/packages/e2e-tests/pages/patients/InvoicePage/panes/InvoicePane.ts
@@ -38,12 +38,10 @@ export class InvoicePane {
   }
 
   // Finalise the invoice: the Finalise button only shows once the encounter is discharged, and it
-  // opens a confirm modal. Finalisation is one-way.
+  // opens a confirm modal. Finalisation is one-way. Clicking the confirm button auto-waits for the
+  // modal; the finalised state is asserted by the caller (expectStatus), so we don't wait on close.
   async finalise(): Promise<void> {
     await this.finaliseButton.click();
-    const modal = this.page.getByTestId('modal-j1bi');
-    await modal.waitFor({ state: 'visible' });
-    await modal.getByRole('button', { name: 'Finalise' }).click();
-    await modal.waitFor({ state: 'hidden' });
+    await this.page.getByTestId('modal-j1bi').getByTestId('confirmbutton-tok1').click();
   }
 }

--- a/packages/e2e-tests/tests/patients/history/encounter/invoice.spec.ts
+++ b/packages/e2e-tests/tests/patients/history/encounter/invoice.spec.ts
@@ -1,5 +1,45 @@
-import { test } from '../../../../fixtures/baseFixture';
+import { test, expect } from '@fixtures/baseFixture';
+import {
+  createHospitalAdmissionEncounterViaAPI,
+  dischargeEncounterViaApi,
+} from '@utils/apiHelpers';
+import { getItemFromLocalStorage } from '@utils/localStorage';
 
-test.describe('Invoicing', () => {
-  test('Create an invoice', async () => {});
+test.setTimeout(60000);
+
+// A ward bed priced with a bed-fee product on the facility catch-all price list ($200/night).
+const PRICED_BED_LOCATION_ID = 'location-Ward1Bed1-tamanu';
+
+// Finalisation is the irreversible "money" action and the one invoicing UI journey with no
+// coverage. The night-counting, per-location and quantity-0-cleanup logic is covered at the
+// model/integration layer; this exercises the button -> confirm modal -> finalised-state journey.
+test.describe('Invoicing — finalisation', () => {
+  test('finalises a discharged admission invoice from the Invoicing tab', async ({
+    api,
+    page,
+    newPatient,
+    patientDetailsPage,
+  }) => {
+    // Arrange (API): admit to a priced bed so the invoice carries a bed-fee line, then discharge —
+    // an invoice can only be finalised once its encounter has an end date.
+    const facilityId = await getItemFromLocalStorage(page, 'facilityId');
+    const encounter = await createHospitalAdmissionEncounterViaAPI(api, newPatient.id, {
+      facilityId,
+      locationId: PRICED_BED_LOCATION_ID,
+    });
+    await dischargeEncounterViaApi(api, encounter.id);
+
+    // Act (UI): open the Invoicing tab, confirm the auto bed fee is present and still in progress,
+    // then finalise.
+    await patientDetailsPage.goToPatient(newPatient);
+    const invoice = await patientDetailsPage.navigateToInvoicingTab();
+    await invoice.expectItemVisible(/bed fee/i);
+    await invoice.expectStatus('In progress');
+    await invoice.finalise();
+
+    // Assert (UI): the invoice is finalised, its fee line persists, and it can't be finalised again.
+    await invoice.expectStatus('Finalised');
+    await invoice.expectItemVisible(/bed fee/i);
+    await expect(invoice.finaliseButton).toBeHidden();
+  });
 });

--- a/packages/e2e-tests/utils/apiHelpers.ts
+++ b/packages/e2e-tests/utils/apiHelpers.ts
@@ -149,6 +149,24 @@ export const createHospitalAdmissionEncounterViaAPI = async (
 
   return response.json();
 };
+
+// Discharge = give the encounter an end date. An invoice can only be finalised once its encounter
+// has been discharged, so this is the arrange step for the finalisation journey.
+export const dischargeEncounterViaApi = async (
+  api: APIRequestContext,
+  encounterId: string,
+  endDate: string = new Date().toISOString().replace('T', ' ').substring(0, 19),
+) => {
+  const encounterUrl = constructFacilityUrl(`/api/encounter/${encounterId}`);
+  const response = await api.put(encounterUrl, { data: { endDate } });
+
+  if (!response.ok()) {
+    const errorText = await response.text();
+    throw new Error(`Failed to discharge encounter: ${response.status()} ${errorText}`);
+  }
+
+  return response.json();
+};
 // TODO: swap these functions to use the new fakeRequests in fakeData package when it's merged
 export const createTriageEncounterViaApi = async (
   api: APIRequestContext,


### PR DESCRIPTION
### Changes

Replaces the empty `patients/history/encounter/invoice.spec.ts` stub (a no-op `Create an invoice` test) with a real invoice-finalisation E2E journey — the irreversible "money" action that had no E2E coverage.

**Journey:** admit a patient to a priced bed (API) so the invoice carries a bed-fee line, discharge (API — an invoice can only be finalised once its encounter has an end date), then via the UI: open the Invoicing tab, confirm the bed-fee line is present and the invoice is *In progress*, finalise it through the confirm modal, and assert it becomes *Finalised*, the fee line persists, and the Finalise button is gone (can't finalise twice).

**Deliberately left to unit/integration** (not re-tested here): night-counting math, per-location batching, per-facility timezone, the nightly charger, and the quantity-0 bed-fee line cleanup at finalisation — all already covered by `BedFee.test.js`, `bedFee.test.ts`, `BedFeeCharger.test.js`, and `EncounterFee(EndToEnd).test.js`.

**Supporting changes:** a `dischargeEncounterViaApi` arrange helper in `apiHelpers.ts`, and `finalise()` / `expectStatus()` accessors on the `InvoicePane` page object (reusing the existing finalise button, confirm modal, and status testids).

**Verification:** eslint clean on all three files; `tsc --noEmit` shows no new errors from these changes (the only `apiHelpers.ts` errors are the pre-existing `@tamanu/database` `Patient`/`User` type-import resolution on line 6, present on epic before this change). The full E2E run needs a live stack (frontend + servers + provisioning) not available in this worktree, so it should be exercised by CI / a reviewer with the stack up; the spec follows the existing `invoicing.spec.ts` arrange/act patterns and page-object conventions.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [x] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->