### PR TITLE
perf(audit): no-issue: drop unused changelog indexes

### DIFF
--- a/packages/database/src/migrations/1785467282357-dropUnusedChangelogIndexes.ts
+++ b/packages/database/src/migrations/1785467282357-dropUnusedChangelogIndexes.ts
@@ -1,0 +1,26 @@
+import { QueryInterface } from 'sequelize';
+
+// None of these records a scan on either server type. The changelog's readers filter by record
+// id, sync tick or user, and a jsonb_ops GIN index cannot serve the `->>` extraction they use.
+const UNUSED_INDEXES = [
+  { name: 'changes_record_data', using: 'gin (record_data)' },
+  { name: 'changes_record_deleted_at', using: 'btree (record_deleted_at)' },
+  { name: 'changes_device_id', using: 'btree (device_id)' },
+  { name: 'changes_table_name', using: "btree ((((table_schema || '.'::text) || table_name)))" },
+  { name: 'changes_version', using: 'btree (version)' },
+  { name: 'changes_table_oid', using: 'btree (table_oid)' },
+];
+
+export async function up(query: QueryInterface): Promise<void> {
+  for (const { name } of UNUSED_INDEXES) {
+    await query.sequelize.query(`DROP INDEX IF EXISTS logs."${name}";`);
+  }
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  for (const { name, using } of UNUSED_INDEXES) {
+    await query.sequelize.query(
+      `CREATE INDEX IF NOT EXISTS "${name}" ON logs.changes USING ${using};`,
+    );
+  }
+}


### PR DESCRIPTION
### Changes

`logs.changes` is the most write-heavy table in the system and carries six sizeable indexes that serve no reads. Sampled from `pg_stat_user_indexes` on a long-running facility and a central deployment, all six at `idx_scan = 0`:

| index | facility | central |
| --- | --- | --- |
| `changes_record_data` (GIN) | 2017 MB | 2862 MB |
| `changes_record_deleted_at` | 86 MB | 116 MB |
| `changes_device_id` | 83 MB | 107 MB |
| `changes_table_name` | 73 MB | 105 MB |
| `changes_version` | 71 MB | 101 MB |
| `changes_table_oid` | 70 MB | 100 MB |

That reclaims about 2.4 GB per facility and 3.4 GB on central, and takes six indexes off the hot insert path. The GIN one dominates both: it indexes the whole row JSON (file bytes included, on the attachment tables), GIN is the most expensive index type to maintain on insert, and it cannot serve its readers in principle, since `jsonb_ops` answers containment while every `record_data` reader uses `->>` extraction. `changes_table_name` indexes the expression `table_schema || '.' || table_name`, so plain `table_name` predicates miss it too.

Kept: `changes_record_id` (facility, 17.2M scans), `changes_table_name_record_id` (central, 1.09 billion, the changelog attach path on every pull), the primary key, the sync tick index, the BRIN indexes, and `changes_updated_by_user_id`, which looks droppable on central at 22 scans but has 50,298 on the facility.

Two things a reviewer would otherwise flag. `DROP INDEX` takes a brief ACCESS EXCLUSIVE lock and waits on conflicting locks, and `CONCURRENTLY` cannot run inside a migration's transaction, so this wants an upgrade window. And an index reading zero scans on a small deployment proves little, since the planner prefers sequential scans on a small changelog; the kept list follows the deployments that do exercise each index.

`down` recreates all six, verified against a real schema to restore byte-identical definitions.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
