### PR TITLE
fix(fhir): no-issue: expire the job queue's leftovers

### DIFF
--- a/database/model/fhir/job_workers.md
+++ b/database/model/fhir/job_workers.md
@@ -17,8 +17,9 @@ This provides a system which is robust against restarts and failures without req
 daemon to track and manage worker state, nor persistent connections from the workers (which is how
 Gearman works).
 
-The function `job_worker_garbage_collect()` should be called occasionally (e.g. once a day) to clean
-out the table of dead workers.
+The function `job_worker_garbage_collect()` cleans dead workers out of the table. The
+`FhirJobWorkerCleaner` scheduled task calls it daily; anything else driving the queue should call it
+about as often.
 
 Worker management is done via SQL functions: `job_worker_register()`, `job_worker_heartbeat()`,
 `job_worker_deregister()`, `job_worker_garbage_collect()`. Additionally there's the querying
@@ -33,11 +34,12 @@ When the worker registered itself.
 {% enddocs %}
 
 {% docs fhir__job_workers__updated_at %}
-Always set to `created_at`.
+When the worker last heartbeated; set to `created_at` on registration.
 {% enddocs %}
 
 {% docs fhir__job_workers__deleted_at %}
-Unused: deregistered and dead workers are hard-deleted instead.
+When the worker left the registry: set on deregistration, and on garbage collection for a worker that
+stopped heartbeating without deregistering.
 {% enddocs %}
 
 {% docs fhir__job_workers__metadata %}

--- a/packages/central-server/__tests__/tasks/fhir/FhirErroredJobCleaner.test.js
+++ b/packages/central-server/__tests__/tasks/fhir/FhirErroredJobCleaner.test.js
@@ -1,0 +1,126 @@
+/**
+ * Tests for FhirErroredJobCleaner (source: @tamanu/shared/tasks).
+ * Run here in central-server so we avoid a circular devDependency between shared and database.
+ */
+import { subDays } from 'date-fns';
+
+import { JOB_QUEUE_STATUSES, JOB_TOPICS } from '@tamanu/constants';
+import { FhirErroredJobCleaner } from '@tamanu/shared/tasks';
+import { fakeUUID } from '@tamanu/utils/generateId';
+
+import { createTestContext } from '../../utilities';
+
+describe('FhirErroredJobCleaner task', () => {
+  let ctx;
+  let models;
+
+  const runCleaner = (overrideConfig = {}) =>
+    new FhirErroredJobCleaner(ctx, {
+      schedule: '',
+      enabled: false,
+      retentionDays: 7,
+      batchSize: 1000,
+      batchSleepAsyncDurationInMilliseconds: 1,
+      ...overrideConfig,
+    }).run();
+
+  const createJob = async ({ status, erroredDaysAgo = null }) => {
+    const erroredAt = erroredDaysAgo === null ? null : subDays(new Date(), erroredDaysAgo);
+    const job = await models.FhirJob.create({
+      topic: JOB_TOPICS.FHIR.REFRESH.FROM_UPSTREAM,
+      discriminant: fakeUUID(),
+      status,
+      errored_at: erroredAt,
+      error: erroredAt === null ? null : 'simulated failure',
+    });
+    return job.id;
+  };
+
+  const exists = async (id) => Boolean(await models.FhirJob.findByPk(id));
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    ({ models } = ctx.store);
+    // eslint-disable-next-line require-atomic-updates
+    ctx.schedules = await ctx.settings.get('schedules');
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await ctx.store.sequelize.query('DELETE FROM fhir.jobs');
+  });
+
+  it('deletes jobs that errored before the retention window', async () => {
+    const job = await createJob({ status: JOB_QUEUE_STATUSES.ERRORED, erroredDaysAgo: 8 });
+
+    await runCleaner();
+
+    expect(await exists(job)).toBe(false);
+  });
+
+  it('keeps jobs that errored within the retention window', async () => {
+    const job = await createJob({ status: JOB_QUEUE_STATUSES.ERRORED, erroredDaysAgo: 6 });
+
+    await runCleaner();
+
+    expect(await exists(job)).toBe(true);
+  });
+
+  it('keeps queued jobs however old they are', async () => {
+    const job = await createJob({ status: JOB_QUEUE_STATUSES.QUEUED });
+    await ctx.store.sequelize.query(
+      `UPDATE fhir.jobs SET created_at = current_timestamp - interval '1 year',
+                            updated_at = current_timestamp - interval '1 year'
+       WHERE id = $id`,
+      { bind: { id: job } },
+    );
+
+    await runCleaner();
+
+    expect(await exists(job)).toBe(true);
+  });
+
+  it('deletes every eligible job across several batches', async () => {
+    const jobs = [];
+    for (let i = 0; i < 5; i += 1) {
+      jobs.push(await createJob({ status: JOB_QUEUE_STATUSES.ERRORED, erroredDaysAgo: 30 }));
+    }
+    const kept = await createJob({ status: JOB_QUEUE_STATUSES.ERRORED, erroredDaysAgo: 1 });
+
+    await runCleaner({ batchSize: 2 });
+
+    for (const job of jobs) {
+      expect(await exists(job)).toBe(false);
+    }
+    expect(await exists(kept)).toBe(true);
+  });
+
+  it('honours a retention window set to something other than the default', async () => {
+    const job = await createJob({ status: JOB_QUEUE_STATUSES.ERRORED, erroredDaysAgo: 2 });
+
+    await runCleaner({ retentionDays: 1 });
+
+    expect(await exists(job)).toBe(false);
+  });
+
+  it.each([
+    ['a zero batch size', { batchSize: 0 }],
+    ['a missing batch size', { batchSize: undefined }],
+    ['a missing retention window', { retentionDays: undefined }],
+    ['a missing batch pause', { batchSleepAsyncDurationInMilliseconds: undefined }],
+  ])('refuses to run with %s', async (_label, overrideConfig) => {
+    await createJob({ status: JOB_QUEUE_STATUSES.ERRORED, erroredDaysAgo: 30 });
+
+    await expect(runCleaner(overrideConfig)).rejects.toThrow('FhirErroredJobCleaner needs');
+  });
+
+  it('takes a seven-day window and its batching from the settings schema', () => {
+    const cleaner = new FhirErroredJobCleaner(ctx);
+    expect(cleaner.isEnabled).toBe(true);
+    expect(cleaner.schedule).toBeTruthy();
+    expect(cleaner.config.retentionDays).toBe(7);
+    expect(cleaner.config.batchSize).toBeGreaterThan(0);
+    expect(cleaner.config.batchSleepAsyncDurationInMilliseconds).toBeGreaterThan(0);
+  });
+});

