### PR TITLE
fix(database): no-issue: serialise reporting grants to avoid boot race (HOTFIX 2.53)

### DIFF
--- a/packages/database/src/services/reporting.js
+++ b/packages/database/src/services/reporting.js
@@ -21,10 +21,21 @@ const validateUser = async (existingStore, username) => {
   }
 };
 
+// Concurrently-starting processes race on this cluster-global grant
+// ("tuple concurrently updated"). Serialise with a transaction-scoped
+// advisory lock; the grant is idempotent so re-applying it once per
+// process startup is harmless. Same lock key as main's reporting roles.
+const REPORTING_GRANTS_LOCK_KEY = '7829301042';
+
 const grantPrivileges = async (existingStore, schemaName, username) => {
-  await existingStore.sequelize.query(`
+  await existingStore.sequelize.transaction(async () => {
+    await existingStore.sequelize.query(
+      `SELECT pg_advisory_xact_lock(${REPORTING_GRANTS_LOCK_KEY}::bigint);`,
+    );
+    await existingStore.sequelize.query(`
       GRANT SELECT ON ALL TABLES IN SCHEMA ${schemaName} TO ${username};
     `);
+  });
 };
 
 const initReportStore = async (existingStore, connectionName, credentials) => {


### PR DESCRIPTION
### Changes

Hotfix for the boot race behind the Tuvalu scheduled-sync outage (2026-07-19). All facility processes run `GRANT SELECT ON ALL TABLES IN SCHEMA public TO raw/reporting` at startup; when two boot simultaneously (pm2 resurrect after reboot/upgrade), Postgres raises `tuple concurrently updated` (XX000). At Tuvalu this killed the fire-and-forget startTasks chain in the sync process, silently disabling scheduled sync for ~25h. Fix serialises the grant behind a transaction-scoped advisory lock, mirroring the pattern already on main/2.60 (`ensureReportingRole`), using the same lock key. Grant is idempotent so re-application under the lock is harmless.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
