### PR TITLE
db(migration): fix long `backfillNoteTypeIds` run time

### DIFF
--- a/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
+++ b/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
@@ -6,6 +6,7 @@ const NOTES_DERIVED_SIDE_EFFECT_TRIGGERS = [
   'notify_notes_changed',
   'record_notes_changelog',
   'fhir_refresh',
+  'fhir_refresh_notes',
 ];
 
 const NOTE_TYPE_REFERENCE_DATA = [


### PR DESCRIPTION
### Changes

Cherry-pick of #10596 onto `release/2.55`. Adds `fhir_refresh_notes` to the `NOTES_DERIVED_SIDE_EFFECT_TRIGGERS` array in the `backfillNoteTypeIds` migration, alongside the existing `fhir_refresh` entry. This prevents the FHIR notes refresh trigger from running redundant work during the migration, fixing its long run time.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->