### PR TITLE
fix(reporting): no-issue: reapply reporting grants when the schema changes

### DIFF
--- a/packages/central-server/app/tasks/index.js
+++ b/packages/central-server/app/tasks/index.js
@@ -1,5 +1,6 @@
 import { log } from '@tamanu/shared/services/logging';
 import { SendStatusToMetaServer } from '@tamanu/shared/tasks/SendStatusToMetaServer';
+import { ReportingGrantsRefresher } from '@tamanu/shared/tasks/ReportingGrantsRefresher';
 
 import { PatientEmailCommunicationProcessor } from './PatientEmailCommunicationProcessor';
 import { PortalCommunicationProcessor } from './PortalCommunicationProcessor';
@@ -72,6 +73,7 @@ export async function startScheduledTasks(context) {
     DHIS2IntegrationProcessor,
     ProgramRegistryPltfuFlagger,
     SendStatusToMetaServer,
+    ReportingGrantsRefresher,
   ];
 
   if (context.integrationSettings.fijiVrs.enabled) {

--- a/packages/database/src/services/reporting.js
+++ b/packages/database/src/services/reporting.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import config from 'config';
+import { QueryTypes } from 'sequelize';
 
 import {
   REPORT_DB_CONNECTION_ROLES,
@@ -90,6 +91,53 @@ const withCatalogRaceRetry = async (label, fn) => {
   }
 };
 
+const grantSchemaAccess = async (sequelize, role, schema) => {
+  if (schema !== 'public') {
+    await sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${schema}";`);
+    // Lets reporting reports reference tables without the schema prefix.
+    await sequelize.query(`ALTER ROLE "${role}" SET search_path TO "${schema}";`);
+  }
+
+  await sequelize.query(`GRANT USAGE ON SCHEMA "${schema}" TO "${role}";`);
+  await sequelize.query(`GRANT SELECT ON ALL TABLES IN SCHEMA "${schema}" TO "${role}";`);
+  // Covers tables created later (e.g. materialised reporting tables), but only
+  // ones this role creates, and a DROP SCHEMA takes the entry with it.
+  await sequelize.query(
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schema}" GRANT SELECT ON TABLES TO "${role}";`,
+  );
+
+  // The raw role reads all of `public` for reporting, but report SQL has no
+  // business reading credential/token tables: local_system_secrets holds the
+  // device private key and the reporting secret (encrypted, but still not for
+  // reports), and the rest hold auth tokens or certificate signing keys. Revoke
+  // SELECT on them.
+  // to_regclass skips any not present on this server (e.g. central-only ones).
+  if (schema === 'public') {
+    const sensitiveTablesArray = REPORTING_SENSITIVE_TABLES.map(table => `'${table}'`).join(', ');
+    await sequelize.query(`
+      DO $$
+      DECLARE
+        sensitive_table text;
+      BEGIN
+        FOREACH sensitive_table IN ARRAY ARRAY[${sensitiveTablesArray}] LOOP
+          IF to_regclass('public.' || sensitive_table) IS NOT NULL THEN
+            EXECUTE format('REVOKE SELECT ON public.%I FROM %I', sensitive_table, '${role}');
+          END IF;
+        END LOOP;
+      END
+      $$;
+    `);
+  }
+};
+
+const reportingRoleExists = async (sequelize, role) => {
+  const [existing] = await sequelize.query('SELECT 1 FROM pg_roles WHERE rolname = :role;', {
+    type: QueryTypes.SELECT,
+    replacements: { role },
+  });
+  return Boolean(existing);
+};
+
 const ensureReportingRole = async (existingStore, connectionName, password) => {
   const role = REPORT_DB_CONNECTION_ROLES[connectionName];
   const schema = REPORT_DB_CONNECTION_SCHEMAS[connectionName];
@@ -125,43 +173,7 @@ const ensureReportingRole = async (existingStore, connectionName, password) => {
         throw new Error(`Failed to set password for reporting role "${role}": ${error.message}`);
       }
 
-      if (schema !== 'public') {
-        await sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${schema}";`);
-        // Lets reporting reports reference tables without the schema prefix.
-        await sequelize.query(`ALTER ROLE "${role}" SET search_path TO "${schema}";`);
-      }
-
-      await sequelize.query(`GRANT USAGE ON SCHEMA "${schema}" TO "${role}";`);
-      await sequelize.query(`GRANT SELECT ON ALL TABLES IN SCHEMA "${schema}" TO "${role}";`);
-      // Covers tables created later (e.g. materialised reporting tables).
-      await sequelize.query(
-        `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schema}" GRANT SELECT ON TABLES TO "${role}";`,
-      );
-
-      // The raw role reads all of `public` for reporting, but report SQL has no
-      // business reading credential/token tables: local_system_secrets holds the
-      // device private key and the reporting secret (encrypted, but still not for
-      // reports), and the rest hold auth tokens or certificate signing keys. Revoke
-      // SELECT on them.
-      // to_regclass skips any not present on this server (e.g. central-only ones).
-      if (schema === 'public') {
-        const sensitiveTablesArray = REPORTING_SENSITIVE_TABLES.map(table => `'${table}'`).join(
-          ', ',
-        );
-        await sequelize.query(`
-        DO $$
-        DECLARE
-          sensitive_table text;
-        BEGIN
-          FOREACH sensitive_table IN ARRAY ARRAY[${sensitiveTablesArray}] LOOP
-            IF to_regclass('public.' || sensitive_table) IS NOT NULL THEN
-              EXECUTE format('REVOKE SELECT ON public.%I FROM %I', sensitive_table, '${role}');
-            END IF;
-          END LOOP;
-        END
-        $$;
-      `);
-      }
+      await grantSchemaAccess(sequelize, role, schema);
     }),
   );
 };
