### PR TITLE
fix(mobile): no-issue: report sync session errors to central

### DIFF
--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -223,6 +223,10 @@ export class CentralServerConnection {
     return this.delete(`sync/${sessionId}`, {});
   }
 
+  async markSessionErrored(sessionId: string, error: string): Promise<unknown> {
+    return this.post(`sync/${sessionId}/error`, {}, { error });
+  }
+
   async initiatePull(
     sessionId: string,
     since: number,

--- a/packages/mobile/App/services/sync/MobileSyncManager.test.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.test.ts
@@ -166,6 +166,26 @@ describe('MobileSyncManager', () => {
       expect(mobileSyncManager.pullIncomingChanges).toBeCalledTimes(1);
       expect(mobileSyncManager.pullIncomingChanges).toBeCalledWith(mockSessionId);
     });
+
+    it('should report the sync error to central when a step fails', async () => {
+      const testError = new Error('pull failed');
+      jest.spyOn(mobileSyncManager, 'pushOutgoingChanges').mockImplementationOnce(jest.fn());
+      jest.spyOn(mobileSyncManager, 'pullIncomingChanges').mockImplementationOnce(() => {
+        throw testError;
+      });
+      jest
+        .spyOn(centralServerConnection, 'startSyncSession')
+        .mockImplementationOnce(
+          jest.fn(async () => ({ sessionId: mockSessionId, startedAtTick: mockSyncTick })),
+        );
+      const markSessionErroredSpy = jest
+        .spyOn(centralServerConnection, 'markSessionErrored')
+        .mockImplementationOnce(jest.fn());
+
+      await expect(mobileSyncManager.runSync()).rejects.toThrow('pull failed');
+
+      expect(markSessionErroredSpy).toHaveBeenCalledWith(mockSessionId, 'pull failed');
+    });
   });
 
   describe('pushOutgoingChanges()', () => {

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -267,16 +267,37 @@ export class MobileSyncManager {
     this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_STARTED);
     console.log('MobileSyncManager.runSync(): Sync started');
 
-    await this.pushOutgoingChanges(sessionId, newSyncClockTime);
-    await this.pullIncomingChanges(sessionId);
-
-    await this.centralServer.endSyncSession(sessionId);
+    try {
+      await this.pushOutgoingChanges(sessionId, newSyncClockTime);
+      await this.pullIncomingChanges(sessionId);
+      await this.centralServer.endSyncSession(sessionId);
+    } catch (error) {
+      // notify central so its own alerting sees the failure immediately, rather than waiting for
+      // the session to time out there (mobile otherwise never reports a session's error to
+      // central, unlike facility servers, which already do this)
+      await this.reportSyncError(sessionId, error);
+      throw error;
+    }
 
     // clear persisted cache from this session
     await dropSnapshotTable();
 
     this.lastSuccessfulSyncTime = new Date();
     this.setProgress(0, '');
+  }
+
+  /**
+   * Notify central that this sync session failed. Best-effort: a failure here (e.g. no
+   * connectivity) is logged and swallowed, since the sync itself has already failed and will
+   * retry on its normal schedule regardless.
+   */
+  async reportSyncError(sessionId: string, error: unknown): Promise<void> {
+    try {
+      const message = error instanceof Error ? error.message : String(error);
+      await this.centralServer.markSessionErrored(sessionId, message);
+    } catch (reportError) {
+      console.error('MobileSyncManager.reportSyncError(): Failed to report sync error', reportError);
+    }
   }
 
   /**


### PR DESCRIPTION
### Changes

Mobile devices never told central when a sync session failed locally — the session was just left open until it timed out server-side. Facility servers already report their own local sync errors via `POST /:sessionId/error`; this brings mobile to parity by wrapping runSync'\''s push/pull/endSyncSession sequence in a try/catch that reports any failure to central before rethrowing, so central'\''s alerting sees mobile sync failures immediately instead of waiting on a timeout.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->