### PR TITLE
feat(labs): TAM-6839: Block ability to update lab priority after request

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Labs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Labs.test.js
@@ -431,7 +431,7 @@ describe('Labs', () => {
       expect(labRequest).toHaveProperty('labTestPriorityId', priorityB.id);
     });
 
-    it('should reject updating priority once status is no longer reception pending', async () => {
+    it('should allow updating priority after status changes when priorityEditable flag is true (default)', async () => {
       const { id: requestId } = await models.LabRequest.createWithTests(
         await randomLabRequest(models, {
           patientId,
@@ -442,19 +442,19 @@ describe('Labs', () => {
       const response = await app
         .put(`/api/labRequest/${requestId}`)
         .send({ labTestPriorityId: priorityB.id });
-      expect(response).toHaveRequestError();
+      expect(response).toHaveSucceeded();
 
       const labRequest = await models.LabRequest.findByPk(requestId);
-      expect(labRequest).toHaveProperty('labTestPriorityId', priorityA.id);
+      expect(labRequest).toHaveProperty('labTestPriorityId', priorityB.id);
     });
 
-    it('should reject updating priority when the priorityEditable feature flag is disabled', async () => {
+    it('should reject updating priority after status changes when priorityEditable flag is false', async () => {
       await models.Setting.set('features.labRequest.priorityEditable', false);
 
       const { id: requestId } = await models.LabRequest.createWithTests(
         await randomLabRequest(models, {
           patientId,
-          status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+          status: LAB_REQUEST_STATUSES.TO_BE_VERIFIED,
           labTestPriorityId: priorityA.id,
         }),
       );

--- a/packages/facility-server/__tests__/apiv1/Labs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Labs.test.js
@@ -448,23 +448,23 @@ describe('Labs', () => {
       expect(labRequest).toHaveProperty('labTestPriorityId', priorityA.id);
     });
 
-    it('should allow updating priority regardless of status when the priorityEditable feature flag is disabled', async () => {
+    it('should reject updating priority when the priorityEditable feature flag is disabled', async () => {
       await models.Setting.set('features.labRequest.priorityEditable', false);
 
       const { id: requestId } = await models.LabRequest.createWithTests(
         await randomLabRequest(models, {
           patientId,
-          status: LAB_REQUEST_STATUSES.TO_BE_VERIFIED,
+          status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
           labTestPriorityId: priorityA.id,
         }),
       );
       const response = await app
         .put(`/api/labRequest/${requestId}`)
         .send({ labTestPriorityId: priorityB.id });
-      expect(response).toHaveSucceeded();
+      expect(response).toHaveRequestError();
 
       const labRequest = await models.LabRequest.findByPk(requestId);
-      expect(labRequest).toHaveProperty('labTestPriorityId', priorityB.id);
+      expect(labRequest).toHaveProperty('labTestPriorityId', priorityA.id);
     });
   });
 

--- a/packages/facility-server/__tests__/apiv1/Labs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Labs.test.js
@@ -395,6 +395,79 @@ describe('Labs', () => {
     expect(labRequest).toHaveProperty('status', status);
   });
 
+  describe('Priority', () => {
+    let priorityA;
+    let priorityB;
+
+    beforeAll(async () => {
+      priorityA = await models.ReferenceData.create({
+        ...fake(models.ReferenceData),
+        type: 'labTestPriority',
+      });
+      priorityB = await models.ReferenceData.create({
+        ...fake(models.ReferenceData),
+        type: 'labTestPriority',
+      });
+    });
+
+    afterEach(async () => {
+      await models.Setting.set('features.labRequest.priorityEditable', true);
+    });
+
+    it('should allow updating priority while status is reception pending', async () => {
+      const { id: requestId } = await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          patientId,
+          status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+          labTestPriorityId: priorityA.id,
+        }),
+      );
+      const response = await app
+        .put(`/api/labRequest/${requestId}`)
+        .send({ labTestPriorityId: priorityB.id });
+      expect(response).toHaveSucceeded();
+
+      const labRequest = await models.LabRequest.findByPk(requestId);
+      expect(labRequest).toHaveProperty('labTestPriorityId', priorityB.id);
+    });
+
+    it('should reject updating priority once status is no longer reception pending', async () => {
+      const { id: requestId } = await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          patientId,
+          status: LAB_REQUEST_STATUSES.TO_BE_VERIFIED,
+          labTestPriorityId: priorityA.id,
+        }),
+      );
+      const response = await app
+        .put(`/api/labRequest/${requestId}`)
+        .send({ labTestPriorityId: priorityB.id });
+      expect(response).toHaveRequestError();
+
+      const labRequest = await models.LabRequest.findByPk(requestId);
+      expect(labRequest).toHaveProperty('labTestPriorityId', priorityA.id);
+    });
+
+    it('should allow updating priority regardless of status when the priorityEditable feature flag is disabled', async () => {
+      await models.Setting.set('features.labRequest.priorityEditable', false);
+
+      const { id: requestId } = await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          patientId,
+          status: LAB_REQUEST_STATUSES.TO_BE_VERIFIED,
+          labTestPriorityId: priorityA.id,
+        }),
+      );
+      const response = await app
+        .put(`/api/labRequest/${requestId}`)
+        .send({ labTestPriorityId: priorityB.id });
+      expect(response).toHaveSucceeded();
+
+      const labRequest = await models.LabRequest.findByPk(requestId);
+      expect(labRequest).toHaveProperty('labTestPriorityId', priorityB.id);
+    });
+  });
+
   it('should not fetch lab test types directly from general labTestType get route when visibilityStatus set to "panelsOnly" or "historical"', async () => {
     const makeLabTestType = async visibilityStatus => {
       const category = await models.ReferenceData.create({

--- a/packages/facility-server/__tests__/apiv1/Labs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Labs.test.js
@@ -448,6 +448,44 @@ describe('Labs', () => {
       expect(labRequest).toHaveProperty('labTestPriorityId', priorityB.id);
     });
 
+    it('should allow updating priority at sample not collected stage when flag is false', async () => {
+      await models.Setting.set('features.labRequest.priorityEditable', false);
+
+      const { id: requestId } = await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          patientId,
+          status: LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED,
+          labTestPriorityId: priorityA.id,
+        }),
+      );
+      const response = await app
+        .put(`/api/labRequest/${requestId}`)
+        .send({ labTestPriorityId: priorityB.id });
+      expect(response).toHaveSucceeded();
+
+      const labRequest = await models.LabRequest.findByPk(requestId);
+      expect(labRequest).toHaveProperty('labTestPriorityId', priorityB.id);
+    });
+
+    it('should allow updating priority at reception pending stage even when priorityEditable flag is false', async () => {
+      await models.Setting.set('features.labRequest.priorityEditable', false);
+
+      const { id: requestId } = await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          patientId,
+          status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+          labTestPriorityId: priorityA.id,
+        }),
+      );
+      const response = await app
+        .put(`/api/labRequest/${requestId}`)
+        .send({ labTestPriorityId: priorityB.id });
+      expect(response).toHaveSucceeded();
+
+      const labRequest = await models.LabRequest.findByPk(requestId);
+      expect(labRequest).toHaveProperty('labTestPriorityId', priorityB.id);
+    });
+
     it('should reject updating priority after status changes when priorityEditable flag is false', async () => {
       await models.Setting.set('features.labRequest.priorityEditable', false);
 

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -75,18 +75,23 @@ labRequest.put(
     }
 
     // priorityEditable: when true (default), priority can be edited at any time.
-    // When false, priority can only be edited while status is reception_pending.
+    // When false, priority can only be edited in early stages (sample_not_collected, reception_pending).
     const priorityEditable =
       (await settings[facilityId]?.get('features.labRequest.priorityEditable')) ?? true;
+
+    const earlyStages = [
+      LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED,
+      LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+    ];
 
     if (
       labRequestData.labTestPriorityId !== undefined &&
       labRequestData.labTestPriorityId !== labRequestRecord.labTestPriorityId &&
       !priorityEditable &&
-      labRequestRecord.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING
+      !earlyStages.includes(labRequestRecord.status)
     ) {
       throw new InvalidOperationError(
-        'Lab request priority cannot be changed once the request is no longer reception pending.',
+        'Lab request priority cannot be changed once the request has moved beyond the initial stages.',
       );
     }
 

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -74,21 +74,20 @@ labRequest.put(
       req.checkPermission('write', 'LabRequestStatus');
     }
 
+    // priorityEditable: when true (default), priority can be edited at any time.
+    // When false, priority can only be edited while status is reception_pending.
     const priorityEditable =
       (await settings[facilityId]?.get('features.labRequest.priorityEditable')) ?? true;
 
     if (
       labRequestData.labTestPriorityId !== undefined &&
-      labRequestData.labTestPriorityId !== labRequestRecord.labTestPriorityId
+      labRequestData.labTestPriorityId !== labRequestRecord.labTestPriorityId &&
+      !priorityEditable &&
+      labRequestRecord.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING
     ) {
-      if (!priorityEditable) {
-        throw new InvalidOperationError('Lab request priority cannot be edited.');
-      }
-      if (labRequestRecord.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING) {
-        throw new InvalidOperationError(
-          'Lab request priority cannot be changed once the request is no longer reception pending.',
-        );
-      }
+      throw new InvalidOperationError(
+        'Lab request priority cannot be changed once the request is no longer reception pending.',
+      );
     }
 
     const hasSensitiveTests = labRequestRecord.tests.some(test => test.labTestType.isSensitive);

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -61,7 +61,7 @@ labRequest.get(
 labRequest.put(
   '/:id',
   asyncHandler(async (req, res) => {
-    const { models, params, db } = req;
+    const { models, params, db, settings, facilityId } = req;
     const { userId, ...labRequestData } = req.body;
     req.checkPermission('read', 'LabRequest');
     const labRequestRecord = await models.LabRequest.findByPk(params.id, {
@@ -72,6 +72,20 @@ labRequest.put(
 
     if (labRequestData.status && labRequestData.status !== labRequestRecord.status) {
       req.checkPermission('write', 'LabRequestStatus');
+    }
+
+    const priorityEditable =
+      (await settings[facilityId]?.get('features.labRequest.priorityEditable')) ?? true;
+
+    if (
+      priorityEditable &&
+      labRequestData.labTestPriorityId !== undefined &&
+      labRequestData.labTestPriorityId !== labRequestRecord.labTestPriorityId &&
+      labRequestRecord.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING
+    ) {
+      throw new InvalidOperationError(
+        'Lab request priority cannot be changed once the request is no longer reception pending.',
+      );
     }
 
     const hasSensitiveTests = labRequestRecord.tests.some(test => test.labTestType.isSensitive);

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -78,14 +78,17 @@ labRequest.put(
       (await settings[facilityId]?.get('features.labRequest.priorityEditable')) ?? true;
 
     if (
-      priorityEditable &&
       labRequestData.labTestPriorityId !== undefined &&
-      labRequestData.labTestPriorityId !== labRequestRecord.labTestPriorityId &&
-      labRequestRecord.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING
+      labRequestData.labTestPriorityId !== labRequestRecord.labTestPriorityId
     ) {
-      throw new InvalidOperationError(
-        'Lab request priority cannot be changed once the request is no longer reception pending.',
-      );
+      if (!priorityEditable) {
+        throw new InvalidOperationError('Lab request priority cannot be edited.');
+      }
+      if (labRequestRecord.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING) {
+        throw new InvalidOperationError(
+          'Lab request priority cannot be changed once the request is no longer reception pending.',
+        );
+      }
     }
 
     const hasSensitiveTests = labRequestRecord.tests.some(test => test.labTestType.isSensitive);

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -476,6 +476,19 @@ export const globalSettings = {
               type: yup.boolean(),
               defaultValue: true,
             },
+            priorityMandatory: {
+              name: 'Lab request priority mandatory',
+              description: 'Require a priority to be selected when creating a lab request',
+              type: yup.boolean(),
+              defaultValue: false,
+            },
+            priorityEditable: {
+              name: 'Lab request priority editable',
+              description:
+                'Allow lab request priority to be edited after the request has been submitted. When disabled, the option to change priority is not offered once the request is no longer reception pending.',
+              type: yup.boolean(),
+              defaultValue: true,
+            },
           },
         },
         covidCertificates: {

--- a/packages/web/app/forms/LabRequestForm/LabRequestFormScreen1.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestFormScreen1.jsx
@@ -16,6 +16,7 @@ export const LabRequestFormScreen1 = ({
   values,
   practitionerSuggester,
   departmentSuggester,
+  isPriorityMandatory,
 }) => {
   return (
     <>
@@ -94,6 +95,7 @@ export const LabRequestFormScreen1 = ({
             data-testid="translatedtext-8z93"
           />
         }
+        required={isPriorityMandatory}
         component={SuggesterSelectField}
         endpoint="labTestPriority"
         data-testid="field-lma4"

--- a/packages/web/app/forms/LabRequestForm/LabRequestMultiStepForm.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestMultiStepForm.jsx
@@ -4,7 +4,7 @@ import { LAB_REQUEST_FORM_TYPES } from '@tamanu/constants/labs';
 import PropTypes from 'prop-types';
 import { useAuth } from '../../contexts/Auth';
 import { useTranslation } from '../../contexts/Translation';
-import { foreignKey } from '../../utils/validation';
+import { foreignKey, optionalForeignKey } from '../../utils/validation';
 import { useDateTime } from '@tamanu/ui-components';
 
 import { FormStep, MultiStepForm } from '../MultiStepForm';
@@ -31,6 +31,7 @@ export const LabRequestMultiStepForm = ({
   const { getCurrentDateTime } = useDateTime();
   const { getSetting } = useSettings();
   const mandateSpecimenType = getSetting(SETTING_KEYS.FEATURE_MANDATE_SPECIMEN_TYPE);
+  const mandatePriority = getSetting('features.labRequest.priorityMandatory');
 
   const { getTranslation } = useTranslation();
   const { currentUser } = useAuth();
@@ -76,6 +77,13 @@ export const LabRequestMultiStepForm = ({
           data-testid="translatedtext-xm3y"
         />,
       ),
+    labTestPriorityId: (mandatePriority ? foreignKey() : optionalForeignKey()).translatedLabel(
+      <TranslatedText
+        stringId="lab.priority.label"
+        fallback="Priority"
+        data-testid="translatedtext-p8sh"
+      />,
+    ),
   });
 
   const screen2ValidationSchema = yup.object().shape({
@@ -161,6 +169,7 @@ export const LabRequestMultiStepForm = ({
         <LabRequestFormScreen1
           practitionerSuggester={practitionerSuggester}
           departmentSuggester={departmentSuggester}
+          isPriorityMandatory={mandatePriority}
           data-testid="labrequestformscreen1-cz7w"
         />
       </FormStep>

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -199,6 +199,7 @@ export const LabRequestView = () => {
   const { isLoading, labRequest, updateLabRequest } = useLabRequest();
 
   const enableLabResultsPrintout = getSetting('features.labRequest.enableLabResultsPrintout');
+  const isPriorityEditingEnabled = getSetting('features.labRequest.priorityEditable');
 
   const closeModal = () => {
     setModalOpen(false);
@@ -241,6 +242,9 @@ export const LabRequestView = () => {
   const isHidden = HIDDEN_STATUSES.includes(labRequest.status);
   const displayAsCancelled = STATUSES_TO_DISPLAY_AS_CANCELLED.includes(labRequest.status);
   const areLabRequestsReadOnly = !canWriteLabRequest || isHidden;
+  const isPriorityLocked =
+    isPriorityEditingEnabled && labRequest.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING;
+  const isPriorityReadOnly = areLabRequestsReadOnly || isPriorityLocked;
   const areLabTestsReadOnly = !canWriteLabTest || isHidden || isPublished;
   const hasAttachment = Boolean(labRequest.latestAttachment);
   const canEnterResults = !isPublished && !areLabTestsReadOnly;
@@ -527,7 +531,7 @@ export const LabRequestView = () => {
                 <>&mdash;</>
               )
             }
-            isReadOnly={areLabRequestsReadOnly}
+            isReadOnly={isPriorityReadOnly}
             actions={[
               {
                 label: (

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -243,9 +243,13 @@ export const LabRequestView = () => {
   const displayAsCancelled = STATUSES_TO_DISPLAY_AS_CANCELLED.includes(labRequest.status);
   const areLabRequestsReadOnly = !canWriteLabRequest || isHidden;
   // isPriorityEditingEnabled: when true (default), priority can be edited at any time.
-  // When false, priority can only be edited while status is reception_pending.
+  // When false, priority can only be edited in early stages (sample_not_collected, reception_pending).
+  const earlyStages = [
+    LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED,
+    LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+  ];
   const isPriorityLocked =
-    !isPriorityEditingEnabled && labRequest.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING;
+    !isPriorityEditingEnabled && !earlyStages.includes(labRequest.status);
   const isPriorityReadOnly = areLabRequestsReadOnly || isPriorityLocked;
   const areLabTestsReadOnly = !canWriteLabTest || isHidden || isPublished;
   const hasAttachment = Boolean(labRequest.latestAttachment);

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -242,8 +242,10 @@ export const LabRequestView = () => {
   const isHidden = HIDDEN_STATUSES.includes(labRequest.status);
   const displayAsCancelled = STATUSES_TO_DISPLAY_AS_CANCELLED.includes(labRequest.status);
   const areLabRequestsReadOnly = !canWriteLabRequest || isHidden;
+  // isPriorityEditingEnabled: when true (default), priority can be edited at any time.
+  // When false, priority can only be edited while status is reception_pending.
   const isPriorityLocked =
-    isPriorityEditingEnabled && labRequest.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING;
+    !isPriorityEditingEnabled && labRequest.status !== LAB_REQUEST_STATUSES.RECEPTION_PENDING;
   const isPriorityReadOnly = areLabRequestsReadOnly || isPriorityLocked;
   const areLabTestsReadOnly = !canWriteLabTest || isHidden || isPublished;
   const hasAttachment = Boolean(labRequest.latestAttachment);


### PR DESCRIPTION
### Changes

This works adds two new settings that control the behavior of the "priority" field from a lab request. One handles it being mandatory, the other one handles if it can be edited AFTER status is no longer reception pending

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._