### PR TITLE
perf(audit): no-issue: skip duplicate changelog entries in the insert

### DIFF
--- a/packages/database/src/utils/audit/insertChangelogRecords.ts
+++ b/packages/database/src/utils/audit/insertChangelogRecords.ts
@@ -8,18 +8,6 @@ export const insertChangelogRecords = async (models: Models, changelogRecords: C
     return;
   }
 
-  const existingRecords = await ChangeLog.findAll({
-    where: {
-      id: changelogRecords.map(({ id }) => id),
-    },
-  });
-
-  const existingIds = existingRecords.map(({ id }) => id);
-  const recordsToInsert = changelogRecords
-    .filter(({ id }) => !existingIds.includes(id))
-    .map((changelogRecord) => ({
-      ...changelogRecord,
-    }));
-
-  await ChangeLog.bulkCreate(recordsToInsert);
+  // Entries are immutable, so a re-delivered batch is skipped rather than merged.
+  await ChangeLog.bulkCreate(changelogRecords, { ignoreDuplicates: true });
 };


### PR DESCRIPTION
### Changes

`insertChangelogRecords` runs on every sync batch that carries changelog entries. It read back the entries that already existed, filtered them out in JavaScript, then inserted the rest. `INSERT ... ON CONFLICT DO NOTHING` does the same job in one statement.

The round trip is the smallest part of the saving. That existence check ran `findAll` with no `attributes`, so it selected every column including `record_data`, which meant fetching the full JSON payload of every already-present entry purely to compare ids. For attachment entries that payload is the file bytes. Measured on a real schema, 2000 entries at 20 KB each: 101 ms to select them with `record_data`, 2 ms for the ids alone. It also drops an `existingIds.includes(id)` scan inside a `filter`, which is quadratic in the batch size when a batch overlaps heavily.

The saving only shows up when a batch contains entries the server already holds. That happens because the sync cursor advances only once a session completes: if a push or pull is interrupted after some entries were inserted, the next session re-sends the same tick range and those entries arrive again. In an ordinary session nothing is present yet, the check matched no rows, and the only waste was the extra round trip.

Behaviour is unchanged. `changes_pkey` is the only unique constraint on `logs.changes`, so `DO NOTHING` can only ever fire on the entry id, exactly what the filter did. Entries are immutable, which is why this skips rather than upserts, and the existing test already pins that: a re-delivered entry with different `record_data` must leave the stored row untouched.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

