### PR TITLE
fix(programs): no-issue: fix blank edited from/to values in form response changelog

### DIFF
--- a/packages/facility-server/__tests__/apiv1/surveyResponse/changes.test.js
+++ b/packages/facility-server/__tests__/apiv1/surveyResponse/changes.test.js
@@ -251,6 +251,34 @@ describe('SurveyResponse GET /:id/changes', () => {
       expect(answerChanges[0].to).not.toBe(await compressSignatureBody(SIGNATURE_ANSWER_BODY_ALT));
     });
 
+    it('should include the survey screen component config so the frontend can render types (e.g. Autocomplete, PatientData) that depend on it', async () => {
+      const { Facility } = models;
+      const facility = await Facility.create(fake(Facility));
+      const otherFacility = await Facility.create(fake(Facility));
+      const sscConfig = JSON.stringify({ source: 'Facility' });
+      const { answer, response, facilityId } = await setupAutocompleteSurvey(
+        sscConfig,
+        facility.id,
+      );
+
+      const edit = await app.patch(`/api/surveyResponse/${encodeURIComponent(response.id)}`).send(
+        buildPatchBody({
+          facilityId,
+          answers: { [answer.dataElementId]: otherFacility.id },
+        }),
+      );
+      expect(edit).toHaveSucceeded();
+
+      const changelog = await app.get(
+        `/api/surveyResponse/${encodeURIComponent(response.id)}/changes`,
+      );
+      expect(changelog).toHaveSucceeded();
+
+      const answerChanges = changelog.body.filter(c => c.recordId === answer.id);
+      expect(answerChanges).toHaveLength(1);
+      expect(answerChanges[0].componentConfig).toBe(sscConfig);
+    });
+
     it('should return changes in reverse chronological order by edit time', async () => {
       const { Facility } = models;
       const facility = await Facility.create(fake(Facility));

--- a/packages/facility-server/app/routes/apiv1/surveyResponse/changes.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse/changes.js
@@ -8,6 +8,7 @@
  *   recordId: ChangeLog['recordId'];
  *   recordData: Pick<SurveyResponseAnswer, 'body' | 'editedTime' | 'id'>;
  *   programDataElement: Pick<ProgramDataElement, 'id' | 'name' | 'type'>;
+ *   componentConfig: import('@tamanu/database').SurveyScreenComponent['config'];
  *   updatedByUser: Pick<User, 'id' | 'displayName'>;
  *   from: SurveyResponseAnswer['body'];
  *   to: SurveyResponseAnswer['body'];
@@ -71,6 +72,7 @@ export const surveyResponseChangesGetHandler = asyncHandler(async (req, res) => 
           'name', pde.name,
           'type', pde.type
         ) AS "programDataElement",
+        ssc.config AS "componentConfig",
         jsonb_build_object(
           'id', c.updated_by_user_id::text,
           'displayName', u.display_name
@@ -79,6 +81,8 @@ export const surveyResponseChangesGetHandler = asyncHandler(async (req, res) => 
         logs.changes c
         LEFT JOIN users u ON u.id = c.updated_by_user_id
         LEFT JOIN program_data_elements pde ON pde.id = (c.record_data ->> 'data_element_id')
+        LEFT JOIN survey_screen_components ssc
+          ON ssc.data_element_id = pde.id AND ssc.survey_id = :surveyId
       WHERE
         c.migration_context IS NULL
         AND c.table_name = 'survey_response_answers'
@@ -88,7 +92,7 @@ export const surveyResponseChangesGetHandler = asyncHandler(async (req, res) => 
         c.id
     `,
     {
-      replacements: { surveyResponseId: params.id },
+      replacements: { surveyResponseId: params.id, surveyId: survey.id },
       type: QueryTypes.SELECT,
     },
   );

--- a/packages/web/app/api/queries/useSurveyResponseChangesQuery.js
+++ b/packages/web/app/api/queries/useSurveyResponseChangesQuery.js
@@ -9,6 +9,7 @@
  *   recordId: ChangeLog['recordId'];
  *   recordData: Pick<SurveyResponseAnswer, 'body' | 'editedTime' | 'id'>;
  *   programDataElement: Pick<ProgramDataElement, 'id' | 'name' | 'type'>;
+ *   componentConfig: import('@tamanu/database').SurveyScreenComponent['config'];
  *   updatedByUser: Pick<User, 'id' | 'displayName'>;
  *   from: SurveyResponseAnswer['body'];
  *   to: SurveyResponseAnswer['body'];

--- a/packages/web/app/components/SurveyResponseChangelogModal.jsx
+++ b/packages/web/app/components/SurveyResponseChangelogModal.jsx
@@ -125,6 +125,8 @@ function ChangeLogListItem({ change, ...props }) {
             <td>
               <SurveyAnswerResult
                 answer={change.from}
+                originalBody={change.from}
+                componentConfig={change.componentConfig}
                 dataElementId={change.programDataElement.id}
                 type={change.programDataElement.type}
               />
@@ -137,6 +139,8 @@ function ChangeLogListItem({ change, ...props }) {
             <td>
               <SurveyAnswerResult
                 answer={change.to}
+                originalBody={change.to}
+                componentConfig={change.componentConfig}
                 dataElementId={change.programDataElement.id}
                 type={change.programDataElement.type}
               />


### PR DESCRIPTION
### Changes

Fixes the Form response Change log showing blank ''Edited from''/''Edited to'' values for certain questions (e.g. ''Phone number'', reported against Confirmed TB Form2).\n\nSurveyResponseChangelogModal rendered each cell via SurveyAnswerResult, but never passed originalBody or componentConfig. Most data element types render fine from the answer prop alone, but PatientData questions (demographic-autofill fields bound directly to a patient attribute, like phone number) render via PatientDataDisplayField, which ignores answer entirely and only reads originalBody/config - so both cells rendered blank regardless of the real diffed values, even though the edit itself was captured and diffed correctly.\n\nAdds componentConfig to the GET /surveyResponse/:id/changes response (joined from survey_screen_components) and passes originalBody/componentConfig through to SurveyAnswerResult, matching the pattern already used successfully in SurveyResponseDetailsModal (the main ''Form response'' view). Verified directly against the database (edited a PatientData-typed answer, confirmed the diff and the new componentConfig join both come through correctly) and confirmed by you in testing. Also adds a backend test locking in the componentConfig join.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->