### PR TITLE
fix(medication): no-issue: fix dosing unit missing from dispense label text (hotfix 2.60)

### DIFF
--- a/packages/web/__tests__/utils/medications.test.jsx
+++ b/packages/web/__tests__/utils/medications.test.jsx
@@ -9,7 +9,6 @@ const getTranslation = (_stringId, fallback) => fallback;
 const getEnumTranslation = (enumValues, value) => enumValues?.[value] ?? value;
 
 const basePrescription = {
-  units: 'Tablet',
   dosingUnit: 'Tablet',
   doseAmount: 1,
   frequency: 'Two times daily',
@@ -34,7 +33,7 @@ describe('buildLabelText', () => {
   it('prefixes the verb configured for the dosing unit and pluralises correctly', () => {
     expect(
       buildLabelText(
-        { units: 'Patch', doseAmount: 2, frequency: 'Daily', route: 'dermal' },
+        { dosingUnit: 'Patch', doseAmount: 2, frequency: 'Daily', route: 'dermal' },
         getTranslation,
         getEnumTranslation,
       ),
@@ -44,7 +43,7 @@ describe('buildLabelText', () => {
   it('keeps invariant units of measurement unchanged when plural', () => {
     expect(
       buildLabelText(
-        { units: 'mg', doseAmount: 500, frequency: 'Daily' },
+        { dosingUnit: 'mg', doseAmount: 500, frequency: 'Daily' },
         getTranslation,
         getEnumTranslation,
       ),
@@ -54,7 +53,7 @@ describe('buildLabelText', () => {
   it("prefixes 'Inhale' for puffs (inhaler/puffer)", () => {
     expect(
       buildLabelText(
-        { units: 'Puff', doseAmount: 2, frequency: 'Two times daily' },
+        { dosingUnit: 'Puff', doseAmount: 2, frequency: 'Two times daily' },
         getTranslation,
         getEnumTranslation,
       ),
@@ -65,7 +64,7 @@ describe('buildLabelText', () => {
     // 'IU' must not become 'iU', and route 'IM' must not become 'iM'.
     expect(
       buildLabelText(
-        { units: 'IU', doseAmount: 2, frequency: 'Daily', route: 'intramuscular' },
+        { dosingUnit: 'IU', doseAmount: 2, frequency: 'Daily', route: 'intramuscular' },
         getTranslation,
         getEnumTranslation,
       ),

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -213,7 +213,7 @@ export const buildLabelText = (prescription, getTranslation, getEnumTranslation)
   if (!prescription) return '';
 
   const {
-    units,
+    dosingUnit,
     doseAmount,
     isVariableDose,
     frequency: prescriptionFrequency,
@@ -227,7 +227,7 @@ export const buildLabelText = (prescription, getTranslation, getEnumTranslation)
   const numericDose = Number(doseAmount);
   const isPlural = !isVariableDose && Number.isFinite(numericDose) && numericDose > 1;
   const unitEnum = isPlural ? DRUG_UNIT_PLURAL_LABELS : DRUG_UNIT_LABELS;
-  const unitText = units ? lowercaseFirstLetter(getEnumTranslation(unitEnum, units)) : '';
+  const unitText = dosingUnit ? lowercaseFirstLetter(getEnumTranslation(unitEnum, dosingUnit)) : '';
   const amountText = isVariableDose
     ? lowercaseFirstLetter(getTranslation('medication.table.variable', 'Variable'))
     : (doseAmount ?? '');
@@ -243,7 +243,8 @@ export const buildLabelText = (prescription, getTranslation, getEnumTranslation)
   // falls back to the raw value, so an unmapped unit would otherwise start the
   // sentence with the unit noun (e.g. 'Wafer 2 wafers...'); omitting it is safer
   // than assuming an (oral) default verb for a unit we don't recognise.
-  const verb = units && DRUG_UNIT_VERBS[units] ? getEnumTranslation(DRUG_UNIT_VERBS, units) : null;
+  const verb =
+    dosingUnit && DRUG_UNIT_VERBS[dosingUnit] ? getEnumTranslation(DRUG_UNIT_VERBS, dosingUnit) : null;
 
   return assembleMedicationLine(
     {


### PR DESCRIPTION
### Changes

Hotfix cherry-pick of #10642 from release/2.61 onto release/2.60.\n\nFixes the dosing unit (e.g. "tablet") going missing from the default Label text on the Dispense medication modal, while the Instructions column right next to it showed it correctly. buildLabelText destructured prescription.units, but the real field on the prescription object is dosingUnit - the same field getMedicationDoseDisplay reads for the Instructions column. Since units was always undefined, the unit text and its associated administration verb (e.g. "Take") silently dropped out of the generated label.\n\nCherry-picked cleanly with no conflicts; lint and the affected test suite both pass on this branch.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->