### PR TITLE
db(migration): fix long `backfillNoteTypeIds` run time

### DIFF
--- a/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
+++ b/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
@@ -6,6 +6,7 @@ const NOTES_DERIVED_SIDE_EFFECT_TRIGGERS = [
   'notify_notes_changed',
   'record_notes_changelog',
   'fhir_refresh',
+  'fhir_refresh_notes',
 ];
 
 const NOTE_TYPE_REFERENCE_DATA = [


### PR DESCRIPTION
During upgrade of a clone from 2.45.9 to 2.54.26, found that `1759894448777-backfillNoteTypeIds` was taking unacceptably long:

|   `running_for` | `pct_done` |
| --------------: | ---------: |
| 14:32:42.657989 |     18.428 |

The migration disables the `fhir_refresh` trigger (if exists) and re-enables after the migration, but 2.45.0 uses `fhir_refresh_notes` as the trigger name.

Mutating the migration directly because:

- It doesn’t matter if a database has already run this migration.
- I’d like to avoid adding a manual pre-upgrade check. Also don’t wanna assume whether a specific database has `fhir_refresh` or `fhir_refresh_notes`.
- Noting also that 2.45.0 also introduces `1760941156572-RemoveOldFhirRefreshTriggers` to remove `fhir_refresh`. (It _does_ assume that migration hooks are in place to add `fhir_refresh_notes`.) But this runs **after** `1759894448777-backfillNoteTypeIds`, which was inserted before `1760941156572-RemoveOldFhirRefreshTriggers` after-the-fact (in 2.57).
- The migration already enables/disables triggers only if it exists (using `SELECT EXISTS` query). This change should make it handle all scenarios:
  - one or the other trigger is present;
  - both triggers present[^foot].

[^foot]: This is fine because `1760941156572-RemoveOldFhirRefreshTriggers` will remove the legacy one, and post migration hook will add the new one.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
