### PR TITLE
fix(sync): no-issue: cap the streaming pull's snapshot inserts at one in flight

### DIFF
--- a/packages/facility-server/__tests__/sync/pullIncomingChanges.test.js
+++ b/packages/facility-server/__tests__/sync/pullIncomingChanges.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, jest } from '@jest/globals';
 
 import { SYNC_STREAM_MESSAGE_KIND } from '@tamanu/constants';
 import { encodeSnapshotCursor } from '@tamanu/database/sync';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { pullIncomingChanges, streamIncomingChanges } from '../../app/sync/pullIncomingChanges';
 
@@ -131,5 +132,94 @@ describe('streamIncomingChanges', () => {
       expect.objectContaining({ id: '7', sortOrder: 2 }),
       expect.objectContaining({ id: '8', sortOrder: 2 }),
     ]);
+  });
+
+  // a totalToPull of 1 caps the write batch at one record, so each streamed record below is its own
+  // insert — enough batches to see how the writes are paced
+  const streamOfRecordPerBatch = count =>
+    streamOf(
+      Array.from({ length: count }, (_, index) =>
+        fakeChange({ id: String(index), sortOrder: 1, recordType: 'users' }),
+      ),
+      () => {},
+    );
+
+  it('keeps at most one snapshot insert in flight', async () => {
+    let inFlight = 0;
+    let mostInFlight = 0;
+    const bulkInsert = jest.fn(async () => {
+      inFlight += 1;
+      mostInFlight = Math.max(mostInFlight, inFlight);
+      await sleepAsync(5);
+      inFlight -= 1;
+    });
+    const centralServer = {
+      initiatePull: jest.fn().mockResolvedValue({ totalToPull: 1, pullUntil: 42 }),
+      stream: streamOfRecordPerBatch(5),
+    };
+
+    await streamIncomingChanges(centralServer, fakeSequelize(bulkInsert), 'sessionId', 1);
+
+    // every batch still gets written, they just don't pile onto the connection pool at once
+    expect(bulkInsert).toHaveBeenCalledTimes(5);
+    expect(mostInFlight).toBe(1);
+  });
+
+  it('fails the pull on a failed insert rather than streaming on to the end', async () => {
+    const bulkInsert = jest.fn().mockRejectedValue(new Error('snapshot table is gone'));
+    const stream = streamOfRecordPerBatch(20);
+    let streamed = 0;
+    const centralServer = {
+      initiatePull: jest.fn().mockResolvedValue({ totalToPull: 1, pullUntil: 42 }),
+      stream: async function* countingStream(endpointFn) {
+        for await (const message of stream(endpointFn)) {
+          streamed += 1;
+          yield message;
+        }
+      },
+    };
+
+    await expect(
+      streamIncomingChanges(centralServer, fakeSequelize(bulkInsert), 'sessionId', 1),
+    ).rejects.toThrow('snapshot table is gone');
+    expect(streamed).toBeLessThan(20);
+  });
+
+  it('settles the in-flight insert when the stream fails, and reports the stream failure', async () => {
+    const unhandled = [];
+    const collectUnhandled = reason => unhandled.push(reason);
+    process.on('unhandledRejection', collectUnhandled);
+
+    try {
+      const bulkInsert = jest.fn(async () => {
+        // fails after the stream does, so nothing is waiting on it by then
+        await sleepAsync(5);
+        throw new Error('insert failed too');
+      });
+      const centralServer = {
+        initiatePull: jest.fn().mockResolvedValue({ totalToPull: 1, pullUntil: 42 }),
+        stream: async function* failingStream() {
+          yield {
+            kind: SYNC_STREAM_MESSAGE_KIND.PULL_CHANGE,
+            message: fakeChange({ id: '1', sortOrder: 1, recordType: 'users' }),
+          };
+          yield {
+            kind: SYNC_STREAM_MESSAGE_KIND.PULL_CHANGE,
+            message: fakeChange({ id: '2', sortOrder: 1, recordType: 'users' }),
+          };
+          throw new Error('stream disconnected');
+        },
+      };
+
+      await expect(
+        streamIncomingChanges(centralServer, fakeSequelize(bulkInsert), 'sessionId', 1),
+      ).rejects.toThrow('stream disconnected');
+
+      // let the insert reject, and node notice if nothing observed it
+      await sleepAsync(30);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', collectUnhandled);
+    }
   });
 });

