### PR TITLE
chore(sync): TAM-6962: warn when sync settings or the settings PSK come from config

### DIFF
--- a/packages/facility-server/app/serverConfig.js
+++ b/packages/facility-server/app/serverConfig.js
@@ -29,6 +29,20 @@ export async function initServerConfig({ context }) {
 
   resolved = { sync: { host, email, password }, facilityIds };
 
+  // TAM-6962: the config leg goes away next release. Name the keys still coming from
+  // it so we can find these servers first. This is a normal resting state, not an
+  // error — provisionSyncUser is failure-tolerant and leaves a server on config when
+  // central was unreachable during an upgrade.
+  const fromConfig = ['host', 'email', 'password'].filter(
+    key => env[key] == null && facts[key] == null && resolved.sync[key] != null,
+  );
+  if (env.facilityIds == null && facts.facilityIds == null && facilityIds != null) {
+    fromConfig.push('facilityIds');
+  }
+  if (fromConfig.length > 0) {
+    log.warn('serverConfig: sync settings resolved from legacy config', { keys: fromConfig });
+  }
+
   /* eslint-disable-next-line require-atomic-updates -- awaits above are settled */
   context.serverConfig = resolved;
 

--- a/packages/shared/src/utils/crypto.js
+++ b/packages/shared/src/utils/crypto.js
@@ -7,6 +7,8 @@ import readSync from 'read';
 
 import { FACT_SETTINGS_PSK } from '@tamanu/constants';
 
+import { log } from '../services/logging';
+
 const read = promisify(readSync);
 
 const SECRET_VERSION = 'S1';
@@ -191,15 +193,22 @@ export async function getSettingsPskKeyBuffer() {
       // provisioned) falls back. A falsy-but-present value (e.g. '' from a
       // corrupted row) passes through and fails loudly rather than silently
       // decrypting with the wrong key.
-      const psk =
-        (settingsPskSource && (await settingsPskSource())) ??
-        (await getConfigSecret('crypto.settingsPsk'));
+      const fromStore = settingsPskSource && (await settingsPskSource());
+      if (fromStore == null) {
+        // TAM-6962: the config value is doing the work here, and that fallback goes
+        // away next release. Cached promise, so this is once per process.
+        log.warn('settings PSK resolved from legacy crypto.settingsPsk config');
+      }
+      const psk = fromStore ?? (await getConfigSecret('crypto.settingsPsk'));
       // Validate before use. Buffer.from(x, 'hex') silently drops invalid/odd
       // characters, so a corrupt or empty PSK would otherwise yield a wrong-length
       // key whose only symptom is an opaque "Decryption failed" far from the cause.
       // Fail here, at the source, with a message that names the problem.
       const expectedHexLength = KEY_LENGTH_BYTES * 2;
-      if (typeof psk !== 'string' || !new RegExp(`^[0-9a-f]{${expectedHexLength}}$`, 'i').test(psk)) {
+      if (
+        typeof psk !== 'string' ||
+        !new RegExp(`^[0-9a-f]{${expectedHexLength}}$`, 'i').test(psk)
+      ) {
         throw new Error(
           `Settings PSK must be exactly ${expectedHexLength} hex characters ` +
             `(${KEY_LENGTH_BYTES} bytes for AES-${KEY_LENGTH}); the local secrets store ` +


### PR DESCRIPTION
### Changes

**Folded into #10586** (commit `7a17ede95f`, cherry-picked with `-x`). Closed in favour of reviewing it there, alongside the change that alters what the PSK warn tells you.

Prep for the TAM-6962 fallback removal in 2.63. Log-only, no behaviour change.

Two fallbacks get removed next release, and today nothing tells us which deployments still rely on them:

- `initServerConfig` (`serverConfig.js`) resolves `env ?? facts ?? config` silently
- `getSettingsPskKeyBuffer` (`crypto.js`) falls through to `crypto.settingsPsk` silently

So the removal would go in blind.

### Why this matters more than it looks

Sitting on the sync config fallback is a *designed resting state*, not an edge case. `provisionSyncUser` is gated on `!FACT_SYNC_EMAIL`, is failure-tolerant, and its own comment says the server "stays on the config fallback and the step retries on the next upgrade". Any facility whose central was unreachable during an upgrade is in that state right now, intentionally.

That matters because people do jump several versions at once — Palau is still on 2.54.7. A facility going straight to 2.63 runs `provisionSyncUser` during the same upgrade that deletes its fallback. If the step skips, that facility has nothing to migrate from and nothing to fall back to: it can't sync, and recovery is manual fact insertion or re-running the wizard on site. The offline-prone facilities are the ones most likely to be affected.

These two lines mean that by the time 2.63 is cut we have the list, and the "how do we handle big version jumps" decision in TAM-6962 has data behind it.

### Notes

- The PSK read is promise-cached, so that warn fires once per process
- `?? not ||` semantics preserved on the PSK path — a falsy-but-present value still passes through and fails loudly
- Tests: `shared/__tests__/utils/crypto.test.js` (19) and `facility-server/__tests__/serverConfig.test.js` (5) pass, including `falls back to legacy config when there are no env vars or facts`

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
