### PR TITLE
fix(web): TAM-6975: faulty rendering of FreeText questions as numbers in encounter Charts tab (2.53 backport)

### DIFF
--- a/packages/web/app/components/FormattedTableCell.jsx
+++ b/packages/web/app/components/FormattedTableCell.jsx
@@ -228,16 +228,25 @@ export const RangeValidatedCell = React.memo(
     validationCriteria,
     onClick,
     isEdited,
+    isFreeText,
     ValueWrapper = DefaultWrapper,
     ...props
   }) => {
     const CellContainer = onClick ? ClickableCellWrapper : CellWrapper;
     const float = round(value, config);
-    const isEditedSuffix = isEdited ? '*' : '';
-    const formattedValue = `${formatValue(value, config)}${isEditedSuffix}`;
+    const displayValue = isFreeText
+      ? value?.trim() || <>&mdash;</>
+      : formatValue(value, config);
+    const formattedValue = (
+      <>
+        {displayValue}
+        {isEdited && '*'}
+      </>
+    );
     const { tooltip, severity } = useMemo(
-      () => getValidationState(float, config, validationCriteria),
-      [float, config, validationCriteria],
+      () =>
+        isFreeText ? { severity: INFO } : getValidationState(float, config, validationCriteria),
+      [isFreeText, float, config, validationCriteria],
     );
 
     const cell = (

--- a/packages/web/app/components/VitalsAndChartsTableColumns.jsx
+++ b/packages/web/app/components/VitalsAndChartsTableColumns.jsx
@@ -187,6 +187,7 @@ const getRecordedDateAccessor = (date, patient, onCellClick, isEditEnabled, char
         config={config}
         validationCriteria={{ normalRange: getNormalRangeByAge(validationCriteria, patient) }}
         isEdited={historyLogs.length > 1}
+        isFreeText={component.dataElement.type === PROGRAM_DATA_ELEMENT_TYPES.TEXT}
         onClick={shouldBeClickable ? handleCellClick : null}
         ValueWrapper={VitalsLimitedLinesCell}
         data-testid={`rangevalidatedcell-${date}`}


### PR DESCRIPTION
### Changes

Backport TAM-6975 FreeText charts guard: skip numeric `formatValue`/range validation for FreeText cells so values are shown as entered. Keeps editability when enabled and the edited marker (`*` or `EditedOrnament`).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
