### PR TITLE
fix(e2e): no-issue: stop two flaky helpers submitting forms before they load

### DIFF
--- a/packages/e2e-tests/pages/patients/NotesPage/modals/editNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/editNoteModal.ts
@@ -1,10 +1,23 @@
-import { Page } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 import { BaseNoteModal } from './BaseModals/BaseNoteModal';
 import { normalizeToIsoDateTimeMinute } from '@utils/testHelper';
 
 export class EditNoteModal extends BaseNoteModal {
+  readonly typeField: Locator;
+
   constructor(page: Page) {
     super(page);
+    this.typeField = page.getByTestId('field-a0mv').locator('input').first();
+  }
+
+  async waitForModalToLoad() {
+    await super.waitForModalToLoad();
+    // The dialog mounts before the note it is editing has loaded, and before the note
+    // type options are fetched. Type is required and read-only in edit mode, so editing
+    // inside that window submits an empty type: the form fails validation silently, the
+    // dialog never closes, and it surfaces 30s later as a timeout waiting for the close
+    // rather than anywhere near the cause.
+    await expect(this.typeField).not.toBeEmpty();
   }
 
   // Helper method to edit a note

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -477,6 +477,12 @@ export class PatientDetailsPage extends BasePatientPage {
     await this.initiateNewAllergyAddButton.click();
     await this.allergyNameField.fill(allergyName);
     await this.page.getByRole('menuitem', { name: allergyName, exact: true }).click();
+    // The suggester re-renders as its debounced fetch resolves, so the click above can
+    // land on a list that is replaced before it selects anything. Submitting then posts
+    // an empty name and the form just sits there failing validation, which surfaces much
+    // later as a timeout waiting for the saved row. Confirm the value landed first.
+    await this.dropdownMenuItem.waitFor({ state: 'hidden' });
+    await expect(this.allergyNameField).toHaveValue(allergyName);
     await this.clickAddButtonToConfirm(this.submitNewAllergyAddButton);
   }
 


### PR DESCRIPTION
### Changes

**Closed.** The edit-note half shipped with a locator that never mounts (`field-a0mv`; a disabled `SelectField` renders `-input`, an enabled one `-select`, never the bare id), which turned four flaky tests into four hard failures in CI. The allergy half, which is sound and independent, is now #10590.

Two flaky clusters, diagnosed from the Playwright error-context snapshots rather than by reading the specs and guessing. Both turned out to be the same shape: a form submitted before it was populated, failing validation silently, surfacing 30s later as a timeout somewhere else.

I scanned the last 19 E2E runs that actually executed shards: **166 events, 163 flaky, 3 hard failures**, around 8.6 per run. `retries: 2` absorbs nearly all of it, so runs go green while this churns underneath. Four spec files are 98% of it: note 59, vaccine 46, Basic 33, patientSideBar 25.

**Allergies** (`[AT-0103]` 12 events, `[AT-0101]` 5). `addNewAllergyWithJustRequiredFields` clicked the suggestion then submitted immediately. The suggester re-renders as its debounced fetch resolves, so that click can land on a list which is replaced before it selects anything. The snapshot at failure shows the form still open with `Eggs` typed, the field `[invalid]`, and `*Required` under it. Fix is to wait for the menu to close and assert the field took the value, which `addNewAllergyNotInDropdown` eleven lines below already does.

**Edit note** (`[AT-0081]` 15, `[AT-0083]` 15, `[AT-0082]` 14, `[AT-0084]` 13). All four fail identically, waiting for the confirm button to detach. The snapshot shows the dialog open, content filled, but **Type** empty and `[invalid]`. `waitForModalToLoad` only waited for the confirm button to be visible, which is true the instant the dialog mounts, before the note and its type options (`encounter/{id}/notes/noteTypes`, `NoteModal.jsx:164`) have loaded. Type is required and read-only in edit mode, so editing in that window submits an empty type and the dialog never closes. Fix is to wait for the type field to be populated.

I can't verify these locally, since e2e needs the full stack and flakiness is statistical regardless. The measure is whether those six tests stop showing up in the flake list over the next several runs. Typecheck is unchanged: 30 pre-existing errors in the package, identical before and after.

Left alone: `networkidle` appears 58 times across the package and Playwright explicitly discourages it, and the `Basic.spec.ts` and `vaccine.spec.ts` clusters are still open. Both want their own change.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [x] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
