### PR TITLE
db: no-issue: add time indexes to sync_sessions (HOTFIX 2.55)

### DIFF
--- a/packages/database/src/migrations/1784601600000-addSyncSessionsTimeIndexes.ts
+++ b/packages/database/src/migrations/1784601600000-addSyncSessionsTimeIndexes.ts
@@ -1,0 +1,25 @@
+import { QueryInterface } from 'sequelize';
+
+// Monitoring and support tooling filter sync_sessions by these time columns
+// (e.g. bestool-tamanu-doctor sweeps); without indexes each check seq-scans
+// the whole table, which on long-lived centrals is millions of rows.
+// IF NOT EXISTS so deployments that already created them manually are adopted.
+const INDEXES = [
+  ['sync_sessions_updated_at_idx', 'updated_at'],
+  ['sync_sessions_created_at_idx', 'created_at'],
+  ['sync_sessions_start_time_idx', 'start_time'],
+];
+
+export async function up(query: QueryInterface): Promise<void> {
+  for (const [name, column] of INDEXES) {
+    await query.sequelize.query(
+      `CREATE INDEX IF NOT EXISTS ${name} ON sync_sessions (${column});`,
+    );
+  }
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  for (const [name] of INDEXES) {
+    await query.sequelize.query(`DROP INDEX IF EXISTS ${name};`);
+  }
+}


### PR DESCRIPTION
### Changes

Backport of the sync_sessions index migration (main PR #10473) for the next 2.55 patch. Monitoring sweeps (bestool-tamanu-doctor) filter sync_sessions by updated_at, created_at, and start_time; with only the completed_at index every check seq-scans the table, which on Tonga central (2.7M rows / 1.2GB) presented as a sustained CPU spike (911ms -> 0.06ms measured for one check after indexing). Same migration file/name as main so SequelizeMeta dedupes on later upgrades, and IF NOT EXISTS adopts manually created indexes. DDL only.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

