### PR TITLE
db: no-issue: backfill null created_at/updated_at timestamps

### DIFF
--- a/packages/database/src/migrations/1784843046612-backfillNullCreatedUpdatedAtTimestamps.ts
+++ b/packages/database/src/migrations/1784843046612-backfillNullCreatedUpdatedAtTimestamps.ts
@@ -2,16 +2,16 @@ import { QueryInterface } from 'sequelize';
 
 // #10364 added DEFAULT now() to created_at / updated_at on these tables, but rows inserted
 // outside the ORM before that (data migrations, manual SQL, bulk loads) still carry NULLs.
-// Backfill each NULL from the sibling timestamp where available, so the value is deterministic
-// and identical on every server, falling back to now().
+// Backfill each NULL from the sibling timestamp where available, falling back to now().
+//
+// Sync: created_at / updated_at are in COLUMNS_EXCLUDED_FROM_SYNC, so these values are
+// per-server and never propagate — every server heals its own rows when it runs this. No sync
+// churn either: runPreMigration drops the set_updated_at_sync_tick triggers while migrations
+// run, so ticks are untouched and nothing gets re-queued.
 //
 // Performance:
 // - Each UPDATE touches only rows with a NULL timestamp, so work is bounded by the actual bad
 //   rows; on servers with none it's a no-op.
-// - The sync tick trigger re-stamps touched rows, so they re-sync once. That's deliberate: it
-//   refreshes sync_lookup with the fixed values, and whichever server migrates first (central,
-//   in practice) syncs the fix to the rest — by the time other servers run this, their WHERE
-//   matches few or no rows.
 // - None of these tables are FHIR upstreams, so no rematerialisation is triggered.
 const TABLES = [
   'ai_chat_sessions',
@@ -36,11 +36,11 @@ const TABLES = [
 
 export async function up(query: QueryInterface): Promise<void> {
   for (const table of TABLES) {
-    // The set_updated_at BEFORE UPDATE trigger re-stamps updated_at to current_timestamp
-    // whenever other columns change but updated_at doesn't. For rows where only created_at is
-    // NULL we want to keep the existing updated_at, so nudge it by 1 microsecond — a changed
-    // value passes through the trigger untouched, stays deterministic across servers, and
-    // preserves the history.
+    // The set_updated_at BEFORE UPDATE trigger (which stays active during migrations, unlike
+    // the sync tick ones) re-stamps updated_at to current_timestamp whenever other columns
+    // change but updated_at doesn't. For rows where only created_at is NULL we want to keep
+    // the row's genuine updated_at rather than stamping migration-run time, so nudge it by
+    // 1 microsecond — a changed value passes through the trigger untouched.
     await query.sequelize.query(`
       UPDATE "${table}"
       SET

--- a/packages/database/src/migrations/1784843046612-backfillNullCreatedUpdatedAtTimestamps.ts
+++ b/packages/database/src/migrations/1784843046612-backfillNullCreatedUpdatedAtTimestamps.ts
@@ -1,0 +1,52 @@
+import { QueryInterface } from 'sequelize';
+
+// #10364 added DEFAULT now() to created_at / updated_at on these tables, but rows inserted
+// outside the ORM before that (data migrations, manual SQL, bulk loads) still carry NULLs.
+// Backfill each NULL from the sibling timestamp where available, so the value is deterministic
+// and identical on every server, falling back to now().
+//
+// Performance:
+// - Each UPDATE touches only rows with a NULL timestamp, so work is bounded by the actual bad
+//   rows; on servers with none it's a no-op.
+// - The sync tick trigger re-stamps touched rows, so they re-sync once. That's deliberate: it
+//   refreshes sync_lookup with the fixed values, and whichever server migrates first (central,
+//   in practice) syncs the fix to the rest — by the time other servers run this, their WHERE
+//   matches few or no rows.
+// - None of these tables are FHIR upstreams, so no rematerialisation is triggered.
+const TABLES = [
+  'ai_chat_sessions',
+  'ai_documents',
+  'appointment_procedure_types',
+  'form_builder_chat_jobs',
+  'imaging_type_external_codes',
+  'local_system_facts',
+  'local_system_secrets',
+  'procedure_survey_responses',
+  'user_leaves',
+  'invoice_discounts',
+  'invoice_insurer_payments',
+  'invoice_item_discounts',
+  'invoice_items',
+  'invoice_patient_payments',
+  'invoice_payments',
+  'invoice_products',
+  'invoices',
+  'ips_requests',
+];
+
+export async function up(query: QueryInterface): Promise<void> {
+  for (const table of TABLES) {
+    await query.sequelize.query(`
+      UPDATE "${table}"
+      SET
+        created_at = COALESCE(created_at, updated_at, now()),
+        updated_at = COALESCE(updated_at, created_at, now())
+      WHERE created_at IS NULL OR updated_at IS NULL;
+    `);
+  }
+}
+
+export async function down(): Promise<void> {
+  // DESTRUCTIVE: there is no record of which rows were backfilled, so the NULLs cannot be
+  // restored. The backfilled values are valid timestamps either way.
+}

--- a/packages/database/src/migrations/1784843046612-backfillNullCreatedUpdatedAtTimestamps.ts
+++ b/packages/database/src/migrations/1784843046612-backfillNullCreatedUpdatedAtTimestamps.ts
@@ -36,11 +36,19 @@ const TABLES = [
 
 export async function up(query: QueryInterface): Promise<void> {
   for (const table of TABLES) {
+    // The set_updated_at BEFORE UPDATE trigger re-stamps updated_at to current_timestamp
+    // whenever other columns change but updated_at doesn't. For rows where only created_at is
+    // NULL we want to keep the existing updated_at, so nudge it by 1 microsecond — a changed
+    // value passes through the trigger untouched, stays deterministic across servers, and
+    // preserves the history.
     await query.sequelize.query(`
       UPDATE "${table}"
       SET
         created_at = COALESCE(created_at, updated_at, now()),
-        updated_at = COALESCE(updated_at, created_at, now())
+        updated_at = CASE
+          WHEN updated_at IS NULL THEN COALESCE(created_at, now())
+          ELSE updated_at + interval '1 microsecond'
+        END
       WHERE created_at IS NULL OR updated_at IS NULL;
     `);
   }


### PR DESCRIPTION
### Changes

Follow-up to #10364, which added `DEFAULT now()` to `created_at` / `updated_at` on 18 tables: this backfills existing rows where those columns are NULL (rows inserted outside the ORM before the defaults existed). Each NULL is filled from the sibling timestamp where available, falling back to `now()`.

Sync: these columns are in `COLUMNS_EXCLUDED_FROM_SYNC` so the values are per-server and never propagate — every server heals its own rows when it runs the migration. There is also no sync re-queue: `runPreMigration` drops the `set_updated_at_sync_tick` triggers while migrations run, so ticks are untouched.

Performance: each UPDATE only touches rows with a NULL timestamp, so work is bounded by the actual bad rows; none of these tables are FHIR upstreams so no rematerialisation. The `set_updated_at` trigger does stay active during migrations, so rows where only `created_at` is NULL nudge `updated_at` by 1µs — a changed value passes through the trigger untouched, keeping the row's genuine `updated_at` instead of stamping migration-run time.

DML-only, no schema change (no dbt or mobile migrations needed). Down is a documented no-op: there is no record of which rows were backfilled.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->