### PR TITLE
ci(release): no-issue: create the auto-deploy control issue at cut

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     outputs:
       branch: ${{ steps.release.outputs.branch }}
       version: ${{ steps.release.outputs.version }}
@@ -60,6 +61,48 @@ jobs:
           const cwd = '${{ github.workspace }}';
           const { checkBranchDoesNotExist } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
           await checkBranchDoesNotExist(github, context, process.env.NEW_BRANCH_NAME);
+
+    # Before the branch push: CD's push run is what looks this issue up, and
+    # GITHUB_TOKEN (not the PAT) suppresses the issues-opened trigger, which
+    # would otherwise fire for a branch that doesn't exist yet. %seed-snapshot
+    # restores the previous minor's snapshot at provisioning, so the release's
+    # migrations run against real data.
+    - name: Create the auto-deploy control issue
+      uses: actions/github-script@v9
+      env:
+        NEW_BRANCH_NAME: ${{ steps.release.outputs.branch }}
+      with:
+        script: |
+          const branch = process.env.NEW_BRANCH_NAME;
+          const title = `Auto-deploy: ${branch}`;
+
+          // Paginated: old control issues stay open (2.42's still is), so the
+          // fleet outgrows the default page size.
+          const issues = await github.paginate(github.rest.issues.listForRepo, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'auto-deploy',
+          });
+          if (issues.some(issue => issue.title === title)) {
+            console.log('Control issue already exists; leaving it alone');
+            return;
+          }
+
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title,
+            labels: ['auto-deploy'],
+            body: [
+              '_This is a control issue for an Auto-Deploy. See [auto-deploy docs](https://beyond-essential.slab.com/posts/tamanu-auto-deploys-kubernetes-kkovoquc#h9fd9-non-pr-branches) for more._',
+              '',
+              `### Deploy <!-- #branch=${branch} -->`,
+              '',
+              '- [x] **Deploy to Tamanu Internal** <!-- #deploy --> %config=rc %ttlhours=0 %seed-snapshot',
+            ].join('\n'),
+          });
+          console.log('Created control issue', title);
 
     - name: Create new release branch
       env:
@@ -146,3 +189,4 @@ jobs:
       version: ${{ needs.run.outputs.version }}
       image: ${{ needs.build-seed-image.outputs.image }}
       git_sha: ${{ needs.build-seed-image.outputs.git_sha }}
+


### PR DESCRIPTION
### Changes

The internal RC deploy is driven by an open `Auto-deploy: release/x.y` control issue that someone remembers to create by hand each cut. This makes the cut workflow create it, with `%seed-snapshot` on the deploy line.

That flag is what arms ops#265: with it, provisioning restores the previous minor's seed snapshot and migrates forward, so the release's migrations run against real-shaped data during the RC deploy instead of a no-op. Today's hand-made issues (see #10559) don't carry it, so RC deploys provision an empty database.

The issue is created *before* the branch push: CD's push-event run is what looks the control issue up, so it has to exist by then. Creating it with `GITHUB_TOKEN` (not the PAT) suppresses the `issues: opened` trigger, which would otherwise fire for a branch that doesn't exist yet. If a matching issue already exists the step leaves it alone.

The generated body was checked against `parseDeployConfig` directly: it yields `name: release-2-62, enabled, config: rc, seed-snapshot: true`.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
