### PR TITLE
tweak(database): no-issue: always refresh trigger definitions on migration hooks

### DIFF
--- a/packages/database/__tests__/services/migrations/migrationHooks.test.ts
+++ b/packages/database/__tests__/services/migrations/migrationHooks.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { closeDatabase, initDatabase } from '../../utilities';
 import { runPostMigration, runPreMigration } from '../../../src/services/migrations/hooks';
-import { tablesWithTrigger, tablesWithoutTrigger } from '../../../src/utils';
+import { tablesWithTrigger } from '../../../src/utils';
 import { createMigrationInterface } from '../../../src/services/migrations/migrations';
 import { log } from '@tamanu/shared/services/logging/log';
 import { Umzug } from 'umzug';
@@ -136,75 +136,6 @@ describe('migrationHooks', () => {
 
       expect(tables.sort(sortTables)).toEqual(
         triggeredTables.filter(table => !excludeTables.includes(table)).sort(sortTables),
-      );
-    });
-  });
-
-  describe('tablesWithoutTrigger', () => {
-    it('should return all tables for non-existing trigger', async () => {
-      const tables = await tablesWithoutTrigger(database.sequelize, 'banana_', '_chocolate');
-      expect(tables.sort(sortTables)).toEqual(allTables.sort(sortTables));
-    });
-
-    it('should return tables that do not have a trigger', async () => {
-      const prefix = 'cat_';
-      const suffix = '_dog';
-      const triggeredTables = randomSelection(allTables);
-      for (const table of triggeredTables) {
-        await addTrigger(database.sequelize, table, prefix, suffix);
-      }
-
-      const tables = await tablesWithoutTrigger(database.sequelize, prefix, suffix);
-
-      for (const table of triggeredTables) {
-        await removeTrigger(database.sequelize, table, prefix, suffix);
-      }
-
-      const expectedTables = allTables.filter(table => !triggeredTables.includes(table));
-      expect(tables.sort(sortTables)).toEqual(expectedTables.sort(sortTables));
-    });
-
-    it('should return tables that do not have a trigger even if it exceeds trigger character limit', async () => {
-      const prefix = 'super_duper_long_trigger_name_';
-      const suffix = '_really_silly_ridiculous_crazy_long_suffix';
-      const triggeredTables = randomSelection(allTables);
-      for (const table of triggeredTables) {
-        await addTrigger(database.sequelize, table, prefix, suffix);
-      }
-
-      const tables = await tablesWithoutTrigger(database.sequelize, prefix, suffix);
-
-      for (const table of triggeredTables) {
-        await removeTrigger(database.sequelize, table, prefix, suffix);
-      }
-
-      const expectedTables = allTables.filter(table => !triggeredTables.includes(table));
-      expect(tables.sort(sortTables)).toEqual(expectedTables.sort(sortTables));
-    });
-
-    it('should not return tables that are flagged in the exclude list', async () => {
-      const prefix = 'bird_';
-      const suffix = '_bat';
-      const triggeredTables = randomSelection(allTables);
-      for (const table of triggeredTables) {
-        await addTrigger(database.sequelize, table, prefix, suffix);
-      }
-
-      const excludeTables = randomSelection(allTables);
-      const tables = await tablesWithoutTrigger(
-        database.sequelize,
-        prefix,
-        suffix,
-        excludeTables.map(({ schema, table }) => `${schema}.${table}`),
-      );
-
-      for (const table of triggeredTables) {
-        await removeTrigger(database.sequelize, table, prefix, suffix);
-      }
-
-      const expectedTables = allTables.filter(table => !triggeredTables.includes(table));
-      expect(tables.sort(sortTables)).toEqual(
-        expectedTables.filter(table => !excludeTables.includes(table)).sort(sortTables),
       );
     });
   });

--- a/packages/database/src/services/migrations/hooks/postMigrationHooks.ts
+++ b/packages/database/src/services/migrations/hooks/postMigrationHooks.ts
@@ -2,7 +2,7 @@ import config from 'config';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { SYNC_TICK_FLAGS } from '../../../sync/constants';
 import { GLOBAL_EXCLUDE_TABLES, NON_LOGGED_TABLES, NON_SYNCING_TABLES } from '../constants';
-import { tablesWithoutColumn, tablesWithoutTrigger } from '../../../utils';
+import { allTables, tablesWithoutColumn } from '../../../utils';
 import { requireFunction } from './prerequisites';
 import type { MigrationHook } from './types';
 
