### PR TITLE
chore(cd): Ensure last part of pulumi output is shown

### DIFF
--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -130,16 +130,25 @@ jobs:
             if (!context.issue.number) return;
 
             const fullOutput = process.env.PULUMI_OUTPUT ?? '';
-            const HEAD_TAIL_LENGTH = 500;
             const marker = '<!-- pulumi-up-report:${{ inputs.deploy-name }} -->';
 
+            const liveLinkMatch = fullOutput.match(/^View Live:\s*(\S+)/m);
+            // "Outputs:" header, then indented "key: value" lines until a blank
+            // line or a line back at column 0 (see pulumi/pulumi printOutputs()).
+            const outputsMatch = fullOutput.match(/^Outputs:\n((?:[ \t]+\S.*\n?)+)/m);
+
             let body;
-            if (fullOutput.length <= HEAD_TAIL_LENGTH * 2) {
-              body = fullOutput;
+            if (liveLinkMatch || outputsMatch) {
+              const parts = [];
+              if (liveLinkMatch) parts.push(`**View Live:** ${liveLinkMatch[1]}`);
+              if (outputsMatch) parts.push(`**Outputs:**\n${outputsMatch[1].trimEnd()}`);
+              body = parts.join('\n\n');
             } else {
-              const head = fullOutput.slice(0, HEAD_TAIL_LENGTH);
-              const tail = fullOutput.slice(-HEAD_TAIL_LENGTH);
-              body = `${head}\n\n...\n\n${tail}`;
+              // Fallback if the expected markers aren't found: head + tail of the raw output.
+              const HEAD_TAIL_LENGTH = 500;
+              body = fullOutput.length <= HEAD_TAIL_LENGTH * 2
+                ? fullOutput
+                : `${fullOutput.slice(0, HEAD_TAIL_LENGTH)}\n\n...\n\n${fullOutput.slice(-HEAD_TAIL_LENGTH)}`;
             }
             body = `${marker}\n${body}`;
 

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -121,10 +121,15 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Comment Pulumi report on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
+        env:
+          PULUMI_OUTPUT: ${{ steps.up.outputs.output }}
         with:
           script: |
-            const fullOutput = `${{ steps.up.outputs.output }}`;
+            if (!context.issue.number) return;
+
+            const fullOutput = process.env.PULUMI_OUTPUT ?? '';
             const HEAD_TAIL_LENGTH = 500;
             const marker = '<!-- pulumi-up-report:${{ inputs.deploy-name }} -->';
 

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -107,14 +107,56 @@ jobs:
           echo "stackname=bes/$project/${{ inputs.deploy-name }}" >> $GITHUB_OUTPUT
 
       - name: Up!
+        id: up
         uses: pulumi/actions@v5
         with:
           work-dir: ops/pulumi/stacks/${{ fromJson(inputs.options).opsstack }}
           command: up
           stack-name: ${{ steps.stack.outputs.stackname }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-pr: true
+          comment-on-pr: false
           upsert: true
           config-map: ${{ steps.config.outputs.pulumi }}
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+      - name: Comment Pulumi report on PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fullOutput = `${{ steps.up.outputs.output }}`;
+            const HEAD_TAIL_LENGTH = 500;
+            const marker = '<!-- pulumi-up-report:${{ inputs.deploy-name }} -->';
+
+            let body;
+            if (fullOutput.length <= HEAD_TAIL_LENGTH * 2) {
+              body = fullOutput;
+            } else {
+              const head = fullOutput.slice(0, HEAD_TAIL_LENGTH);
+              const tail = fullOutput.slice(-HEAD_TAIL_LENGTH);
+              body = `${head}\n\n...\n\n${tail}`;
+            }
+            body = `${marker}\n${body}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
### Changes

Sometimes the pulumi output is too long and gets trimmed. Ideally we want the start which has the URL of the full output plus the last part of the output that has the server URLs

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._