### PR TITLE
fix(web): TAM-6927: remove leading slash on sync/status calls (HOTFIX 2.58)

### DIFF
--- a/packages/web/app/components/HiddenSyncAvatar.jsx
+++ b/packages/web/app/components/HiddenSyncAvatar.jsx
@@ -112,7 +112,7 @@ export const HiddenSyncAvatar = forwardRef(({ children, onClick, onMetaClick, im
 
     if (event.ctrlKey || event.altKey) {
       handleEvent(async () => {
-        const status = await api.get('/sync/status');
+        const status = await api.get('sync/status');
         const parts = [];
         if (status.lastCompletedAt === 0) {
           parts.push(

--- a/packages/web/app/contexts/SyncState.jsx
+++ b/packages/web/app/contexts/SyncState.jsx
@@ -53,7 +53,7 @@ export const SyncStateProvider = ({ children }) => {
 
   // query the facility server for sync status
   const querySync = useCallback(async () => {
-    const status = await api.get('/sync/status');
+    const status = await api.get('sync/status');
     setSyncStatus(status);
     clearSyncingPatients(status.lastCompletedPull, status.lastCompletedPush);
   }, [api, clearSyncingPatients]);


### PR DESCRIPTION
### Changes

Backport of the URL fix from #10126 (TAM-6927) for the next 2.58 patch. `HiddenSyncAvatar` and `SyncState` called `api.get('/sync/status')` with a leading slash; the api-client joins `prefix + '/' + path`, producing `/api//sync/status`, which 404s with an empty body. Every manual sync therefore toasted "Manual sync failed: Server error: No response data" even though the sync itself completed, and the sync status poll never worked. Diagnosed in production at Tuvalu (2.57.10) on 2026-07-21. Two-line URL fix only.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