@@ -34,12 +34,13 @@ const addUpdatedAtTrigger: MigrationHook = {
   name: 'addUpdatedAtTrigger',
   prerequisites: [requireFunction('set_updated_at')],
   async run({ log, sequelize }) {
-    for (const { schema, table } of await tablesWithoutTrigger(sequelize, 'set_', '_updated_at', [
+    for (const { schema, table } of await allTables(sequelize, [
       ...GLOBAL_EXCLUDE_TABLES,
       ...NON_SYNCING_TABLES,
     ])) {
       log.info(`Adding updated_at trigger to ${schema}.${table}`);
       await sequelize.query(`
+      DROP TRIGGER IF EXISTS set_${table}_updated_at ON "${schema}"."${table}";
       CREATE TRIGGER set_${table}_updated_at
       BEFORE INSERT OR UPDATE ON "${schema}"."${table}"
       FOR EACH ROW
@@ -53,14 +54,13 @@ const addUpdatedAtSyncTickTrigger: MigrationHook = {
   name: 'addUpdatedAtSyncTickTrigger',
   prerequisites: [requireFunction('set_updated_at_sync_tick')],
   async run({ log, sequelize }) {
-    for (const { schema, table } of await tablesWithoutTrigger(
-      sequelize,
-      'set_',
-      '_updated_at_sync_tick',
-      [...GLOBAL_EXCLUDE_TABLES, ...NON_SYNCING_TABLES],
-    )) {
+    for (const { schema, table } of await allTables(sequelize, [
+      ...GLOBAL_EXCLUDE_TABLES,
+      ...NON_SYNCING_TABLES,
+    ])) {
       log.info(`Adding updated_at_sync_tick trigger to ${schema}.${table}`);
       await sequelize.query(`
+      DROP TRIGGER IF EXISTS set_${table}_updated_at_sync_tick ON "${schema}"."${table}";
       CREATE TRIGGER set_${table}_updated_at_sync_tick
       BEFORE INSERT OR UPDATE ON "${schema}"."${table}"
       FOR EACH ROW
@@ -74,12 +74,13 @@ const addNotifyTableChangedTrigger: MigrationHook = {
   name: 'addNotifyTableChangedTrigger',
   prerequisites: [requireFunction('notify_table_changed')],
   async run({ log, sequelize }) {
-    for (const { schema, table } of await tablesWithoutTrigger(sequelize, 'notify_', '_changed', [
+    for (const { schema, table } of await allTables(sequelize, [
       ...GLOBAL_EXCLUDE_TABLES,
       ...NON_SYNCING_TABLES,
     ])) {
       log.info(`Adding notify change trigger to ${schema}.${table}`);
       await sequelize.query(`
+      DROP TRIGGER IF EXISTS notify_${table}_changed ON "${schema}"."${table}";
       CREATE TRIGGER notify_${table}_changed
       AFTER INSERT OR UPDATE OR DELETE ON "${schema}"."${table}"
       FOR EACH ROW
@@ -93,12 +94,13 @@ const addRecordChangeTrigger: MigrationHook = {
   name: 'addRecordChangeTrigger',
   prerequisites: [requireFunction('record_change')],
   async run({ log, sequelize }) {
-    for (const { schema, table } of await tablesWithoutTrigger(sequelize, 'record_', '_changelog', [
+    for (const { schema, table } of await allTables(sequelize, [
       ...GLOBAL_EXCLUDE_TABLES,
       ...NON_LOGGED_TABLES,
     ])) {
       log.info(`Adding changelog trigger to ${schema}.${table}`);
       await sequelize.query(`
+      DROP TRIGGER IF EXISTS record_${table}_changelog ON "${schema}"."${table}";
       CREATE CONSTRAINT TRIGGER record_${table}_changelog
       AFTER INSERT OR UPDATE ON "${schema}"."${table}"
       DEFERRABLE INITIALLY DEFERRED

--- a/packages/database/src/services/setFhirRefreshTriggers.js
+++ b/packages/database/src/services/setFhirRefreshTriggers.js
@@ -25,11 +25,18 @@ export const setFhirRefreshTriggers = async (sequelize, { fhirWorkerEnabled }) =
     if (fhirWorkerEnabled) {
       for (const table of allUpstreams) {
         log.info(`Adding fhir_refresh trigger to public.${table}`);
+        // PL/pgSQL block handles the race where multiple concurrent
+        // ApplicationContext.init() calls all see the trigger as missing
+        // and try to create it simultaneously.
         await sequelize.query(`
-          DROP TRIGGER IF EXISTS "fhir_refresh_${table}" ON "public"."${table}";
-          CREATE TRIGGER "fhir_refresh_${table}"
-            AFTER INSERT OR UPDATE OR DELETE ON "public"."${table}"
-            FOR EACH ROW EXECUTE FUNCTION fhir.refresh_trigger();
+          DO $block$ BEGIN
+            DROP TRIGGER IF EXISTS "fhir_refresh_${table}" ON "public"."${table}";
+            CREATE TRIGGER "fhir_refresh_${table}"
+              AFTER INSERT OR UPDATE OR DELETE ON "public"."${table}"
+              FOR EACH ROW EXECUTE FUNCTION fhir.refresh_trigger();
+          EXCEPTION WHEN duplicate_object THEN
+            NULL;
+          END $block$;
         `);
       }
     }

--- a/packages/database/src/services/setFhirRefreshTriggers.js
+++ b/packages/database/src/services/setFhirRefreshTriggers.js
@@ -1,4 +1,4 @@
-import { tablesWithoutTrigger, tablesWithTrigger } from '../utils';
+import { tablesWithTrigger } from '../utils';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { log } from '@tamanu/shared/services/logging';
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
@@ -22,24 +22,16 @@ export const setFhirRefreshTriggers = async (sequelize, { fhirWorkerEnabled }) =
   );
 
   await sequelize.transaction(async () => {
-    for (const { schema, table } of await tablesWithoutTrigger(sequelize, 'fhir_refresh_', '')) {
-      if (!fhirWorkerEnabled || schema !== 'public' || !allUpstreams.includes(table)) {
-        continue;
+    if (fhirWorkerEnabled) {
+      for (const table of allUpstreams) {
+        log.info(`Adding fhir_refresh trigger to public.${table}`);
+        await sequelize.query(`
+          DROP TRIGGER IF EXISTS "fhir_refresh_${table}" ON "public"."${table}";
+          CREATE TRIGGER "fhir_refresh_${table}"
+            AFTER INSERT OR UPDATE OR DELETE ON "public"."${table}"
+            FOR EACH ROW EXECUTE FUNCTION fhir.refresh_trigger();
+        `);
       }
-
-      log.info(`Adding fhir_refresh trigger to ${schema}.${table}`);
-      // PL/pgSQL block handles the race where multiple concurrent
-      // ApplicationContext.init() calls all see the trigger as missing
-      // and try to create it simultaneously.
-      await sequelize.query(`
-          DO $block$ BEGIN
-            CREATE TRIGGER "fhir_refresh_${table}"
-              AFTER INSERT OR UPDATE OR DELETE ON "${schema}"."${table}"
-              FOR EACH ROW EXECUTE FUNCTION fhir.refresh_trigger();
-          EXCEPTION WHEN duplicate_object THEN
-            NULL;
-          END $block$;
-      `);
     }
 
     for (const { schema, table } of await tablesWithTrigger(sequelize, 'fhir_refresh_', '')) {

--- a/packages/database/src/utils/tablesWithTrigger.ts
+++ b/packages/database/src/utils/tablesWithTrigger.ts
@@ -50,12 +50,7 @@ export const tablesWithTrigger = (
     );
 };
 
-export const tablesWithoutTrigger = (
-  sequelize: Sequelize,
-  prefix: string,
-  suffix: string,
-  excludes: string[] = [],
-) => {
+export const allTables = (sequelize: Sequelize, excludes: string[] = []) => {
   return sequelize
     .query(
       `
@@ -63,17 +58,11 @@ export const tablesWithoutTrigger = (
           t.table_schema as schema,
           t.table_name as table
         FROM information_schema.tables t
-        LEFT JOIN information_schema.triggers triggers ON
-          t.table_name = triggers.event_object_table
-          AND t.table_schema = triggers.event_object_schema
-          AND triggers.trigger_name = substring(concat($prefix::text, lower(t.table_name), $suffix::text), 0, 64)
         WHERE
           t.table_schema IN ('public', 'logs')
           AND t.table_type != 'VIEW'
-          AND triggers.trigger_name IS NULL -- No matching trigger
-        GROUP BY t.table_schema, t.table_name -- Group to ensure unique results
       `,
-      { type: QueryTypes.SELECT, bind: { prefix, suffix } },
+      { type: QueryTypes.SELECT },
     )
     .then(rows =>
       rows


### PR DESCRIPTION
### Changes

Several places in the migration hooks used a `tablesWithoutTrigger` query to only install a trigger on tables that lacked it, meaning the trigger definition would go stale after the first install if the DDL for that trigger changed later. This replaces that pattern with an unconditional `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER` (or `CREATE CONSTRAINT TRIGGER` where applicable) over all matching tables, so the trigger definition is refreshed on every migration run. Went with drop-and-recreate rather than `CREATE OR REPLACE TRIGGER` to stay compatible with Postgres 12 deployments still in production (CREATE OR REPLACE TRIGGER needs PG14+), and confirmed this is race-safe and atomic within the existing transaction/multi-statement query boundaries. Also simplified `setFhirRefreshTriggers.js` to iterate directly over the known list of upstream tables instead of querying for tables missing the trigger, dropping the old DO-block/exception-handling workaround for concurrent installs.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->