### PR TITLE
db: no-issue: tune logs.changes storage for reads

### DIFF
--- a/packages/database/src/migrations/1785812910339-tuneChangelogStorage.ts
+++ b/packages/database/src/migrations/1785812910339-tuneChangelogStorage.ts
@@ -1,0 +1,37 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // lz4 is a postgres compile-time option; a build without it must not fail the upgrade.
+  await query.sequelize.query(`
+    DO $$
+    BEGIN
+      ALTER TABLE logs.changes ALTER COLUMN record_data SET COMPRESSION lz4;
+    EXCEPTION
+      WHEN feature_not_supported OR undefined_object THEN
+        RAISE NOTICE 'lz4 not available, record_data stays on default compression';
+    END
+    $$;
+  `);
+
+  // Default analyze thresholds almost never fire on a table this large, and stale
+  // stats push the changelog readers off their indexes.
+  await query.sequelize.query(`
+    ALTER TABLE logs.changes SET (
+      autovacuum_analyze_scale_factor = 0,
+      autovacuum_analyze_threshold = 500000
+    );
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    ALTER TABLE logs.changes ALTER COLUMN record_data SET COMPRESSION pglz;
+  `);
+
+  await query.sequelize.query(`
+    ALTER TABLE logs.changes RESET (
+      autovacuum_analyze_scale_factor,
+      autovacuum_analyze_threshold
+    );
+  `);
+}


### PR DESCRIPTION
### Changes

Two storage-parameter tweaks on logs.changes for read performance, no schema change.

**`record_data` TOAST compression → lz4.** Every changelog reader detoasts `record_data` (the sync pull is `SELECT *`), and pglz decompression is the slow part of that. lz4 decompresses several times faster at a similar ratio for JSON. Applies to newly written rows only; existing rows stay pglz until rewritten, which is fine — the two coexist per-value. Guarded in a DO block because lz4 is a postgres compile-time option: a build without it logs a notice and keeps the default rather than failing the upgrade.

**Analyze thresholds pinned.** Default autovacuum analyze fires at ~10% table growth, which on a changelog this size means stats go stale for weeks, and stale stats are how the `(table_name, record_id)` lookups fall off the index. `scale_factor = 0, threshold = 500000` re-analyzes roughly every 500k new rows.

Both statements plus the down migration verified against postgres 16.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->