### PR TITLE
ci(cd): no-issue: link deploy urls in the pulumi PR comment

### DIFF
--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -125,6 +125,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           PULUMI_OUTPUT: ${{ steps.up.outputs.output }}
+          STACK_URLS: ${{ steps.up.outputs.urls }}
         with:
           script: |
             if (!context.issue.number) return;
@@ -137,20 +138,36 @@ jobs:
             // line or a line back at column 0 (see pulumi/pulumi printOutputs()).
             const outputsMatch = fullOutput.match(/^Outputs:\n((?:[ \t]+\S.*\n?)+)/m);
 
-            let body;
-            if (liveLinkMatch || outputsMatch) {
-              const parts = [];
-              if (liveLinkMatch) parts.push(`**View Live:** ${liveLinkMatch[1]}`);
-              if (outputsMatch) parts.push(`**Outputs:**\n${outputsMatch[1].trimEnd()}`);
-              body = parts.join('\n\n');
-            } else {
+            // pulumi/actions exposes each stack output as a step output, so the
+            // deploy URLs can be linked directly; the Outputs block covers stacks
+            // that don't export `urls`.
+            const deployLinks = (() => {
+              try {
+                return Object.values(JSON.parse(process.env.STACK_URLS || '{}'))
+                  .filter(url => typeof url === 'string')
+                  .map(url => `- [${new URL(url).hostname.split('.')[0]}](${url})`);
+              } catch {
+                return [];
+              }
+            })();
+
+            const parts = [];
+            if (liveLinkMatch) parts.push(`**View Live:** ${liveLinkMatch[1]}`);
+            if (deployLinks.length) {
+              parts.push(`**Deployed:**\n${deployLinks.join('\n')}`);
+            } else if (outputsMatch) {
+              parts.push(`**Outputs:**\n\`\`\`\n${outputsMatch[1].trimEnd()}\n\`\`\``);
+            }
+
+            if (!parts.length) {
               // Fallback if the expected markers aren't found: head + tail of the raw output.
               const HEAD_TAIL_LENGTH = 500;
-              body = fullOutput.length <= HEAD_TAIL_LENGTH * 2
+              parts.push(fullOutput.length <= HEAD_TAIL_LENGTH * 2
                 ? fullOutput
-                : `${fullOutput.slice(0, HEAD_TAIL_LENGTH)}\n\n...\n\n${fullOutput.slice(-HEAD_TAIL_LENGTH)}`;
+                : `${fullOutput.slice(0, HEAD_TAIL_LENGTH)}\n\n...\n\n${fullOutput.slice(-HEAD_TAIL_LENGTH)}`);
             }
-            body = `${marker}\n${body}`;
+
+            const body = `${marker}\n${parts.join('\n\n')}`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,


### PR DESCRIPTION
### Changes

#10616 got the Pulumi outputs into the PR comment, but pastes the raw `Outputs:` block into markdown, so the indent decides how it lands: 2 spaces on a create renders as a bullet list, 4 on an update as a code block.

`pulumi/actions` exposes each stack output as a step output, so `steps.up.outputs.urls` already holds the map. It now renders as:

> **Deployed:**
> - [central](https://central.my-branch.cd.tamanu.app)
> - [facility-1](https://facility-1.my-branch.cd.tamanu.app)
> - [portal](https://portal.my-branch.cd.tamanu.app)

Link text is the leading hostname label rather than the output key, which the stack generates as `Facility- 1` and `PatientPortal`. The `Outputs:` block stays as the fallback for stacks that don't export `urls`, fenced so it renders the same way every time.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->