### PR TITLE
fix(adminPanel): TAM-6891: correct searchById where-merge and trim FK-name joins

### DIFF
--- a/packages/central-server/app/admin/referenceDataManage.js
+++ b/packages/central-server/app/admin/referenceDataManage.js
@@ -121,11 +121,11 @@ referenceDataManageRouter.get(
     const columns = await getColumnsForModel(model);
 
     // Read-only companion columns that surface each FK's associated name (see getColumnsForModel).
-    // We eager-load those associations so the name can be displayed and searched on.
+    // The list query eager-loads those associations so the name can be displayed in the row.
     const fkNameColumns = columns.filter(c => c.isFkName);
     const fkNameByKey = new Map(fkNameColumns.map(c => [c.key, c]));
     const include = fkNameColumns.map(c => ({
-      association: c.fkAlias,
+      association: c.key,
       attributes: ['id', 'name'],
       required: false,
     }));
@@ -173,7 +173,7 @@ referenceDataManageRouter.get(
       const fkNameCol = fkNameByKey.get(key);
       if (fkNameCol) {
         // search the associated record's name, not a column on this model
-        searchWhere[`$${fkNameCol.fkAlias}.name$`] = { [Op.iLike]: `%${value}%` };
+        searchWhere[`$${fkNameCol.key}.name$`] = { [Op.iLike]: `%${value}%` };
         continue;
       }
       if (searchableKeys.has(key)) {
@@ -189,7 +189,14 @@ referenceDataManageRouter.get(
 
     const where = { ...typeFilter, ...searchWhere };
 
-    const count = await model.count({ where, include });
+    // count() only needs the FK joins that a name filter actually references; the rest are
+    // display-only and would add pointless LEFT JOINs to the count query. findAll keeps them
+    // all so every companion column can be populated in the response.
+    const countInclude = include.filter(({ association }) =>
+      Object.prototype.hasOwnProperty.call(searchWhere, `$${association}.name$`),
+    );
+
+    const count = await model.count({ where, include: countInclude });
     const data = await model.findAll({
       where,
       include,
@@ -206,7 +213,7 @@ referenceDataManageRouter.get(
       data: data.map(record => {
         const row = record.forResponse();
         for (const c of fkNameColumns) {
-          row[c.key] = record[c.fkAlias]?.name ?? null;
+          row[c.key] = record[c.key]?.name ?? null;
         }
         return row;
       }),

--- a/packages/central-server/app/admin/referenceDataManageUtils.js
+++ b/packages/central-server/app/admin/referenceDataManageUtils.js
@@ -101,7 +101,6 @@ const getForeignKeyNameColumns = model => {
       readOnly: true, // excluded from the create/edit form, validation and writable data
       isFkName: true,
       fkKey: assoc.foreignKey,
-      fkAlias: assoc.as,
       // lets the search bar render a name-mode autocomplete rather than free text
       suggesterEndpoint: endpoint,
     });

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -604,6 +604,32 @@ describe('Suggestions', () => {
       expect(names).toContain('Suggestions Sync Clinician');
       expect(names).not.toContain('System: facility-sync-test sync');
     });
+
+    it('should match a drug by id with searchById even when facilityId is passed', async () => {
+      // Regression: with facilityId present the drug endpoint moves name-matching into Op.and,
+      // which previously combined with the searchById id match under AND and returned nothing. The admin
+      // reference-data screen always sends facilityId, so this is the real-world path.
+      const drug = await models.ReferenceData.create({
+        id: 'drug-searchbyid-RX99123',
+        type: 'drug',
+        name: 'Ibuprofen tablet',
+        code: 'searchbyid-RX99123',
+      });
+      const facility = await models.Facility.create(fake(models.Facility));
+
+      const byId = await userApp.get(
+        `/api/suggestions/drug?q=RX99123&searchById=true&facilityId=${facility.id}`,
+      );
+      expect(byId).toHaveSucceeded();
+      expect(byId.body.map(({ id }) => id)).toContain(drug.id);
+
+      // and the same term must not match by name under searchById
+      const byName = await userApp.get(
+        `/api/suggestions/drug?q=Ibuprofen&searchById=true&facilityId=${facility.id}`,
+      );
+      expect(byName).toHaveSucceeded();
+      expect(byName.body.map(({ id }) => id)).not.toContain(drug.id);
+    });
   });
 
   describe('Order of results (via diagnoses)', () => {

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -140,10 +140,13 @@ function createSuggesterRoute(
         searchColumn,
       });
 
-      // The admin reference-data screen displays and filters FK columns by raw id, so it sends
-      // searchById=true to match the search term against the record id instead of the translated
-      // name. Handled here rather than in each where-builder so every suggester endpoint honours it.
+      // searchById (admin reference-data screen only) matches the term against the record id
+      // instead of the name. Builders put term-matching in Op.or, or move it into Op.and next to
+      // structural filters (e.g. drug facility-availability) — dropping both and replacing with an
+      // id match avoids the name clause being AND-combined with the id and returning nothing. Scalar
+      // filters (visibilityStatus, sensitive-drug guard) are plain keys and survive.
       if (query.searchById === 'true' && searchQuery) {
+        delete where[Op.and];
         where[Op.or] = [{ id: { [Op.iLike]: search } }];
       }
 


### PR DESCRIPTION
### Changes

Addresses review findings on #10420 (merged).

**Fixed**
- **Correctness (main one):** `searchById` did `where[Op.or] = [{id}]`, overwriting whatever the where-builder put in `Op.or`. For endpoints whose builder moves name-matching into `Op.and` alongside a structural filter — the **drug** endpoint when `facilityId` is present, which the admin screen *always* sends — the name clause survived in `Op.and` and ANDed against the id match, so id lookups on vaccine FK fields returned nothing. Now drops the builder's term-matching clauses and searches purely by id; scalar filters (`visibilityStatus`, sensitive-drug guard) are preserved. Only the admin reference-data screen sends `searchById`, so ignoring name/availability scoping for a pure id lookup is the intended behaviour.
- **Perf:** `count()` was given the full FK-name `include` on every list request. The eager-load is needed on `findAll` (it populates the companion column values in the response — so it can't just be made conditional), but `count()` only needs the joins a name filter actually references. Added a filtered `countInclude`.
- **Cleanup:** removed the redundant `fkAlias` column field (always identical to `key`).

**Test:** regression test for drug `searchById` + `facilityId` (the live bug), asserting id matches and name does not under the flag.

**Considered, not changed**
- *Leading wildcard on the id match (`%term%`).* The suggested `term%` (prefix-only) fix would break the actual UX: ids are structured (`invoiceProduct-drug-RX00343`) and users search the meaningful suffix (`RX00343`), which prefix-only wouldn't match. A `pg_trgm` GIN index on `id` is the real optimisation but is a separate migration/infra call, not a correctness fix.

**Follow-up (not in this PR)**
- Integration test for the FK-name search path, and an E2E spec for ManageReferenceDataTab (no admin reference-data E2E exists yet). Left out here to keep this a focused correctness fix and because they need association-setup I can't validate without running the suite.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
