### PR TITLE
fix(sync): no-issue: make streaming pull paging work

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.getOutgoingChanges.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.getOutgoingChanges.test.js
@@ -1,6 +1,7 @@
 import { FACT_CURRENT_SYNC_TICK, FACT_LOOKUP_UP_TO_TICK } from '@tamanu/constants/facts';
 import { fake, fakeUser } from '@tamanu/fake-data/fake';
 import { SYSTEM_USER_UUID } from '@tamanu/constants';
+import { encodeSnapshotCursor } from '@tamanu/database/sync';
 
 import {
   createTestContext,
@@ -85,6 +86,41 @@ describe('CentralSyncManager.getOutgoingChanges', () => {
       limit: 10,
     });
     expect(changes.filter(({ recordId }) => recordId !== SYSTEM_USER_UUID)).toHaveLength(3);
+  });
+
+  it('pages through the outgoing changes with the cursor of the previous page', async () => {
+    // records across several tables, so paging has to cross a record type boundary: snapshot ids
+    // ascend within a table, but a table later in dependency order can hold lower ids
+    const facility = await models.Facility.create(fake(models.Facility));
+    await models.Program.create(fake(models.Program));
+    await models.ReferenceData.create(fake(models.ReferenceData));
+    const centralSyncManager = initializeCentralSyncManager();
+    const { sessionId } = await centralSyncManager.startSession();
+    await waitForSession(centralSyncManager, sessionId);
+
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: 1,
+        facilityIds: [facility.id],
+      },
+      () => true,
+    );
+
+    const allChanges = await centralSyncManager.getOutgoingChanges(sessionId, {});
+    expect(allChanges.length).toBeGreaterThan(2);
+
+    const pagedRecordIds = [];
+    let fromId;
+    // bounded, so a cursor that fails to advance fails the test instead of looping forever
+    for (let request = 0; request <= allChanges.length; request++) {
+      const page = await centralSyncManager.getOutgoingChanges(sessionId, { fromId, limit: 1 });
+      if (page.length === 0) break;
+      pagedRecordIds.push(page[0].recordId);
+      fromId = encodeSnapshotCursor(page[0]);
+    }
+
+    expect(pagedRecordIds).toEqual(allChanges.map(({ recordId }) => recordId));
   });
 
   it('includes audit changes in outgoing changes', async () => {

--- a/packages/central-server/__tests__/sync/pullStreamRoute.test.js
+++ b/packages/central-server/__tests__/sync/pullStreamRoute.test.js
@@ -1,0 +1,158 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import {
+  DEVICE_SCOPES,
+  SERVER_TYPES,
+  SETTINGS_SCOPES,
+  SYNC_STREAM_MESSAGE_KIND,
+} from '@tamanu/constants';
+import { FACT_CURRENT_SYNC_TICK } from '@tamanu/constants/facts';
+import { settingsCache } from '@tamanu/settings';
+import { fake } from '@tamanu/fake-data/fake';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
+
+import { createTestContext } from '../utilities';
+
+const DEVICE_ID = 'pull-stream-device';
+// one record per page, so the route has to page: the cursor it hands itself is what is under test,
+// and it is only exercised from the second iteration onwards
+const PAGE_SIZE = 1;
+
+/**
+ * The stream is a sequence of frames, each CRLF, a two-byte kind, a four-byte payload length, and
+ * that many bytes of JSON. Built by StreamMessage on the server and read by TamanuApi#stream on the
+ * client; parsed here rather than reused because the client's reader wants a live fetch response.
+ */
+const parseStreamFrames = buffer => {
+  const frames = [];
+  let offset = 0;
+  while (offset + 8 <= buffer.length) {
+    const kind = buffer.readUInt16BE(offset + 2);
+    const length = buffer.readUInt32BE(offset + 4);
+    const body = buffer.subarray(offset + 8, offset + 8 + length);
+    frames.push({ kind, message: length > 0 ? JSON.parse(body.toString('utf8')) : undefined });
+    offset += 8 + length;
+  }
+  return frames;
+};
+
+describe('GET /sync/:sessionId/pull/stream', () => {
+  let ctx;
+  let baseApp;
+  let models;
+  let facility;
+  let token;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.store.models;
+
+    const user = await models.User.create(fake(models.User, { password: 'password' }));
+    await models.Device.create(
+      fake(models.Device, {
+        id: DEVICE_ID,
+        registeredById: user.id,
+        scopes: [DEVICE_SCOPES.SYNC_CLIENT],
+      }),
+    );
+
+    const { CentralSyncManager } = require('../../app/sync/CentralSyncManager');
+    CentralSyncManager.overrideConfig({
+      sync: {
+        // the routes hand the snapshot off to the background and the client polls for it; awaiting
+        // preparation takes that race out of the test without changing what is under test
+        awaitPreparation: true,
+        maxRecordsPerSnapshotChunk: 1000000000,
+        lookupTable: { enabled: true },
+      },
+    });
+
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 2);
+
+    facility = await models.Facility.create(fake(models.Facility));
+    // several records of a kind that pulls to every facility, so the snapshot spans several pages
+    await models.Program.create(fake(models.Program));
+    await models.Program.create(fake(models.Program));
+    await models.Program.create(fake(models.Program));
+
+    // outgoing snapshots are built from the lookup table, so it has to know about those records
+    await new CentralSyncManager(ctx).updateLookupTable();
+
+    await models.Setting.set(
+      'sync.streaming.databasePollBatchSize',
+      PAGE_SIZE,
+      SETTINGS_SCOPES.CENTRAL,
+    );
+    settingsCache.reset();
+
+    const login = await baseApp
+      .post('/api/login')
+      .set('X-Tamanu-Client', SERVER_TYPES.FACILITY)
+      .send({
+        email: user.email,
+        password: 'password',
+        deviceId: DEVICE_ID,
+        scopes: [DEVICE_SCOPES.SYNC_CLIENT],
+      });
+    expect(login).toHaveSucceeded();
+    token = login.body.token;
+  });
+
+  afterAll(async () => {
+    await models.Setting.destroy({ where: { key: 'sync.streaming.databasePollBatchSize' } });
+    settingsCache.reset();
+    await ctx.close();
+  });
+
+  const asDevice = request =>
+    request.set('Authorization', `Bearer ${token}`).set('X-Tamanu-Client', SERVER_TYPES.FACILITY);
+
+  it('streams every record in the snapshot, paging itself through it', async () => {
+    const session = await asDevice(baseApp.post('/api/sync')).send({
+      facilityIds: [facility.id],
+      lastSyncedTick: 1,
+    });
+    expect(session).toHaveSucceeded();
+    const { sessionId } = session.body;
+
+    const initiated = await asDevice(baseApp.post(`/api/sync/${sessionId}/pull/initiate`)).send({
+      since: 1,
+      facilityIds: [facility.id],
+    });
+    expect(initiated).toHaveSucceeded();
+
+    // the snapshot is built in the background, and the stream route refuses until it is done
+    let ready = false;
+    for (let attempt = 0; attempt < 40 && !ready; attempt++) {
+      const readyCheck = await asDevice(baseApp.get(`/api/sync/${sessionId}/pull/ready`));
+      ready = readyCheck.body === true;
+      if (!ready) await sleepAsync(100);
+    }
+    expect(ready).toBe(true);
+
+    // comes back as a string, being a SQL count
+    const totalToPull = Number(
+      (await asDevice(baseApp.get(`/api/sync/${sessionId}/pull/metadata`))).body.totalToPull,
+    );
+    expect(totalToPull).toBeGreaterThan(PAGE_SIZE);
+
+    // the frames are served as application/json+frame, which superagent would otherwise hand to its
+    // JSON parser on the strength of the substring; take the bytes instead
+    const streamed = await asDevice(baseApp.get(`/api/sync/${sessionId}/pull/stream`)).responseType(
+      'blob',
+    );
+    expect(streamed.status).toBe(200);
+
+    const frames = parseStreamFrames(streamed.body);
+    const changes = frames
+      .filter(({ kind }) => kind === SYNC_STREAM_MESSAGE_KIND.PULL_CHANGE)
+      .map(({ message }) => message);
+
+    // every record exactly once: a cursor that failed to advance would repeat the first page, and one
+    // that skipped would come up short
+    expect(changes).toHaveLength(totalToPull);
+    expect(new Set(changes.map(({ recordId }) => recordId)).size).toBe(totalToPull);
+    expect(frames.at(-1).kind).toBe(SYNC_STREAM_MESSAGE_KIND.END);
+  });
+});

