### PR TITLE
fix(e2e): no-issue: confirm the allergy suggester selection before submitting (flaky test failure)

### DIFF
--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -477,6 +477,9 @@ export class PatientDetailsPage extends BasePatientPage {
     await this.initiateNewAllergyAddButton.click();
     await this.allergyNameField.fill(allergyName);
     await this.page.getByRole('menuitem', { name: allergyName, exact: true }).click();
+    // The suggester re-renders as its fetch resolves, so the click can select nothing.
+    await this.dropdownMenuItem.waitFor({ state: 'hidden' });
+    await expect(this.allergyNameField).toHaveValue(allergyName);
     await this.clickAddButtonToConfirm(this.submitNewAllergyAddButton);
   }
 


### PR DESCRIPTION
### Changes

`[AT-0103] Edit allergy` and `[AT-0101] Add allergy with just the required fields` flake constantly: 17 events across the last 19 E2E runs that ran shards, and `[AT-0103]` is one of only three tests in that window to exhaust its retries and actually fail.

`addNewAllergyWithJustRequiredFields` clicked the suggestion and submitted straight away. The suggester re-renders as its debounced fetch resolves, so that click can land on a list which is replaced before it selects anything. The Playwright error-context snapshot at failure shows the form still open with `Eggs` typed, the field `[invalid]`, and `*Required` beneath it: submitted empty, failed validation, never saved. It surfaces 30s later as a timeout waiting for the saved row, which is nowhere near the cause.

The fix is the two guards `addNewAllergyNotInDropdown` already uses eleven lines below, waiting for the menu to close and asserting the field took the value.

Verification is statistical, so the measure is whether those two stop appearing in the flake list over the next several runs rather than one green build here.

This is one of four spec files producing 98% of our E2E flakes (note 59, vaccine 46, Basic 33, patientSideBar 25, 166 events total, 163 of them absorbed by `retries: 2`). The other three are untouched, as is `networkidle`, which appears 58 times across the package despite Playwright discouraging it and is the likely background contributor.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [x] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
