### PR TITLE
fix(ci): no-issue: build the seed image on node 26

### DIFF
--- a/Dockerfile.seed
+++ b/Dockerfile.seed
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS build
+FROM node:26-alpine AS build
 RUN apk add --no-cache bash g++ gcc git jq make python3 py3-setuptools && \
     npm install -g node-gyp
 WORKDIR /app
@@ -18,7 +18,7 @@ RUN npm ci && \
     rm -rf packages/web packages/patient-portal packages/mobile \
            packages/*/__tests__ packages/*/coverage
 
-FROM node:20-alpine
+FROM node:26-alpine
 RUN apk add --no-cache bash
 WORKDIR /app
 ARG GIT_SHA=unknown


### PR DESCRIPTION
Fixes `build-seed-image`, which has failed on every release cut since the node 26 upgrade.

## The failure

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Missing: react@16.8.5 from lock file
npm error Missing: scheduler@0.13.6 from lock file
```

The lockfile is not actually drifted. `Dockerfile.seed` was pinned to `node:20-alpine`, so npm 10 was validating a lockfile npm 11 wrote, and the two disagree about how `react`/`scheduler` should be recorded.

Reproduced locally against `release/2.61`, same checkout, only the node version changed:

| node | npm | `npm ci --dry-run` |
| --- | --- | --- |
| 26.3.1 | 11.16.0 | passes |
| 20.20.2 | 10.8.2 | fails, byte-identical to CI |

## Why it was missed

`.node-version` is `v26.3.1`, and the node 26 upgrade moved the other two images:

| file | base |
| --- | --- |
| `Dockerfile` | `node:26-alpine` |
| `packages/synthetic-tests/Dockerfile` | `node:26-slim` |
| `Dockerfile.seed` | `node:20-alpine` ← missed |

This one was the only straggler.

## The change

Both stages to `node:26-alpine`, matching `Dockerfile`. Two lines, nothing else.

## Testing caveat

I could not build the image — no docker on this machine. What is verified: the npm-version reproduction above, that `26-alpine` is a published tag, and that no `node:20` reference remains in the file. The base image matches what `Dockerfile` already builds on, so the apk/node-gyp setup has precedent, but the first real proof will be CI on this PR.

## Note on 2.61

This lands on main, so it fixes cuts from 2.62 onward. `release/2.61` still carries `node:20-alpine`, so if a 2.61 seed image is wanted it needs this cherry-picked onto that branch and `build-seed-image` re-run.