### PR TITLE
fix(upgrade): no-issue: name the config key file when the upgrade can't read it

### DIFF
--- a/packages/upgrade/__tests__/checkConfigKey.test.ts
+++ b/packages/upgrade/__tests__/checkConfigKey.test.ts
@@ -1,0 +1,88 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const keyFile = vi.hoisted(() => ({ path: '' }));
+
+vi.mock('config', () => ({
+  default: {
+    get: (name: string) => (name === 'crypto.keyFile' ? keyFile.path : undefined),
+  },
+}));
+
+import { checkConfigKey } from '../src/checkConfigKey.js';
+
+type Row = { key: string; value: string | null };
+
+const fakeSequelize = (tables: Record<string, Row[]>) =>
+  ({
+    query: vi.fn(async (sql: string, options?: any) => {
+      if (sql.includes('to_regclass')) {
+        const table = options.bind.table.replace('public.', '');
+        return [{ name: tables[table] ? table : null }];
+      }
+      const table = Object.keys(tables).find(name => sql.includes(`public.${name}`));
+      return table ? tables[table] : [];
+    }),
+  }) as any;
+
+const ENCRYPTED = 'S1:aXYtYnl0ZXM=:Y2lwaGVydGV4dA==';
+
+describe('checkConfigKey', () => {
+  let dir: string;
+  let missing: string;
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'tamanu-config-key-'));
+    missing = join(dir, 'missing.key');
+    await fs.writeFile(join(dir, 'present.key'), new Uint8Array(32));
+    keyFile.path = missing;
+  });
+
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('passes when neither table exists', async () => {
+    await expect(checkConfigKey(fakeSequelize({}))).resolves.toBeUndefined();
+  });
+
+  it('passes when no stored value is encrypted', async () => {
+    const sequelize = fakeSequelize({
+      local_system_secrets: [{ key: 'syncPassword', value: 'plaintext' }],
+      local_system_facts: [{ key: 'currentSyncTick', value: '42' }],
+    });
+    await expect(checkConfigKey(sequelize)).resolves.toBeUndefined();
+  });
+
+  it('passes when the key file exists', async () => {
+    keyFile.path = join(dir, 'present.key');
+    const sequelize = fakeSequelize({
+      local_system_secrets: [{ key: 'deviceKey', value: ENCRYPTED }],
+    });
+    await expect(checkConfigKey(sequelize)).resolves.toBeUndefined();
+    keyFile.path = missing;
+  });
+
+  it('names the path and the config key when the key file is missing', async () => {
+    const sequelize = fakeSequelize({
+      local_system_secrets: [{ key: 'deviceKey', value: ENCRYPTED }],
+    });
+
+    const error = await checkConfigKey(sequelize).catch((err: Error) => err);
+    expect(error).toBeInstanceOf(Error);
+    const { message } = error as Error;
+    expect(message).toContain(missing);
+    expect(message).toContain('crypto.keyFile');
+    expect(message).toContain('mounted');
+    expect(message).not.toContain('deviceKey');
+  });
+
+  it('fires for encrypted rows still held in local_system_facts', async () => {
+    const sequelize = fakeSequelize({
+      local_system_facts: [{ key: 'deviceKey', value: ENCRYPTED }],
+    });
+    await expect(checkConfigKey(sequelize)).rejects.toThrow(missing);
+  });
+});

--- a/packages/upgrade/src/checkConfigKey.ts
+++ b/packages/upgrade/src/checkConfigKey.ts
@@ -1,0 +1,39 @@
+import { QueryTypes } from 'sequelize';
+import type { Sequelize } from '@tamanu/database';
+import { getConfigKeyFilePath, isEncryptedSecret, readKeyFile } from '@tamanu/shared/utils/crypto';
+
+const SECRET_TABLES = ['local_system_secrets', 'local_system_facts'];
+
+async function hasEncryptedSecrets(sequelize: Sequelize): Promise<boolean> {
+  for (const table of SECRET_TABLES) {
+    const [exists] = await sequelize.query<{ name: string | null }>(
+      `SELECT to_regclass($table) AS name`,
+      { type: QueryTypes.SELECT, bind: { table: `public.${table}` } },
+    );
+    if (!exists?.name) continue;
+
+    const rows = await sequelize.query<{ value: string | null }>(
+      `SELECT value FROM public.${table} WHERE deleted_at IS NULL`,
+      { type: QueryTypes.SELECT },
+    );
+    if (rows.some(({ value }) => isEncryptedSecret(value))) return true;
+  }
+  return false;
+}
+
+export async function checkConfigKey(sequelize: Sequelize): Promise<void> {
+  if (!(await hasEncryptedSecrets(sequelize))) return;
+
+  const keyFilePath = getConfigKeyFilePath();
+  try {
+    await readKeyFile(keyFilePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    throw new Error(
+      [
+        `The config key file at ${keyFilePath} (config crypto.keyFile) is not present, and this database holds values encrypted with it.`,
+        'Where the server runs in a container, that path is a mounted secret: check it is mounted into the process running the upgrade.',
+      ].join('\n'),
+    );
+  }
+}

--- a/packages/upgrade/src/index.ts
+++ b/packages/upgrade/src/index.ts
@@ -8,6 +8,7 @@ import {
   runInRollbackTransaction,
 } from '@tamanu/database/services/migrations';
 import type { Transaction } from 'sequelize';
+import { checkConfigKey } from './checkConfigKey.js';
 import { normaliseMigrationStorageExtensions } from './normaliseMigrationStorage.js';
 import { listSteps, MIGRATIONS_END } from './listSteps.js';
 import { END, MIGRATION_PREFIX, migrationFile, onlyMigrations, START } from './step.js';
@@ -76,6 +77,8 @@ async function runUpgrade({
 
   const upgradeRunId = crypto.randomUUID();
   log.info('Upgrade run id', { upgradeRunId });
+
+  await checkConfigKey(sequelize);
 
   // Databases migrated before the build-less switch hold `.js` migration-storage records; rewrite
   // them to `.ts` before any migration state is read (createMigrationInterface asserts this done).


### PR DESCRIPTION
### Changes


This feels optional part of https://github.com/beyondessential/ops/pull/264 to me, mabye dont need this

An upgrade that can't read the file named by `crypto.keyFile` fails with a raw `ENOENT` from `readKeyFile`, deep inside whichever step read a stored secret first (usually `initDeviceKey`). The trace names the path and nothing else, so it reads as data corruption when the process running the upgrade simply couldn't see the key file. On container hosts that path is a mounted secret: the running services read it fine, an upgrade without the mount can't.

This adds a preflight in `runUpgrade`, ahead of `normaliseMigrationStorageExtensions` and any migration or step, that fails with the path, the config key it came from, and a note that the path may be a secret not mounted into the upgrade process.

For review:

- It sits in the upgrade rather than wrapping `readKeyFile` or `LocalSystemSecret.get`, so the whole upgrade fails once and up front, before any migration commits, instead of once per caller.
- It fires only when the database actually holds encrypted values (`S1:` prefixed). Requiring it unconditionally would newly fail upgrades where no step touches a secret, since those steps are gated on their migration not having run yet.
- `local_system_facts` is scanned as well as `local_system_secrets`: a database upgrading from before the secrets move still holds those rows in facts, and the move migration runs later in the same upgrade.
- Only `ENOENT` is wrapped. A wrong-length or unreadable key file already fails with its own clear message.
- Two read-only queries, so dry runs are unaffected. It reports no key names and no values.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