--- a/packages/central-server/__tests__/tasks/fhir/FhirJobWorkerCleaner.test.js
+++ b/packages/central-server/__tests__/tasks/fhir/FhirJobWorkerCleaner.test.js
@@ -1,0 +1,127 @@
+/**
+ * Tests for FhirJobWorkerCleaner (source: @tamanu/shared/tasks).
+ * Run here in central-server so we avoid a circular devDependency between shared and database.
+ */
+import { FhirJobWorkerCleaner } from '@tamanu/shared/tasks';
+import { fakeUUID } from '@tamanu/utils/generateId';
+
+import { createTestContext } from '../../utilities';
+
+describe('FhirJobWorkerCleaner task', () => {
+  let ctx;
+  let models;
+  let sequelize;
+
+  const runCleaner = () =>
+    new FhirJobWorkerCleaner(ctx, { schedule: '', enabled: false }).run();
+
+  // Insert directly so the heartbeat can be backdated: the model's timestamps
+  // would otherwise stamp updated_at as now.
+  const createWorker = async ({ heartbeatAge = '0 minutes', deregistered = false } = {}) => {
+    const id = fakeUUID();
+    await sequelize.query(
+      `INSERT INTO fhir.job_workers (id, created_at, updated_at, deleted_at)
+       VALUES (
+         $id,
+         current_timestamp - $heartbeatAge::interval,
+         current_timestamp - $heartbeatAge::interval,
+         CASE WHEN $deregistered THEN current_timestamp ELSE NULL END
+       )`,
+      { bind: { id, heartbeatAge, deregistered } },
+    );
+    return id;
+  };
+
+  const deletedAt = async (id) => {
+    const [[row]] = await sequelize.query(
+      'SELECT deleted_at FROM fhir.job_workers WHERE id = $id',
+      { bind: { id } },
+    );
+    return row.deleted_at;
+  };
+
+  const isPruned = async (id) => (await deletedAt(id)) !== null;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    ({ models, sequelize } = ctx.store);
+    // eslint-disable-next-line require-atomic-updates
+    ctx.schedules = await ctx.settings.get('schedules');
+    // Pin the drop window the expectations below are written against, rather
+    // than leaning on whatever the deployment's settings happen to hold.
+    await models.Setting.set('fhir.worker.assumeDroppedAfter', '10 minutes');
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await sequelize.query('DELETE FROM fhir.job_workers');
+  });
+
+  it('prunes a worker whose heartbeat is past the drop window', async () => {
+    const worker = await createWorker({ heartbeatAge: '30 minutes' });
+
+    await runCleaner();
+
+    expect(await isPruned(worker)).toBe(true);
+  });
+
+  it('leaves a heartbeating worker registered', async () => {
+    const worker = await createWorker({ heartbeatAge: '1 minute' });
+
+    await runCleaner();
+
+    expect(await isPruned(worker)).toBe(false);
+  });
+
+  it('prunes only the dropped workers, leaving the live ones', async () => {
+    const dropped = await createWorker({ heartbeatAge: '2 hours' });
+    const live = await createWorker({ heartbeatAge: '30 seconds' });
+
+    await runCleaner();
+
+    expect(await isPruned(dropped)).toBe(true);
+    expect(await isPruned(live)).toBe(false);
+  });
+
+  it('reports how many workers it pruned', async () => {
+    await createWorker({ heartbeatAge: '2 hours' });
+    await createWorker({ heartbeatAge: '3 hours' });
+    await createWorker({ heartbeatAge: '30 seconds' });
+
+    expect(await models.FhirJobWorker.clearDead()).toBe(2);
+    expect(await models.FhirJobWorker.clearDead()).toBe(0);
+  });
+
+  it('leaves an already-deregistered worker as it was', async () => {
+    const worker = await createWorker({ heartbeatAge: '30 minutes', deregistered: true });
+    const before = await deletedAt(worker);
+
+    await runCleaner();
+
+    expect(await deletedAt(worker)).toEqual(before);
+  });
+
+  it('runs clean when there is nothing to prune', async () => {
+    await expect(runCleaner()).resolves.not.toThrow();
+  });
+
+  it('prunes on the default window when the deployment sets no drop window', async () => {
+    await sequelize.query(`DELETE FROM settings WHERE key = 'fhir.worker.assumeDroppedAfter'`);
+    try {
+      const worker = await createWorker({ heartbeatAge: '30 minutes' });
+
+      await runCleaner();
+
+      expect(await isPruned(worker)).toBe(true);
+    } finally {
+      await ctx.store.models.Setting.set('fhir.worker.assumeDroppedAfter', '10 minutes');
+    }
+  });
+
+  it('is scheduled and enabled by the settings schema', () => {
+    const cleaner = new FhirJobWorkerCleaner(ctx);
+    expect(cleaner.isEnabled).toBe(true);
+    expect(cleaner.schedule).toBeTruthy();
+  });
+});

