### PR TITLE
db: no-issue: add missing indexes for hot API query paths

### DIFF
--- a/packages/database/src/migrations/1784900000000-addMissingApiQueryIndexes.ts
+++ b/packages/database/src/migrations/1784900000000-addMissingApiQueryIndexes.ts
@@ -1,0 +1,110 @@
+import { QueryInterface } from 'sequelize';
+
+// Indexes backing hot API query paths that were previously running as
+// sequential scans on large tables (audit of facility- and central-server
+// endpoints against the schema, 2026-07).
+const INDEXES: [name: string, definition: string][] = [
+  // Tasking: GET /user/tasks (status + due_time worklist), GET /encounter/:id/tasks,
+  // repeating-task delete/re-parent by parent_task_id, and the assignedTo EXISTS
+  // subquery on task_designations.
+  ['tasks_status_due_time', 'ON tasks (status, due_time)'],
+  ['tasks_encounter_id', 'ON tasks (encounter_id)'],
+  ['tasks_parent_task_id', 'ON tasks (parent_task_id)'],
+  ['task_designations_task_id', 'ON task_designations (task_id)'],
+  // GET /user/tasks joins designations -> users via user_designations on
+  // designation_id; the existing index only covers user_id.
+  ['user_designations_designation_id', 'ON user_designations (designation_id)'],
+
+  // Notification bell: polled per client, filters user_id + status (+ created_time
+  // window) and sorts by created_time.
+  ['notifications_user_id_status_created_time', 'ON notifications (user_id, status, created_time)'],
+  // Patient merge updates notifications by patient_id.
+  ['notifications_patient_id', 'ON notifications (patient_id)'],
+
+  // Patient appointment tabs (facility + patient portal) filter by patient_id.
+  ['appointments_patient_id_start_time', 'ON appointments (patient_id, start_time)'],
+  // Location-booking conflict checks filter by location_id + overlap; mirrors the
+  // existing partial index on (location_group_id, start_time).
+  [
+    'appointments_location_id_start_time',
+    "ON appointments (location_id, start_time) WHERE deleted_at IS NULL AND status <> 'Cancelled'",
+  ],
+
+  // GET /encounter/:id/medications and discharge-medication lookups filter by
+  // encounter_id alone; the existing composite leads with prescription_id.
+  ['encounter_prescriptions_encounter_id', 'ON encounter_prescriptions (encounter_id)'],
+
+  // Invoicing: invoice-per-encounter lookups on open/create/update/payment, and
+  // the insurer payment importer's per-row display_id lookups.
+  ['invoices_encounter_id', 'ON invoices (encounter_id)'],
+  ['invoices_display_id', 'ON invoices (display_id)'],
+  // Labs/imaging worklists run correlated subqueries on (source_record_type,
+  // source_record_id); the existing unique index leads with invoice_id.
+  [
+    'invoice_items_source_record_type_source_record_id',
+    'ON invoice_items (source_record_type, source_record_id)',
+  ],
+  ['invoice_payments_invoice_id', 'ON invoice_payments (invoice_id)'],
+  ['invoice_discounts_invoice_id', 'ON invoice_discounts (invoice_id)'],
+  ['invoice_item_discounts_invoice_item_id', 'ON invoice_item_discounts (invoice_item_id)'],
+
+  // Pharmacy/dispensing join chain from encounters.
+  ['pharmacy_orders_encounter_id', 'ON pharmacy_orders (encounter_id)'],
+  ['pharmacy_order_prescriptions_pharmacy_order_id', 'ON pharmacy_order_prescriptions (pharmacy_order_id)'],
+  ['pharmacy_order_prescriptions_prescription_id', 'ON pharmacy_order_prescriptions (prescription_id)'],
+
+  // Lab request status history, ordered newest-first.
+  ['lab_request_logs_lab_request_id_created_at', 'ON lab_request_logs (lab_request_id, created_at)'],
+
+  // Program registry registrations view filters by program_registry_id alone; the
+  // PK leads with patient_id. Conditions are joined per registration.
+  ['patient_program_registrations_program_registry_id', 'ON patient_program_registrations (program_registry_id)'],
+  [
+    'patient_program_registration_conditions_registration_id',
+    'ON patient_program_registration_conditions (patient_program_registration_id)',
+  ],
+
+  // Ongoing prescriptions (facility + patient portal) filter by patient_id and
+  // join prescriptions on prescription_id.
+  ['patient_ongoing_prescriptions_patient_id', 'ON patient_ongoing_prescriptions (patient_id)'],
+  ['patient_ongoing_prescriptions_prescription_id', 'ON patient_ongoing_prescriptions (prescription_id)'],
+
+  // GET /patient/:id/documentMetadata filters patient_id OR encounter_id; only
+  // encounter_id was indexed, so the OR degraded to a seq scan.
+  ['document_metadata_patient_id', 'ON document_metadata (patient_id)'],
+
+  // Clinician-filtered assignment calendar; existing composite leads with date.
+  ['location_assignments_user_id_date', 'ON location_assignments (user_id, date)'],
+
+  // Imaging worklist approved-status correlated subquery.
+  ['imaging_request_areas_imaging_request_id', 'ON imaging_request_areas (imaging_request_id)'],
+
+  // Password reset lookups; the table is never pruned so it grows unbounded.
+  ['one_time_logins_user_id_token', 'ON one_time_logins (user_id, token)'],
+
+  // Reminder contacts list.
+  ['patient_contacts_patient_id', 'ON patient_contacts (patient_id)'],
+
+  // Patient merge updates certificate_notifications by patient_id.
+  ['certificate_notifications_patient_id', 'ON certificate_notifications (patient_id)'],
+
+  // Portal login/token request looks up lower(email) pre-auth; the plain unique
+  // index on email cannot serve the case-insensitive comparison.
+  ['portal_users_lower_email', 'ON portal_users (lower(email))'],
+
+  // GET /portal/survey/:surveyId joins assignments by survey_id; the existing
+  // composite leads with patient_id.
+  ['portal_survey_assignments_survey_id', 'ON portal_survey_assignments (survey_id)'],
+];
+
+export async function up(query: QueryInterface): Promise<void> {
+  for (const [name, definition] of INDEXES) {
+    await query.sequelize.query(`CREATE INDEX IF NOT EXISTS ${name} ${definition};`);
+  }
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  for (const [name] of INDEXES) {
+    await query.sequelize.query(`DROP INDEX IF EXISTS ${name};`);
+  }
+}


