### PR TITLE
tweak(database): no-issue: disable sync tick trigger via fact during migrations

### DIFF
--- a/packages/database/src/services/migrations/hooks/postMigrationHooks.ts
+++ b/packages/database/src/services/migrations/hooks/postMigrationHooks.ts
@@ -1,9 +1,10 @@
 import config from 'config';
+import { FACT_SYNC_TRIGGER_CONTROL } from '@tamanu/constants/facts';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { SYNC_TICK_FLAGS } from '../../../sync/constants';
 import { GLOBAL_EXCLUDE_TABLES, NON_LOGGED_TABLES, NON_SYNCING_TABLES } from '../constants';
 import { tablesWithoutColumn, tablesWithoutTrigger } from '../../../utils';
-import { requireFunction } from './prerequisites';
+import { requireFunction, requireTable } from './prerequisites';
 import type { MigrationHook } from './types';
 
 const addUpdatedAtSyncTickColumn: MigrationHook = {
@@ -109,10 +110,22 @@ const addRecordChangeTrigger: MigrationHook = {
   },
 };
 
+const enableSyncTickTrigger: MigrationHook = {
+  name: 'enableSyncTickTrigger',
+  prerequisites: [requireTable('local_system_facts')],
+  async run({ log, sequelize }) {
+    log.info('Re-enabling sync tick trigger after migrations');
+    await sequelize.query(`
+      UPDATE local_system_facts SET value = 'enabled' WHERE key = '${FACT_SYNC_TRIGGER_CONTROL}';
+    `);
+  },
+};
+
 export const POST_MIGRATION_HOOKS: MigrationHook[] = [
   addUpdatedAtSyncTickColumn,
   addUpdatedAtTrigger,
   addUpdatedAtSyncTickTrigger,
   addNotifyTableChangedTrigger,
   addRecordChangeTrigger,
+  enableSyncTickTrigger,
 ];

--- a/packages/database/src/services/migrations/hooks/preMigrationHooks.ts
+++ b/packages/database/src/services/migrations/hooks/preMigrationHooks.ts
@@ -1,31 +1,21 @@
-import { GLOBAL_EXCLUDE_TABLES, NON_SYNCING_TABLES } from '../constants';
-import { tablesWithTrigger } from '../../../utils';
+import { FACT_SYNC_TRIGGER_CONTROL } from '@tamanu/constants/facts';
+import { requireTable } from './prerequisites';
 import type { MigrationHook } from './types';
 
-const removeUpdatedAtSyncTickTrigger: MigrationHook = {
-  name: 'removeUpdatedAtSyncTickTrigger',
-  prerequisites: [],
+const disableSyncTickTrigger: MigrationHook = {
+  name: 'disableSyncTickTrigger',
+  prerequisites: [requireTable('local_system_facts')],
   async run({ log, sequelize }) {
-    // remove updated sync tick trigger before migrations
-    // migrations are deterministic, so updating the sync tick just creates useless churn
-    for (const { schema, table } of await tablesWithTrigger(
-      sequelize,
-      'set_',
-      '_updated_at_sync_tick',
-      [...GLOBAL_EXCLUDE_TABLES, ...NON_SYNCING_TABLES],
-    )) {
-      // we need to keep the updated_at_sync_tick trigger on the changes table
-      if (schema === 'logs' && table === 'changes') {
-        continue;
-      }
-
-      log.info(`Removing updated_at_sync_tick trigger from ${schema}.${table}`);
-
-      await sequelize.query(
-        `DROP TRIGGER set_${table}_updated_at_sync_tick ON "${schema}"."${table}"`,
-      );
-    }
+    // Put the sync tick trigger into disabled mode (the same mechanism dataMigrations'
+    // disableSyncTrigger uses) rather than dropping it. Migrations are deterministic, so
+    // updating the sync tick causes us to unnecessarily sync large amounts of data
+    log.info('Disabling sync tick trigger for migrations');
+    await sequelize.query(`
+      INSERT INTO local_system_facts (key, value)
+      VALUES ('${FACT_SYNC_TRIGGER_CONTROL}', 'disabled')
+      ON CONFLICT (key) DO UPDATE SET value = 'disabled';
+    `);
   },
 };
 
-export const PRE_MIGRATION_HOOKS: MigrationHook[] = [removeUpdatedAtSyncTickTrigger];
+export const PRE_MIGRATION_HOOKS: MigrationHook[] = [disableSyncTickTrigger];

--- a/packages/database/src/services/migrations/hooks/prerequisites.ts
+++ b/packages/database/src/services/migrations/hooks/prerequisites.ts
@@ -17,3 +17,23 @@ async function functionExists(sequelize: Sequelize, name: string): Promise<boole
 export function requireFunction(name: string): Prerequisite {
   return async context => await functionExists(context.sequelize, name);
 }
+
+async function tableExists(sequelize: Sequelize, name: string): Promise<boolean> {
+  const rows = await sequelize.query(
+    "select count(*) as count from information_schema.tables where table_schema = 'public' and table_name = $name",
+    {
+      type: QueryTypes.SELECT,
+      bind: { name },
+    },
+  );
+  const row = rows?.[0] as { count: number } | undefined;
+  return (row?.count ?? 0) > 0;
+}
+
+/**
+ * Pre-requisite: the given table exists in the public schema. Guards hooks that read/write
+ * local_system_facts against running before the baseline migration has created it.
+ */
+export function requireTable(name: string): Prerequisite {
+  return async context => await tableExists(context.sequelize, name);
+}


### PR DESCRIPTION
### Changes

Breaks out one piece of #10485 (sync_lookup self-healing): switch the sync tick
trigger's pre/post-migration handling from dropping and recreating
`set_updated_at_sync_tick` on every syncing table to toggling
`local_system_facts.syncTrigger` between `'disabled'`/`'enabled'` instead — the
trigger function already no-ops while that fact is `'disabled'`, the same
mechanism `dataMigrations`' `disableSyncTrigger` already uses.

- `preMigrationHooks.ts`: `removeUpdatedAtSyncTickTrigger` (dropped the trigger
  from every table, special-casing `logs.changes` to keep its trigger) replaced
  with `disableSyncTickTrigger`, which just flips the fact.
- `postMigrationHooks.ts`: added `enableSyncTickTrigger`, restoring the fact to
  `'enabled'` after migrations.
- `prerequisites.ts`: added `requireTable`, guarding both hooks against running
  before the baseline migration creates `local_system_facts`.

The trigger now stays installed on every table throughout a migration batch
rather than being dropped and recreated, and the `logs.changes` special case is
no longer needed.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
