### PR TITLE
release: Bump version to 2.61.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamanu",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamanu",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-and-later AND BUSL-1.1",
       "dependencies": {
         "concurrently": "^9.2.1",
@@ -37139,7 +37139,7 @@
     },
     "packages/api-client": {
       "name": "@tamanu/api-client",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -37157,7 +37157,7 @@
     },
     "packages/build-tooling": {
       "name": "@tamanu/build-tooling",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@swc/cli": "^0.1.63",
@@ -37484,7 +37484,7 @@
     },
     "packages/central-server": {
       "name": "@tamanu/central-server",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.49.0",
@@ -37737,7 +37737,7 @@
     },
     "packages/constants": {
       "name": "@tamanu/constants",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@tamanu/build-tooling": "*",
@@ -37766,7 +37766,7 @@
     },
     "packages/database": {
       "name": "@tamanu/database",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -38119,7 +38119,7 @@
     },
     "packages/e2e-tests": {
       "name": "@tamanu/e2e-tests",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "devDependencies": {
         "@faker-js/faker": "^9.8.0",
         "@playwright/test": "1.61.0",
@@ -38161,7 +38161,7 @@
     },
     "packages/errors": {
       "name": "@tamanu/errors",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -38195,7 +38195,7 @@
     },
     "packages/facility-server": {
       "name": "@tamanu/facility-server",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^7.22.4",
@@ -38629,7 +38629,7 @@
     },
     "packages/fake-data": {
       "name": "@tamanu/fake-data",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@faker-js/faker": "^9.8.0",
@@ -38737,7 +38737,7 @@
     },
     "packages/mobile": {
       "name": "@tamanu/mobile",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "dependencies": {
         "@casl/ability": "^6.8.0",
         "@react-native-anywhere/polyfill-base64": "^0.0.1-alpha.0",
@@ -40720,7 +40720,7 @@
     },
     "packages/patient-portal": {
       "name": "@tamanu/patient-portal",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@emotion/react": "^11.13.3",
@@ -40830,7 +40830,7 @@
       "license": "MIT"
     },
     "packages/scripts": {
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -40868,7 +40868,7 @@
     },
     "packages/settings": {
       "name": "@tamanu/settings",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -41156,7 +41156,7 @@
     },
     "packages/shared": {
       "name": "@tamanu/shared",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@bugsnag/js": "^8.9.0",
@@ -41365,7 +41365,7 @@
     },
     "packages/synthetic-tests": {
       "name": "@tamanu/synthetic-tests",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "ISC",
       "dependencies": {
         "@tamanu/api-client": "*",
@@ -41397,7 +41397,7 @@
     },
     "packages/ui-components": {
       "name": "@tamanu/ui-components",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/shared": "*",
@@ -41423,7 +41423,7 @@
     },
     "packages/upgrade": {
       "name": "@tamanu/upgrade",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -41602,7 +41602,7 @@
     },
     "packages/utils": {
       "name": "@tamanu/utils",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -41788,7 +41788,7 @@
     },
     "packages/web": {
       "name": "@tamanu/web-frontend",
-      "version": "2.60.0",
+      "version": "2.61.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanu",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "This repo contains all the packages for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/api-client",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "API client for Tamanu Facility Server",
   "main": "./src/index",

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/build-tooling",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "Build tooling for Tamanu packages",
   "main": "index.mjs",
   "type": "module",

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/central-server",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "Central server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/constants",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "Shared constants",
   "main": "./src/index",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/database",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "BES - Database",
   "main": "./src/index",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/e2e-tests",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=\"--import tsx ${NODE_OPTIONS:-}\" playwright test",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/errors",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "API errors",
   "main": "./src/index",

--- a/packages/facility-server/package.json
+++ b/packages/facility-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/facility-server",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "Facility server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/fake-data/package.json
+++ b/packages/fake-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/fake-data",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "TODO",
   "main": "./src/index",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/mobile",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "scripts": {
     "android": "npx react-native start --reset-cache",

--- a/packages/patient-portal/package.json
+++ b/packages/patient-portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tamanu/patient-portal",
   "productName": "Tamanu",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "Tamanu Patient Portal",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripts",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "clean": "rimraf -- dist",

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/settings",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "BES - Settings",
   "main": "./src/index",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/shared",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "Common code across Tamanu packages",
   "main": "./src/index",
   "exports": {

--- a/packages/synthetic-tests/package.json
+++ b/packages/synthetic-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/synthetic-tests",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "dependencies": {
     "@tamanu/api-client": "*",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/ui-components",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "Tamanu UI components",
   "private": true,
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/upgrade",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "Tamanu upgrade files",
   "main": "./src/index",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/utils",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "private": true,
   "description": "Common code across Tamanu packages",
   "main": "./src/index",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tamanu/web-frontend",
   "productName": "Tamanu",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "Tamanu Web application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",


### PR DESCRIPTION
Restores the version bump that the **Cut Release Branch** run on 2026-07-09 computed but failed to push.

## Why

That run cut `release/2.60` successfully, then died pushing the bump to main:

```
+ version=2.61.0
[main bec02a7] release: Bump version to 2.61.0
 21 files changed, 47 insertions(+), 47 deletions(-)
+ git push
 ! [rejected]        main -> main (fetch first)
```

Non-fast-forward — main moved during the job. The release branch was already pushed by then, so the repo was left half-cut: `release/2.60` exists, main never advanced.

`currentVersion()` derives the branch name purely from mains `package.json`:

```js
const [major, minor] = version.split(".", 3);
const branch = `release/${major}.${minor}`;
```

Main still reads `2.60.0`, so every dispatch since recomputes `release/2.60` and dies on `Branch release/2.60 already exists`. The 2026-07-24 run failed exactly that way. **Re-running cannot fix itself** — it needs this bump first.

Downstream, no `release/2.61` branch means no `tamanu-release-2-61` namespace on the internal cluster, which is how this surfaced.

## What this does

Exactly what `node scripts/version.mjs minor` produces, plus `npm install --package-lock-only` to keep the lockfile in sync. 21 files, 41 lines, all version strings and nothing else.

The original run showed 47 lines because it also carried an `npx update-browserslist-db@latest` refresh (+6/-6 on the lockfile). Left out here to keep this reviewable — the next successful cut does it anyway.

`npm ci --dry-run` passes against the updated lockfile.

## After merging

Dispatch **Cut Release Branch** with `minor`. It will cut `release/2.61` and bump main to `2.62.0`.

The race that caused this is still live and will recur. Fix in a separate PR.