### PR TITLE
fix(admin): no-issue: fix reference data export crashing on 31 char sheet name limit

### DIFF
--- a/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
+++ b/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
@@ -186,6 +186,36 @@ describe('Reference data exporter', () => {
     );
   });
 
+  it('Should export a tab with name "Medication Dispense Mod Reason" for "medicationDispenseModifyReason"', async () => {
+    // The exported tab name is shortened to fit Excel's 31 character sheet name limit
+    // (the full startCase'd name is 33 characters); see ReferenceDataExporter's CUSTOM_TAB_NAMES.
+    await models.ReferenceData.create({
+      type: 'medicationDispenseModifyReason',
+      id: 'medicationDispenseModifyReason-outOfStock',
+      code: 'outOfStock',
+      name: 'Out of stock',
+    });
+    await exporter(store, { 1: 'medicationDispenseModifyReason' });
+    expect(writeExcelFile).toBeCalledWith(
+      [
+        {
+          data: [
+            ['id', 'code', 'name', 'visibilityStatus', 'availableFacilities'],
+            [
+              'medicationDispenseModifyReason-outOfStock',
+              'outOfStock',
+              'Out of stock',
+              'current',
+              null,
+            ],
+          ],
+          name: 'Medication Dispense Mod Reason',
+        },
+      ],
+      '',
+    );
+  });
+
   it('It should export Patient field definition with the right options', async () => {
     await createPatientFieldDefCategory(models);
     await createPatientFieldDefinitions(models);

--- a/packages/central-server/__tests__/importers/normaliser.test.js
+++ b/packages/central-server/__tests__/importers/normaliser.test.js
@@ -62,4 +62,11 @@ describe('Sheet name normaliser', () => {
     const name = normaliseSheetName('Registry', 'ProgramRegistryClinicalStatus');
     expect(name).toEqual('programRegistryClinicalStatus');
   });
+
+  it('should normalise the shortened export tab name for medicationDispenseModifyReason', () => {
+    // The exported tab name is shortened to fit Excel's 31 character sheet name limit
+    // (see DefaultDataExporter's CUSTOM_TAB_NAMES) so this mapping must be kept in sync with it.
+    const name = normaliseSheetName('Medication Dispense Mod Reason');
+    expect(name).toEqual('medicationDispenseModifyReason');
+  });
 });

--- a/packages/central-server/app/admin/exporter/modelExporters/DefaultDataExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/DefaultDataExporter.js
@@ -1,18 +1,10 @@
 import { ModelExporter } from './ModelExporter';
 
-const CUSTOM_TAB_NAMES = {
-  patientFieldDefinitionCategory: 'Patient Field Def Category',
-};
-
 export class DefaultDataExporter extends ModelExporter {
   async getData() {
     const modelName = this.dataType.charAt(0).toUpperCase() + this.dataType.slice(1);
     const data = await this.models[modelName].findAll();
 
     return data;
-  }
-
-  customTabName() {
-    return CUSTOM_TAB_NAMES[this.dataType];
   }
 }

--- a/packages/central-server/app/admin/exporter/modelExporters/ModelExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/ModelExporter.js
@@ -1,6 +1,8 @@
 import { startCase } from 'es-toolkit/compat';
 import { Model } from 'sequelize';
 
+import { SHORTENED_TAB_NAMES } from '../../shortenedTabNames';
+
 const METADATA_COLUMNS = [
   'createdAt',
   'updatedAt',
@@ -27,7 +29,7 @@ export class ModelExporter {
   }
 
   getTabName() {
-    return this.customTabName() || startCase(this.dataType);
+    return this.customTabName() || SHORTENED_TAB_NAMES[this.dataType] || startCase(this.dataType);
   }
 
   formattedCell(header, value) {

--- a/packages/central-server/app/admin/importer/importerEndpoint.js
+++ b/packages/central-server/app/admin/importer/importerEndpoint.js
@@ -13,14 +13,21 @@ import { log } from '@tamanu/shared/services/logging/log';
 
 import { DataImportError, DryRun } from '../errors';
 import { coalesceStats } from '../stats';
+import { SHORTENED_TAB_NAMES } from '../shortenedTabNames';
+
+const toCamelCaseSingular = name =>
+  camelCase(
+    lowerCase(name)
+      .split(/\s+/)
+      .map(word => singularize(word))
+      .join(' '),
+  );
 
 const normMapping = {
   // singularize transforms 'reference data' to 'reference datum', which is not what we want
   referenceDatumRelation: 'referenceDataRelation',
   vaccineSchedule: OTHER_REFERENCE_TYPES.SCHEDULED_VACCINE,
   procedure: 'procedureType',
-  // This is needed to handle the way we are exporting that data
-  patientFieldDefCategory: OTHER_REFERENCE_TYPES.PATIENT_FIELD_DEFINITION_CATEGORY,
   invoiceInsuranceItem: OTHER_REFERENCE_TYPES.INVOICE_INSURANCE_PLAN_ITEM,
   // We need mapping for program registry imports because program registry data is imported in the
   // worksheet sheets called registry and registryCondition but the full model names
@@ -29,15 +36,18 @@ const normMapping = {
   registry: PROGRAM_REFERENCE_TYPES.PROGRAM_REGISTRY,
   registryCondition: PROGRAM_REFERENCE_TYPES.PROGRAM_REGISTRY_CONDITION,
   registryConditionCategory: PROGRAM_REFERENCE_TYPES.PROGRAM_REGISTRY_CONDITION_CATEGORY,
+  // The exporter shortens these tab names to fit Excel's 31 character sheet name limit;
+  // derived from the same table it uses, so the two sides can't drift out of sync.
+  ...Object.fromEntries(
+    Object.entries(SHORTENED_TAB_NAMES).map(([dataType, tabName]) => [
+      toCamelCaseSingular(tabName),
+      dataType,
+    ]),
+  ),
 };
 
 export function normaliseSheetName(name, modelName) {
-  const norm = camelCase(
-    lowerCase(name)
-      .split(/\s+/)
-      .map(word => singularize(word))
-      .join(' '),
-  );
+  const norm = toCamelCaseSingular(name);
 
   // Exceptions where the sheet name for the program/survey/etc is not consistent with the model name
   if (modelName === 'ProgramRegistryClinicalStatus') {

--- a/packages/central-server/app/admin/shortenedTabNames.js
+++ b/packages/central-server/app/admin/shortenedTabNames.js
@@ -1,0 +1,6 @@
+// Excel/SheetJS worksheet names cannot exceed 31 characters. A data type whose startCase'd
+// name is longer than that needs an explicit, shorter tab name here.
+export const SHORTENED_TAB_NAMES = {
+  patientFieldDefinitionCategory: 'Patient Field Def Category',
+  medicationDispenseModifyReason: 'Medication Dispense Mod Reason',
+};


### PR DESCRIPTION
### Changes

Fixes reference data export crashing with "Sheet name cannot exceed 31 chars" when exporting all data types. medicationDispenseModifyReason'''s startCase'''d tab name ("Medication Dispense Modify Reason") is 33 characters, over Excel'''s 31 character sheet name limit.\n\nFollows the existing precedent already in the codebase for patientFieldDefinitionCategory: an explicit shortened tab name on export, with a matching reverse mapping on import so a reimported file still resolves the shortened sheet name back to the correct data type - a plain truncation would break that round trip (verified: normalising a truncated name doesn'''t match the original data type key, so the sheet would silently be dropped on reimport with no error).\n\nBoth sides now read from a single shared table (shortenedTabNames.js) instead of maintaining separate copies, so they can'''t drift out of sync.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->