### PR TITLE
config(database): no-issue: set idle_in_transaction_session_timeout on pg connections

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -15,6 +15,9 @@
     "password": "",
     "migrateOnStartup": false,
     "skipVersionCompatibilityCheck": false,
+    // Abort sessions left idle inside an open transaction for longer than this
+    // (milliseconds; 0 disables), so a stuck process can't hold locks forever.
+    "idleInTransactionSessionTimeout": 600000,
     "pool": {
       "max": 10
       // "min": 5,

--- a/packages/database/__tests__/services/connectionConfig.test.js
+++ b/packages/database/__tests__/services/connectionConfig.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { resolveDbConfig } from '../../src/services/connectionConfig';
+import { pgStartupOptions, resolveDbConfig } from '../../src/services/connectionConfig';
 
 describe('resolveDbConfig', () => {
   const structured = {
@@ -54,5 +54,27 @@ describe('resolveDbConfig', () => {
   it('throws a clear error when DATABASE_URL is not a postgres connection string', () => {
     process.env.DATABASE_URL = 'localhost:5432/tamanu';
     expect(() => resolveDbConfig(structured)).toThrow(/postgres/);
+  });
+});
+
+describe('pgStartupOptions', () => {
+  it('returns the GUC flag for a positive millisecond value', () => {
+    expect(pgStartupOptions({ idleInTransactionSessionTimeout: 600000 })).toEqual(
+      '-c idle_in_transaction_session_timeout=600000',
+    );
+  });
+
+  it('floors fractional values', () => {
+    expect(pgStartupOptions({ idleInTransactionSessionTimeout: 1500.9 })).toEqual(
+      '-c idle_in_transaction_session_timeout=1500',
+    );
+  });
+
+  it('is disabled when unset, zero, negative, or junk', () => {
+    expect(pgStartupOptions()).toBeUndefined();
+    expect(pgStartupOptions({})).toBeUndefined();
+    expect(pgStartupOptions({ idleInTransactionSessionTimeout: 0 })).toBeUndefined();
+    expect(pgStartupOptions({ idleInTransactionSessionTimeout: -5 })).toBeUndefined();
+    expect(pgStartupOptions({ idleInTransactionSessionTimeout: 'ten minutes' })).toBeUndefined();
   });
 });

--- a/packages/database/src/services/connectionConfig.js
+++ b/packages/database/src/services/connectionConfig.js
@@ -25,6 +25,19 @@ const poolFromConnectionString = parsed => {
  * Callers spread the result and may still override individual fields (e.g. the
  * reporting connections reuse the resolved host/name but set their own user).
  */
+/**
+ * Postgres startup options (the `options` connection parameter): session GUCs
+ * applied to every pooled connection at connect time, no per-connect round
+ * trip. Currently just idle_in_transaction_session_timeout, which aborts
+ * sessions left idle inside an open transaction so a stuck process can't hold
+ * locks forever. Milliseconds; unset/zero/invalid disables.
+ */
+export const pgStartupOptions = ({ idleInTransactionSessionTimeout } = {}) => {
+  const ms = Number(idleInTransactionSessionTimeout);
+  if (!Number.isFinite(ms) || ms <= 0) return undefined;
+  return `-c idle_in_transaction_session_timeout=${Math.floor(ms)}`;
+};
+
 export const resolveDbConfig = (dbConfig = {}) => {
   const url = process.env.DATABASE_URL;
   if (!url) return dbConfig;

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -8,6 +8,7 @@ import { log } from '@tamanu/shared/services/logging';
 import { serviceContext, serviceName } from '@tamanu/shared/services/logging/context';
 
 import { assertUpToDate, migrate, NON_SYNCING_TABLES } from './migrations';
+import { pgStartupOptions } from './connectionConfig';
 import * as models from '../models';
 import { createDateTypes } from './createDateTypes';
 import { setupQuote } from '../utils/pgComposite';
@@ -110,9 +111,13 @@ async function connectToDatabase(dbOptions) {
     logging = null;
   }
 
+  const startupOptions = pgStartupOptions(dbOptions);
   const options = {
     dialect: 'postgres',
-    dialectOptions: { application_name: serviceName(serviceContext()) ?? 'tamanu' },
+    dialectOptions: {
+      application_name: serviceName(serviceContext()) ?? 'tamanu',
+      ...(startupOptions && { options: startupOptions }),
+    },
   };
 
   const sequelize = new Sequelize(name, username, password, {

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -63,6 +63,9 @@
     "verbose": false,
     "migrateOnStartup": false,
     "skipVersionCompatibilityCheck": false,
+    // Abort sessions left idle inside an open transaction for longer than this
+    // (milliseconds; 0 disables), so a stuck process can't hold locks forever.
+    "idleInTransactionSessionTimeout": 600000,
   },
   "metaServer": {
     "hosts": [


### PR DESCRIPTION
### Changes
⚠️ JUST A DRAFT
just playin here 

Sets `idle_in_transaction_session_timeout` on every Postgres connection (central + facility), default 10 minutes, configurable via `db.idleInTransactionSessionTimeout` (milliseconds, 0 disables). A session idle inside an open transaction holds its locks indefinitely — a stuck or crashed-mid-transaction process can quietly block autovacuum, DDL, and other writers with nothing in any log. The GUC is applied through the postgres `options` startup parameter so it covers the whole pool (including reporting stores) with no per-connect round trip. Deliberately conservative default: it only aborts sessions *idle between statements inside a transaction* — long-running active queries, migrations mid-ALTER, and busy sync persists are unaffected, and 10 minutes of in-transaction idleness is unambiguously a leak. Follow-up hardening from the Tuvalu/Tonga incident review (see #10456, #10473). Unit tests cover the option-string builder; config reference doc needs an entry for the new key.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