--- a/packages/central-server/app/sync/buildSyncRoutes.js
+++ b/packages/central-server/app/sync/buildSyncRoutes.js
@@ -5,7 +5,7 @@ import * as z from 'zod';
 import { Op } from 'sequelize';
 import { log } from '@tamanu/shared/services/logging';
 import { ForbiddenError, InvalidParameterError } from '@tamanu/errors';
-import { completeSyncSession } from '@tamanu/database/sync';
+import { completeSyncSession, encodeSnapshotCursor } from '@tamanu/database/sync';
 import { DEVICE_SCOPES } from '@tamanu/constants';
 
 import { CentralSyncManager } from './CentralSyncManager';
@@ -176,7 +176,7 @@ export const buildSyncRoutes = ctx => {
 
       startStream(res);
 
-      const interval = await ctx.settings.get('sync.databasePollInterval');
+      const interval = await ctx.settings.get('sync.streaming.databasePollInterval');
       while (!(await syncManager.checkSessionReady(sessionId))) {
         res.write(StreamMessage.sessionWaiting());
         await sleepAsync(interval);
@@ -235,7 +235,7 @@ export const buildSyncRoutes = ctx => {
 
       startStream(res);
 
-      const interval = await ctx.settings.get('sync.databasePollInterval');
+      const interval = await ctx.settings.get('sync.streaming.databasePollInterval');
       while (!(await syncManager.checkPullReady(sessionId))) {
         res.write(StreamMessage.pullWaiting());
         await sleepAsync(interval);
@@ -288,19 +288,18 @@ export const buildSyncRoutes = ctx => {
 
       startStream(res);
 
-      let startId = fromId ? parseInt(fromId, 10) : 0;
-      const limit = await ctx.settings.get('sync.databasePollBatchSize');
+      let cursor = fromId;
+      const limit = await ctx.settings.get('sync.streaming.databasePollBatchSize');
       // eslint-disable-next-line no-constant-condition
       while (true) {
-        // TODO: change this to a cursor
         const changes = await syncManager.getOutgoingChanges(sessionId, {
-          fromId: startId,
+          fromId: cursor,
           limit,
         });
         if (changes.length === 0) {
           break;
         }
-        startId = changes[changes.length - 1].id;
+        cursor = encodeSnapshotCursor(changes[changes.length - 1]);
 
         log.info(`STREAM /pull : returning ${changes.length} changes`);
         for (const change of changes) {

--- a/packages/database/__tests__/sync/snapshotCursor.test.ts
+++ b/packages/database/__tests__/sync/snapshotCursor.test.ts
@@ -23,4 +23,27 @@ describe('snapshot cursor', () => {
     // the cursor is a query parameter, so a malformed one is the client's mistake, not a fault
     expect(() => decodeSnapshotCursor(cursor)).toThrow(InvalidParameterError);
   });
+
+  // Both parts are compared against (sort_order, id) in SQL, so a cursor that decodes cleanly but
+  // carries the wrong types would otherwise reach the database and come back as a server fault.
+  it.each([
+    ['a sort order that is not a number', { sortOrder: 'x', id: '1234' }],
+    ['a fractional sort order', { sortOrder: 1.5, id: '1234' }],
+    ['an id that is neither string nor number', { sortOrder: 1, id: {} }],
+    ['no id at all', { sortOrder: 1 }],
+    ['no sort order at all', { id: '1234' }],
+    ['not an object', 1234],
+  ])('rejects a decodable cursor with %s', (_description, payload) => {
+    expect(() => decodeSnapshotCursor(btoa(JSON.stringify(payload)))).toThrow(
+      InvalidParameterError,
+    );
+  });
+
+  it('accepts an id that arrives as a number', () => {
+    // bigint ids come back from postgres as strings, but nothing stops a client sending the number
+    expect(decodeSnapshotCursor(btoa(JSON.stringify({ sortOrder: 2, id: 1234 })))).toEqual({
+      sortOrder: 2,
+      id: 1234,
+    });
+  });
 });

--- a/packages/database/__tests__/sync/snapshotCursor.test.ts
+++ b/packages/database/__tests__/sync/snapshotCursor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { InvalidParameterError } from '@tamanu/errors';
+
+import { decodeSnapshotCursor, encodeSnapshotCursor } from '../../src/sync/snapshotCursor';
+
+describe('snapshot cursor', () => {
+  it('round-trips both parts of the cursor', () => {
+    const cursor = encodeSnapshotCursor({ sortOrder: 4, id: '1234' });
+
+    expect(decodeSnapshotCursor(cursor)).toEqual({ sortOrder: 4, id: '1234' });
+  });
+
+  it('reads a missing cursor as the start of the snapshot', () => {
+    expect(decodeSnapshotCursor()).toEqual({});
+    expect(decodeSnapshotCursor(null)).toEqual({});
+    expect(decodeSnapshotCursor('')).toEqual({});
+  });
+
+  it.each([
+    ['not base64 at all', 'not-a-cursor'],
+    ['base64 of something that is not json', btoa('still not a cursor')],
+  ])('rejects a cursor that is %s', (_description, cursor) => {
+    // the cursor is a query parameter, so a malformed one is the client's mistake, not a fault
+    expect(() => decodeSnapshotCursor(cursor)).toThrow(InvalidParameterError);
+  });
+});

--- a/packages/database/src/sync/findSyncSnapshotRecords.ts
+++ b/packages/database/src/sync/findSyncSnapshotRecords.ts
@@ -5,6 +5,7 @@ import { QueryTypes, Sequelize } from 'sequelize';
 import { getSnapshotTableName } from './manageSnapshotTable';
 import { getModelsForPull } from './getModelsForDirection';
 import { sortInDependencyOrder } from '../utils/sortInDependencyOrder';
+import { decodeSnapshotCursor } from './snapshotCursor';
 
 import type {
   RecordType,
@@ -66,7 +67,7 @@ export const findSyncSnapshotRecordsOrderByDependency = async (
   const modelsForPull = getModelsForPull(models);
   const sortedModels = sortInDependencyOrder(modelsForPull as Models);
 
-  const { sortOrder: lastRecordTypeOrder, id: lastId } = fromId ? JSON.parse(atob(fromId)) : {};
+  const { sortOrder: lastRecordTypeOrder, id: lastId } = decodeSnapshotCursor(fromId);
 
   const records = await sequelize.query(
     `

--- a/packages/database/src/sync/index.ts
+++ b/packages/database/src/sync/index.ts
@@ -21,5 +21,6 @@ export * from './waitForPendingEditsUsingSyncTick';
 export * from './bumpSyncTickForRepull';
 export * from './incomingSyncHook';
 export * from './sanitizeRecord';
+export * from './snapshotCursor';
 export * from './transactions';
 export * from './withDeferredSyncSafeguards';

--- a/packages/database/src/sync/snapshotCursor.ts
+++ b/packages/database/src/sync/snapshotCursor.ts
@@ -21,11 +21,24 @@ export const decodeSnapshotCursor = (cursor?: string | null): Partial<SnapshotCu
 
   // the cursor arrives as a query parameter, so a malformed one is a bad request rather than a
   // server fault, and it says which parameter to look at
+  let decoded;
   try {
-    return JSON.parse(atob(cursor));
+    decoded = JSON.parse(atob(cursor));
   } catch (error) {
     throw new InvalidParameterError(
       `fromId is not a valid pull cursor: ${(error as Error).message}`,
     );
   }
+
+  // Both parts go into a SQL comparison against (sort_order, id), so a cursor that decodes but
+  // carries the wrong types is still the client's mistake — checked here rather than left to fail as
+  // a query error, which reaches the client as a server fault and says nothing about the cause.
+  const { sortOrder, id } = decoded ?? {};
+  if (!Number.isInteger(sortOrder) || !['string', 'number'].includes(typeof id)) {
+    throw new InvalidParameterError(
+      'fromId is not a valid pull cursor: expected a sort order and a record id',
+    );
+  }
+
+  return { sortOrder, id };
 };

--- a/packages/database/src/sync/snapshotCursor.ts
+++ b/packages/database/src/sync/snapshotCursor.ts
@@ -1,0 +1,18 @@
+/**
+ * Outgoing pull pages are ordered by (dependency sort order, snapshot id), so a resume cursor has
+ * to carry both parts: snapshot ids ascend within a table, but a later table's ids can be lower
+ * than an earlier table's. Paging on the id alone silently skips records.
+ *
+ * The encoded form is opaque to clients — it is only ever produced and consumed here, so both the
+ * polling and streaming pull endpoints stay in step with what the query expects.
+ */
+export type SnapshotCursor = {
+  sortOrder: number;
+  id: string | number;
+};
+
+export const encodeSnapshotCursor = ({ sortOrder, id }: SnapshotCursor): string =>
+  btoa(JSON.stringify({ sortOrder, id }));
+
+export const decodeSnapshotCursor = (cursor?: string | null): Partial<SnapshotCursor> =>
+  cursor ? JSON.parse(atob(cursor)) : {};

--- a/packages/database/src/sync/snapshotCursor.ts
+++ b/packages/database/src/sync/snapshotCursor.ts
@@ -1,3 +1,5 @@
+import { InvalidParameterError } from '@tamanu/errors';
+
 /**
  * Outgoing pull pages are ordered by (dependency sort order, snapshot id), so a resume cursor has
  * to carry both parts: snapshot ids ascend within a table, but a later table's ids can be lower
@@ -14,5 +16,16 @@ export type SnapshotCursor = {
 export const encodeSnapshotCursor = ({ sortOrder, id }: SnapshotCursor): string =>
   btoa(JSON.stringify({ sortOrder, id }));
 
-export const decodeSnapshotCursor = (cursor?: string | null): Partial<SnapshotCursor> =>
-  cursor ? JSON.parse(atob(cursor)) : {};
+export const decodeSnapshotCursor = (cursor?: string | null): Partial<SnapshotCursor> => {
+  if (!cursor) return {};
+
+  // the cursor arrives as a query parameter, so a malformed one is a bad request rather than a
+  // server fault, and it says which parameter to look at
+  try {
+    return JSON.parse(atob(cursor));
+  } catch (error) {
+    throw new InvalidParameterError(
+      `fromId is not a valid pull cursor: ${(error as Error).message}`,
+    );
+  }
+};

--- a/packages/facility-server/__tests__/sync/pullIncomingChanges.test.js
+++ b/packages/facility-server/__tests__/sync/pullIncomingChanges.test.js
@@ -1,6 +1,21 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { pullIncomingChanges } from '../../app/sync/pullIncomingChanges';
+import { SYNC_STREAM_MESSAGE_KIND } from '@tamanu/constants';
+import { encodeSnapshotCursor } from '@tamanu/database/sync';
+
+import { pullIncomingChanges, streamIncomingChanges } from '../../app/sync/pullIncomingChanges';
+
+const fakeChange = ({ id, sortOrder, recordType }) => ({
+  id,
+  sortOrder,
+  recordType,
+  recordId: `record-${id}`,
+  isDeleted: false,
+  data: { id: `record-${id}` },
+});
+
+// stands in for a snapshot table, so we can see what would be inserted into it
+const fakeSequelize = bulkInsert => ({ getQueryInterface: () => ({ bulkInsert }) });
 
 describe('pullIncomingChanges', () => {
   it('completes cleanly when the central server returns an empty page', async () => {
@@ -16,5 +31,81 @@ describe('pullIncomingChanges', () => {
 
     expect(centralServer.pull).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ totalPulled: 10, pullUntil: 42 });
+  });
+
+  it('pages from the last record of the previous page, on both cursor parts', async () => {
+    const page = [
+      fakeChange({ id: '1', sortOrder: 1, recordType: 'facilities' }),
+      fakeChange({ id: '2', sortOrder: 4, recordType: 'users' }),
+    ];
+    const centralServer = {
+      // more to pull than the page returns, so a second page is requested
+      initiatePull: jest.fn().mockResolvedValue({ totalToPull: 3, pullUntil: 42 }),
+      pull: jest.fn().mockResolvedValueOnce(page).mockResolvedValue([]),
+    };
+
+    await pullIncomingChanges(centralServer, fakeSequelize(jest.fn()), 'sessionId', 1);
+
+    expect(centralServer.pull).toHaveBeenNthCalledWith(
+      2,
+      'sessionId',
+      expect.objectContaining({ fromId: encodeSnapshotCursor({ sortOrder: 4, id: '2' }) }),
+    );
+  });
+
+  it('keeps sortOrder out of the snapshot table', async () => {
+    const bulkInsert = jest.fn();
+    const centralServer = {
+      initiatePull: jest.fn().mockResolvedValue({ totalToPull: 1, pullUntil: 42 }),
+      pull: jest
+        .fn()
+        .mockResolvedValueOnce([fakeChange({ id: '1', sortOrder: 1, recordType: 'facilities' })]),
+    };
+
+    await pullIncomingChanges(centralServer, fakeSequelize(bulkInsert), 'sessionId', 1);
+
+    const [, insertedRows] = bulkInsert.mock.calls[0];
+    expect(insertedRows[0]).not.toHaveProperty('sort_order');
+    expect(insertedRows[0]).toHaveProperty('record_id', 'record-1');
+  });
+});
+
+describe('streamIncomingChanges', () => {
+  const streamOf = (changes, captureResume) =>
+    async function* stream(endpointFn) {
+      for (const change of changes) {
+        yield { kind: SYNC_STREAM_MESSAGE_KIND.PULL_CHANGE, message: change };
+      }
+      captureResume(endpointFn().query);
+      yield { kind: SYNC_STREAM_MESSAGE_KIND.END };
+    };
+
+  it('resumes from the last streamed record, on both cursor parts', async () => {
+    const change = fakeChange({ id: '7', sortOrder: 2, recordType: 'users' });
+    let resumeQuery;
+    const centralServer = {
+      initiatePull: jest.fn().mockResolvedValue({ totalToPull: 1, pullUntil: 42 }),
+      stream: streamOf([change], query => {
+        resumeQuery = query;
+      }),
+    };
+
+    await streamIncomingChanges(centralServer, fakeSequelize(jest.fn()), 'sessionId', 1);
+
+    expect(resumeQuery.fromId).toBe(encodeSnapshotCursor(change));
+  });
+
+  it('keeps sortOrder out of the snapshot table', async () => {
+    const bulkInsert = jest.fn();
+    const centralServer = {
+      initiatePull: jest.fn().mockResolvedValue({ totalToPull: 1, pullUntil: 42 }),
+      stream: streamOf([fakeChange({ id: '7', sortOrder: 2, recordType: 'users' })], () => {}),
+    };
+
+    await streamIncomingChanges(centralServer, fakeSequelize(bulkInsert), 'sessionId', 1);
+
+    const [, insertedRows] = bulkInsert.mock.calls[0];
+    expect(insertedRows[0]).not.toHaveProperty('sort_order');
+    expect(insertedRows[0]).toHaveProperty('record_id', 'record-7');
   });
 });

--- a/packages/facility-server/__tests__/sync/pullIncomingChanges.test.js
+++ b/packages/facility-server/__tests__/sync/pullIncomingChanges.test.js
@@ -108,4 +108,28 @@ describe('streamIncomingChanges', () => {
     expect(insertedRows[0]).not.toHaveProperty('sort_order');
     expect(insertedRows[0]).toHaveProperty('record_id', 'record-7');
   });
+
+  it('leaves the streamed records intact, so a write cannot blank the resume cursor', async () => {
+    // the streamed records are the cursor: writing a batch must not take sortOrder off them, or a
+    // reconnect after that write resumes from a cursor missing half its key and restarts the pull
+    // from the beginning of the snapshot. totalToPull of 1 caps the write batch at one record, so
+    // the first record is written while the second is still streaming.
+    const changes = [
+      fakeChange({ id: '7', sortOrder: 2, recordType: 'users' }),
+      fakeChange({ id: '8', sortOrder: 2, recordType: 'users' }),
+    ];
+    const bulkInsert = jest.fn();
+    const centralServer = {
+      initiatePull: jest.fn().mockResolvedValue({ totalToPull: 1, pullUntil: 42 }),
+      stream: streamOf(changes, () => {}),
+    };
+
+    await streamIncomingChanges(centralServer, fakeSequelize(bulkInsert), 'sessionId', 1);
+
+    expect(bulkInsert).toHaveBeenCalled();
+    expect(changes).toEqual([
+      expect.objectContaining({ id: '7', sortOrder: 2 }),
+      expect.objectContaining({ id: '8', sortOrder: 2 }),
+    ]);
+  });
 });

--- a/packages/facility-server/app/sync/pullIncomingChanges.js
+++ b/packages/facility-server/app/sync/pullIncomingChanges.js
@@ -1,8 +1,9 @@
 import config from 'config';
-import { chunk } from 'es-toolkit/compat';
+import { chunk, omit } from 'es-toolkit/compat';
 import { log } from '@tamanu/shared/services/logging';
 import { SYNC_STREAM_MESSAGE_KIND } from '@tamanu/constants';
 import {
+  encodeSnapshotCursor,
   insertSnapshotRecords,
   SYNC_SESSION_DIRECTION,
   SYNC_TICK_FLAGS,
@@ -12,6 +13,15 @@ import { sleepAsync } from '@tamanu/utils/sleepAsync';
 import { calculatePageLimit } from './calculatePageLimit';
 
 const { persistedCacheBatchSize, pauseBetweenCacheBatchInMilliseconds } = config.sync;
+
+// sortOrder comes from the dependency ordering central pages by; it belongs to the cursor, not to
+// the snapshot table, which has no such column
+const toSnapshotRecord = record => ({
+  ...omit(record, ['sortOrder']),
+  // mark as never updated, so we don't push it back to the central server until the next local update
+  data: { ...record.data, updatedAtSyncTick: SYNC_TICK_FLAGS.INCOMING_FROM_CENTRAL_SERVER },
+  direction: SYNC_SESSION_DIRECTION.INCOMING,
+});
 
 export const pullIncomingChanges = async (centralServer, sequelize, sessionId, since) => {
   const start = Date.now();
@@ -42,21 +52,13 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
       break;
     }
 
-    const { id, sortOrder } = records[records.length - 1];
-    fromId = btoa(JSON.stringify({ sortOrder, id }));
+    fromId = encodeSnapshotCursor(records[records.length - 1]);
     totalPulled += records.length;
     const pullTime = Date.now() - startTime;
 
     log.info('FacilitySyncManager.savingChangesToSnapshot', { count: records.length });
 
-    const recordsToSave = records.map(r => {
-      delete r.sortOrder;
-      return {
-      ...r,
-      data: { ...r.data, updatedAtSyncTick: SYNC_TICK_FLAGS.INCOMING_FROM_CENTRAL_SERVER }, // mark as never updated, so we don't push it back to the central server until the next local update
-      direction: SYNC_SESSION_DIRECTION.INCOMING,
-    };
-  });
+    const recordsToSave = records.map(toSnapshotRecord);
 
     // This is an attempt to avoid storing all the pulled data
     // in the memory because we might run into memory issue when:
@@ -87,16 +89,7 @@ export const streamIncomingChanges = async (centralServer, sequelize, sessionId,
 
   const writeBatch = async records => {
     if (records.length === 0) return;
-    await insertSnapshotRecords(
-      sequelize,
-      sessionId,
-      records.map(r => ({
-        ...r,
-        // mark as never updated, so we don't push it back to the central server until the next local update
-        data: { ...r.data, updatedAtSyncTick: SYNC_TICK_FLAGS.INCOMING_FROM_CENTRAL_SERVER },
-        direction: SYNC_SESSION_DIRECTION.INCOMING,
-      })),
-    );
+    await insertSnapshotRecords(sequelize, sessionId, records.map(toSnapshotRecord));
   };
 
   log.info('FacilitySyncManager.pulling', { since, totalToPull });
@@ -123,7 +116,7 @@ export const streamIncomingChanges = async (centralServer, sequelize, sessionId,
       case SYNC_STREAM_MESSAGE_KIND.PULL_CHANGE:
         records.push(message);
         totalPulled += 1;
-        fromId = message.id;
+        fromId = encodeSnapshotCursor(message);
         break handler;
       case SYNC_STREAM_MESSAGE_KIND.END:
         log.debug(`FacilitySyncManager.pull.noMoreChanges`);

--- a/packages/facility-server/app/sync/pullIncomingChanges.js
+++ b/packages/facility-server/app/sync/pullIncomingChanges.js
@@ -97,12 +97,13 @@ export const streamIncomingChanges = async (centralServer, sequelize, sessionId,
   let records = []; // for batching writes
   let writes = []; // ongoing write promises
 
-  // keep track of the ID we're on so we can resume the stream
-  // on disconnect from where we left off rather than the start
-  let fromId;
+  // keep track of the record we're on so we can resume the stream on disconnect from where we left
+  // off rather than the start. Only the last one is ever encoded, on the reconnect that needs it,
+  // rather than once per record streamed
+  let lastRecord;
   const endpointFn = () => ({
     endpoint: `sync/${sessionId}/pull/stream`,
-    query: { fromId },
+    query: { fromId: lastRecord && encodeSnapshotCursor(lastRecord) },
   });
 
   stream: for await (const { kind, message } of centralServer.stream(endpointFn)) {
@@ -116,7 +117,7 @@ export const streamIncomingChanges = async (centralServer, sequelize, sessionId,
       case SYNC_STREAM_MESSAGE_KIND.PULL_CHANGE:
         records.push(message);
         totalPulled += 1;
-        fromId = encodeSnapshotCursor(message);
+        lastRecord = message;
         break handler;
       case SYNC_STREAM_MESSAGE_KIND.END:
         log.debug(`FacilitySyncManager.pull.noMoreChanges`);

--- a/packages/facility-server/app/sync/pullIncomingChanges.js
+++ b/packages/facility-server/app/sync/pullIncomingChanges.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { chunk, omit } from 'es-toolkit/compat';
+import { chunk } from 'es-toolkit/compat';
 import { log } from '@tamanu/shared/services/logging';
 import { SYNC_STREAM_MESSAGE_KIND } from '@tamanu/constants';
 import {
@@ -15,9 +15,16 @@ import { calculatePageLimit } from './calculatePageLimit';
 const { persistedCacheBatchSize, pauseBetweenCacheBatchInMilliseconds } = config.sync;
 
 // sortOrder comes from the dependency ordering central pages by; it belongs to the cursor, not to
-// the snapshot table, which has no such column
-const toSnapshotRecord = record => ({
-  ...omit(record, ['sortOrder']),
+// the snapshot table, which has no such column.
+//
+// Must not mutate the record it is given: the streaming path holds the same objects in both its
+// write batch and its resume cursor, so dropping sortOrder in place would blank the cursor and
+// restart the stream from the beginning of the snapshot. Removing the key by destructuring rather
+// than `delete` also keeps the object out of dictionary mode, so the spread below stays cheap —
+// this runs once per pulled record.
+// eslint-disable-next-line no-unused-vars
+const toSnapshotRecord = ({ sortOrder, ...record }) => ({
+  ...record,
   // mark as never updated, so we don't push it back to the central server until the next local update
   data: { ...record.data, updatedAtSyncTick: SYNC_TICK_FLAGS.INCOMING_FROM_CENTRAL_SERVER },
   direction: SYNC_SESSION_DIRECTION.INCOMING,
@@ -99,7 +106,11 @@ export const streamIncomingChanges = async (centralServer, sequelize, sessionId,
 
   // keep track of the record we're on so we can resume the stream on disconnect from where we left
   // off rather than the start. Only the last one is ever encoded, on the reconnect that needs it,
-  // rather than once per record streamed
+  // rather than once per record streamed.
+  //
+  // This is the same object that goes into the write batch below, and its sortOrder is half of the
+  // cursor, so whatever the batch does to a record on its way to the snapshot table has to leave the
+  // record itself alone — see toSnapshotRecord
   let lastRecord;
   const endpointFn = () => ({
     endpoint: `sync/${sessionId}/pull/stream`,


### PR DESCRIPTION
### Changes

🤖 Streaming pull (`sync.streaming.enabled`, off by default) does not page. The stream route read its batch size and poll interval from `sync.databasePollBatchSize` / `sync.databasePollInterval`, but those settings live under `sync.streaming.*`, so both reads returned undefined: the page limit fell back to `Number.MAX_SAFE_INTEGER`, pulling the whole snapshot in one query — which is the thing streaming exists to avoid — and the two wait loops slept for ~1ms per iteration, polling the database in a tight loop while waiting for a snapshot that can take hours.

Behind that, the paging cursor was wrong on both ends. The dependency-ordered pull query orders by `(sort_order, id)` and expects a cursor carrying both parts, but the stream route and the streaming client each passed the bare snapshot id — the route throws on its second page, the client silently restarts from the beginning of the snapshot instead of resuming. The unbounded limit masked the route side by never needing a second page. The streaming client also wrote pulled records to the snapshot table without stripping `sortOrder`, which is not a column on it; the polling client deletes it, and the two paths had drifted apart.

The cursor format now has a single definition shared by the query, both pull routes and both clients, and the facility’s two pull paths share one record-preparation step so they cannot diverge again. Mobile keeps its own copy of the encoding, as it cannot depend on `@tamanu/database`.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->