### PR TITLE
fix(seedSnapshot): no-issue: stop errexit aborting the seed watch step on 2.61

### DIFF
--- a/.github/workflows/seed-snapshot.yml
+++ b/.github/workflows/seed-snapshot.yml
@@ -156,13 +156,15 @@ jobs:
       # itself is already done either way, hence continue-on-error.
       - name: Wait for the seed to start
         continue-on-error: true
+        # Not the default `bash -e`: this step polls for a pod that does not exist yet, so
+        # a non-zero kubectl is expected and errexit would abort the watch before it starts.
+        shell: bash --noprofile --norc -uo pipefail {0}
         env:
           JOB_NAME: ${{ steps.names.outputs.job_name }}
           VERSION: ${{ inputs.version }}
           START_TIMEOUT_SECONDS: '600'
           SETTLE_SECONDS: '60'
         run: |
-          set -uo pipefail
           follow="kubectl logs -f -n $SEED_NAMESPACE job/$JOB_NAME"
 
           if ! kubectl get job "$JOB_NAME" -n "$SEED_NAMESPACE" >/dev/null 2>&1; then
@@ -186,9 +188,11 @@ jobs:
               fail "" "Seed job $JOB_NAME failed; no snapshot for $VERSION."
             fi
 
+            # `items[*]` rather than `items[0]`: the latter errors while the Job is still
+            # suspended and no pod exists.
             pod=$(kubectl get pods -n "$SEED_NAMESPACE" \
               -l "batch.kubernetes.io/job-name=$JOB_NAME" \
-              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+              -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | awk '{print $1}')
 
             status=
             if [[ -n "$pod" ]]; then


### PR DESCRIPTION
### Changes

2.61 backport of #10623, keeping this branch's copy of the watch step in step with main's.

The step exits 1 within two seconds and reports nothing, which `continue-on-error` then renders green. GitHub runs `run:` steps as `bash -e {0}`, so errexit is on regardless of the step's own `set -uo pipefail`, and the watch polls for a pod that legitimately does not exist yet because the Job is submitted suspended until the operator unsuspends it. `kubectl get pods -o jsonpath='{.items[0]...}'` errors on that empty list and errexit killed the step before the watch began.

So the step declares its own shell without `-e`, and uses `items[*]` through awk, which yields empty rather than erroring.

Low urgency here rather than none: dispatches target main, so main's definition is what runs, and nothing cuts a release from a release branch. This copy is only reachable by deliberately dispatching against release/2.61. It is worth keeping identical anyway, since a drifted copy of the seed tooling between branches is what caused the original breakage.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->