### PR TITLE
ci: no-issue: stop #deployopt lines parsing as deploys (HOTFIX 2.49)

### DIFF
--- a/packages/scripts/src/ghaCdHelpers.mjs
+++ b/packages/scripts/src/ghaCdHelpers.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 const RX_DEPLOY_LINE =
-  /^\s*-\s+\[(?<enabled>[\sx])\]\s+.+(?:<!--)?\s*#deploy(?:=(?<name>[\w-]+))?\s*(?:-->)?\s*(?:%(?<options>.+))?(?:-->)?/;
+  /^\s*-\s+\[(?<enabled>[\sx])\]\s+.+(?:<!--)?\s*#deploy(?!opt)(?:=(?<name>[\w-]+))?\s*(?:-->)?\s*(?:%(?<options>.+))?(?:-->)?/;
 const RX_BRANCH_LINE = /(?:<!--)?\s*#branch=(?<ref>[^\s]+)\s*(?:-->)?/;
 
 // It's important this remains stable or doesn't change: doing so will create


### PR DESCRIPTION
Backports the `#deploy(?!opt)` regex fix from main. Without it, every unchecked `#deployopt` checkbox in the current PR template parses as a *disabled deploy* named after the branch, spawning undeploy jobs that race the real deploy and delete its namespace mid-provision. Bit #10540 (`Going UP 1, Going DOWN 14`).