@@ -183,6 +195,92 @@ const initReportStore = async (existingStore, connectionName, secret) => {
   };
 
   return openDatabase(`reporting-${connectionName}`, overrides);
+};
+
+// `GRANT SELECT ON ALL TABLES` only covers what exists when it runs, and the
+// default privileges above only cover objects this role creates. So a reporting
+// build that recreates the schema, or that creates its views as another role,
+// leaves the role able to log in and read nothing.
+const countMissingGrantsFor = async (sequelize, connectionName) => {
+  const role = REPORT_DB_CONNECTION_ROLES[connectionName];
+  const schema = REPORT_DB_CONNECTION_SCHEMAS[connectionName];
+
+  // Startup owns creating the roles; there's nothing to grant to without one.
+  if (!(await reportingRoleExists(sequelize, role))) return 0;
+
+  // Revoked on purpose, so their missing SELECT isn't a signal.
+  const excludedTables = schema === 'public' ? REPORTING_SENSITIVE_TABLES : [];
+  const excludedArray = `ARRAY[${excludedTables.map(table => `'${table}'`).join(', ')}]::text[]`;
+
+  const [counts] = await sequelize.query(
+    `
+    SELECT
+      (SELECT count(*)
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = :schema
+          AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+          AND c.relname <> ALL(${excludedArray})
+          AND has_table_privilege(current_user, c.oid, 'SELECT WITH GRANT OPTION')
+          AND NOT has_table_privilege(:role, c.oid, 'SELECT'))::int AS unreadable_objects,
+      -- Someone else's objects (a reporting build running as another role): only
+      -- their owner can grant on them, so re-running our grants won't help.
+      (SELECT count(*)
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = :schema
+          AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+          AND NOT has_table_privilege(current_user, c.oid, 'SELECT WITH GRANT OPTION')
+          AND NOT has_table_privilege(:role, c.oid, 'SELECT'))::int AS ungrantable_objects,
+      (SELECT count(*)
+         FROM pg_namespace
+        WHERE nspname = :schema
+          AND NOT has_schema_privilege(:role, oid, 'USAGE'))::int AS schema_usage_missing,
+      (SELECT CASE WHEN EXISTS (
+          SELECT 1
+            FROM pg_default_acl d
+            JOIN pg_namespace n ON n.oid = d.defaclnamespace
+            CROSS JOIN aclexplode(d.defaclacl) acl
+           WHERE n.nspname = :schema
+             AND d.defaclobjtype = 'r'
+             AND d.defaclrole = current_user::regrole
+             AND acl.grantee = (SELECT oid FROM pg_roles WHERE rolname = :role)
+             AND acl.privilege_type = 'SELECT'
+        ) THEN 0 ELSE 1 END) AS default_privileges_missing;
+  `,
+    { type: QueryTypes.SELECT, replacements: { role, schema } },
+  );
+
+  const missing =
+    counts.unreadable_objects + counts.schema_usage_missing + counts.default_privileges_missing;
+  if (missing > 0 || counts.ungrantable_objects > 0) {
+    log.warn('Reporting grants incomplete', { role, schema, ...counts });
+  }
+  return missing;
+};
+
+export const countMissingReportingGrants = async ({ sequelize }) => {
+  const counts = [];
+  for (const connectionName of REPORT_DB_CONNECTION_VALUES) {
+    counts.push(await countMissingGrantsFor(sequelize, connectionName));
+  }
+  return counts.reduce((total, count) => total + count, 0);
+};
+
+export const refreshReportingGrants = async ({ sequelize }) => {
+  // Sequential: concurrent role/schema DDL on the same db can deadlock.
+  for (const connectionName of REPORT_DB_CONNECTION_VALUES) {
+    const role = REPORT_DB_CONNECTION_ROLES[connectionName];
+    const schema = REPORT_DB_CONNECTION_SCHEMAS[connectionName];
+    if (!(await reportingRoleExists(sequelize, role))) continue;
+
+    await withCatalogRaceRetry(`refreshReportingGrants(${role})`, () =>
+      sequelize.transaction(async () => {
+        await sequelize.query(`SELECT pg_advisory_xact_lock(${REPORTING_ROLES_LOCK_KEY}::bigint);`);
+        await grantSchemaAccess(sequelize, role, schema);
+      }),
+    );
+  }
 };
 
 export const initReporting = async existingStore => {

--- a/packages/facility-server/__tests__/apiv1/ReportSchemaRoles.test.js
+++ b/packages/facility-server/__tests__/apiv1/ReportSchemaRoles.test.js
@@ -1,6 +1,12 @@
 import { QueryTypes } from 'sequelize';
 import { fake } from '@tamanu/fake-data/fake';
 import { REPORT_DB_CONNECTIONS, REPORT_DB_CONNECTION_ROLES } from '@tamanu/constants';
+import {
+  countMissingReportingGrants,
+  refreshReportingGrants,
+} from '@tamanu/database/services/reporting';
+import { ReportingGrantsRefresher } from '@tamanu/shared/tasks';
+import { facilityDefaults } from '@tamanu/settings';
 import { createTestContext } from '../utilities';
 
 // Each reporting connection logs in as its own unprivileged, read-only role,
@@ -219,5 +225,61 @@ describe('ReportSchemaRoles', () => {
       { type: QueryTypes.SELECT },
     );
     expect(count).toBe(0);
+  });
+
+  describe('grant refresh', () => {
+    const reportingRole = REPORT_DB_CONNECTION_ROLES.reporting;
+
+    afterEach(async () => {
+      await refreshReportingGrants(ctx.store);
+    });
+
+    it('has nothing to do while the grants are intact', async () => {
+      const task = new ReportingGrantsRefresher({
+        store: ctx.store,
+        schedules: facilityDefaults.schedules,
+      });
+      expect(task.schedule).toBeTruthy();
+      expect(await task.countQueue()).toBe(0);
+    });
+
+    it('restores select on an object the role has lost', async () => {
+      await ctx.sequelize.query(
+        `REVOKE SELECT ON reporting.reporting_test_table FROM ${reportingRole};`,
+      );
+      expect(await countMissingReportingGrants(ctx.store)).toBeGreaterThan(0);
+
+      await refreshReportingGrants(ctx.store);
+
+      expect(await countMissingReportingGrants(ctx.store)).toBe(0);
+      const rows = await reporting.query(
+        'SELECT * FROM reporting.reporting_test_table WHERE id = 1;',
+        { type: QueryTypes.SELECT },
+      );
+      expect(rows).toEqual([{ id: 1, name: 'A' }]);
+    });
+
+    // The state a dropped and recreated schema leaves behind: both the usage grant
+    // and the default privileges go with it, so objects built afterwards are unreadable.
+    it('restores schema usage and default privileges, covering later objects', async () => {
+      await ctx.sequelize.query(`
+        REVOKE USAGE ON SCHEMA reporting FROM ${reportingRole};
+        ALTER DEFAULT PRIVILEGES IN SCHEMA reporting REVOKE SELECT ON TABLES FROM ${reportingRole};
+      `);
+      expect(await countMissingReportingGrants(ctx.store)).toBeGreaterThan(0);
+
+      await refreshReportingGrants(ctx.store);
+      await ctx.sequelize.query(`
+        CREATE TABLE reporting.rebuilt_test_table ("id" integer PRIMARY KEY);
+        INSERT INTO reporting.rebuilt_test_table ("id") VALUES (1);
+      `);
+
+      const rows = await reporting.query('SELECT * FROM reporting.rebuilt_test_table;', {
+        type: QueryTypes.SELECT,
+      });
+      expect(rows).toEqual([{ id: 1 }]);
+
+      await ctx.sequelize.query('DROP TABLE reporting.rebuilt_test_table;');
+    });
   });
 });

