### PR TITLE
fix(patientCertificates): ‘Place of death’ when died outside health facility

### DIFF
--- a/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
@@ -185,8 +185,14 @@ const AuthorisedAndSignSection = () => {
   );
 };
 
-const placeOfDeathAccessor = ({ facility }) => {
-  return facility?.name;
+const placeOfDeathAccessor = ({ facility, outsideHealthFacility }, { getTranslation }) => {
+  if (outsideHealthFacility) {
+    return getTranslation('death.outsideHealthFacility.label', 'Died outside health facility');
+  }
+  if (facility?.name) {
+    return facility.name;
+  }
+  return undefined;
 };
 
 const getCauseName = cause => cause?.condition?.name;

--- a/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
@@ -186,13 +186,9 @@ const AuthorisedAndSignSection = () => {
 };
 
 const placeOfDeathAccessor = ({ facility, outsideHealthFacility }, { getTranslation }) => {
-  if (outsideHealthFacility) {
-    return getTranslation('death.outsideHealthFacility.label', 'Died outside health facility');
-  }
-  if (facility?.name) {
-    return facility.name;
-  }
-  return undefined;
+  return outsideHealthFacility
+    ? getTranslation('death.outsideHealthFacility.label', 'Died outside health facility')
+    : facility?.name;
 };
 
 const getCauseName = cause => cause?.condition?.name;

--- a/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
@@ -213,7 +213,7 @@ const getDateAndTimeOfDeath = (patientData, { getTranslation, formatShortExplici
   return `${date} ${time}`.trim();
 };
 
-const PATIENT_DETAIL_FIELDS = {
+const PATIENT_DETAIL_FIELDS = /** @type {const} */ ({
   leftCol: [
     { key: 'firstName', label: 'First name' },
     { key: 'lastName', label: 'Last name' },
@@ -226,9 +226,9 @@ const PATIENT_DETAIL_FIELDS = {
     { key: 'ethnicityId', label: 'Ethnicity', accessor: getEthnicity },
     { key: 'villageId', label: 'Village', accessor: getVillage },
   ],
-};
+});
 
-const PATIENT_DEATH_DETAILS = {
+const PATIENT_DEATH_DETAILS = /** @type {const} */ ({
   leftCol: [
     { key: 'deathDateAndTime', label: 'Date & time of death', accessor: getDateAndTimeOfDeath },
     { key: 'placeOfDeath', label: 'Place of death', accessor: placeOfDeathAccessor },
@@ -237,7 +237,7 @@ const PATIENT_DEATH_DETAILS = {
     { key: 'causeOfDeath', label: 'Cause of death', accessor: causeOfDeathAccessor },
     { key: 'attendingClinician', label: 'Attending clinician', accessor: getClinician },
   ],
-};
+});
 
 const SectionContainer = props => <View style={generalStyles.sectionContainer} {...props} />;
 


### PR DESCRIPTION
### Changes

Cherry-pick of PR #10571 to release\/2.54. Fixes the death certificate "Place of death" field to check the "outside health facility" flag first (matching the patient Summary screen), so it prints "Died outside health facility" when that flag is set rather than falling back to the facility name.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->