### PR TITLE
fix(patientCertificates): ‘Place of death’ when died outside health facility

### DIFF
--- a/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
@@ -185,8 +185,14 @@ const AuthorisedAndSignSection = () => {
   );
 };
 
-const placeOfDeathAccessor = ({ facility }) => {
-  return facility?.name;
+const placeOfDeathAccessor = ({ facility, outsideHealthFacility }, { getTranslation }) => {
+  if (outsideHealthFacility) {
+    return getTranslation('death.outsideHealthFacility.label', 'Died outside health facility');
+  }
+  if (facility?.name) {
+    return facility.name;
+  }
+  return undefined;
 };
 
 const getCauseName = cause => cause?.condition?.name;

--- a/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
@@ -217,7 +217,7 @@ const getDateAndTimeOfDeath = (patientData, { getTranslation, formatShortExplici
   return `${date} ${time}`.trim();
 };
 
-const PATIENT_DETAIL_FIELDS = {
+const PATIENT_DETAIL_FIELDS = /** @type {const} */ ({
   leftCol: [
     { key: 'firstName', label: 'First name' },
     { key: 'lastName', label: 'Last name' },
@@ -230,9 +230,9 @@ const PATIENT_DETAIL_FIELDS = {
     { key: 'ethnicityId', label: 'Ethnicity', accessor: getEthnicity },
     { key: 'villageId', label: 'Village', accessor: getVillage },
   ],
-};
+});
 
-const PATIENT_DEATH_DETAILS = {
+const PATIENT_DEATH_DETAILS = /** @type {const} */ ({
   leftCol: [
     { key: 'deathDateAndTime', label: 'Date & time of death', accessor: getDateAndTimeOfDeath },
     { key: 'placeOfDeath', label: 'Place of death', accessor: placeOfDeathAccessor },
@@ -241,7 +241,7 @@ const PATIENT_DEATH_DETAILS = {
     { key: 'causeOfDeath', label: 'Cause of death', accessor: causeOfDeathAccessor },
     { key: 'attendingClinician', label: 'Attending clinician', accessor: getClinician },
   ],
-};
+});
 
 const SectionContainer = props => <View style={generalStyles.sectionContainer} {...props} />;
 

--- a/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
@@ -186,13 +186,9 @@ const AuthorisedAndSignSection = () => {
 };
 
 const placeOfDeathAccessor = ({ facility, outsideHealthFacility }, { getTranslation }) => {
-  if (outsideHealthFacility) {
-    return getTranslation('death.outsideHealthFacility.label', 'Died outside health facility');
-  }
-  if (facility?.name) {
-    return facility.name;
-  }
-  return undefined;
+  return outsideHealthFacility
+    ? getTranslation('death.outsideHealthFacility.label', 'Died outside health facility')
+    : facility?.name;
 };
 
 const getCauseName = cause => cause?.condition?.name;


### PR DESCRIPTION
### Changes

Cherry-pick of PR #10571 to release\/2.59. Fixes the death certificate "Place of death" field to check the "outside health facility" flag first (matching the patient Summary screen), so it prints "Died outside health facility" when that flag is set rather than falling back to the facility name.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->