### PR TITLE
db(migration): make `addIndexToFhirJobsResourceColumn` idempotent

### DIFF
--- a/packages/database/src/migrations/1771472857000-addIndexToFhirJobsResourceColumn.ts
+++ b/packages/database/src/migrations/1771472857000-addIndexToFhirJobsResourceColumn.ts
@@ -3,7 +3,7 @@ import { QueryInterface } from 'sequelize';
 /**
  * Migration to add an index on the 'resource' field within the JSONB payload column
  * of the fhir.jobs table.
- * 
+ *
  * Context:
  * - The fhir.jobs table has a JSONB 'payload' column that contains a 'resource' field
  * - The resource field identifies the FHIR resource type (Patient, Encounter, etc.)
@@ -14,7 +14,7 @@ import { QueryInterface } from 'sequelize';
 
 export async function up(query: QueryInterface): Promise<void> {
   await query.sequelize.query(`
-    CREATE INDEX job_payload_resource_idx ON fhir.jobs
+    CREATE INDEX IF NOT EXISTS job_payload_resource_idx ON fhir.jobs
     USING btree ((payload->>'resource'))
   `);
 }


### PR DESCRIPTION
### Changes

Cherry-pick of #10597 onto this release branch. Uses `CREATE INDEX IF NOT EXISTS` in the `addIndexToFhirJobsResourceColumn` migration so it is idempotent and does not fail on deployments where `fhir.job_payload_resource_idx` already exists.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->