### PR TITLE
db(migration): no-issue: fix fhir.job_worker_is_alive always returning false

### DIFF
--- a/packages/database/src/migrations/1785454879980-fixFhirJobWorkerIsAliveDefaultSetting.ts
+++ b/packages/database/src/migrations/1785454879980-fixFhirJobWorkerIsAliveDefaultSetting.ts
@@ -1,0 +1,63 @@
+import { QueryInterface } from 'sequelize';
+
+// `setting_get` only returns a value when one has been explicitly stored in the `settings`
+// table; `fhir.worker.assumeDroppedAfter` is never stored unless someone overrides it away
+// from its schema default (see packages/settings/src/schema/global.ts), so setting_get()
+// normally returns NULL here. Casting NULL to an interval makes the `updated_at > ...`
+// comparison NULL too, and `coalesce(NULL, false)` resolves to false — so job_worker_is_alive
+// always reported workers as dead, and job_worker_garbage_collect always reaped them, even
+// moments after registration. Falling back to the schema default of '10 minutes' when no
+// override is stored fixes both.
+const FALLBACK_ASSUME_DROPPED_AFTER = `'"10 minutes"'::jsonb`;
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION fhir.job_worker_is_alive(worker_id uuid, OUT alive boolean) RETURNS boolean
+      LANGUAGE sql STABLE PARALLEL SAFE
+      AS $$
+        SELECT coalesce((
+          SELECT updated_at > current_timestamp - (coalesce(setting_get('fhir.worker.assumeDroppedAfter'), ${FALLBACK_ASSUME_DROPPED_AFTER}) ->> 0)::interval
+          FROM fhir.job_workers
+          WHERE id = worker_id
+        ), false)
+      $$
+  `);
+
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION fhir.job_worker_garbage_collect()
+      RETURNS void
+      LANGUAGE SQL
+      VOLATILE PARALLEL UNSAFE
+    AS $$
+      UPDATE fhir.job_workers
+      SET deleted_at = current_timestamp
+      WHERE updated_at < current_timestamp - (coalesce(setting_get('fhir.worker.assumeDroppedAfter'), ${FALLBACK_ASSUME_DROPPED_AFTER}) ->> 0)::interval
+    $$
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION fhir.job_worker_is_alive(worker_id uuid, OUT alive boolean) RETURNS boolean
+      LANGUAGE sql STABLE PARALLEL SAFE
+      AS $$
+        SELECT coalesce((
+          SELECT updated_at > current_timestamp - (setting_get('fhir.worker.assumeDroppedAfter') ->> 0)::interval
+          FROM fhir.job_workers
+          WHERE id = worker_id
+        ), false)
+      $$
+  `);
+
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION fhir.job_worker_garbage_collect()
+      RETURNS void
+      LANGUAGE SQL
+      VOLATILE PARALLEL UNSAFE
+    AS $$
+      UPDATE fhir.job_workers
+      SET deleted_at = current_timestamp
+      WHERE updated_at < current_timestamp - (setting_get('fhir.worker.assumeDroppedAfter') ->> 0)::interval
+    $$
+  `);
+}


### PR DESCRIPTION
### Changes

Fixes fhir.job_worker_is_alive (and job_worker_garbage_collect) always returning false. Both call setting_get('''fhir.worker.assumeDroppedAfter'''), which only reads from the settings table - it has no knowledge of the JS-side schema default (10 minutes), since Setting.set() deliberately skips writing values that match their default. So on any database where that setting was never explicitly overridden (e.g. most fresh/local databases), setting_get() returns NULL, the interval cast becomes NULL, and coalesce(NULL, false) resolves to false - meaning every worker is treated as dead the moment it registers, and job_grab/job_start/job_complete/job_fail permanently fail with worker is not alive. Verified locally: before the fix a worker registered milliseconds earlier reported is_alive=false; after the fix (and after testing the down migration reverts cleanly) it correctly reports true.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->