### PR TITLE
ci(release): no-issue: rebase and retry the version bump push

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -89,7 +89,21 @@ jobs:
         set -ex
         version=$(jq -r .version package.json)
         git commit -am "release: Bump version to $version"
-        git push
+
+        # The release branch is already pushed by now, so bailing here leaves
+        # main un-bumped and the next run trips the "already exists" guard.
+        # A fair bit of time has passed since checkout, so rebase and retry
+        # rather than give up on the first reject.
+        for attempt in $(seq 1 5); do
+          if git push; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt/5), rebasing onto main and retrying"
+          git pull --rebase origin main
+        done
+
+        echo "::error::Could not push the version bump after 5 attempts. The release branch is already cut, so main needs bumping manually before this can run again."
+        exit 1
 
     - name: Trigger tamanu-source-dbt upgrade workflow
       env:


### PR DESCRIPTION
Stops **Cut Release Branch** from wedging itself when a merge lands on main mid-run.

## The failure

On 2026-07-09 the run cut `release/2.60`, then died pushing the bump to main:

```
+ version=2.61.0
[main bec02a7] release: Bump version to 2.61.0
+ git push
 ! [rejected]        main -> main (fetch first)
```

Non-fast-forward. The push step was a bare `git commit -am` / `git push` with no rebase and no retry.

## Why it does not self-heal

`Create new release branch` pushes the branch at step 4. `Commit and push` bumps main at step 6. When 6 fails there is no rollback, so the repo is left half-cut: the branch exists, main never advanced.

`currentVersion()` then derives the next branch name purely from mains `package.json`, so every subsequent dispatch recomputes the same name and dies on the `checkBranchDoesNotExist` guard. The 2026-07-24 run failed exactly that way, and 2.61 stayed unreleased for over two weeks. It went unnoticed because this workflow is manually dispatched and has no failure notification.

## The fix

Rebase and retry the push, up to 5 attempts. The window is genuinely wide: `actions/checkout`, `version.mjs`, `npm install` and `update-browserslist-db` all run before the push, so on a repo as busy as this one a collision is routine rather than unlucky.

If all 5 attempts fail, the error now says what state the repo is in and what a human has to do, rather than leaving the next person to work it out from `branch already exists`.

## Testing

The retry path only executes during a race, so it was exercised against a real one rather than shipped unverified. Two clones of a bare repo, a concurrent commit pushed to main, then the extracted step script run against the stale checkout:

```
+ git push
 ! [rejected]        main -> main (fetch first)
Push rejected (attempt 1/5), rebasing onto main and retrying
+ git pull --rebase origin main
Rebasing (1/1)Successfully rebased and updated refs/heads/main.
+ git push
   214346e..d1c856e  main -> main
+ exit 0
```

Both commits survive, bump on top of the concurrent merge. YAML parses and the step is `bash -n` clean.

## Not included

A failure notification. The retry handles the common case, but a genuine failure is still silent on a manually-dispatched workflow. Worth adding separately.

Depends on nothing, but #10580 is what actually unblocks 2.61 — this only stops it happening again.