### PR TITLE
ci(seedSnapshot): no-issue: give the seed watch time to see a pod

### DIFF
--- a/.github/workflows/seed-snapshot.yml
+++ b/.github/workflows/seed-snapshot.yml
@@ -47,7 +47,9 @@ jobs:
   create-snapshot:
     runs-on: ubuntu-latest
     name: Seed snapshot for ${{ inputs.version }}
-    timeout-minutes: 25
+    # Must exceed the watch step's own budget: a job-level timeout is a hard failure that
+    # continue-on-error can't absorb, so it would fail the release cut over a watchdog.
+    timeout-minutes: 30
     steps:
       - name: Validate version format
         env:
@@ -162,7 +164,9 @@ jobs:
         env:
           JOB_NAME: ${{ steps.names.outputs.job_name }}
           VERSION: ${{ inputs.version }}
-          START_TIMEOUT_SECONDS: '600'
+          # The Job stays suspended until the operator has a CNPG cluster accepting
+          # connections, which measured ~10 minutes on the 2.61.0 snapshot.
+          START_TIMEOUT_SECONDS: '1200'
           SETTLE_SECONDS: '60'
         run: |
           follow="kubectl logs -f -n $SEED_NAMESPACE job/$JOB_NAME"


### PR DESCRIPTION
### Changes

The watch step's 600s start budget is too tight to see the pod at all. The 2.61.0 snapshot run measured the Job as suspended from 03:03:22 to 03:13:13, so the operator took just under ten minutes to get a CNPG cluster accepting connections before unsuspending it. That lands on the boundary, so the step would have timed out with a warning on a run that in fact seeded fine.

Raised to 1200s. The job's own `timeout-minutes` goes to 30 to stay clear of the watch step's 21 minute budget, because a job-level timeout is a hard failure that `continue-on-error` cannot absorb, and it would fail the release cut over a watchdog rather than over the seed.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->