### PR TITLE
fix(database): no-issue: retry reporting grant on catalog update race (HOTFIX 2.53)

### DIFF
--- a/packages/database/src/services/reporting.js
+++ b/packages/database/src/services/reporting.js
@@ -27,15 +27,34 @@ const validateUser = async (existingStore, username) => {
 // process startup is harmless. Same lock key as main's reporting roles.
 const REPORTING_GRANTS_LOCK_KEY = '7829301042';
 
+// The grant can also race autovacuum's in-place pg_class updates ("tuple
+// concurrently updated", XX000) — the advisory lock only serialises our own
+// processes, not background workers. Fixed upstream in the 2024-11 postgres
+// minors (12.21+), but deployments run older; the grant is idempotent, so
+// retry with backoff.
+const GRANT_ATTEMPTS = 3;
+
 const grantPrivileges = async (existingStore, schemaName, username) => {
-  await existingStore.sequelize.transaction(async () => {
-    await existingStore.sequelize.query(
-      `SELECT pg_advisory_xact_lock(${REPORTING_GRANTS_LOCK_KEY}::bigint);`,
-    );
-    await existingStore.sequelize.query(`
-      GRANT SELECT ON ALL TABLES IN SCHEMA ${schemaName} TO ${username};
-    `);
-  });
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await existingStore.sequelize.transaction(async () => {
+        await existingStore.sequelize.query(
+          `SELECT pg_advisory_xact_lock(${REPORTING_GRANTS_LOCK_KEY}::bigint);`,
+        );
+        await existingStore.sequelize.query(`
+          GRANT SELECT ON ALL TABLES IN SCHEMA ${schemaName} TO ${username};
+        `);
+      });
+      return;
+    } catch (error) {
+      const code = error?.original?.code ?? error?.parent?.code;
+      if (code !== 'XX000' || attempt >= GRANT_ATTEMPTS) throw error;
+      log.warn(`grantPrivileges(${username}): retrying after catalog update race`, { attempt });
+      await new Promise(resolve => {
+        setTimeout(resolve, 500 * attempt);
+      });
+    }
+  }
 };
 
 const initReportStore = async (existingStore, connectionName, credentials) => {


### PR DESCRIPTION
### Changes

Bounded retry (3 attempts, backoff) on `tuple concurrently updated` (XX000) around the advisory-locked reporting grant. The lock serialises Tamanu's own processes, but GRANT's `pg_class` updates can also race autovacuum's in-place catalog updates — observed at Tuvalu (postgres 12.10) during the 2.57.11 deploy, where it killed the sync process's task bootstrap and silently disabled scheduled sync until a restart. Fixed upstream in postgres 12.21+ (2024-11 minors) but deployed boxes run older EOL builds. Grant is idempotent so retrying under the lock is safe. Mirrors main PR #10491.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
