### PR TITLE
fix(patients): TAM-7006: hide Record death without the permissions to complete it (HOTFIX 2.55)

### DIFF
--- a/packages/web/app/components/PatientInfoPane/PatientInfoPane.jsx
+++ b/packages/web/app/components/PatientInfoPane/PatientInfoPane.jsx
@@ -23,6 +23,7 @@ import { PANE_SECTION_IDS } from './paneSections';
 import { RecordDeathSection } from '../RecordDeathSection';
 import { TranslatedText, TranslatedReferenceData } from '../Translation';
 import { useSettings } from '../../contexts/Settings';
+import { useAuth } from '../../contexts/Auth';
 
 const OngoingConditionDisplay = memo(({ patient, readonly }) => (
   <InfoPaneList
@@ -261,7 +262,18 @@ export const PatientInfoPane = () => {
   );
 
   const readonly = !!patient.dateOfDeath;
-  const showRecordDeathActions = !isFetching && patientDeathsEnabled && !deathData?.isFinal;
+  const { ability } = useAuth();
+  const canRecordPatientDeath =
+    ability?.can('create', 'PatientDeath') && ability?.can('write', 'Patient');
+  const canReadPatientDeath = ability?.can('read', 'PatientDeath');
+  const isPatientDeceased = readonly;
+  // Reverting a death record requires read as well as create: the revert link is only
+  // valid for a non-final record, and isFinal can only be determined with read access.
+  const canActOnDeath = isPatientDeceased
+    ? canRecordPatientDeath && canReadPatientDeath
+    : canRecordPatientDeath;
+  const showRecordDeathActions =
+    !isFetching && patientDeathsEnabled && !deathData?.isFinal && canActOnDeath;
   const showCauseOfDeathButton = showRecordDeathActions && Boolean(deathData);
 
   return (


### PR DESCRIPTION
### Changes

Backport for TAM-7006 (silent Record Death failure — reported from Samoa TTM Hospital on v2.54.16, high priority). This branch predates the TAM-6833 UI gate entirely, so the Record/Revert death workflow rendered for any role and failed silently without write Patient or create PatientDeath (403s are not toasted; clinically dangerous for death recording). Applies the TAM-6833 gate (659f0a1f7, first released 2.59.0) combined with the TAM-7006 correction so the gate matches the backend's full permission pair: create PatientDeath AND write Patient, plus read PatientDeath for revert. Matches main PR #10528.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
