### PR TITLE
fix(web): TAM-6927: remove leading slash on sync/status calls (HOTFIX 2.52)

### DIFF
--- a/packages/web/app/components/HiddenSyncAvatar.jsx
+++ b/packages/web/app/components/HiddenSyncAvatar.jsx
@@ -96,7 +96,7 @@ export const HiddenSyncAvatar = ({ children, onClick, ...props }) => {
 
     if (event.ctrlKey || event.altKey) {
       handleEvent(async () => {
-        const status = await api.get('/sync/status');
+        const status = await api.get('sync/status');
         const parts = [];
         if (status.lastCompletedAt === 0) {
           parts.push(

--- a/packages/web/app/contexts/SyncState.jsx
+++ b/packages/web/app/contexts/SyncState.jsx
@@ -53,7 +53,7 @@ export const SyncStateProvider = ({ children }) => {
 
   // query the facility server for sync status
   const querySync = useCallback(async () => {
-    const status = await api.get('/sync/status');
+    const status = await api.get('sync/status');
     setSyncStatus(status);
     clearSyncingPatients(status.lastCompletedPull, status.lastCompletedPush);
   }, [api, clearSyncingPatients]);


### PR DESCRIPTION
### Changes

Backport of the URL fix from #10126 (TAM-6927) for the next 2.52 patch. `HiddenSyncAvatar` and `SyncState` called `api.get('/sync/status')` with a leading slash; the api-client joins `prefix + '/' + path`, producing `/api//sync/status`, which 404s with an empty body. Every manual sync therefore toasted "Manual sync failed: Server error: No response data" even though the sync itself completed, and the sync status poll never worked. Diagnosed in production at Tuvalu (2.57.10) on 2026-07-21; this branch has deployed sites too. Two-line URL fix only.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
