### PR TITLE
fix(web): TAM-7023: admin report and settings editor bugs

### DIFF
--- a/packages/e2e-tests/pages/facilityAdmin/SettingsPage.ts
+++ b/packages/e2e-tests/pages/facilityAdmin/SettingsPage.ts
@@ -82,4 +82,14 @@ export class SettingsPage extends BasePage {
   async resetToDefault(setting: Locator): Promise<void> {
     await setting.getByTestId('defaultsettingbutton-4vbq').click();
   }
+
+  // plain string settings render a TextInput; enum strings render a select instead
+  textInput(setting: Locator): Locator {
+    return setting.getByTestId('styledtextinput-fpam').locator('input');
+  }
+
+  async save(): Promise<void> {
+    await this.page.getByTestId('button-s1z4').click();
+    await this.page.getByText('Settings saved').waitFor();
+  }
 }

--- a/packages/e2e-tests/tests/settings/settingsEditor.spec.ts
+++ b/packages/e2e-tests/tests/settings/settingsEditor.spec.ts
@@ -133,3 +133,51 @@ test.describe('Admin settings editor — array (list) inputs', () => {
     await expect(setting.getByTestId('listsettinginput-remove-0')).toBeHidden();
   });
 });
+
+test.describe('Admin settings editor — saving string settings', () => {
+  let settingsPage: SettingsPage;
+
+  // country.name is a plain yup.string() in the global scope, directly under the
+  // Country category, so its value survives a save untouched by any structured
+  // editor. Scope defaults to global.
+  const COUNTRY_NAME = 'name';
+
+  test.beforeEach(async ({ page }) => {
+    settingsPage = new SettingsPage(page);
+    await settingsPage.goto();
+    await expect(settingsPage.scopeSelect).toBeVisible();
+    await settingsPage.selectCategory('Country');
+  });
+
+  test.afterEach(async () => {
+    const setting = settingsPage.settingLine(COUNTRY_NAME);
+    await settingsPage.resetToDefault(setting);
+    await settingsPage.save();
+  });
+
+  // A string setting whose text happens to parse as JSON must come back as that
+  // text. The save path used to run JSON.parse over every value and keep
+  // anything that parsed to an object, which turned these into real objects.
+  test('[SET-0006] keeps a string setting whose content looks like JSON', async ({ page }) => {
+    const setting = settingsPage.settingLine(COUNTRY_NAME);
+    await settingsPage.textInput(setting).fill('{"a":1}');
+    await settingsPage.save();
+
+    await page.reload();
+    await expect(settingsPage.textInput(settingsPage.settingLine(COUNTRY_NAME))).toHaveValue(
+      '{"a":1}',
+    );
+  });
+
+  // "null" parses to null, and typeof null is 'object', so it took the same path.
+  test('[SET-0007] keeps the literal string "null"', async ({ page }) => {
+    const setting = settingsPage.settingLine(COUNTRY_NAME);
+    await settingsPage.textInput(setting).fill('null');
+    await settingsPage.save();
+
+    await page.reload();
+    await expect(settingsPage.textInput(settingsPage.settingLine(COUNTRY_NAME))).toHaveValue(
+      'null',
+    );
+  });
+});