### PR DESCRIPTION
### Changes

An audit of all facility- and central-server API endpoints against the schema (baseline + all post-baseline migrations) found a number of frequently-hit queries running as sequential scans on large tables — the same shape as the recent `tasks (status, due_time)` incident. This adds a single DDL-only migration creating 32 btree indexes, each tied to a specific verified query path:

- **Tasking**: `tasks (status, due_time)` (the known fix, now as a migration), `tasks (encounter_id)` for the encounter tasks pane, `tasks (parent_task_id)` for repeating-task delete/re-parent, and `task_designations (task_id)` for the assignedTo `EXISTS` subqueries.
- **Notifications**: `(user_id, status, created_time)` — the notification bell polls this on every client with no usable index at all — plus `(patient_id)` for patient merge.
- **Appointments**: `(patient_id, start_time)` for the patient appointment tabs (facility + portal), and a partial `(location_id, start_time)` mirroring the existing `location_group_id` index for booking-conflict checks.
- **Medications**: `encounter_prescriptions (encounter_id)` — the existing composite leads with `prescription_id`, so the encounter medications list couldn't use it — plus the pharmacy join chain (`pharmacy_orders.encounter_id`, `pharmacy_order_prescriptions.pharmacy_order_id`/`.prescription_id`) and `patient_ongoing_prescriptions` FKs.
- **Invoicing**: `invoices (encounter_id)` (invoice-per-encounter lookups on every open/create/payment), `invoices (display_id)` (insurer payment importer scans the table twice per spreadsheet row), `invoice_items (source_record_type, source_record_id)` (correlated subqueries per row on the labs/imaging worklists; the existing unique leads with `invoice_id`), and `invoice_payments`/`invoice_discounts`/`invoice_item_discounts` FKs.
- **Program registry**: `patient_program_registrations (program_registry_id)` (registrations list; the PK leads with `patient_id`) and `patient_program_registration_conditions (patient_program_registration_id)`.
- **Others**: `lab_request_logs (lab_request_id, created_at)`, `document_metadata (patient_id)` (the `patient_id OR encounter_id` filter degraded to a seq scan), `location_assignments (user_id, date)`, `imaging_request_areas (imaging_request_id)`, `one_time_logins (user_id, token)`, `patient_contacts (patient_id)`, `certificate_notifications (patient_id)`, `portal_users (lower(email))` (pre-auth portal login does a case-insensitive lookup the plain unique on `email` can't serve), and `portal_survey_assignments (survey_id)`.

Indexes are created plainly (not `CONCURRENTLY`) since migrations run in a downtime window. DDL only, no DML; no schema/column changes so no dbt model updates needed. Deliberately not included (need EXPLAIN at a real site first): `lab_requests`/`imaging_requests` worklist `requested_date` candidates, a trigram index for patient-suggester ILIKE, and the `sync_sessions` lastCompleted JSON-expression aggregate.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8wCEyrwkvVQvEW9W2yv3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8wCEyrwkvVQvEW9W2yv3k)_