--- a/packages/central-server/app/tasks/index.js
+++ b/packages/central-server/app/tasks/index.js
@@ -17,7 +17,11 @@ import { CovidClearanceCertificatePublisher } from './CovidClearanceCertificateP
 import { PlannedMoveTimeout } from './PlannedMoveTimeout';
 import { SnapshotTableCleaner } from './SnapshotTableCleaner';
 import { StaleSyncSessionCleaner } from './StaleSyncSessionCleaner';
-import { FhirMissingResources } from '@tamanu/shared/tasks';
+import {
+  FhirErroredJobCleaner,
+  FhirJobWorkerCleaner,
+  FhirMissingResources,
+} from '@tamanu/shared/tasks';
 import { FormBuilderChatCleaner } from './FormBuilderChatCleaner';
 import { PatientTelegramCommunicationProcessor } from './PatientTelegramCommunicationProcessor';
 import { VaccinationReminderProcessor } from './VaccinationReminderProcessor';
@@ -62,6 +66,8 @@ export async function startScheduledTasks(context) {
     FormBuilderChatCleaner,
     PlannedMoveTimeout,
     FhirMissingResources,
+    FhirJobWorkerCleaner,
+    FhirErroredJobCleaner,
     SurveyCompletionNotifierProcessor,
     SyncLookupRefresher,
     GenerateRepeatingTasks,

--- a/packages/database/src/migrations/1785492810675-skipDeletedWorkersInGarbageCollect.ts
+++ b/packages/database/src/migrations/1785492810675-skipDeletedWorkersInGarbageCollect.ts
@@ -1,0 +1,47 @@
+import { QueryInterface } from 'sequelize';
+
+// Garbage collection matched every stale row, including the ones already
+// soft-deleted, so each run rewrote the whole history of the registry rather
+// than only what it had to prune. Now that a scheduled task runs it daily, skip
+// the rows that are already gone, and fall back to the documented ten-minute
+// window when the deployment has no assumeDroppedAfter setting of its own —
+// without a fallback the whole statement matches nothing at all. It now reports
+// how many workers it pruned, so a caller can say so.
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`DROP FUNCTION IF EXISTS fhir.job_worker_garbage_collect()`);
+  await query.sequelize.query(`
+    CREATE FUNCTION fhir.job_worker_garbage_collect()
+      RETURNS bigint
+      LANGUAGE SQL
+      VOLATILE PARALLEL UNSAFE
+    AS $$
+      WITH pruned AS (
+        UPDATE fhir.job_workers
+        SET deleted_at = current_timestamp
+        WHERE deleted_at IS NULL
+        AND updated_at < current_timestamp - (
+          SELECT coalesce(
+            (setting_get('fhir.worker.assumeDroppedAfter') ->> 0)::interval,
+            interval '10 minutes')
+        )
+        RETURNING 1
+      )
+      SELECT count(*) FROM pruned
+    $$
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`DROP FUNCTION IF EXISTS fhir.job_worker_garbage_collect()`);
+  await query.sequelize.query(`
+    CREATE FUNCTION fhir.job_worker_garbage_collect()
+      RETURNS void
+      LANGUAGE SQL
+      VOLATILE PARALLEL UNSAFE
+    AS $$
+      UPDATE fhir.job_workers
+      SET deleted_at = current_timestamp
+      WHERE updated_at < current_timestamp - (setting_get('fhir.worker.assumeDroppedAfter') ->> 0)::interval
+    $$
+  `);
+}

--- a/packages/database/src/migrations/1785503476823-indexFhirJobsErroredAt.ts
+++ b/packages/database/src/migrations/1785503476823-indexFhirJobsErroredAt.ts
@@ -1,0 +1,24 @@
+import { QueryInterface } from 'sequelize';
+
+/**
+ * Serves FhirErroredJobCleaner, which deletes errored jobs past a retention
+ * window in batches.
+ *
+ * `job_status_idx` narrows to the errored rows, but they're the bulk of the
+ * table once completed jobs have deleted themselves, so every batch fell back
+ * to reading what was left of them to find the ones past the window. A partial
+ * index on the timestamp answers each batch directly, and only the failure path
+ * maintains it.
+ */
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS job_errored_at_idx ON fhir.jobs
+    USING btree (errored_at) WHERE status = 'Errored'
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    DROP INDEX IF EXISTS fhir.job_errored_at_idx
+  `);
+}