--- a/packages/facility-server/app/tasks/index.js
+++ b/packages/facility-server/app/tasks/index.js
@@ -1,6 +1,7 @@
 import {
   SendStatusToMetaServer,
   FhirMissingResources,
+  ReportingGrantsRefresher,
   startFhirWorkerTasks,
 } from '@tamanu/shared/tasks';
 import { facilityDefaults } from '@tamanu/settings';
@@ -23,6 +24,7 @@ const DEFAULT_TASK_CLASSES = [
   mSupplyMedIntegrationProcessor,
   MSupplyStockOnHandProcessor,
   BedFeeCharger,
+  ReportingGrantsRefresher,
 ];
 
 // Resolved once at startup (idempotent); schedule changes apply on server restart.

--- a/packages/settings/src/schema/central.ts
+++ b/packages/settings/src/schema/central.ts
@@ -945,6 +945,7 @@ export const centralSettings = {
             },
           },
         ),
+        reportingGrantsRefresher: scheduledTaskSchema({ schedule: '* * * * *' }),
         sendStatusToMetaServer: scheduledTaskSchema({ schedule: '* * * * *', jitterTime: '30s' }),
         medicationDiscontinuer: scheduledTaskSchema({ schedule: '0 * * * *' }),
         autoDeleteMedicationRequests: scheduledTaskSchema(

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -214,6 +214,7 @@ export const facilitySettings = {
           batchingProperties(100, 50),
         ),
         fhirMissingResources: scheduledTaskSchema({ schedule: '48 1 * * *', enabled: false }),
+        reportingGrantsRefresher: scheduledTaskSchema({ schedule: '* * * * *' }),
         sendStatusToMetaServer: scheduledTaskSchema({ schedule: '* * * * *', jitterTime: '30s' }),
         timeSync: scheduledTaskSchema({ schedule: '0 * * * *', enabled: false }),
         mSupplyMedIntegrationProcessor: scheduledTaskSchema(

--- a/packages/shared/src/tasks/ReportingGrantsRefresher.js
+++ b/packages/shared/src/tasks/ReportingGrantsRefresher.js
@@ -1,0 +1,28 @@
+import {
+  countMissingReportingGrants,
+  refreshReportingGrants,
+} from '@tamanu/database/services/reporting';
+
+import { log } from '../services/logging';
+import { ScheduledTask } from './ScheduledTask';
+
+export class ReportingGrantsRefresher extends ScheduledTask {
+  getName() {
+    return 'ReportingGrantsRefresher';
+  }
+
+  constructor(context) {
+    // schedules is settings-resolved before task startup on both server types
+    const { schedule, jitterTime, enabled } = context.schedules?.reportingGrantsRefresher ?? {};
+    super(schedule, log, jitterTime, enabled);
+    this.store = context.store;
+  }
+
+  async countQueue() {
+    return countMissingReportingGrants(this.store);
+  }
+
+  async run() {
+    await refreshReportingGrants(this.store);
+  }
+}

--- a/packages/shared/src/tasks/index.js
+++ b/packages/shared/src/tasks/index.js
@@ -1,6 +1,7 @@
 export { ScheduledTask } from './ScheduledTask';
 export { FhirQueueManager } from './fhir/FhirQueueManager';
 export { SendStatusToMetaServer } from './SendStatusToMetaServer';
+export { ReportingGrantsRefresher } from './ReportingGrantsRefresher';
 export { startFhirWorkerTasks, runStartFhirWorker } from './fhir';
 export { createFhirCommand } from './fhir/fhirCommand';
 export { prepareQuery } from './fhir/prepareQuery';


### PR DESCRIPTION
### Changes


**This would be a temporary fix before full reporting schema automation - the workaround is to `bestool tamanu restart` after installing schema**

Tamanu grants the `tamanu_reporting`/`tamanu_raw` roles their read access once, at boot, and both grants are point-in-time. `GRANT SELECT ON ALL TABLES` only covers what exists at that moment, and the `ALTER DEFAULT PRIVILEGES` backstop only covers objects the app role itself creates, and is dropped along with the schema. So when the `reporting` schema is rebuilt by hand while the server is up (the ansible upgrade drops it, the views get pasted back afterwards via `bestool tamanu psql -W`), the role keeps LOGIN and can read nothing until someone re-grants or the server restarts. It fails silently: BI connects as those roles directly, so nothing in the request path notices.

Adds `ReportingGrantsRefresher` on central and facility, every minute. `countQueue` is a catalog read, so DDL only runs when something is actually missing: objects the role can't SELECT, schema USAGE, or the default-privileges entry. Measured at ~3ms warm for both connections on a live facility (1641 `pg_class` rows), which is why a minute is affordable. The grant block moved out of `ensureReportingRole` into `grantSchemaAccess`, so boot and the refresh apply identical DDL under the same advisory lock and catalog-race retry.

Two things that look wrong but aren't. The unreadable count is gated on `SELECT WITH GRANT OPTION` for the app role: ungated, an object we can't grant on (an extension's view in `public`) counts as missing forever and the task re-runs DDL every tick for something it cannot fix, so those are counted separately as `ungrantable_objects` and logged instead. And the `public` count excludes `REPORTING_SENSITIVE_TABLES`, which are revoked on purpose, otherwise the count sits permanently at 5.

A DDL event trigger would be the natural fit and isn't available: it needs superuser, and the app role has CREATEROLE only.

Stopgap until reporting-schema management moves into Tamanu.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
