### PR TITLE
fix(sync): TAM-6962: record legacy sync credentials without needing central (2.61 FIX)

### DIFF
--- a/packages/upgrade/__tests__/steps/1783048813000-provisionSyncUser.test.ts
+++ b/packages/upgrade/__tests__/steps/1783048813000-provisionSyncUser.test.ts
@@ -21,7 +21,9 @@ vi.mock('config', () => ({
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-const [step] = STEPS;
+const [recordStep, provisionStep] = STEPS;
+
+const LEGACY_EMAIL = 'legacy@sync.tamanu';
 
 const makeArgs = (facts: Record<string, string> = {}) => {
   const factStore = new Map(Object.entries(facts));
@@ -53,12 +55,31 @@ describe('1783048813000-provisionSyncUser', () => {
     mockFetch.mockReset();
   });
 
-  it('checks in only on facility servers with legacy config and no email fact', async () => {
+  it('records legacy credentials only on facility servers that have none yet', async () => {
     const { args } = makeArgs();
-    await expect(step.check(args)).resolves.toBe(true);
-    await expect(step.check({ ...args, serverType: 'central' })).resolves.toBe(false);
+    await expect(recordStep.check(args)).resolves.toBe(true);
+    await expect(recordStep.check({ ...args, serverType: 'central' })).resolves.toBe(false);
     const { args: configured } = makeArgs({ [FACT_SYNC_EMAIL]: 'sync.abc@sync.tamanu' });
-    await expect(step.check(configured)).resolves.toBe(false);
+    await expect(recordStep.check(configured)).resolves.toBe(false);
+  });
+
+  it('records the legacy credentials without touching the network', async () => {
+    const { args, factStore, secretStore } = makeArgs();
+
+    await recordStep.run(args);
+
+    // the whole point: no central round-trip, so this cannot fail
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(factStore.get(FACT_CENTRAL_HOST)).toBe('https://central.example.com');
+    expect(factStore.get(FACT_SYNC_EMAIL)).toBe(LEGACY_EMAIL);
+    expect(secretStore.get(FACT_SYNC_PASSWORD)).toBe('legacy-password');
+  });
+
+  it('provisions a dedicated user only while the recorded email is still the legacy one', async () => {
+    const { args: legacy } = makeArgs({ [FACT_SYNC_EMAIL]: LEGACY_EMAIL });
+    await expect(provisionStep.check(legacy)).resolves.toBe(true);
+    const { args: dedicated } = makeArgs({ [FACT_SYNC_EMAIL]: 'sync.abc@sync.tamanu' });
+    await expect(provisionStep.check(dedicated)).resolves.toBe(false);
   });
 
   it('provisions a dedicated sync user and records it in facts', async () => {
@@ -70,7 +91,7 @@ describe('1783048813000-provisionSyncUser', () => {
       .mockResolvedValueOnce(jsonResponse({ token: 'a-token' }))
       .mockResolvedValueOnce(jsonResponse({ email: 'sync.abc@sync.tamanu', password: 'minted' }));
 
-    await step.run(args);
+    await provisionStep.run(args);
 
     // login with legacy creds, then provision with the token
     expect(mockFetch).toHaveBeenNthCalledWith(
@@ -91,22 +112,25 @@ describe('1783048813000-provisionSyncUser', () => {
     expect(secretStore.get(FACT_SYNC_PASSWORD)).toBe('minted');
   });
 
-  it('leaves the server on config fallback when central refuses', async () => {
+  it('leaves the recorded legacy credentials in place when central refuses', async () => {
     const { args, factStore } = makeArgs({
       [FACT_DEVICE_ID]: 'device-1',
       [FACT_FACILITY_IDS]: JSON.stringify(['facility-a']),
+      [FACT_SYNC_EMAIL]: LEGACY_EMAIL, // as the record step left it
     });
     mockFetch.mockResolvedValue({ ok: false, status: 403 });
 
-    await expect(step.run(args)).resolves.toBeUndefined(); // must not throw — it would fail the upgrade
-    expect(factStore.has(FACT_SYNC_EMAIL)).toBe(false);
+    await expect(provisionStep.run(args)).resolves.toBeUndefined(); // must not throw — it would fail the upgrade
+    // still on the legacy credentials the record step wrote, so sync keeps working
+    expect(factStore.get(FACT_SYNC_EMAIL)).toBe(LEGACY_EMAIL);
     expect(args.log.warn).toHaveBeenCalled();
   });
 
-  it('skips servers that never registered with central', async () => {
-    const { args, factStore } = makeArgs();
-    await step.run(args);
+  it('skips provisioning on servers that never registered with central', async () => {
+    const { args } = makeArgs({ [FACT_SYNC_EMAIL]: LEGACY_EMAIL });
+    await provisionStep.run(args);
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(factStore.has(FACT_SYNC_EMAIL)).toBe(false);
+    // untouched: no dedicated user, but the legacy credentials still sync
+    expect(args.log.warn).toHaveBeenCalled();
   });
 });

--- a/packages/upgrade/src/steps/1783048813000-provisionSyncUser.ts
+++ b/packages/upgrade/src/steps/1783048813000-provisionSyncUser.ts
@@ -34,20 +34,45 @@ const postJson = async (url: string, body: unknown, token?: string) => {
 export const STEPS: Steps = [
   {
     at: END,
-    // Existing facility servers hold sync credentials in config; new ones get a
-    // dedicated per-device sync user from the setup wizard. This converges the
-    // existing servers: use the legacy credentials (their sync user is role
-    // admin, so it may mint sync users) to provision a dedicated user on
-    // central and record it in facts, so the deprecated config keys can be
-    // dropped next version. Failure-tolerant: if central is unreachable or
-    // refuses, the server stays on the config fallback and the step retries on
-    // the next upgrade (it's gated on the email fact, not recorded as done).
+    // Copy the legacy config credentials into facts verbatim. Local writes only,
+    // so it can't fail — the config fallback can only go once every server is
+    // guaranteed to have these. Swapping them for a dedicated user is the step below.
     async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
       if (serverType !== 'facility') return false;
       const { host, email, password } = legacySyncConfig();
       // nothing to migrate — fresh installs are configured by the wizard
       if (!host || !email || !password) return false;
       return !(await LocalSystemFact.get(FACT_SYNC_EMAIL));
+    },
+    async run({ sequelize, models: { LocalSystemFact, LocalSystemSecret }, log }: StepArgs) {
+      const { host: legacyHost, email, password } = legacySyncConfig();
+      const host = new URL(legacyHost!.trim()).origin;
+
+      await sequelize.transaction(async () => {
+        await LocalSystemFact.set(FACT_CENTRAL_HOST, host);
+        await LocalSystemFact.set(FACT_SYNC_EMAIL, email!);
+        // Encrypted at rest, out of local_system_facts and the raw reporting role.
+        await LocalSystemSecret.set(FACT_SYNC_PASSWORD, password!);
+      });
+      log.info('provisionSyncUser: legacy sync credentials recorded to facts');
+    },
+  },
+  {
+    at: END,
+    // Existing facility servers hold sync credentials in config; new ones get a
+    // dedicated per-device sync user from the setup wizard. This converges the
+    // existing servers: use the legacy credentials (their sync user is role
+    // admin, so it may mint sync users) to provision a dedicated user on
+    // central and record it in facts. Failure-tolerant: if central is unreachable
+    // or refuses, the server keeps syncing on the credentials recorded above and
+    // this retries on the next upgrade.
+    async check({ serverType, models: { LocalSystemFact } }: StepArgs) {
+      if (serverType !== 'facility') return false;
+      const { host, email, password } = legacySyncConfig();
+      // nothing to migrate — fresh installs are configured by the wizard
+      if (!host || !email || !password) return false;
+      // still the legacy email means the swap hasn't happened yet
+      return (await LocalSystemFact.get(FACT_SYNC_EMAIL)) === email;
     },
     async run({ sequelize, models: { LocalSystemFact, LocalSystemSecret }, log }: StepArgs) {
       const { host: legacyHost, email, password } = legacySyncConfig();


### PR DESCRIPTION
### Changes

Off `release/2.61` since it's unreleased. Forward-ported to `main` in #10586.

`provisionSyncUser` writes facts only if it can reach central, otherwise it leaves the server on the config fallback to retry next upgrade. Fine until TAM-6962 removes that fallback: a facility whose central was unreachable during the upgrade would have nothing in facts and nothing to fall back to, with recovery needing someone on site.

Split in two. **Record** copies the legacy credentials into facts verbatim, local writes only, so it can't fail. **Provision** is the existing central round-trip, unchanged, swapping them for a dedicated per-device user whenever central is next reachable, re-gated on the recorded email still being the legacy one since step 1 now always populates `FACT_SYNC_EMAIL`.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [x] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
