### PR TITLE
tweak(fhir): TAM-6998: stop rematerialising FHIR resources on reference data changes

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/databaseTriggers.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/databaseTriggers.test.js
@@ -43,7 +43,21 @@ expect.extend({
 // If for some reason we don't want to add triggers to a specific table
 // this would be the place to add them.
 const versioningTablesToIgnore = ['non_fhir_medici_report'];
-const refreshTablesToIgnore = [];
+// Reference data (and reference-data-like config/master data) tables stay listed as upstreams
+// (they still feed resource builds triggered by other tables), but must not queue a
+// rematerialisation on their own, so they never get a fhir_refresh trigger. See
+// setFhirRefreshTriggers.js — keep this list in sync with REFERENCE_DATA_MODELS there.
+const refreshTablesToIgnore = [
+  'reference_data',
+  'departments',
+  'locations',
+  'location_groups',
+  'lab_test_types',
+  'lab_test_panels',
+  'scheduled_vaccines',
+  'imaging_area_external_codes',
+  'imaging_type_external_codes',
+];
 
 describe('databaseTriggers', () => {
   let ctx;

--- a/packages/database/__tests__/services/setFhirRefreshTriggers.test.js
+++ b/packages/database/__tests__/services/setFhirRefreshTriggers.test.js
@@ -30,6 +30,45 @@ describe('setFhirRefreshTriggers', () => {
     expect(rows.every(r => r.event_object_schema === 'public')).toBe(true);
   });
 
+  it('does not add a fhir_refresh trigger to reference data (or reference-data-like) tables', async () => {
+    const { sequelize } = database;
+
+    await setFhirRefreshTriggers(sequelize, { fhirWorkerEnabled: true });
+
+    const [rows] = await sequelize.query(`
+      SELECT event_object_table
+      FROM information_schema.triggers
+      WHERE trigger_name IN (
+        'fhir_refresh_reference_data',
+        'fhir_refresh_departments',
+        'fhir_refresh_locations',
+        'fhir_refresh_location_groups',
+        'fhir_refresh_lab_test_types',
+        'fhir_refresh_lab_test_panels',
+        'fhir_refresh_scheduled_vaccines',
+        'fhir_refresh_imaging_area_external_codes',
+        'fhir_refresh_imaging_type_external_codes'
+      )
+    `);
+
+    expect(rows.length).toBe(0);
+  });
+
+  it('still adds a fhir_refresh trigger to facilities, a resource\'s own primary entity', async () => {
+    const { sequelize } = database;
+
+    await setFhirRefreshTriggers(sequelize, { fhirWorkerEnabled: true });
+
+    const [rows] = await sequelize.query(`
+      SELECT 1
+      FROM information_schema.triggers
+      WHERE trigger_name = 'fhir_refresh_facilities'
+      LIMIT 1
+    `);
+
+    expect(rows.length).toBe(1);
+  });
+
   it('removes fhir_refresh triggers when fhirWorkerEnabled is false', async () => {
     const { sequelize } = database;
 

--- a/packages/database/src/migrations/1784590365191-removeFhirRefreshTriggerFromReferenceDataTables.ts
+++ b/packages/database/src/migrations/1784590365191-removeFhirRefreshTriggerFromReferenceDataTables.ts
@@ -1,0 +1,42 @@
+import { QueryInterface } from 'sequelize';
+
+// Tables that currently do carry a live fhir_refresh trigger (they're listed as an incidental
+// upstream of one or more FHIR resources, e.g. a location name shown on a materialised encounter),
+// which we're switching off here.
+const REFERENCE_DATA_TABLES_WITH_FHIR_TRIGGER = [
+  'reference_data',
+  'departments',
+  'locations',
+  'location_groups',
+  'lab_test_types',
+  'lab_test_panels',
+  'scheduled_vaccines',
+  'imaging_area_external_codes',
+  'imaging_type_external_codes',
+];
+
+export async function up(query: QueryInterface): Promise<void> {
+  // Reference data (and reference-data-like config/master data such as lab test types or location
+  // groups) changes should no longer queue a FHIR rematerialisation on their own. This data is
+  // still read when a resource is rematerialised for some other reason, so eventual drift between
+  // it and already-materialised resources is accepted.
+  for (const table of REFERENCE_DATA_TABLES_WITH_FHIR_TRIGGER) {
+    await query.sequelize.query(`DROP TRIGGER IF EXISTS "fhir_refresh_${table}" ON "${table}"`);
+  }
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  // DESTRUCTIVE: any FHIR rematerialisation jobs that these changes would have queued between
+  // up() and down() were never created, so they can't be replayed here.
+  for (const table of REFERENCE_DATA_TABLES_WITH_FHIR_TRIGGER) {
+    await query.sequelize.query(`
+      DO $block$ BEGIN
+        CREATE TRIGGER "fhir_refresh_${table}"
+          AFTER INSERT OR UPDATE OR DELETE ON "${table}"
+          FOR EACH ROW EXECUTE FUNCTION fhir.refresh_trigger();
+      EXCEPTION WHEN duplicate_object THEN
+        NULL;
+      END $block$;
+    `);
+  }
+}

--- a/packages/database/src/services/setFhirRefreshTriggers.js
+++ b/packages/database/src/services/setFhirRefreshTriggers.js
@@ -2,6 +2,38 @@ import { tablesWithoutTrigger, tablesWithTrigger } from '../utils';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { log } from '@tamanu/shared/services/logging';
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
+import {
+  ReferenceData,
+  Department,
+  Location,
+  LocationGroup,
+  LabTestType,
+  LabTestPanel,
+  ScheduledVaccine,
+  ImagingAreaExternalCode,
+  ImagingTypeExternalCode,
+} from '../models';
+
+// Reference data (and reference-data-like config/master data such as lab test types or location
+// groups) is still read when a FHIR resource is (re)materialised for some other reason, so these
+// models stay listed in each resource's `upstreams`. But changes to this data must not queue a
+// rematerialisation on their own (eventual drift is accepted), so their tables are excluded here
+// rather than getting a fhir_refresh trigger.
+//
+// Excludes only models that are always *incidental* context (never a resource's own primary
+// `UpstreamModels` entity) — e.g. `Facility` is reference data too, but it's `FhirOrganization`'s
+// own upstream, so it stays out of this list and keeps triggering FhirOrganization's refresh.
+const REFERENCE_DATA_MODELS = [
+  ReferenceData,
+  Department,
+  Location,
+  LocationGroup,
+  LabTestType,
+  LabTestPanel,
+  ScheduledVaccine,
+  ImagingAreaExternalCode,
+  ImagingTypeExternalCode,
+];
 
 /**
  * Add or remove fhir_refresh triggers on upstream tables of materialisable FHIR resources.
@@ -13,13 +45,14 @@ export const setFhirRefreshTriggers = async (sequelize, { fhirWorkerEnabled }) =
     Object.values(sequelize.models),
     FHIR_INTERACTIONS.INTERNAL.MATERIALISE,
   );
+  const referenceDataTables = new Set(REFERENCE_DATA_MODELS.map(model => model.tableName));
   const allUpstreams = Array.from(
     new Set(
       materialisableResources.flatMap(
         resource => resource.upstreams?.map(upstream => upstream.tableName) || [],
       ),
     ),
-  );
+  ).filter(table => !referenceDataTables.has(table));
 
   await sequelize.transaction(async () => {
     for (const { schema, table } of await tablesWithoutTrigger(sequelize, 'fhir_refresh_', '')) {


### PR DESCRIPTION
### Changes

Stops FHIR reference-data tables from queueing a rematerialisation on their own. Reference data (and reference-data-like master data such as lab test types, locations, and location groups) still feeds resource builds triggered by other tables — this only removes the `fhir_refresh` trigger *from those tables themselves*, so drift between them and already-materialised resources is accepted going forward. Tables that are a resource's own primary entity (e.g. `facilities` for `FhirOrganization`) are left untouched and keep triggering as before.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->