### PR TITLE
perf(tasking): no-issue: drive clinician-tasks medication EXISTS from encounter

### DIFF
--- a/packages/facility-server/app/routes/apiv1/user.js
+++ b/packages/facility-server/app/routes/apiv1/user.js
@@ -307,18 +307,23 @@ user.get(
               ...(hasMedicationPermission ? [{ 
                 [Op.and]: [
                   { taskType: TASK_TYPES.MEDICATION_DUE_TASK },
-                  // Check if there exists at least one MAR at the same dueTime that is not recorded and not paused
+                  // Check if there exists at least one MAR at the same dueTime that is not recorded and not paused.
+                  // Driven from encounter_prescriptions filtered by encounter_id (few rows for this
+                  // encounter) rather than from medication_administration_records by due_at (every MAR at
+                  // that time across all patients), so the MAR probe uses its
+                  // (prescription_id, due_at, status) index instead of a global scan. prescriptions is only
+                  // a bridge between mar.prescription_id and ep.prescription_id, so it is joined directly.
                   Sequelize.literal(`
                     EXISTS (
                       SELECT 1
-                      FROM medication_administration_records mar
-                      INNER JOIN prescriptions p ON p.id = mar.prescription_id
-                      INNER JOIN encounter_prescriptions ep ON ep.prescription_id = p.id
-                      CROSS JOIN LATERAL get_medication_time_slot(mar.due_at::timestamp) AS mar_time_slot
-                      WHERE ep.encounter_id = "Task"."encounter_id"
+                      FROM encounter_prescriptions ep
+                      INNER JOIN medication_administration_records mar
+                        ON mar.prescription_id = ep.prescription_id
                         AND mar.due_at = "Task"."due_time"
                         AND mar.status IS NULL
                         AND mar.deleted_at IS NULL
+                      CROSS JOIN LATERAL get_medication_time_slot(mar.due_at::timestamp) AS mar_time_slot
+                      WHERE ep.encounter_id = "Task"."encounter_id"
 
                         -- Check if MAR is not currently paused
                         AND NOT EXISTS (


### PR DESCRIPTION
### Changes

The `GET /user/tasks` clinician worklist (`packages/facility-server/app/routes/apiv1/user.js`) filters out `medication_due_task` rows whose MARs are all recorded or paused, via a correlated `EXISTS` subquery in the `count`/`findAll` where-clause.

The subquery drove from `medication_administration_records`, keyed on `(due_at, status)` — matching **every** MAR at that due-time across all patients (~25 per task on a loaded site) — then walked up `prescriptions → encounter_prescriptions` and only *then* discarded ~96% of them by `encounter_id`. `EXPLAIN (ANALYZE, BUFFERS)` at a loaded site showed this subquery dominating the tasks count query (~2.2s of ~2.4s total; ~1M of ~1.26M buffer hits; the inner prescription/encounter_prescription lookups ran ~102k times).

This flips the driver to the selective side:

- Drive from `encounter_prescriptions` filtered by `encounter_id` (a handful of rows for the one encounter), then probe `medication_administration_records` via its existing `(prescription_id, due_at, status) WHERE deleted_at IS NULL` index — a full three-column match instead of a global scan.
- `prescriptions` was only a bridge between `mar.prescription_id` and `ep.prescription_id` with no filter on it, so `mar` is joined to `ep` on `prescription_id` directly and the `prescriptions` join is dropped (~102k lookups removed).

Semantics are unchanged — same rows qualify. This is a pure query-shape change; no schema or behaviour change.

**Context / dependency:** this is a follow-up to the recent `tasks (status, due_time)` slowness. The index prerequisites (including `encounter_prescriptions (encounter_id)`, which this rewrite relies on to be effective) are added in #10561 — that PR should land first. This PR removes the *remaining* ~2.2s that indexing alone doesn't address.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

---
_Generated by [Claude Code](https://claude.ai/code/session_017onp9w1ivRKtGGS3B5zPpD)_