### PR TITLE
fix(adminPanel): TAM-6891: reference data id search fields match on id, not name (HOTFIX 2.57)

### DIFF
--- a/packages/central-server/__tests__/admin/referenceDataManage.test.js
+++ b/packages/central-server/__tests__/admin/referenceDataManage.test.js
@@ -82,6 +82,25 @@ describe('Reference Data Manage', () => {
       }
       expect(failures).toEqual([]);
     });
+
+    it('should add a read-only name companion column for FK columns whose target has a name', async () => {
+      let sawCompanion = false;
+      for (const type of MANAGEABLE_REFERENCE_DATA_TYPES) {
+        const response = await adminApp.get(COLUMNS_URL).query({ referenceDataType: type });
+        if (response.status >= 400) continue;
+        const cols = response.body;
+        for (const col of cols.filter(c => c.isFkName)) {
+          sawCompanion = true;
+          // display/search only — never written through the create/edit form
+          expect(col).toMatchObject({ type: 'STRING', readOnly: true, isFkName: true });
+          expect(typeof col.fkKey).toBe('string');
+          // it sits alongside a real FK id column that carries the suggester
+          const fkCol = cols.find(c => c.key === col.fkKey);
+          expect(fkCol?.suggesterEndpoint).toBeTruthy();
+        }
+      }
+      expect(sawCompanion).toBe(true);
+    });
   });
 
   describe('POST /', () => {

--- a/packages/central-server/app/admin/referenceDataManage.js
+++ b/packages/central-server/app/admin/referenceDataManage.js
@@ -120,6 +120,16 @@ referenceDataManageRouter.get(
     const { model, typeFilter } = getModelForType(req.store.models, referenceDataType);
     const columns = await getColumnsForModel(model);
 
+    // Read-only companion columns that surface each FK's associated name (see getColumnsForModel).
+    // We eager-load those associations so the name can be displayed and searched on.
+    const fkNameColumns = columns.filter(c => c.isFkName);
+    const fkNameByKey = new Map(fkNameColumns.map(c => [c.key, c]));
+    const include = fkNameColumns.map(c => ({
+      association: c.fkAlias,
+      attributes: ['id', 'name'],
+      required: false,
+    }));
+
     // Build search filters from query params
     const searchWhere = {};
     const searchableKeys = new Set(
@@ -160,6 +170,12 @@ referenceDataManageRouter.get(
         searchWhere.visibilityStatus = value.split(',');
         continue;
       }
+      const fkNameCol = fkNameByKey.get(key);
+      if (fkNameCol) {
+        // search the associated record's name, not a column on this model
+        searchWhere[`$${fkNameCol.fkAlias}.name$`] = { [Op.iLike]: `%${value}%` };
+        continue;
+      }
       if (searchableKeys.has(key)) {
         searchWhere[key] = exactMatchKeys.has(key) ? value : { [Op.iLike]: `%${value}%` };
       }
@@ -173,9 +189,10 @@ referenceDataManageRouter.get(
 
     const where = { ...typeFilter, ...searchWhere };
 
-    const count = await model.count({ where });
+    const count = await model.count({ where, include });
     const data = await model.findAll({
       where,
+      include,
       order: [
         [orderBy, normalizedOrder],
         ['id', 'ASC'],
@@ -186,7 +203,13 @@ referenceDataManageRouter.get(
 
     res.send({
       count,
-      data: data.map(record => record.forResponse()),
+      data: data.map(record => {
+        const row = record.forResponse();
+        for (const c of fkNameColumns) {
+          row[c.key] = record[c.fkAlias]?.name ?? null;
+        }
+        return row;
+      }),
     });
   }),
 );

--- a/packages/central-server/app/admin/referenceDataManage.js
+++ b/packages/central-server/app/admin/referenceDataManage.js
@@ -121,11 +121,11 @@ referenceDataManageRouter.get(
     const columns = await getColumnsForModel(model);
 
     // Read-only companion columns that surface each FK's associated name (see getColumnsForModel).
-    // We eager-load those associations so the name can be displayed and searched on.
+    // The list query eager-loads those associations so the name can be displayed in the row.
     const fkNameColumns = columns.filter(c => c.isFkName);
     const fkNameByKey = new Map(fkNameColumns.map(c => [c.key, c]));
     const include = fkNameColumns.map(c => ({
-      association: c.fkAlias,
+      association: c.key,
       attributes: ['id', 'name'],
       required: false,
     }));
@@ -173,7 +173,7 @@ referenceDataManageRouter.get(
       const fkNameCol = fkNameByKey.get(key);
       if (fkNameCol) {
         // search the associated record's name, not a column on this model
-        searchWhere[`$${fkNameCol.fkAlias}.name$`] = { [Op.iLike]: `%${value}%` };
+        searchWhere[`$${fkNameCol.key}.name$`] = { [Op.iLike]: `%${value}%` };
         continue;
       }
       if (searchableKeys.has(key)) {
@@ -189,7 +189,14 @@ referenceDataManageRouter.get(
 
     const where = { ...typeFilter, ...searchWhere };
 
-    const count = await model.count({ where, include });
+    // count() only needs the FK joins that a name filter actually references; the rest are
+    // display-only and would add pointless LEFT JOINs to the count query. findAll keeps them
+    // all so every companion column can be populated in the response.
+    const countInclude = include.filter(({ association }) =>
+      Object.prototype.hasOwnProperty.call(searchWhere, `$${association}.name$`),
+    );
+
+    const count = await model.count({ where, include: countInclude });
     const data = await model.findAll({
       where,
       include,
@@ -206,7 +213,7 @@ referenceDataManageRouter.get(
       data: data.map(record => {
         const row = record.forResponse();
         for (const c of fkNameColumns) {
-          row[c.key] = record[c.fkAlias]?.name ?? null;
+          row[c.key] = record[c.key]?.name ?? null;
         }
         return row;
       }),

--- a/packages/central-server/app/admin/referenceDataManageUtils.js
+++ b/packages/central-server/app/admin/referenceDataManageUtils.js
@@ -56,6 +56,7 @@ const FK_ENDPOINT_OVERRIDES = /** @type {const} */ {
   'PatientFieldDefinition.categoryId': 'patientFieldDefinitionCategory',
   'InvoicePriceListItem.invoiceProductId': 'invoiceProduct',
   'InvoicePriceListItem.invoicePriceListId': 'invoicePriceList',
+  'InvoiceInsurancePlanItem.invoiceProductId': 'invoiceProduct',
   'CertifiableVaccine.vaccineId': 'drug',
   'ScheduledVaccine.vaccineId': 'drug',
   'ReferenceDataRelation.referenceDataId': 'referenceData',
@@ -80,6 +81,34 @@ const getForeignKeySuggesters = model => {
   return fkToEndpoint;
 };
 
+// For each BelongsTo FK column that gets a suggester, expose a read-only companion column holding
+// the associated record's name, so admins can see and search on the name (the raw FK column shows
+// only the id). Keyed by the association alias, and only when the target actually has a `name`.
+const getForeignKeyNameColumns = model => {
+  const associations = model.associations ?? {};
+  const columns = [];
+  for (const assoc of Object.values(associations)) {
+    if (assoc.associationType !== 'BelongsTo') continue;
+    const overrideKey = `${model.name}.${assoc.foreignKey}`;
+    const endpoint = FK_ENDPOINT_OVERRIDES[overrideKey] ?? assoc.as;
+    if (!SUGGESTER_ENDPOINTS.includes(endpoint)) continue;
+    if (!assoc.target?.rawAttributes?.name) continue;
+    columns.push({
+      key: assoc.as,
+      type: 'STRING',
+      allowNull: true,
+      hasDefault: false,
+      readOnly: true, // excluded from the create/edit form, validation and writable data
+      isFkName: true,
+      fkKey: assoc.foreignKey,
+      fkAlias: assoc.as,
+      // lets the search bar render a name-mode autocomplete rather than free text
+      suggesterEndpoint: endpoint,
+    });
+  }
+  return columns;
+};
+
 const getDbColumnInfo = async model => {
   const tableName = model.getTableName();
   const [results] = await model.sequelize.query(
@@ -96,7 +125,7 @@ export const getColumnsForModel = async model => {
   const fkSuggesters = getForeignKeySuggesters(model);
   const dbColumns = await getDbColumnInfo(model);
 
-  return Object.entries(rawAttributes)
+  const baseColumns = Object.entries(rawAttributes)
     .filter(([key]) => !isColumnHidden(key, model.name))
     .map(([key, attr]) => {
       const dbField = attr.field ?? key;
@@ -122,6 +151,13 @@ export const getColumnsForModel = async model => {
       }
       return col;
     });
+
+  // Slot each FK's read-only name column in immediately after its id column.
+  const nameColByFk = new Map(getForeignKeyNameColumns(model).map(c => [c.fkKey, c]));
+  return baseColumns.flatMap(col => {
+    const nameCol = nameColByFk.get(col.key);
+    return nameCol ? [col, nameCol] : [col];
+  });
 };
 
 export const assertValidType = type => {

--- a/packages/central-server/app/admin/referenceDataManageUtils.js
+++ b/packages/central-server/app/admin/referenceDataManageUtils.js
@@ -101,7 +101,6 @@ const getForeignKeyNameColumns = model => {
       readOnly: true, // excluded from the create/edit form, validation and writable data
       isFkName: true,
       fkKey: assoc.foreignKey,
-      fkAlias: assoc.as,
       // lets the search bar render a name-mode autocomplete rather than free text
       suggesterEndpoint: endpoint,
     });

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -1159,6 +1159,29 @@ describe('Suggestions', () => {
     expect(body[0]).toHaveProperty('id', invoiceProduct.id);
   });
 
+  it('should match on record id instead of name when searchById is passed', async () => {
+    const product = await models.InvoiceProduct.create({
+      id: 'invoiceProduct-drug-RX00343',
+      name: 'Paracetamol tablet',
+      category: INVOICE_ITEMS_CATEGORIES.OTHER,
+      visibilityStatus: 'current',
+    });
+
+    const byId = await userApp.get('/api/suggestions/invoiceProduct?q=RX00343&searchById=true');
+    expect(byId).toHaveSucceeded();
+    expect(byId.body.map(({ id }) => id)).toContain(product.id);
+
+    const byNameWithFlag = await userApp.get(
+      '/api/suggestions/invoiceProduct?q=Paracetamol&searchById=true',
+    );
+    expect(byNameWithFlag).toHaveSucceeded();
+    expect(byNameWithFlag.body.map(({ id }) => id)).not.toContain(product.id);
+
+    const byIdWithoutFlag = await userApp.get('/api/suggestions/invoiceProduct?q=RX00343');
+    expect(byIdWithoutFlag).toHaveSucceeded();
+    expect(byIdWithoutFlag.body.map(({ id }) => id)).not.toContain(product.id);
+  });
+
   it('should only return non-hidden invoice products', async () => {
     await models.InvoiceProduct.truncate({ cascade: true });
 

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -583,6 +583,33 @@ describe('Suggestions', () => {
       const idArray = body.map(({ id }) => id);
       expect(idArray).not.toContain(obsoleteSurveyId);
     });
+
+    it('should match a drug by id with searchById even when facilityId is passed', async () => {
+      // Regression: with facilityId present the drug endpoint moves name-matching into Op.and,
+      // which previously combined with the searchById id match under AND and returned nothing. The admin
+      // reference-data screen always sends facilityId, so this is the real-world path.
+      const drug = await models.ReferenceData.create({
+        id: 'drug-searchbyid-RX99123',
+        type: 'drug',
+        name: 'Ibuprofen tablet',
+        code: 'searchbyid-RX99123',
+      });
+      const facility = await models.Facility.create(fake(models.Facility));
+
+      const byId = await userApp.get(
+        `/api/suggestions/drug?q=RX99123&searchById=true&facilityId=${facility.id}`,
+      );
+      expect(byId).toHaveSucceeded();
+      expect(byId.body.map(({ id }) => id)).toContain(drug.id);
+
+      // and the same term must not match by name under searchById
+      const byName = await userApp.get(
+        `/api/suggestions/drug?q=Ibuprofen&searchById=true&facilityId=${facility.id}`,
+      );
+      expect(byName).toHaveSucceeded();
+      expect(byName.body.map(({ id }) => id)).not.toContain(drug.id);
+    });
+
   });
 
   describe('Order of results (via diagnoses)', () => {

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -139,10 +139,13 @@ function createSuggesterRoute(
         searchColumn,
       });
 
-      // The admin reference-data screen displays and filters FK columns by raw id, so it sends
-      // searchById=true to match the search term against the record id instead of the translated
-      // name. Handled here rather than in each where-builder so every suggester endpoint honours it.
+      // searchById (admin reference-data screen only) matches the term against the record id
+      // instead of the name. Builders put term-matching in Op.or, or move it into Op.and next to
+      // structural filters (e.g. drug facility-availability) — dropping both and replacing with an
+      // id match avoids the name clause being AND-combined with the id and returning nothing. Scalar
+      // filters (visibilityStatus, sensitive-drug guard) are plain keys and survive.
       if (query.searchById === 'true' && searchQuery) {
+        delete where[Op.and];
         where[Op.or] = [{ id: { [Op.iLike]: search } }];
       }
 

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -123,6 +123,7 @@ function createSuggesterRoute(
       delete query.noLimit;
 
       const searchQuery = (query.q || '').trim().toLowerCase();
+      const search = `%${searchQuery}%`;
       const positionQuery = literal(
         `POSITION(LOWER($positionMatch) in LOWER(${translationCoalesce(endpoint, modelName, searchColumn)})) > 1`,
       );
@@ -130,13 +131,20 @@ function createSuggesterRoute(
       // We supply the searchQuery to both the whereBuilder and the bind so that we can
       // either use the bind key in SQL or in the whereBuilder directly using sequelize
       const where = whereBuilder({
-        search: `%${searchQuery}%`,
+        search,
         query,
         req,
         endpoint,
         modelName,
         searchColumn,
       });
+
+      // The admin reference-data screen displays and filters FK columns by raw id, so it sends
+      // searchById=true to match the search term against the record id instead of the translated
+      // name. Handled here rather than in each where-builder so every suggester endpoint honours it.
+      if (query.searchById === 'true' && searchQuery) {
+        where[Op.or] = [{ id: { [Op.iLike]: search } }];
+      }
 
       if (endpoint === 'location' && query.locationGroupId) {
         where.locationGroupId = query.locationGroupId;

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/ManageReferenceDataTab.jsx
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/ManageReferenceDataTab.jsx
@@ -120,7 +120,8 @@ export const ManageReferenceDataTab = () => {
       const column = {
         key: col.key,
         title: col.key,
-        sortable: true,
+        // FK name columns are computed from an association, not a sortable DB column on this model
+        sortable: !col.isFkName,
       };
       if (col.type === 'BOOLEAN') {
         column.accessor = row => (row[col.key] ? 'Yes' : 'No');

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/SearchField.jsx
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/SearchField.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import styled from 'styled-components';
 import { useTranslation } from '@tamanu/ui-components';
@@ -13,11 +13,17 @@ import {
 import { NumberField } from '../../../../components/Field/NumberField';
 import { TranslatedText } from '../../../../components/Translation/TranslatedText';
 import { useSuggester } from '../../../../api/suggesters';
-import { SUGGESTER_OPTIONS } from './constants';
+import { ID_SEARCH_SUGGESTER_OPTIONS, SUGGESTER_OPTIONS } from './constants';
 
 const VISIBILITY_STATUS_KEY = 'visibilityStatus';
 const AVAILABLE_FACILITIES_KEY = 'availableFacilities';
 const NUMERIC_TYPES = ['INTEGER', 'FLOAT', 'DOUBLE', 'DECIMAL', 'REAL'];
+// string values so an explicit "No" survives the search bar's empty-value filtering
+// ('false' is truthy as a string); Postgres casts them back to booleans on the exact match
+const BOOLEAN_SEARCH_OPTIONS = [
+  { value: 'true', label: 'Yes' },
+  { value: 'false', label: 'No' },
+];
 
 const CentredCheckContainer = styled.div`
   display: flex;
@@ -40,13 +46,39 @@ const AvailableFacilitiesSearchField = () => {
 };
 
 const SuggesterSearchField = ({ col }) => {
-  const suggester = useSuggester(col.suggesterEndpoint, SUGGESTER_OPTIONS);
+  const suggester = useSuggester(col.suggesterEndpoint, ID_SEARCH_SUGGESTER_OPTIONS);
   return (
     <Field
       name={col.key}
       label={col.key}
       component={AutocompleteField}
       suggester={suggester}
+      data-testid={`searchfield-${col.key}`}
+    />
+  );
+};
+
+// Companion name column for an FK: a name-mode autocomplete over the same suggester.
+// The submitted value is the record's name (not id), matching the server's name filter.
+const NameSuggesterSearchField = ({ col }) => {
+  const suggester = useSuggester(col.suggesterEndpoint, {
+    formatter: ({ name }) => ({ label: name, value: name }),
+  });
+  // The field's value IS the name, so resolve "current option" locally — the autocomplete's
+  // default behaviour is a by-id lookup, which 404s when handed a name
+  const nameModeSuggester = useMemo(
+    () => ({
+      fetchSuggestions: search => suggester.fetchSuggestions(search),
+      fetchCurrentOption: async value => ({ label: value, value }),
+    }),
+    [suggester],
+  );
+  return (
+    <Field
+      name={col.key}
+      label={col.key}
+      component={AutocompleteField}
+      suggester={nameModeSuggester}
       data-testid={`searchfield-${col.key}`}
     />
   );
@@ -89,19 +121,25 @@ export const SearchField = ({ col }) => {
       />
     );
   }
+  if (col.isFkName) {
+    return <NameSuggesterSearchField col={col} />;
+  }
   if (col.suggesterEndpoint) {
     return <SuggesterSearchField col={col} />;
   }
   if (col.type === 'BOOLEAN') {
+    // a Yes/No dropdown over a bare checkbox: the raw column-name label isn't sentence
+    // English so a checkbox is hard to read, and a cleared dropdown (no filter) is
+    // distinct from an explicit "No"
     return (
-      <CentredCheckContainer>
-        <Field
-          component={CheckField}
-          name={col.key}
-          label={col.key}
-          data-testid={`searchfield-${col.key}`}
-        />
-      </CentredCheckContainer>
+      <Field
+        component={SelectField}
+        name={col.key}
+        label={col.key}
+        options={BOOLEAN_SEARCH_OPTIONS}
+        size="small"
+        data-testid={`searchfield-${col.key}`}
+      />
     );
   }
   const isNumeric = NUMERIC_TYPES.includes(col.type);
@@ -110,7 +148,8 @@ export const SearchField = ({ col }) => {
       component={isNumeric ? NumberField : SearchTextField}
       name={col.key}
       label={col.key}
-      placeholder={getTranslation('general.placeholder.search...', 'Search…')}
+      // a "Search…" hint reads oddly on numeric fields (e.g. price), so leave those empty
+      placeholder={isNumeric ? undefined : getTranslation('general.placeholder.search...', 'Search…')}
       data-testid={`searchfield-${col.key}`}
     />
   );

--- a/packages/web/app/views/administration/components/ManageReferenceDataTab/constants.js
+++ b/packages/web/app/views/administration/components/ManageReferenceDataTab/constants.js
@@ -13,3 +13,10 @@ export const REQUIRED_FIELDS = new Set(['id', 'code', 'name']);
 
 export const SUGGESTER_FORMATTER = ({ name, id }) => ({ label: `${name} (${id})`, value: id });
 export const SUGGESTER_OPTIONS = { formatter: SUGGESTER_FORMATTER };
+
+// Search bar fields sit over columns that display raw ids, so they search on and display the
+// id alone — unlike the create/edit form, which searches by name.
+export const ID_SEARCH_SUGGESTER_OPTIONS = {
+  formatter: ({ id }) => ({ label: id, value: id }),
+  baseQueryParameters: { searchById: true },
+};


### PR DESCRIPTION
### Changes

Backport of #10420 (TAM-6891) to release/2.57. In the admin Manage Reference Data screen, search fields over FK columns searched by record *name* while the column displays/filters on the raw *id*, so searching an id returned nothing. This makes those fields search and display the id (via `searchById=true`), and adds read-only FK-name companion columns. The two added tests were re-inserted by hand (surrounding test context has drifted on this branch); the adjacent `PSEUDO_REFERENCE_TYPES` / `INVOICE_PRICE_LIST_CHARGING` test on main is not part of this PR and those constants don't exist here, so it is intentionally excluded. Source cherry-picks cleanly; all referenced models/constants exist on this branch.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
