### PR TITLE
fix(facility): no-issue: register SyncTask synchronously in sync process

### DIFF
--- a/packages/facility-server/app/setupSyncRuntime.js
+++ b/packages/facility-server/app/setupSyncRuntime.js
@@ -16,7 +16,7 @@ export const SYNC_NOT_CONFIGURED_WARNING =
 
 // Wire up the sync runtime when configured, else warn and leave it disabled (a
 // fresh server still boots to serve the wizard). Returns whether it was set up.
-export async function setupSyncRuntime(context, { syncManager } = {}) {
+export async function setupSyncRuntime(context) {
   if (!isServerConfigured()) {
     log.warn(SYNC_NOT_CONFIGURED_WARNING);
     return false;
@@ -29,7 +29,7 @@ export async function setupSyncRuntime(context, { syncManager } = {}) {
     url: `${host.replace(/\/*$/, '')}/api/timesync`,
   });
   context.centralServer = new CentralServerConnection(context);
-  context.syncManager = syncManager ?? new FacilitySyncManager(context);
+  context.syncManager = new FacilitySyncManager(context);
 
   await performTimeZoneChecks({
     remote: context.centralServer,

--- a/packages/facility-server/app/subCommands/startApp.js
+++ b/packages/facility-server/app/subCommands/startApp.js
@@ -23,7 +23,7 @@ import { createApiApp } from '../createApiApp';
 import { version } from '../serverInfo';
 import { ApplicationContext } from '../ApplicationContext';
 import { createSyncApp } from '../createSyncApp';
-import { startTasks } from './startTasks';
+import { startScheduledTasks } from '../tasks';
 import { SyncTask } from '../tasks/SyncTask';
 
 const APP_TYPES = {
@@ -82,6 +82,7 @@ const startApp =
     }
 
     let server, express, port;
+    let cancelSyncTask = () => {};
     switch (appType) {
       case APP_TYPES.API:
         ({ express, server } = await createApiApp(context));
@@ -91,25 +92,16 @@ const startApp =
         ({ express, server } = await createSyncApp(context));
         ({ port } = config.sync.syncApiConnection);
 
-        // start SyncTask as part of sync app so that it is in the same process with tamanu-sync process
-        const startSyncTask = () =>
-          startTasks({
-            skipMigrationCheck: false,
-            taskClasses: [SyncTask],
-            syncManager: context.syncManager, // passing syncManager because it must be shared with SyncTask to prevent multiple syncs
-          });
-        if (context.syncManager) {
-          startSyncTask();
-        } else {
-          // Booted unconfigured: wire the runtime once setup completes, and only
-          // then start SyncTask so it shares the manager created here rather than
-          // its own startTasks poll making a second one.
-          cancelConfigPoll = startSyncRuntimeWhenConfigured(context, {
-            setup: async ctx => {
-              await setupSyncRuntime(ctx);
-              startSyncTask();
-            },
-          });
+        // Register SyncTask synchronously on this process's context (matching
+        // startAll): starting it via startTasks' full boot chain left an
+        // unawaited promise that could stall silently (e.g. central unreachable
+        // during a restart) and leave the facility without scheduled sync while
+        // manual sync kept working. SyncTask no-ops until syncManager is wired,
+        // so scheduling it before first-run setup completes is safe.
+        cancelSyncTask = startScheduledTasks(context, [SyncTask]);
+        if (!context.syncManager) {
+          // Booted unconfigured: poll for first-run setup, then wire the runtime.
+          cancelConfigPoll = startSyncRuntimeWhenConfigured(context);
         }
         break;
       }
@@ -120,6 +112,7 @@ const startApp =
     listenForBindAddresses({ server, app: express, fallbackPort: port });
     process.once('SIGTERM', () => {
       log.info('Received SIGTERM, closing HTTP server');
+      cancelSyncTask();
       cancelConfigPoll();
       server.close();
     });

--- a/packages/facility-server/app/subCommands/startTasks.js
+++ b/packages/facility-server/app/subCommands/startTasks.js
@@ -13,7 +13,7 @@ import { startScheduledTasks } from '../tasks';
 import { version } from '../serverInfo';
 import { ApplicationContext } from '../ApplicationContext';
 
-export async function startTasks({ skipMigrationCheck, taskClasses, syncManager }) {
+export async function startTasks({ skipMigrationCheck }) {
   log.info(`Starting facility task runner version ${version}`, {
     serverFacilityIds: getServerFacilityIds(),
   });
@@ -31,9 +31,9 @@ export async function startTasks({ skipMigrationCheck, taskClasses, syncManager 
   await checkConfig(context);
   await performDatabaseIntegrityChecks(context);
 
-  const isConfigured = await setupSyncRuntime(context, { syncManager });
+  const isConfigured = await setupSyncRuntime(context);
 
-  const cancelTasks = startScheduledTasks(context, taskClasses);
+  const cancelTasks = startScheduledTasks(context);
   // If booted unconfigured, start syncing once first-run setup completes.
   const cancelConfigPoll = isConfigured ? () => {} : startSyncRuntimeWhenConfigured(context);
   process.once('SIGTERM', () => {


### PR DESCRIPTION
### Changes

In the facility sync process (`startSync`), SyncTask was started via `startTasks(...)` as a fire-and-forget promise. `startTasks` redoes a full boot chain (second ApplicationContext, DB prep, integrity checks, timesync/timezone against central) before it ever registers the task, and nothing awaits or watches that promise. If any of those steps stalls or rejects (observed in production when a facility and its central were restarted together and central was unreachable mid-boot), the promise dies silently: no crash, no error log, and the sync HTTP server keeps serving manual syncs — but scheduled sync never starts until the next restart. This is how Tuvalu ran manual-only for ~25 hours on 2026-07-20/21.

Fix: register SyncTask synchronously on the process's already-initialised context via `startScheduledTasks(context, [SyncTask])`, exactly as `startAll` already does. SyncTask no-ops until `syncManager` is wired, so registering before first-run setup completes is safe, and the unconfigured-boot path can use the default config poll. Also removes the now-dead `taskClasses`/`syncManager` plumbing from `startTasks` and `setupSyncRuntime`.

No new tests: there's no existing harness for subcommand boot, and the pattern is the one `startAll` already uses. A follow-up backport for currently-deployed releases will be worked out separately.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
