### PR TITLE
perf(labs): no-issue: exclude sensitive labs with NOT EXISTS anti-join in worklist query (HOTFIX 2.55)

### DIFF
--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -129,12 +129,21 @@ labRequest.get(
   '/$',
   asyncHandler(async (req, res) => {
     const {
-      models: { LabRequest },
+      models: { LabRequest, LabTestType },
       query,
       settings,
     } = req;
     req.checkPermission('list', 'LabRequest');
     const canListSensitive = req.ability.can('list', 'SensitiveLabRequest');
+    // With no sensitive test types (most deployments) the anti-join below is vacuous, so skip
+    // it. paranoid: false mirrors the raw filter, which doesn't exclude soft-deleted types.
+    const mustExcludeSensitive =
+      !canListSensitive &&
+      (await LabTestType.findOne({
+        where: { isSensitive: true },
+        attributes: ['id'],
+        paranoid: false,
+      })) !== null;
 
     const {
       order = 'ASC',
@@ -219,7 +228,18 @@ labRequest.get(
         },
       ),
       makeDeletedAtIsNullFilter('encounter'),
-      makeFilter(!canListSensitive, 'sensitive_labs.is_sensitive IS NULL', () => {}),
+      makeFilter(
+        mustExcludeSensitive,
+        `NOT EXISTS (
+          SELECT 1
+          FROM lab_tests
+          INNER JOIN lab_test_types
+            ON (lab_test_types.id = lab_tests.lab_test_type_id)
+          WHERE lab_tests.lab_request_id = lab_requests.id
+            AND lab_test_types.is_sensitive IS TRUE
+        )`,
+        () => {},
+      ),
     ].filter(f => f);
 
     const { whereClauses, filterReplacements } = getWhereClausesAndReplacementsFromFilters(
@@ -255,8 +275,6 @@ labRequest.get(
           ON (examiner.id = encounter.examiner_id)
         LEFT JOIN users AS requester
           ON (requester.id = lab_requests.requested_by_id)
-        LEFT JOIN sensitive_labs
-          ON (sensitive_labs.id = lab_requests.id)
         ${
           isInvoicingEnabled
             ? `
@@ -289,22 +307,8 @@ labRequest.get(
         ${whereClauses && `WHERE ${whereClauses}`}
     `;
 
-    const queryCte = `
-      WITH sensitive_labs AS (
-        SELECT lab_requests.id as id, TRUE as is_sensitive
-        FROM lab_requests
-        INNER JOIN lab_tests
-          ON (lab_requests.id = lab_tests.lab_request_id)
-        INNER JOIN lab_test_types
-          ON (lab_test_types.id = lab_tests.lab_test_type_id)
-        WHERE lab_test_types.is_sensitive IS TRUE
-        GROUP BY lab_requests.id
-      )
-    `;
-
     const countResult = await req.db.query(
       `
-      ${queryCte}
       SELECT COUNT(1) AS count ${from}
       `,
       { replacements: filterReplacements, type: QueryTypes.SELECT },
@@ -345,7 +349,6 @@ labRequest.get(
 
     const result = await req.db.query(
       `
-        ${queryCte}
         SELECT
           lab_requests.*,
           ${isInvoicingEnabled ? `lab_approval.approved AS approved,` : ''}


### PR DESCRIPTION
### Changes

Backport of #10402 to release/2.55. The lab worklist query built a `sensitive_labs` CTE that scanned every lab request in the table on each page view (twice: count + data), causing multi-second queries and DB load on lab-heavy facilities (observed on Palau BNH). Replaces it with a NOT EXISTS anti-join. Clean cherry-pick of acbe7aab71, no conflicts.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->