--- a/packages/facility-server/app/sync/pullIncomingChanges.js
+++ b/packages/facility-server/app/sync/pullIncomingChanges.js
@@ -106,12 +106,13 @@ export const streamIncomingChanges = async (centralServer, sequelize, sessionId,
 
   // Inserts run in the background so the stream isn't stalled waiting on the database, but only one
   // runs at a time. With no ceiling, a stream that outruns the database starts an insert per batch
-  // and nothing stops it: the connection pool is finite and shared with the rest of the facility
-  // server, and every batch still waiting on it is held in memory — which is the problem streaming
-  // exists to solve, arrived at from the other side. Waiting for the previous insert before starting
-  // the next keeps the overlap that backgrounding is for (one batch inserting while the next
-  // streams), caps what we hold at two batches, and turns a failed insert into a failed pull at the
-  // next batch instead of at the final await, hours of streaming later.
+  // and nothing stops it: the pool is finite whichever process we're in (sync gets its own under the
+  // tasks runner, and shares the API's only in the all-in-one dev server), the database behind it is
+  // shared with everything else either way, and every batch still waiting is held in memory — which
+  // is the problem streaming exists to solve, arrived at from the other side. Waiting for the
+  // previous insert before starting the next keeps the overlap that backgrounding is for (one batch
+  // inserting while the next streams), caps what we hold at two batches, and turns a failed insert
+  // into a failed pull at the next batch instead of at the final await, hours of streaming later.
   const flushRecords = async () => {
     if (records.length === 0) return;
     const batch = records;

--- a/packages/facility-server/app/sync/pullIncomingChanges.js
+++ b/packages/facility-server/app/sync/pullIncomingChanges.js
@@ -102,7 +102,26 @@ export const streamIncomingChanges = async (centralServer, sequelize, sessionId,
   log.info('FacilitySyncManager.pulling', { since, totalToPull });
   let totalPulled = 0; // statistics
   let records = []; // for batching writes
-  let writes = []; // ongoing write promises
+  let pendingWrite = null; // the insert running in the background, of which there is at most one
+
+  // Inserts run in the background so the stream isn't stalled waiting on the database, but only one
+  // runs at a time. With no ceiling, a stream that outruns the database starts an insert per batch
+  // and nothing stops it: the connection pool is finite and shared with the rest of the facility
+  // server, and every batch still waiting on it is held in memory — which is the problem streaming
+  // exists to solve, arrived at from the other side. Waiting for the previous insert before starting
+  // the next keeps the overlap that backgrounding is for (one batch inserting while the next
+  // streams), caps what we hold at two batches, and turns a failed insert into a failed pull at the
+  // next batch instead of at the final await, hours of streaming later.
+  const flushRecords = async () => {
+    if (records.length === 0) return;
+    const batch = records;
+    records = [];
+    // chain this insert onto the one before it rather than starting it alongside, and only wait here
+    // for that earlier one: the stream carries on into the next batch while this one is inserting
+    const previousWrite = pendingWrite;
+    pendingWrite = Promise.resolve(previousWrite).then(() => writeBatch(batch));
+    await previousWrite;
+  };
 
   // keep track of the record we're on so we can resume the stream on disconnect from where we left
   // off rather than the start. Only the last one is ever encoded, on the reconnect that needs it,
@@ -117,32 +136,34 @@ export const streamIncomingChanges = async (centralServer, sequelize, sessionId,
     query: { fromId: lastRecord && encodeSnapshotCursor(lastRecord) },
   });
 
-  stream: for await (const { kind, message } of centralServer.stream(endpointFn)) {
-    if (records.length >= WRITE_BATCH_SIZE) {
-      // do writes in the background while we're continuing to stream data
-      writes.push(writeBatch(records));
-      records = [];
+  try {
+    stream: for await (const { kind, message } of centralServer.stream(endpointFn)) {
+      if (records.length >= WRITE_BATCH_SIZE) {
+        await flushRecords();
+      }
+
+      handler: switch (kind) {
+        case SYNC_STREAM_MESSAGE_KIND.PULL_CHANGE:
+          records.push(message);
+          totalPulled += 1;
+          lastRecord = message;
+          break handler;
+        case SYNC_STREAM_MESSAGE_KIND.END:
+          log.debug(`FacilitySyncManager.pull.noMoreChanges`);
+          break stream;
+        default:
+          log.warn('FacilitySyncManager.pull.unknownMessageKind', { kind });
+      }
     }
 
-    handler: switch (kind) {
-      case SYNC_STREAM_MESSAGE_KIND.PULL_CHANGE:
-        records.push(message);
-        totalPulled += 1;
-        lastRecord = message;
-        break handler;
-      case SYNC_STREAM_MESSAGE_KIND.END:
-        log.debug(`FacilitySyncManager.pull.noMoreChanges`);
-        break stream;
-      default:
-        log.warn('FacilitySyncManager.pull.unknownMessageKind', { kind });
-    }
+    await flushRecords();
+    await pendingWrite;
+  } finally {
+    // the awaits above are what report a failed insert, but they are skipped if the stream itself
+    // throws first, and an unobserved rejection takes the process down. Settle it either way without
+    // replacing the error we're already unwinding with.
+    await Promise.allSettled([pendingWrite]);
   }
-
-  if (records.length > 0) {
-    writes.push(writeBatch(records));
-  }
-
-  await Promise.all(writes);
 
   log.info('FacilitySyncManager.pulled', { durationMs: Date.now() - start });
   return { totalPulled, totalToPull, pullUntil };


### PR DESCRIPTION
### Changes

Follows up a below-consensus Review Hero note on #10648 about the `writes` array in `streamIncomingChanges`. The array itself is harmless — a settled promise retains nothing, and it's ~50 entries for a million records — but looking at why it's unbounded turned up two things that aren't.

**Unbounded insert concurrency.** Every batch's snapshot insert was pushed into `writes` and only awaited at the very end, so a stream that outruns the database starts an insert per batch with nothing to stop it. The pool is finite whichever process we're in — sync gets its own under the tasks runner, and only shares the API's in the all-in-one dev server — and the database behind it is shared with everything else in every deployment, so unbounded fan-out means contention (`coding-rules.md`: limit concurrency). Meanwhile every batch still waiting is held in memory, which is the problem streaming exists to solve, arrived at from the other side. Each insert now chains onto the previous one, and a flush waits for that previous insert before the loop reads the next batch: the overlap that backgrounding is for is kept (one batch inserting while the next streams), what's held is capped at two batches, and the stream gets backpressure instead of a queue.

**Failures surfaced hours late, and fatally.** A rejected insert was invisible until the final `await Promise.all(writes)`, so a pull would keep streaming long after its writes started failing — on a first sync, potentially hours of pointless traffic before the session fails anyway. Worse, nothing observed the rejection in the meantime, and an unhandled rejection is fatal by default in current node, so a transient insert failure could take the sync process down rather than failing the sync session. The pull now fails at the next batch boundary, and the in-flight insert is settled even when the stream is what failed, without masking the stream's error.

Three tests cover the new behaviour, each verified to fail against the previous implementation (5 concurrent inserts where 1 is expected; the whole stream drained despite a failing insert; the leaked rejection).

Based on `fix/sync/streaming-pull-cursor` rather than `main`, because #10648 restructures this same function — GitHub will retarget this to `main` when that lands. Behaviour change only, no config or settings, and streaming pull is still off by default (`sync.streaming.enabled`).

Tested: `packages/facility-server` `__tests__/sync/pullIncomingChanges.test.js` passes (9 tests). The DB-backed sync suites also pass against a local postgres — `facility-server __tests__/sync/` 14 suites / 87 tests, `central-server __tests__/sync/` 23 suites / 173 tests.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of