--- a/packages/database/src/models/fhir/Job.ts
+++ b/packages/database/src/models/fhir/Job.ts
@@ -2,7 +2,7 @@ import { trace } from '@opentelemetry/api';
 import ms from 'ms';
 import { DataTypes, QueryTypes, Sequelize } from 'sequelize';
 
-import { JOB_PRIORITIES, SYNC_DIRECTIONS } from '@tamanu/constants';
+import { JOB_PRIORITIES, JOB_QUEUE_STATUSES, SYNC_DIRECTIONS } from '@tamanu/constants';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 import { log } from '@tamanu/shared/services/logging';
 import { Model } from '../Model';
@@ -92,6 +92,42 @@ export class FhirJob extends Model {
       },
     );
     return result?.[0]?.count;
+  }
+
+  /**
+   * Deletes up to `limit` jobs that errored before `cutoff`, returning how many
+   * went.
+   *
+   * An errored job is an audit record and nothing more: failing a job rewrites
+   * its discriminant so it doesn't block a resubmission, and the queue's counts
+   * pass over the status entirely. Completed jobs delete themselves on
+   * completion, so errored ones are the only rows that outlive their work.
+   *
+   * `job_fail()` sets `errored_at` in the same statement that sets the status,
+   * so the two always agree and the window can be read straight off the column,
+   * which is what lets each batch resolve through `job_errored_at_idx` instead
+   * of scanning what's left of the errored rows.
+   */
+  static async deleteErroredBefore(cutoff: Date, limit: number) {
+    const [result] = await this.sequelize.query<{ count: number }>(
+      `WITH deleted AS (
+         DELETE FROM fhir.jobs
+         WHERE id IN (
+           SELECT id
+           FROM fhir.jobs
+           WHERE status = $status
+             AND errored_at < $cutoff
+           LIMIT $limit
+         )
+         RETURNING 1
+       )
+       SELECT count(*)::int AS count FROM deleted`,
+      {
+        type: QueryTypes.SELECT,
+        bind: { status: JOB_QUEUE_STATUSES.ERRORED, cutoff, limit },
+      },
+    );
+    return result.count;
   }
 
   static async grab(workerId: string, topic: string) {

--- a/packages/database/src/models/fhir/JobWorker.ts
+++ b/packages/database/src/models/fhir/JobWorker.ts
@@ -42,8 +42,13 @@ export class FhirJobWorker extends Model {
     return FhirJobWorker.findByPk(result?.[0]?.id);
   }
 
+  /** Soft-deletes the workers that stopped heartbeating, returning how many. */
   static async clearDead() {
-    await this.sequelize.query('SELECT fhir.job_worker_garbage_collect()');
+    const [result] = await this.sequelize.query<{ pruned: string }>(
+      'SELECT fhir.job_worker_garbage_collect() AS pruned',
+      { type: QueryTypes.SELECT },
+    );
+    return Number(result?.pruned ?? 0);
   }
 
   async heartbeat() {

--- a/packages/facility-server/app/tasks/index.js
+++ b/packages/facility-server/app/tasks/index.js
@@ -1,5 +1,7 @@
 import {
   SendStatusToMetaServer,
+  FhirErroredJobCleaner,
+  FhirJobWorkerCleaner,
   FhirMissingResources,
   startFhirWorkerTasks,
 } from '@tamanu/shared/tasks';
@@ -20,6 +22,8 @@ const DEFAULT_TASK_CLASSES = [
   SendStatusToMetaServer,
   TimeSyncTask,
   FhirMissingResources,
+  FhirJobWorkerCleaner,
+  FhirErroredJobCleaner,
   mSupplyMedIntegrationProcessor,
   MSupplyStockOnHandProcessor,
   BedFeeCharger,

--- a/packages/settings/src/schema/central.ts
+++ b/packages/settings/src/schema/central.ts
@@ -885,6 +885,20 @@ export const centralSettings = {
           enabled: false,
         }),
         fhirMissingResources: scheduledTaskSchema({ schedule: '48 1 * * *' }),
+        fhirJobWorkerCleaner: scheduledTaskSchema({ schedule: '37 2 * * *' }),
+        fhirErroredJobCleaner: scheduledTaskSchema(
+          { schedule: '52 2 * * *' },
+          {
+            retentionDays: {
+              name: 'Retention',
+              description: 'Delete FHIR jobs that errored longer ago than this',
+              type: yup.number().integer().positive(),
+              defaultValue: 7,
+              unit: 'days',
+            },
+            ...batchingProperties(1000, 100),
+          },
+        ),
         plannedMoveTimeout: scheduledTaskSchema(
           { schedule: '0 * * * *' },
           {

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -214,6 +214,22 @@ export const facilitySettings = {
           batchingProperties(100, 50),
         ),
         fhirMissingResources: scheduledTaskSchema({ schedule: '48 1 * * *', enabled: false }),
+        // Enabled even where the FHIR worker is not: a facility that once ran one
+        // has rows to prune, and where none ever ran there is nothing to match.
+        fhirJobWorkerCleaner: scheduledTaskSchema({ schedule: '37 2 * * *' }),
+        fhirErroredJobCleaner: scheduledTaskSchema(
+          { schedule: '52 2 * * *' },
+          {
+            retentionDays: {
+              name: 'Retention',
+              description: 'Delete FHIR jobs that errored longer ago than this',
+              type: yup.number().integer().positive(),
+              defaultValue: 7,
+              unit: 'days',
+            },
+            ...batchingProperties(1000, 100),
+          },
+        ),
         sendStatusToMetaServer: scheduledTaskSchema({ schedule: '* * * * *', jitterTime: '30s' }),
         timeSync: scheduledTaskSchema({ schedule: '0 * * * *', enabled: false }),
         mSupplyMedIntegrationProcessor: scheduledTaskSchema(

--- a/packages/shared/src/tasks/fhir/FhirErroredJobCleaner.js
+++ b/packages/shared/src/tasks/fhir/FhirErroredJobCleaner.js
@@ -1,0 +1,66 @@
+import { subDays } from 'date-fns';
+
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
+
+import { ScheduledTask } from '../ScheduledTask';
+import { log } from '../../services/logging';
+
+/**
+ * Expires the errored jobs left behind in the FHIR job queue.
+ *
+ * A job that completes deletes its own row, so an errored job is the only kind
+ * that outlives its work: the row stays as the record of what went wrong. That
+ * record is worth keeping while someone might still act on it and not after, so
+ * this drops the ones past the retention window, in batches, to keep a first
+ * run on a long-neglected queue from holding the table for minutes at a time.
+ */
+export class FhirErroredJobCleaner extends ScheduledTask {
+  getName() {
+    return 'FhirErroredJobCleaner';
+  }
+
+  constructor(context, overrideConfig = null) {
+    // schedules is settings-resolved before task startup on both server types
+    const conf = {
+      ...context.schedules?.fhirErroredJobCleaner,
+      ...overrideConfig,
+    };
+    const { schedule, jitterTime, enabled } = conf;
+    super(schedule, log.child({ task: 'FhirErroredJobCleaner' }), jitterTime, enabled);
+    this.config = conf;
+    this.store = context.store;
+  }
+
+  async run() {
+    const { retentionDays, batchSize, batchSleepAsyncDurationInMilliseconds } = this.config;
+    // A batch size of zero would make the loop below never finish, and a missing
+    // retention window would set the cutoff to an invalid date.
+    if (
+      !(retentionDays > 0) ||
+      !(batchSize > 0) ||
+      !(batchSleepAsyncDurationInMilliseconds > 0)
+    ) {
+      throw new Error(
+        `FhirErroredJobCleaner needs a positive retentionDays, batchSize, and batchSleepAsyncDurationInMilliseconds, got ${JSON.stringify(
+          { retentionDays, batchSize, batchSleepAsyncDurationInMilliseconds },
+        )}`,
+      );
+    }
+
+    const cutoff = subDays(new Date(), retentionDays);
+
+    let deleted = 0;
+    for (;;) {
+      const batch = await this.store.models.FhirJob.deleteErroredBefore(cutoff, batchSize);
+      deleted += batch;
+      if (batch < batchSize) break;
+      await sleepAsync(batchSleepAsyncDurationInMilliseconds);
+    }
+
+    this.log.info('FhirErroredJobCleaner: expired errored jobs', {
+      deleted,
+      retentionDays,
+      cutoff,
+    });
+  }
+}

--- a/packages/shared/src/tasks/fhir/FhirJobWorkerCleaner.js
+++ b/packages/shared/src/tasks/fhir/FhirJobWorkerCleaner.js
@@ -1,0 +1,37 @@
+import { ScheduledTask } from '../ScheduledTask';
+import { log } from '../../services/logging';
+
+/**
+ * Prunes the worker registry of workers that stopped heartbeating without
+ * deregistering.
+ *
+ * A worker that crashed or was killed leaves its row behind with a frozen
+ * heartbeat. The jobs it had grabbed are already back in the pool — the queue
+ * treats a worker as dead once its heartbeat is older than
+ * `fhir.worker.assumeDroppedAfter` — but nothing reclaims the row itself, so
+ * without this the registry grows by one row for every worker that has ever
+ * died, and an operator reading it cannot tell a worker that died this minute
+ * from one that died last year.
+ */
+export class FhirJobWorkerCleaner extends ScheduledTask {
+  getName() {
+    return 'FhirJobWorkerCleaner';
+  }
+
+  constructor(context, overrideConfig = null) {
+    // schedules is settings-resolved before task startup on both server types
+    const conf = {
+      ...context.schedules?.fhirJobWorkerCleaner,
+      ...overrideConfig,
+    };
+    const { schedule, jitterTime, enabled } = conf;
+    super(schedule, log.child({ task: 'FhirJobWorkerCleaner' }), jitterTime, enabled);
+    this.config = conf;
+    this.store = context.store;
+  }
+
+  async run() {
+    const pruned = await this.store.models.FhirJobWorker.clearDead();
+    this.log.info('FhirJobWorkerCleaner: pruned dead workers', { pruned });
+  }
+}

--- a/packages/shared/src/tasks/index.js
+++ b/packages/shared/src/tasks/index.js
@@ -10,3 +10,5 @@ export { entireResource } from './fhir/refresh/entireResource';
 export { fromUpstream } from './fhir/refresh/fromUpstream';
 export { resolver } from './fhir/resolver';
 export { FhirMissingResources } from './fhir/FhirMissingResources';
+export { FhirJobWorkerCleaner } from './fhir/FhirJobWorkerCleaner';
+export { FhirErroredJobCleaner } from './fhir/FhirErroredJobCleaner';


### PR DESCRIPTION
### Changes

🤖 The FHIR job queue leaves two kinds of row behind, and nothing was clearing either. A monitored deployment had 1935 dead workers on its books, which is what surfaced this.

**Dead workers.** A worker that crashed or was killed without deregistering leaves its registry row with a frozen heartbeat. `job_worker_garbage_collect()` has always existed to soft-delete those, and `database/model/fhir/job_workers.md` says to call it about once a day, but no caller was ever wired up — `FhirJobWorker.clearDead()` had no callers in the repo and never has. `FhirJobWorkerCleaner` now calls it daily.

There are two problems in the function itself that a daily run would have made matter. It matched every stale row rather than only the ones still registered, so each run would have re-stamped `deleted_at` across the whole history of the registry; and it read `fhir.worker.assumeDroppedAfter` with no fallback, so on a deployment where that setting isn't in the `settings` table the interval is null and the statement matches nothing at all. A migration adds the `deleted_at IS NULL` guard and the documented ten-minute fallback.

**Errored jobs.** `job_complete` deletes the row it completes, so an errored job is the only kind that outlives its work, and it stays for good. That record is worth keeping while someone might act on it and not after, so `FhirErroredJobCleaner` drops the ones past a retention window — seven days by default — in batches, so a first run on a long-neglected queue doesn't hold the table for minutes at a time.

Deleting them is safe: `job_fail` rewrites `discriminant` so an errored row never blocks a resubmission through the unique index, and `job_backlog` only counts `Queued`, stale `Grabbed`, and `Started` rows owned by dead workers.

Both tasks are registered on central and facility, wherever a FHIR worker might have run, and both are settings-scheduled like their siblings. The `job_workers` doc block is corrected while nearby: it still described `deleted_at` as unused and hard deletion, which stopped being true with the soft-delete migration.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
