### PR TITLE
fix(database): no-issue: retry reporting grant on catalog update race

### DIFF
--- a/packages/database/src/services/reporting.js
+++ b/packages/database/src/services/reporting.js
@@ -9,6 +9,7 @@ import {
   FACT_REPORTING_SECRET_ROTATED_AT,
 } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
+import { log } from '@tamanu/shared/services/logging';
 import { ReadSettings } from '@tamanu/settings/reader';
 import { openDatabase } from './database';
 import { resolveDbConfig } from './connectionConfig';
@@ -68,6 +69,27 @@ export const getReportingSecret = async ({ models, sequelize }) => {
   });
 };
 
+// Catalog DDL (GRANT etc) updates pg_class rows, which can race autovacuum's
+// in-place catalog updates: "tuple concurrently updated" (XX000). The advisory
+// lock below only serialises our own processes, not background workers. Fixed
+// upstream in the 2024-11 postgres minors (e.g. 12.21), but deployments run
+// older; the DDL is idempotent, so just retry.
+const CATALOG_RACE_ATTEMPTS = 3;
+const withCatalogRaceRetry = async (label, fn) => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      const code = error?.original?.code ?? error?.parent?.code;
+      if (code !== 'XX000' || attempt >= CATALOG_RACE_ATTEMPTS) throw error;
+      log.warn(`${label}: retrying after catalog update race`, { attempt });
+      await new Promise(resolve => {
+        setTimeout(resolve, 500 * attempt);
+      });
+    }
+  }
+};
+
 const ensureReportingRole = async (existingStore, connectionName, password) => {
   const role = REPORT_DB_CONNECTION_ROLES[connectionName];
   const schema = REPORT_DB_CONNECTION_SCHEMAS[connectionName];
@@ -77,10 +99,11 @@ const ensureReportingRole = async (existingStore, connectionName, password) => {
   // would race on these cluster-global role objects ("tuple concurrently
   // updated"). Serialise with a transaction-scoped advisory lock; the DDL is
   // idempotent so re-applying it once per startup is harmless.
-  await sequelize.transaction(async () => {
-    await sequelize.query(`SELECT pg_advisory_xact_lock(${REPORTING_ROLES_LOCK_KEY}::bigint);`);
+  await withCatalogRaceRetry(`ensureReportingRole(${role})`, () =>
+    sequelize.transaction(async () => {
+      await sequelize.query(`SELECT pg_advisory_xact_lock(${REPORTING_ROLES_LOCK_KEY}::bigint);`);
 
-    await sequelize.query(`
+      await sequelize.query(`
       DO $$
       BEGIN
         CREATE ROLE "${role}" LOGIN;
@@ -90,40 +113,42 @@ const ensureReportingRole = async (existingStore, connectionName, password) => {
       $$;
     `);
 
-    // Escape as a literal (DDL can't bind it) and don't log it — it's a credential.
-    // On failure, re-throw without the original error: its `sql` field holds the
-    // statement with the password inline, which a generic error log would leak.
-    try {
+      // Escape as a literal (DDL can't bind it) and don't log it — it's a credential.
+      // On failure, re-throw without the original error: its `sql` field holds the
+      // statement with the password inline, which a generic error log would leak.
+      try {
+        await sequelize.query(
+          `ALTER ROLE "${role}" WITH LOGIN PASSWORD ${sequelize.escape(password)};`,
+          { logging: false },
+        );
+      } catch (error) {
+        throw new Error(`Failed to set password for reporting role "${role}": ${error.message}`);
+      }
+
+      if (schema !== 'public') {
+        await sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${schema}";`);
+        // Lets reporting reports reference tables without the schema prefix.
+        await sequelize.query(`ALTER ROLE "${role}" SET search_path TO "${schema}";`);
+      }
+
+      await sequelize.query(`GRANT USAGE ON SCHEMA "${schema}" TO "${role}";`);
+      await sequelize.query(`GRANT SELECT ON ALL TABLES IN SCHEMA "${schema}" TO "${role}";`);
+      // Covers tables created later (e.g. materialised reporting tables).
       await sequelize.query(
-        `ALTER ROLE "${role}" WITH LOGIN PASSWORD ${sequelize.escape(password)};`,
-        { logging: false },
+        `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schema}" GRANT SELECT ON TABLES TO "${role}";`,
       );
-    } catch (error) {
-      throw new Error(`Failed to set password for reporting role "${role}": ${error.message}`);
-    }
 
-    if (schema !== 'public') {
-      await sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${schema}";`);
-      // Lets reporting reports reference tables without the schema prefix.
-      await sequelize.query(`ALTER ROLE "${role}" SET search_path TO "${schema}";`);
-    }
-
-    await sequelize.query(`GRANT USAGE ON SCHEMA "${schema}" TO "${role}";`);
-    await sequelize.query(`GRANT SELECT ON ALL TABLES IN SCHEMA "${schema}" TO "${role}";`);
-    // Covers tables created later (e.g. materialised reporting tables).
-    await sequelize.query(
-      `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schema}" GRANT SELECT ON TABLES TO "${role}";`,
-    );
-
-    // The raw role reads all of `public` for reporting, but report SQL has no
-    // business reading credential/token tables: local_system_secrets holds the
-    // device private key and the reporting secret (encrypted, but still not for
-    // reports), and the rest hold auth tokens or certificate signing keys. Revoke
-    // SELECT on them.
-    // to_regclass skips any not present on this server (e.g. central-only ones).
-    if (schema === 'public') {
-      const sensitiveTablesArray = REPORTING_SENSITIVE_TABLES.map(table => `'${table}'`).join(', ');
-      await sequelize.query(`
+      // The raw role reads all of `public` for reporting, but report SQL has no
+      // business reading credential/token tables: local_system_secrets holds the
+      // device private key and the reporting secret (encrypted, but still not for
+      // reports), and the rest hold auth tokens or certificate signing keys. Revoke
+      // SELECT on them.
+      // to_regclass skips any not present on this server (e.g. central-only ones).
+      if (schema === 'public') {
+        const sensitiveTablesArray = REPORTING_SENSITIVE_TABLES.map(table => `'${table}'`).join(
+          ', ',
+        );
+        await sequelize.query(`
         DO $$
         DECLARE
           sensitive_table text;
@@ -136,8 +161,9 @@ const ensureReportingRole = async (existingStore, connectionName, password) => {
         END
         $$;
       `);
-    }
-  });
+      }
+    }),
+  );
 };
 
 const initReportStore = async (existingStore, connectionName, secret) => {


### PR DESCRIPTION
### Changes

Wraps `ensureReportingRole`'s locked DDL transaction in a bounded retry (3 attempts, backoff) on `tuple concurrently updated` (XX000). The advisory lock added earlier serialises Tamanu's own processes, but GRANT's `pg_class` updates can also race **autovacuum's in-place catalog updates** — observed in production at Tuvalu (postgres 12.10) during the 2.57.11 deploy, where it killed the sync process's task bootstrap. That race was fixed upstream in the 2024-11 postgres minors (12.21+ / [release notes](https://www.postgresql.org/docs/release/12.21/)) but deployments run older EOL builds. The DDL is idempotent so retrying under the lock is safe. Companion hotfix PRs apply the same retry to the simpler `grantPrivileges` on release/2.52-2.59.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