--- a/packages/e2e-tests/tests/settings/settingsEditor.spec.ts
+++ b/packages/e2e-tests/tests/settings/settingsEditor.spec.ts
@@ -136,6 +136,7 @@ test.describe('Admin settings editor — array (list) inputs', () => {
 
 test.describe('Admin settings editor — saving string settings', () => {
   let settingsPage: SettingsPage;
+  let seededName: string;
 
   // country.name is a plain yup.string() in the global scope, directly under the
   // Country category, so its value survives a save untouched by any structured
@@ -147,12 +148,17 @@ test.describe('Admin settings editor — saving string settings', () => {
     await settingsPage.goto();
     await expect(settingsPage.scopeSelect).toBeVisible();
     await settingsPage.selectCategory('Country');
+    seededName = await settingsPage.textInput(settingsPage.settingLine(COUNTRY_NAME)).inputValue();
   });
 
+  // restore rather than reset to default: reset deletes the environment's stored
+  // country name instead of putting it back
   test.afterEach(async () => {
-    const setting = settingsPage.settingLine(COUNTRY_NAME);
-    await settingsPage.resetToDefault(setting);
-    await settingsPage.save();
+    const input = settingsPage.textInput(settingsPage.settingLine(COUNTRY_NAME));
+    if ((await input.inputValue()) !== seededName) {
+      await input.fill(seededName);
+      await settingsPage.save();
+    }
   });
 
   // A string setting whose text happens to parse as JSON must come back as that

--- a/packages/web/__tests__/views/administration/settings/parseJsonEditedSettings.test.js
+++ b/packages/web/__tests__/views/administration/settings/parseJsonEditedSettings.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import * as yup from 'yup';
+import { parseJsonEditedSettings } from '../../../../app/views/administration/settings/parseJsonEditedSettings';
+
+const schema = {
+  properties: {
+    templates: {
+      properties: {
+        letterhead: { type: yup.string() },
+        vaccineCertificate: { type: yup.object() },
+        allowedCodes: { type: yup.array() },
+        maxPageSize: { type: yup.number() },
+      },
+    },
+  },
+};
+
+const parse = settings => parseJsonEditedSettings(settings, schema);
+
+describe('parseJsonEditedSettings', () => {
+  it('parses the JSON text held by object and array settings', () => {
+    expect(
+      parse({ templates: { vaccineCertificate: '{"a":1}', allowedCodes: '[1,2]' } }),
+    ).toEqual({ templates: { vaccineCertificate: { a: 1 }, allowedCodes: [1, 2] } });
+  });
+
+  it('leaves a string setting alone when its content looks like JSON', () => {
+    expect(parse({ templates: { letterhead: '{"a":1}' } })).toEqual({
+      templates: { letterhead: '{"a":1}' },
+    });
+  });
+
+  it('leaves the string "null" as a string', () => {
+    expect(parse({ templates: { letterhead: 'null' } })).toEqual({
+      templates: { letterhead: 'null' },
+    });
+  });
+
+  it('keeps malformed JSON as text so validation can flag it', () => {
+    expect(parse({ templates: { vaccineCertificate: '{"a":' } })).toEqual({
+      templates: { vaccineCertificate: '{"a":' },
+    });
+  });
+
+  it('passes through values that are already parsed', () => {
+    expect(
+      parse({ templates: { vaccineCertificate: { a: 1 }, maxPageSize: 20 } }),
+    ).toEqual({ templates: { vaccineCertificate: { a: 1 }, maxPageSize: 20 } });
+  });
+
+  it('leaves settings with no matching schema node untouched', () => {
+    expect(parse({ removed: { setting: '{"a":1}' } })).toEqual({
+      removed: { setting: '{"a":1}' },
+    });
+  });
+});

--- a/packages/web/app/views/administration/reports/EditReportView.jsx
+++ b/packages/web/app/views/administration/reports/EditReportView.jsx
@@ -1,6 +1,7 @@
 import ChevronLeft from '@mui/icons-material/ChevronLeft';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import React from 'react';
+import { omit } from 'es-toolkit/compat';
+import React, { useMemo } from 'react';
 import { toast } from 'react-toastify';
 import styled from 'styled-components';
 import { Box } from '@material-ui/core';
@@ -9,7 +10,7 @@ import { OutlinedButton } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
 import { useApi } from '../../../api';
 import { VersionInfo } from './components/VersionInfo';
-import { ReportEditor } from './ReportEditor';
+import { ReportEditor, withParameterIds } from './ReportEditor';
 import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
@@ -26,7 +27,7 @@ const StyledButton = styled(OutlinedButton)`
 
 const getInitialValues = (version, report) => {
   const { query, status, queryOptions, notes } = version;
-  const { dataSources, ...options } = queryOptions;
+  const { dataSources, parameters, ...options } = queryOptions;
   const { name, dbSchema } = report;
   return {
     name,
@@ -34,6 +35,7 @@ const getInitialValues = (version, report) => {
     status,
     dbSchema,
     ...options,
+    parameters: withParameterIds(parameters),
     dataSources,
     notes,
   };
@@ -53,18 +55,22 @@ export const EditReportView = () => {
     },
   );
 
+  // Keyed once per fetched version: withParameterIds mints fresh ids each call,
+  // and enableReinitialize would reset the form on every render otherwise.
+  const initialValues = useMemo(
+    () => version && getInitialValues(version, version.reportDefinition),
+    [version],
+  );
+
   const handleBack = () => {
     navigate('/admin/reports');
   };
 
-  const handleSave = async ({ query, status, dbSchema, notes, ...queryOptions }) => {
-    const { dataSources } = queryOptions;
+  const handleSave = async values => {
+    const { query, status, dbSchema, notes } = values;
     const { reportDefinition } = version;
     const payload = {
-      queryOptions: {
-        ...queryOptions,
-        dataSources,
-      },
+      queryOptions: omit(values, ['name', 'query', 'status', 'dbSchema', 'notes']),
       query,
       status,
       dbSchema,
@@ -120,7 +126,7 @@ export const EditReportView = () => {
           <ReportEditor
             isEdit
             onSubmit={handleSave}
-            initialValues={getInitialValues(version, version.reportDefinition)}
+            initialValues={initialValues}
             data-testid="reporteditor-89qw"
           />
         </>

--- a/packages/web/app/views/administration/reports/ReportEditor.jsx
+++ b/packages/web/app/views/administration/reports/ReportEditor.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
+import { omit } from 'es-toolkit/compat';
+import { generate } from 'shortid';
 import * as yup from 'yup';
 import { Accordion, AccordionDetails, AccordionSummary, Grid } from '@material-ui/core';
 import {
@@ -42,15 +44,14 @@ const StatusField = styled(Field)`
 `;
 
 const generateDefaultParameter = () => ({
-  id: Math.random(),
+  id: generate(),
 });
 
 const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit, setFieldValue }) => {
   const { ability } = useAuth();
   const api = useApi();
   const setQuery = query => setValues({ ...values, query });
-  const params =
-    values.parameters.map(param => ({ ...generateDefaultParameter(), ...param })) || [];
+  const params = values.parameters ?? [];
   const setParams = newParams => setValues({ ...values, parameters: newParams });
   const onParamsAdd = () => setParams([...params, generateDefaultParameter()]);
 
@@ -230,11 +231,21 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit, setF
   );
 };
 
+// Parameter ids exist only to key the editor rows; they are not part of a report
+// definition and must not reach the saved queryOptions.
+export const withParameterIds = parameters =>
+  (parameters ?? []).map(parameter => ({ ...parameter, id: generate() }));
+
 export const ReportEditor = ({ initialValues, onSubmit, isEdit }) => {
   const { getTranslation } = useTranslation();
+  const handleSubmit = ({ parameters, ...values }, formikHelpers) =>
+    onSubmit(
+      { ...values, parameters: parameters.map(parameter => omit(parameter, ['id'])) },
+      formikHelpers,
+    );
   return (
     <Form
-      onSubmit={onSubmit}
+      onSubmit={handleSubmit}
       enableReinitialize
       validationSchema={yup.object().shape({
         name: yup

--- a/packages/web/app/views/administration/reports/ReportTables.jsx
+++ b/packages/web/app/views/administration/reports/ReportTables.jsx
@@ -137,7 +137,7 @@ export const VersionTable = React.memo(({ data, onRowClick, loading, error }) =>
             />
           ),
           key: 'createdAt',
-          accessor: ({ updatedAt }) => formatShortDateTime(updatedAt),
+          accessor: ({ createdAt }) => formatShortDateTime(createdAt),
         },
         {
           title: (

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -23,6 +23,7 @@ import { Category } from './components/Category';
 import { SettingsSubmitContext } from './components/SettingsSubmitContext';
 import { filterSettingsSchema } from './filterSettingsSchema';
 import { formatSettingName } from './formatSettingName';
+import { parseJsonEditedSettings } from './parseJsonEditedSettings';
 import { readUrlParam, writeUrlParams } from './urlState';
 import { notifyValidationErrors } from './notifyValidationErrors';
 
@@ -106,24 +107,6 @@ const countSettings = schema =>
     0,
   );
 
-
-const recursiveJsonParse = obj => {
-  if (typeof obj !== 'object') return obj;
-  if (Array.isArray(obj)) return obj.map(recursiveJsonParse);
-  return Object.entries(obj).reduce((acc, [key, value]) => {
-    try {
-      const parsed = JSON.parse(value);
-      if (typeof parsed === 'object') {
-        acc[key] = parsed;
-      } else {
-        acc[key] = value;
-      }
-    } catch {
-      acc[key] = recursiveJsonParse(value);
-    }
-    return acc;
-  }, {});
-};
 
 // Group any top-level settings under a synthetic category; it's not offered
 // in the category dropdown but shown whenever no category is selected. Copies
@@ -360,8 +343,7 @@ export const EditorView = memo(
       : undefined;
 
     const saveSettings = async event => {
-      // Need to parse json string objects stored in keys
-      const parsedSettings = recursiveJsonParse(values.settings);
+      const parsedSettings = parseJsonEditedSettings(values.settings, getScopedSchema(scope));
       delete parsedSettings.uncategorised;
       const submittedValues = { ...values, settings: parsedSettings };
       setValues(submittedValues);

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -1655,7 +1655,7 @@ export const SettingInput = ({
     );
   const defaultHandleChange = e => handleChangeValue(e.target.value);
   const handleChangeSwitch = e => handleChangeValue(e.target.checked);
-  const handleChangeNumber = e => handleChangeValue(Number(e.target.value));
+  const handleChangeNumber = e => handleChangeValue(coerceNumericInput(e.target.value));
   const handleChangeJSON = e => handleChangeValue(e);
 
   const handleSecretChange = e => {

--- a/packages/web/app/views/administration/settings/parseJsonEditedSettings.js
+++ b/packages/web/app/views/administration/settings/parseJsonEditedSettings.js
@@ -1,0 +1,29 @@
+import { isPlainObject, isString } from 'es-toolkit/compat';
+import { isSetting } from '@tamanu/settings/schema';
+
+const JSON_EDITED_TYPES = ['array', 'object'];
+
+// The JSON editor holds its value as raw text, so those settings arrive as
+// strings and need parsing back before save. Only the schema can say which ones
+// they are: sniffing for parseable text rewrites a string setting whose content
+// happens to look like JSON.
+export const parseJsonEditedSettings = (settings, schema) => {
+  if (!isPlainObject(settings)) return settings;
+  return Object.entries(settings).reduce((acc, [key, value]) => {
+    const node = schema?.properties?.[key];
+    if (!node || !isSetting(node)) {
+      acc[key] = parseJsonEditedSettings(value, node);
+      return acc;
+    }
+    if (!JSON_EDITED_TYPES.includes(node.type?.type) || !isString(value)) {
+      acc[key] = value;
+      return acc;
+    }
+    try {
+      acc[key] = JSON.parse(value);
+    } catch {
+      acc[key] = value; // leave malformed text in place for validation to flag
+    }
+    return acc;
+  }, {});
+};


### PR DESCRIPTION
### Changes

Six unrelated bugs in the admin report and settings editors.

**Report editor.** Parameter rows were keyed by an id generated inside the render map, so parameters loaded from a saved version got a fresh key every render and React remounted the row on each keystroke, dropping input focus. Those ids also reached form values and persisted into `queryOptions.parameters[].id`, alongside the report `name`, which `handleSave` never pulled out of the rest spread. Ids are now editor-only: minted on load, stripped in a submit wrapper. `values.parameters ?? []` replaces a misplaced `|| []` that guarded the result of `.map` rather than the array, which threw for versions stored without a `parameters` key (reachable via import). Version table "Created time" read `updatedAt`.

**Settings editor.** Clearing a number field stored 0 (`Number('')`); it now uses the existing `coerceNumericInput` that the list inputs already used. `recursiveJsonParse` ran `JSON.parse` over every value at save and swapped in whatever parsed to an object, so a string setting containing `{"a":1}` (or `"null"`) was saved as an object. Replaced by `parseJsonEditedSettings`, which walks the scoped schema and only parses leaves whose yup type is object or array, leaving malformed text in place for validation to flag. Unit tested.

Two things that might read as mistakes:

- `withParameterIds` mints fresh ids per call, so `EditReportView` memoises `getInitialValues` on the fetched version. Without that, `enableReinitialize` resets the form on every render.
- An empty number field now fails validation rather than silently saving 0. Intended.

Existing versions keep the stray keys already stored in their `queryOptions`; only newly saved ones are clean. No migration.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
