### PR TITLE
fix: no-issue: fix flaky e2e [AT-0103] Edit allergy

### DIFF
--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -1,5 +1,6 @@
 import { routes } from '@config/routes';
 import { Locator, Page, expect } from '@playwright/test';
+import { searchAndSelectAutocompleteOption } from '@utils/fieldHelpers';
 import { constructFacilityUrl } from '@utils/navigation';
 import { fillMuiDateField } from '@utils/testHelper';
 import { format } from 'date-fns';
@@ -93,7 +94,7 @@ export class PatientDetailsPage extends BasePatientPage {
   readonly otherPatientIssueNote: Locator;
   readonly submitNewOtherPatientIssuesAddButton: Locator;
   readonly initiateNewCarePlanAddButton: Locator;
-  readonly dropdownMenuItem: Locator;
+  readonly allergySuggestionsList: Locator;
   readonly firstListItem: Locator;
   readonly patientNHN: Locator;
   readonly firstCarePlanListItem: Locator;
@@ -139,7 +140,7 @@ export class PatientDetailsPage extends BasePatientPage {
       .locator('div')
       .filter({ hasText: 'Ongoing conditionsAdd' })
       .getByTestId('addbutton-b0ln');
-    this.ongoingConditionNameField = this.page.getByTestId('field-j30y-input').locator('input');
+    this.ongoingConditionNameField = this.page.getByTestId('field-j30y-input');
     this.ongoingConditionDateRecordedField = this.page.getByTestId('field-2775').locator('input');
     this.ongoingConditionClinicianField = this.page.getByTestId('field-9miu-input');
     this.ongoingConditionNotes = this.page.getByTestId('field-e52k-input');
@@ -169,7 +170,8 @@ export class PatientDetailsPage extends BasePatientPage {
       .locator('div')
       .filter({ hasText: 'AllergiesAdd' })
       .getByTestId('addbutton-b0ln');
-    this.allergyNameField = this.page.getByTestId('field-hwfk-input').locator('input');
+    this.allergyNameField = this.page.getByTestId('field-hwfk-input');
+    this.allergySuggestionsList = this.page.getByTestId('field-hwfk-suggestionslist');
     this.savedAllergyName = this.page
       .getByTestId('collapse-0a33')
       .getByTestId('field-hwfk-input')
@@ -187,7 +189,7 @@ export class PatientDetailsPage extends BasePatientPage {
       .locator('div')
       .filter({ hasText: 'Family historyAdd' })
       .getByTestId('addbutton-b0ln');
-    this.familyHistoryDiagnosisField = this.page.getByTestId('field-3b4u-input').locator('input');
+    this.familyHistoryDiagnosisField = this.page.getByTestId('field-3b4u-input');
     this.familyHistoryDateRecordedField = this.page.getByTestId('field-wrp3').locator('input');
     this.familyHistoryRelationshipField = this.page.getByTestId('field-t0k5-input');
     this.familyHistoryClinicianField = this.page.getByTestId('field-kbwi-input');
@@ -233,7 +235,6 @@ export class PatientDetailsPage extends BasePatientPage {
       .locator('div')
       .filter({ hasText: 'Care plansAdd' })
       .getByTestId('addbutton-b0ln');
-    this.dropdownMenuItem = this.page.getByTestId('typography-qxy3');
     this.firstListItem = this.page.getByTestId('listitem-adip-0');
     this.patientNHN = this.page.getByTestId('healthidtext-fqvn');
     this.firstCarePlanListItem = this.page.getByTestId('listitem-fx300');
@@ -452,8 +453,11 @@ export class PatientDetailsPage extends BasePatientPage {
 
   async addNewOngoingConditionWithJustRequiredFields(conditionName: string) {
     await this.initiateNewOngoingConditionAddButton.click();
-    await this.ongoingConditionNameField.fill(conditionName);
-    await this.page.getByRole('menuitem', { name: conditionName, exact: true }).click();
+    await searchAndSelectAutocompleteOption(
+      this.page,
+      this.ongoingConditionNameField,
+      conditionName,
+    );
     await this.clickAddButtonToConfirm(this.submitNewOngoingConditionAddButton);
   }
 
@@ -464,8 +468,11 @@ export class PatientDetailsPage extends BasePatientPage {
     notes: string,
   ) {
     await this.initiateNewOngoingConditionAddButton.click();
-    await this.ongoingConditionNameField.fill(conditionName);
-    await this.page.getByRole('menuitem', { name: conditionName, exact: true }).click();
+    await searchAndSelectAutocompleteOption(
+      this.page,
+      this.ongoingConditionNameField,
+      conditionName,
+    );
     await fillMuiDateField(this.ongoingConditionDateRecordedField, dateRecorded);
     await this.ongoingConditionClinicianField.click();
     await this.page.getByRole('menuitem', { name: clinicianName, exact: true }).click();
@@ -475,30 +482,28 @@ export class PatientDetailsPage extends BasePatientPage {
 
   async addNewAllergyWithJustRequiredFields(allergyName: string) {
     await this.initiateNewAllergyAddButton.click();
-    await this.allergyNameField.fill(allergyName);
-    await this.page.getByRole('menuitem', { name: allergyName, exact: true }).click();
-    // The suggester re-renders as its fetch resolves, so the click can select nothing.
-    await this.dropdownMenuItem.waitFor({ state: 'hidden' });
-    await expect(this.allergyNameField).toHaveValue(allergyName);
+    await searchAndSelectAutocompleteOption(this.page, this.allergyNameField, allergyName);
     await this.clickAddButtonToConfirm(this.submitNewAllergyAddButton);
   }
 
   async searchNewAllergyNotInDropdown(allergyName: string) {
     await this.initiateNewAllergyAddButton.click();
-    await this.allergyNameField.fill(allergyName);
+    await this.allergyNameField.locator('input').fill(allergyName);
   }
 
   async addNewAllergyNotInDropdown(allergyName: string) {
     await this.page.getByRole('menuitem', { name: allergyName }).click();
-    await this.dropdownMenuItem.waitFor({ state: 'hidden' });
-    await expect(this.allergyNameField).toHaveValue(allergyName);
+    await expect(this.allergySuggestionsList).not.toBeVisible();
     await this.clickAddButtonToConfirm(this.submitNewAllergyAddButton);
   }
 
   async addNewFamilyHistoryWithJustRequiredFields(familyHistoryCondition: string) {
     await this.initiateNewFamilyHistoryAddButton.click();
-    await this.familyHistoryDiagnosisField.fill(familyHistoryCondition);
-    await this.page.getByRole('menuitem', { name: familyHistoryCondition, exact: true }).click();
+    await searchAndSelectAutocompleteOption(
+      this.page,
+      this.familyHistoryDiagnosisField,
+      familyHistoryCondition,
+    );
     await this.clickAddButtonToConfirm(this.submitNewFamilyHistoryAddButton);
   }
 
@@ -510,8 +515,11 @@ export class PatientDetailsPage extends BasePatientPage {
     notes: string,
   ) {
     await this.initiateNewFamilyHistoryAddButton.click();
-    await this.familyHistoryDiagnosisField.fill(familyHistoryCondition);
-    await this.page.getByRole('menuitem', { name: familyHistoryCondition, exact: true }).click();
+    await searchAndSelectAutocompleteOption(
+      this.page,
+      this.familyHistoryDiagnosisField,
+      familyHistoryCondition,
+    );
     await fillMuiDateField(this.familyHistoryDateRecordedField, dateRecorded);
     await this.familyHistoryRelationshipField.fill(relationship);
     await this.familyHistoryClinicianField.click();

--- a/packages/e2e-tests/utils/fieldHelpers.ts
+++ b/packages/e2e-tests/utils/fieldHelpers.ts
@@ -161,6 +161,31 @@ export const selectAutocompleteFieldOption = async (
   }
 };
 
+/**
+ * Searches an AutocompleteField and selects the matching suggestion.
+ * @param page - The page object.
+ * @param field - The field locator.
+ * @param searchText - The text to type into the field.
+ * @param optionToSelect - The option to select, when it differs from searchText.
+ */
+export const searchAndSelectAutocompleteOption = async (
+  page: Page,
+  field: Locator,
+  searchText: string,
+  { optionToSelect = searchText }: { optionToSelect?: string } = {},
+) => {
+  const input = field.locator('input');
+  const testId = await getBaseTestId(field, '-input');
+  const suggestionsContainer = page.getByTestId(`${testId}-suggestionslist`);
+
+  // The input reads back the typed text either way, so only the list closing proves the
+  // form took the selection. Search again when a click lands on a list being replaced.
+  await expect(async () => {
+    await input.fill(searchText);
+    await selectOptionFromPopper(testId, suggestionsContainer, { optionToSelect });
+  }).toPass({ timeout: 20000, intervals: [500, 1000, 2000] });
+};
+
 export const editFieldOption = async (
   page: Page,
   field: Locator,


### PR DESCRIPTION
### Changes

`[AT-0103] Edit allergy` lost all three retries in the merge queue and booted #10595 out of it. `[AT-0101]` hits the same thing on nearly every queue run and gets absorbed by `retries: 2`. Neither shows up on the PR itself, since E2E only runs in the queue unless `#e2e` is ticked.

The suggester re-renders as its debounced fetch resolves, so the menuitem click lands on a list that has already been replaced and selects nothing. The form then submits empty, fails validation silently, and surfaces 30s later as a timeout waiting for a list item that was never created. The snapshot at failure shows the field holding "Dust mites" while marked `[invalid]` with `*Required` under it.

The guard from #10590 doesn't catch it. `toHaveValue(name)` reads the display string: `handleInputChange` writes the typed text into `selectedOption.value`, which is what the input renders, without touching the Formik value, so `fill()` alone satisfies it. And `dropdownMenuItem` was `typography-qxy3`, which matches nothing in the DOM (the suggester's own option typography is `field-hwfk-option-typography`), so `waitFor({ state: 'hidden' })` resolved instantly.

`searchAndSelectAutocompleteOption` keys off the suggestions list closing instead, which `fetchOptions` only does on `reason === 'suggestion-selected'`, and retries the search when a click misses.

The custom-value path (AT-0104) keeps its raw click: its label renders as `"Xyz" (item not in list)`, and it's split across two methods with an assertion in between. The note-edit cluster (AT-0081/82/83) is a separate unfixed bug, the closed half of #10589.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [x] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
