### PR TITLE
test(fhir): no-issue: await the lastUpdated updates in materialised search tests

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/Encounter.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Encounter.test.js
@@ -379,7 +379,7 @@ describe(`Materialised FHIR - Encounter`, () => {
     describe('filters', () => {
       it('by lastUpdated=gt', async () => {
         const [newEncounter, newMat] = await makeEncounter({ encounterType: 'emergency' });
-        newMat.update({ lastUpdated: addDays(new Date(), 5) });
+        await newMat.update({ lastUpdated: addDays(new Date(), 5) });
         const response = await app.get(
           `/api/integration/${INTEGRATION_ROUTE}/Encounter?_lastUpdated=gt${encodeURIComponent(
             formatFhirDate(addDays(new Date(), 4)),

--- a/packages/central-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
@@ -1087,7 +1087,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
             await ir.setAreas([resources.area1.id]);
             await ir.reload();
             const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
-            mat.update({ lastUpdated: addDays(new Date(), 5) });
+            await mat.update({ lastUpdated: addDays(new Date(), 5) });
             return ir;
           })(),
           (async () => {
@@ -1105,7 +1105,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
             await ir.setAreas([resources.area2.id]);
             await ir.reload();
             const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
-            mat.update({ lastUpdated: addDays(new Date(), 10) });
+            await mat.update({ lastUpdated: addDays(new Date(), 10) });
             return ir;
           })(),
         ]);


### PR DESCRIPTION
### Changes

Fixes a read-after-write race that fails a whole central-server CI shard when it lands wrong. It turned up on #10648, where `Test @tamanu/central-server 6/8` went red on `Materialised FHIR - Encounter › search › filters › by lastUpdated=gt` (expected 1 result, got 0) on a diff that only touched facility-server sync code.

The test sets a materialised resource's `lastUpdated` and then searches on it, without awaiting the update:

```js
newMat.update({ lastUpdated: addDays(new Date(), 5) });   // ← no await
const response = await app.get(`...Encounter?_lastUpdated=gt...`);
```

The request races the `UPDATE`. When the `UPDATE` wins — which it nearly always does on an unloaded machine — the test passes; when it loses, the search finds nothing and the assertion fails. Adding `await` is the whole fix.

The same shape appears twice more in `ServiceRequest.test.js`, inside a `beforeAll` whose async IIFEs return before their update commits, feeding the `_sort=_lastUpdated` and `_lastUpdated=gt` cases below them. Fixing only the Encounter one would leave the same flake to resurface from another file, so all three are in here. A sweep of `packages/central-server/__tests__` found no other unawaited model mutations of this kind.

**Testing.** Ran both suites against a local postgres with the fix: `Encounter.test.js` 12/12 and `ServiceRequest.test.js` 39 passed + 1 todo. I could not force the failure locally — 6 runs of the unfixed test all passed — which is what you would expect of a race that needs the `UPDATE` to lose to a loopback query on an idle machine; the CI failure above is the observed instance. Neither file is prettier-clean on `main` today, so I left the formatting alone rather than bury a one-word fix in a reformat; ESLint is clean.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

---
_Generated by [Claude Code](https://claude.ai/code/session_01PY2b5rPpsgBDyQKEFTTfgE)_