### PR TITLE
fix(database): no-issue: record failed migration batches

### DIFF
--- a/packages/database/__tests__/services/migrations/failedBatchAudit.test.ts
+++ b/packages/database/__tests__/services/migrations/failedBatchAudit.test.ts
@@ -29,12 +29,14 @@ describe('migration batch auditing', () => {
   });
 
   it('records what applied and where it stopped when a migration throws', async () => {
+    const executed: { file: string }[] = [];
     const migrations = {
       up: async () => {
+        // a committed on its own before b threw
+        executed.push({ file: 'a.ts' });
         throw new Error('migration blew up');
       },
-      // a committed on its own before b threw
-      executed: async () => [{ file: 'a.ts' }],
+      executed: async () => [...executed],
     };
 
     await expect(
@@ -51,6 +53,34 @@ describe('migration batch auditing', () => {
     expect(batch.migrations).toEqual(['a.ts']);
     expect(batch.stats.failedMigration).toBe('b.ts');
     expect(batch.stats.durationMsPerMigration).toEqual({ 'a.ts': 4000 });
+  });
+
+  it('credits only this batch when the caller passes a stale pending list', async () => {
+    // An upgrade runs several batches through one interface without regathering `pending`,
+    // so a and b here were applied by an earlier batch and already audited under it.
+    const executed = [{ file: 'a.ts' }, { file: 'b.ts' }];
+    const migrations = {
+      up: async () => {
+        executed.push({ file: 'c.ts' });
+        throw new Error('migration blew up');
+      },
+      executed: async () => [...executed],
+    };
+
+    await expect(
+      migrateUpTo({
+        log,
+        sequelize,
+        pending: [...pending, { file: 'd.ts' }],
+        migrations,
+        getDurationStats: () => ({ 'a.ts': 1000, 'b.ts': 2000, 'c.ts': 3000 }),
+      }),
+    ).rejects.toThrow('migration blew up');
+
+    const batch = await latestBatch();
+    expect(batch.migrations).toEqual(['c.ts']);
+    expect(batch.stats.failedMigration).toBe('d.ts');
+    expect(batch.stats.durationMsPerMigration).toEqual({ 'c.ts': 3000 });
   });
 
   it('records no failure on a batch that completes', async () => {
@@ -73,12 +103,16 @@ describe('migration batch auditing', () => {
   });
 
   it('throws the migration error even when the batch cannot be recorded', async () => {
+    let hasRun = false;
     const migrations = {
       up: async () => {
+        hasRun = true;
         throw new Error('migration blew up');
       },
+      // fine when the batch starts, gone by the time the failure is recorded
       executed: async () => {
-        throw new Error('connection gone');
+        if (hasRun) throw new Error('connection gone');
+        return [];
       },
     };
 

--- a/packages/database/__tests__/services/migrations/failedBatchAudit.test.ts
+++ b/packages/database/__tests__/services/migrations/failedBatchAudit.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { log } from '@tamanu/shared/services/logging/log';
+import { closeDatabase, createTestDatabase } from '../../utilities';
+import { migrateUpTo } from '../../../src/services/migrations/migrations';
+
+// These drive migrateUpTo with a stub umzug so a partway failure can be staged without
+// coupling the test to whichever migration happens to be the tip, and without needing a
+// migration that genuinely breaks.
+describe('migration batch auditing', () => {
+  let sequelize;
+
+  const pending = [{ file: 'a.ts' }, { file: 'b.ts' }, { file: 'c.ts' }];
+
+  const latestBatch = async () => {
+    const [rows] = await sequelize.query(
+      `SELECT migrations, stats FROM logs.migrations WHERE direction = 'up'
+       ORDER BY logged_at DESC LIMIT 1`,
+    );
+    return rows[0];
+  };
+
+  beforeEach(async () => {
+    ({ sequelize } = await createTestDatabase());
+    await sequelize.query('DELETE FROM logs.migrations');
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  it('records what applied and where it stopped when a migration throws', async () => {
+    const migrations = {
+      up: async () => {
+        throw new Error('migration blew up');
+      },
+      // a committed on its own before b threw
+      executed: async () => [{ file: 'a.ts' }],
+    };
+
+    await expect(
+      migrateUpTo({
+        log,
+        sequelize,
+        pending,
+        migrations,
+        getDurationStats: () => ({ 'a.ts': 4000 }),
+      }),
+    ).rejects.toThrow('migration blew up');
+
+    const batch = await latestBatch();
+    expect(batch.migrations).toEqual(['a.ts']);
+    expect(batch.stats.failedMigration).toBe('b.ts');
+    expect(batch.stats.durationMsPerMigration).toEqual({ 'a.ts': 4000 });
+  });
+
+  it('records no failure on a batch that completes', async () => {
+    const migrations = {
+      up: async () => pending,
+      executed: async () => pending,
+    };
+
+    await migrateUpTo({
+      log,
+      sequelize,
+      pending,
+      migrations,
+      getDurationStats: () => ({}),
+    });
+
+    const batch = await latestBatch();
+    expect(batch.migrations).toEqual(['a.ts', 'b.ts', 'c.ts']);
+    expect(batch.stats.failedMigration).toBeUndefined();
+  });
+
+  it('throws the migration error even when the batch cannot be recorded', async () => {
+    const migrations = {
+      up: async () => {
+        throw new Error('migration blew up');
+      },
+      executed: async () => {
+        throw new Error('connection gone');
+      },
+    };
+
+    await expect(
+      migrateUpTo({
+        log,
+        sequelize,
+        pending,
+        migrations,
+        getDurationStats: () => ({}),
+      }),
+    ).rejects.toThrow('migration blew up');
+  });
+});

--- a/packages/database/src/services/migrations/migrations.js
+++ b/packages/database/src/services/migrations/migrations.js
@@ -323,6 +323,11 @@ export async function migrateUpTo({
 
   const preSnapshot = await tryGatherPreMigrationDbSnapshot(log, sequelize);
 
+  // An upgrade drives several of these calls through one interface and can pass a `pending`
+  // list gathered before the earlier ones ran, so only what was already executed when this
+  // batch started distinguishes the migrations it applies from theirs.
+  const executedBefore = new Set((await migrations.executed()).map(({ file }) => file));
+
   const auditBatch = async (batch, failedMigration = undefined) => {
     const durationMsPerMigration = migrationDurationsForBatch(getDurationStats(), batch);
     await createMigrationAuditLog(sequelize, batch, 'up', {
@@ -338,7 +343,7 @@ export async function migrateUpTo({
   };
 
   const applied = await migrations.up(upOpts).catch(async (error) => {
-    await auditFailedBatch({ log, migrations, pending, auditBatch });
+    await auditFailedBatch({ log, migrations, pending, executedBefore, auditBatch });
     throw error;
   });
 
@@ -358,16 +363,17 @@ export async function migrateUpTo({
 
 /**
  * Record a batch that stopped partway, so a failed upgrade leaves the same audit trail a
- * successful one does. Migrations apply in order and each commits on its own, so the pending
- * entries now recorded as executed are the ones that survived, and the first that isn't is
- * where the batch stopped. Timings for the migrations that did apply are only in memory, so
- * this is the one chance to record them.
+ * successful one does. Migrations apply in order and each commits on its own, so whatever
+ * became executed while this batch ran is what it applied, and the first pending migration
+ * still not executed is where it stopped. Timings for the migrations that did apply are only
+ * in memory, so this is the one chance to record them.
  */
-async function auditFailedBatch({ log, migrations, pending, auditBatch }) {
+async function auditFailedBatch({ log, migrations, pending, executedBefore, auditBatch }) {
   try {
-    const executed = new Set((await migrations.executed()).map(({ file }) => file));
-    const applied = pending.filter(({ file }) => executed.has(file));
-    const failedMigration = pending.find(({ file }) => !executed.has(file))?.file;
+    const executedAfter = await migrations.executed();
+    const executedAfterFiles = new Set(executedAfter.map(({ file }) => file));
+    const applied = executedAfter.filter(({ file }) => !executedBefore.has(file));
+    const failedMigration = pending.find(({ file }) => !executedAfterFiles.has(file))?.file;
     await auditBatch(applied, failedMigration);
     log.info(`Recorded failed migration batch, stopped at ${failedMigration}`);
   } catch (error) {

--- a/packages/database/src/services/migrations/migrations.js
+++ b/packages/database/src/services/migrations/migrations.js
@@ -323,10 +323,24 @@ export async function migrateUpTo({
 
   const preSnapshot = await tryGatherPreMigrationDbSnapshot(log, sequelize);
 
-  const applied = await migrations.up(upOpts);
-  const durationStats = getDurationStats();
-  const durationMsPerMigration = migrationDurationsForBatch(durationStats, applied);
-  const totalMigrationsDurationMs = totalMigrationsDurationMsFromMap(durationMsPerMigration);
+  const auditBatch = async (batch, failedMigration = undefined) => {
+    const durationMsPerMigration = migrationDurationsForBatch(getDurationStats(), batch);
+    await createMigrationAuditLog(sequelize, batch, 'up', {
+      batchDurationMs: Date.now() - batchStart,
+      upgradeRunId,
+      stats: {
+        durationMsPerMigration,
+        totalMigrationsDurationMs: totalMigrationsDurationMsFromMap(durationMsPerMigration),
+        ...(preSnapshot ? { preSnapshot } : {}),
+        ...(failedMigration ? { failedMigration } : {}),
+      },
+    });
+  };
+
+  const applied = await migrations.up(upOpts).catch(async (error) => {
+    await auditFailedBatch({ log, migrations, pending, auditBatch });
+    throw error;
+  });
 
   log.info('Applied migrations successfully');
 
@@ -339,17 +353,27 @@ export async function migrateUpTo({
   await runPostMigration(log, sequelize);
   log.info(`Applied post-migration steps successfully.`);
 
-  const batchDurationMs = Date.now() - batchStart;
+  await auditBatch(applied);
+}
 
-  await createMigrationAuditLog(sequelize, applied, 'up', {
-    batchDurationMs,
-    upgradeRunId,
-    stats: {
-      durationMsPerMigration,
-      totalMigrationsDurationMs,
-      ...(preSnapshot ? { preSnapshot } : {}),
-    },
-  });
+/**
+ * Record a batch that stopped partway, so a failed upgrade leaves the same audit trail a
+ * successful one does. Migrations apply in order and each commits on its own, so the pending
+ * entries now recorded as executed are the ones that survived, and the first that isn't is
+ * where the batch stopped. Timings for the migrations that did apply are only in memory, so
+ * this is the one chance to record them.
+ */
+async function auditFailedBatch({ log, migrations, pending, auditBatch }) {
+  try {
+    const executed = new Set((await migrations.executed()).map(({ file }) => file));
+    const applied = pending.filter(({ file }) => executed.has(file));
+    const failedMigration = pending.find(({ file }) => !executed.has(file))?.file;
+    await auditBatch(applied, failedMigration);
+    log.info(`Recorded failed migration batch, stopped at ${failedMigration}`);
+  } catch (error) {
+    // Must not replace the migration failure the caller is about to throw.
+    log.warn('Could not record the failed migration batch', { error });
+  }
 }
 
 async function migrateUp(log, sequelize, upOpts = undefined, options = {}) {

--- a/packages/database/src/utils/audit/createMigrationAuditLog.ts
+++ b/packages/database/src/utils/audit/createMigrationAuditLog.ts
@@ -9,6 +9,12 @@ export type MigrationLogStats = {
   totalMigrationsDurationMs: number;
   /** Snapshot of the database before the migration batch was applied. */
   preSnapshot?: PreMigrationDbSnapshot;
+  /**
+   * The migration that threw, when the batch stopped partway. Its presence is what
+   * distinguishes a failed batch from one that ran to completion; `migrations` lists only
+   * those that applied before it.
+   */
+  failedMigration?: string;
 };
 
 export type CreateMigrationAuditLogOptions = {


### PR DESCRIPTION
### Changes

A migration batch is only recorded in `logs.migrations` after every migration in it has applied: `createMigrationAuditLog` sits after `await migrations.up()` with no try/catch. So a failed upgrade leaves no audit row at all, which is the case you most want a record of. An operator debugging one has nothing to read, and the per-migration timings for the ones that did apply are in process memory, so they die with the container.

On failure the batch is now recorded anyway, with the migrations that applied and `stats.failedMigration` naming the one that threw. Migrations apply in order and each commits on its own, so the fix derives both from `pending` against `executed()` rather than needing new bookkeeping.

Prompted by pgro's pre-upgrade migration testing, which restores a deployment's backup and runs the next version's migrations against it. It reads its verdict from this table, so today it can report that an upgrade failed but never which migration broke.

Two things a reviewer might otherwise flag:

**`failedMigration` goes in the existing `stats` jsonb, not a new column.** Avoids a DDL migration and the dbt model regeneration that comes with it. The tradeoff is that a failed batch is distinguished by that key's presence rather than by anything on the row itself, so a query counting upgrades needs to check it.

**The audit write is wrapped so it can never replace the migration error.** If recording fails (dead connection, say) it warns and the original error still propagates, since that error is the actual finding.

The `down` path has the same gap and is left alone deliberately, to keep this to the case pgro exercises.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
