### PR TITLE
tweak(invoicing): TAM-6936: invoicing UI tweaks

### DIFF
--- a/packages/web/app/components/Field/PriceField.jsx
+++ b/packages/web/app/components/Field/PriceField.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NumberInput } from './NumberField';
 
-export const PriceField = ({ field, ...props }) => {
+export const PriceField = ({ field, step = '0.01', ...props }) => {
   const handleInput = e => {
     const value = e.target.value;
     // If value is negative just return empty
@@ -23,7 +23,7 @@ export const PriceField = ({ field, ...props }) => {
       name={field.name}
       onChange={field.onChange}
       onInput={handleInput}
-      step="0.01"
+      step={step}
       min={0}
       max={999999}
       {...props}

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -28,6 +28,7 @@ import { isZeroedBedFeeItem } from '../../../utils/invoice';
 
 const Table = styled.table`
   background-color: ${p => p.theme.palette.background.paper};
+  border: 1px solid ${Colors.outline};
   border-radius: ${p => p.theme.shape.borderRadius}px;
   inline-size: 100%;
   font-size: 14px;
@@ -46,10 +47,16 @@ const Table = styled.table`
 
 const AddButton = styled(TextButton).attrs({ startIcon: <Plus /> })`
   font-size: inherit;
+  font-weight: 500;
+  color: ${Colors.primary};
   .MuiButton-startIcon {
     font-size: inherit;
     margin-inline-end: 4px;
     width: 18px;
+  }
+  &:hover {
+    color: ${Colors.primary};
+    text-decoration: underline;
   }
 `;
 

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Plus } from 'lucide-react';
 import { FieldArray } from 'formik';
 
@@ -26,9 +26,22 @@ import { invoiceFormSchema } from './invoiceFormSchema';
 import { INVOICE_MODAL_TYPES } from '../../../constants';
 import { isZeroedBedFeeItem } from '../../../utils/invoice';
 
+// The table stays border-collapsed so the row-separator borders render; a border-radius on a
+// collapsed table is ignored, so the rounded outer border lives on TableWrapper, which clips the
+// square table corners with overflow: hidden. The edit-mode product dropdown portals out, so it
+// isn't affected by the clipping.
+const TableWrapper = styled.div`
+  ${p =>
+    p.$bordered &&
+    css`
+      border: 1px solid ${Colors.outline};
+      border-radius: 3px;
+      overflow: hidden;
+    `}
+`;
+
 const Table = styled.table`
   background-color: ${p => p.theme.palette.background.paper};
-  border: 1px solid ${Colors.outline};
   border-radius: ${p => p.theme.shape.borderRadius}px;
   inline-size: 100%;
   font-size: 14px;
@@ -179,58 +192,63 @@ export const InvoiceForm = ({ invoice, invoiceFormType, onClose, setInvoiceModal
       validationSchema={invoiceFormSchema}
       render={({ submitForm, values }) => (
         <>
-          <Table>
-            <FieldArray name="invoiceItems">
-              {formArrayMethods => (
-                <>
-                  <InvoiceItemHeader cellWidths={cellWidths} isEditing={isAddForm || isEditForm} />
-                  <tbody>
-                    {values.invoiceItems?.map((item, index) => {
-                      // Hide bed-fee lines zeroed by a ward move; kept in the array so their index
-                      // and the save payload are unchanged.
-                      if (isZeroedBedFeeItem(item)) return null;
-                      return (
-                        <InvoiceItemRow
-                          cellWidths={cellWidths}
-                          encounterId={invoice.encounterId}
-                          formArrayMethods={formArrayMethods}
-                          index={index}
-                          isCancelled={isCancelled}
-                          isEditing={isAddForm || isEditForm}
-                          isFinalised={isFinalised}
-                          item={item}
-                          key={item.id}
-                          onUpdateApproval={updateItemApproval}
-                          onUpdateInvoice={handleUpdateItem}
-                          priceListId={invoice.priceList?.id}
-                        />
-                      );
-                    })}
-                  </tbody>
-                  {editable && (isReadOnlyForm || isAddForm) && (
-                    <FormFooter>
-                      <AddButton
-                        onClick={() => {
-                          if (isReadOnlyForm) {
-                            setInvoiceModalType(INVOICE_MODAL_TYPES.ADD_ITEMS);
-                          } else {
-                            formArrayMethods.push(
-                              getDefaultRow(getCurrentDate, invoice.encounter?.examinerId),
-                            );
-                          }
-                        }}
-                      >
-                        <TranslatedText
-                          stringId="invoice.form.action.addItem"
-                          fallback="Add item"
-                        />
-                      </AddButton>
-                    </FormFooter>
-                  )}
-                </>
-              )}
-            </FieldArray>
-          </Table>
+          <TableWrapper $bordered={isEditForm || isAddForm}>
+            <Table>
+              <FieldArray name="invoiceItems">
+                {formArrayMethods => (
+                  <>
+                    <InvoiceItemHeader
+                      cellWidths={cellWidths}
+                      isEditing={isAddForm || isEditForm}
+                    />
+                    <tbody>
+                      {values.invoiceItems?.map((item, index) => {
+                        // Hide bed-fee lines zeroed by a ward move; kept in the array so their index
+                        // and the save payload are unchanged.
+                        if (isZeroedBedFeeItem(item)) return null;
+                        return (
+                          <InvoiceItemRow
+                            cellWidths={cellWidths}
+                            encounterId={invoice.encounterId}
+                            formArrayMethods={formArrayMethods}
+                            index={index}
+                            isCancelled={isCancelled}
+                            isEditing={isAddForm || isEditForm}
+                            isFinalised={isFinalised}
+                            item={item}
+                            key={item.id}
+                            onUpdateApproval={updateItemApproval}
+                            onUpdateInvoice={handleUpdateItem}
+                            priceListId={invoice.priceList?.id}
+                          />
+                        );
+                      })}
+                    </tbody>
+                    {editable && (isReadOnlyForm || isAddForm) && (
+                      <FormFooter>
+                        <AddButton
+                          onClick={() => {
+                            if (isReadOnlyForm) {
+                              setInvoiceModalType(INVOICE_MODAL_TYPES.ADD_ITEMS);
+                            } else {
+                              formArrayMethods.push(
+                                getDefaultRow(getCurrentDate, invoice.encounter?.examinerId),
+                              );
+                            }
+                          }}
+                        >
+                          <TranslatedText
+                            stringId="invoice.form.action.addItem"
+                            fallback="Add item"
+                          />
+                        </AddButton>
+                      </FormFooter>
+                    )}
+                  </>
+                )}
+              </FieldArray>
+            </Table>
+          </TableWrapper>
           {editable && (isEditForm || isAddForm) && (
             <EditModalFooter>
               <FormCancelButton

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/PriceCell.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/PriceCell.jsx
@@ -21,7 +21,7 @@ const Container = styled.div`
   align-self: stretch;
 
   .MuiTextField-root {
-    max-width: 80px;
+    max-width: 110px;
   }
 `;
 
@@ -151,6 +151,7 @@ export const PriceCell = ({
                 <StyledField
                   name={`invoiceItems.${index}.manualEntryPrice`}
                   component={PriceField}
+                  step={1}
                   required
                   data-testid="field-05x9"
                 />

--- a/packages/web/app/features/Invoice/InvoiceInsuranceModal.jsx
+++ b/packages/web/app/features/Invoice/InvoiceInsuranceModal.jsx
@@ -33,21 +33,12 @@ export const InvoiceInsuranceModal = ({ open, onClose, invoice }) => {
   const defaultValues = invoice?.insurancePlans?.map(({ id }) => id) || [];
   const [selectedPlans, setSelectedPlans] = useState(defaultValues);
   const { mutate } = useInvoiceInsurancePlansMutation(invoice.id, invoice.encounterId, patientId);
-  const {
-    data: insurancePlans = [],
-    isLoading: isLoadingInsurancePlans,
-  } = usePatientInsurancePlansQuery({ patientId });
+  const { data: insurancePlans = [], isLoading: isLoadingInsurancePlans } =
+    usePatientInsurancePlansQuery({ patientId });
   const { navigateToPatient } = usePatientNavigation();
-  // Only offer multi-select when the patient has more than one plan to choose from
-  const isMultiSelect = insurancePlans.length > 1;
   const onChange = ({ target }) => {
-    if (isMultiSelect) {
-      const value = typeof target.value === 'string' ? JSON.parse(target.value) : target.value;
-      setSelectedPlans(value ?? []);
-    } else {
-      // Single-select emits a scalar id; keep state as an array so submission is consistent
-      setSelectedPlans(target.value ? [target.value] : []);
-    }
+    const value = typeof target.value === 'string' ? JSON.parse(target.value) : target.value;
+    setSelectedPlans(value);
   };
 
   const onConfirm = async () => {
@@ -147,11 +138,11 @@ export const InvoiceInsuranceModal = ({ open, onClose, invoice }) => {
           }
           field={{
             name: 'insurancePlans',
-            value: isMultiSelect ? selectedPlans : (selectedPlans[0] ?? ''),
+            value: selectedPlans,
             onChange,
           }}
           endpoint="invoiceInsurancePlan"
-          isMulti={isMultiSelect}
+          isMulti
           baseQueryParameters={{ patientId }}
         />
       </ModalBody>

--- a/packages/web/app/features/Invoice/InvoiceInsuranceModal.jsx
+++ b/packages/web/app/features/Invoice/InvoiceInsuranceModal.jsx
@@ -38,9 +38,16 @@ export const InvoiceInsuranceModal = ({ open, onClose, invoice }) => {
     isLoading: isLoadingInsurancePlans,
   } = usePatientInsurancePlansQuery({ patientId });
   const { navigateToPatient } = usePatientNavigation();
+  // Only offer multi-select when the patient has more than one plan to choose from
+  const isMultiSelect = insurancePlans.length > 1;
   const onChange = ({ target }) => {
-    const value = typeof target.value === 'string' ? JSON.parse(target.value) : target.value;
-    setSelectedPlans(value);
+    if (isMultiSelect) {
+      const value = typeof target.value === 'string' ? JSON.parse(target.value) : target.value;
+      setSelectedPlans(value ?? []);
+    } else {
+      // Single-select emits a scalar id; keep state as an array so submission is consistent
+      setSelectedPlans(target.value ? [target.value] : []);
+    }
   };
 
   const onConfirm = async () => {
@@ -140,11 +147,11 @@ export const InvoiceInsuranceModal = ({ open, onClose, invoice }) => {
           }
           field={{
             name: 'insurancePlans',
-            value: selectedPlans,
+            value: isMultiSelect ? selectedPlans : (selectedPlans[0] ?? ''),
             onChange,
           }}
           endpoint="invoiceInsurancePlan"
-          isMulti
+          isMulti={isMultiSelect}
           baseQueryParameters={{ patientId }}
         />
       </ModalBody>

--- a/packages/web/app/features/Invoice/PatientPaymentStyledComponents.jsx
+++ b/packages/web/app/features/Invoice/PatientPaymentStyledComponents.jsx
@@ -6,7 +6,7 @@ import { Modal } from '../../components/Modal';
 
 export const StyledModal = styled(Modal)`
   .MuiPaper-root {
-    max-width: 680px;
+    max-width: 760px;
   }
 `;
 

--- a/packages/web/app/features/Invoice/PatientPaymentsTable.jsx
+++ b/packages/web/app/features/Invoice/PatientPaymentsTable.jsx
@@ -38,11 +38,11 @@ const TableContainer = styled.div`
 
     th {
       &:nth-child(1) {
-        width: 80px;
+        width: 100px;
       }
 
       &:nth-child(2) {
-        // intentionally empty to take up remaining space
+        // intentionally empty to take up remaining space (method column)
       }
 
       &:nth-child(3) {

--- a/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
@@ -86,6 +86,7 @@ const PaymentsSection = styled.div`
   display: grid;
   grid-template-columns: 1fr 300px;
   gap: 8px;
+  margin-block-start: 20px;
 
   @media (min-width: 1600px) {
     grid-template-columns: 1fr 360px;
@@ -112,6 +113,7 @@ const InvoiceMenu = ({ encounter, invoice, setInvoiceModalType }) => {
   const finalisable =
     invoice && isInvoiceEditable(invoice) && canCreateInvoice && encounter.endDate;
   const allItemsAreApproved = invoice.items.every(item => item.approved);
+  const someItemsAreApproved = invoice.items.some(item => item.approved);
   const zeroItems = invoice.items.length === 0;
 
   const handleAllApprovals = approved => {
@@ -119,6 +121,39 @@ const InvoiceMenu = ({ encounter, invoice, setInvoiceModalType }) => {
   };
 
   const ACTIONS = [
+    {
+      label: (
+        <TranslatedText
+          stringId="invoice.editInvoice.markAllAsApproved"
+          fallback="Mark all as approved"
+          data-testid="translatedtext-95jh"
+        />
+      ),
+      onClick: () => handleAllApprovals(true),
+      hidden: allItemsAreApproved || isCancelled,
+    },
+    {
+      label: (
+        <TranslatedText
+          stringId="invoice.editInvoice.removeAllApprovals"
+          fallback="Remove all approvals"
+          data-testid="translatedtext-k3ds"
+        />
+      ),
+      onClick: () => handleAllApprovals(false),
+      hidden: !someItemsAreApproved || isCancelled || zeroItems,
+    },
+    {
+      label: (
+        <TranslatedText
+          stringId="invoice.editInvoice.printInvoice"
+          fallback="Print invoice"
+          data-testid="translatedtext-31yh"
+        />
+      ),
+      onClick: () => setInvoiceModalType(INVOICE_MODAL_TYPES.PRINT),
+      hidden: !isInProgress,
+    },
     {
       label: (
         <TranslatedText
@@ -140,39 +175,6 @@ const InvoiceMenu = ({ encounter, invoice, setInvoiceModalType }) => {
       ),
       onClick: () => setInvoiceModalType(INVOICE_MODAL_TYPES.DELETE_INVOICE),
       hidden: !deletable,
-    },
-    {
-      label: (
-        <TranslatedText
-          stringId="invoice.editInvoice.removeAllApprovals"
-          fallback="Remove all approvals"
-          data-testid="translatedtext-k3ds"
-        />
-      ),
-      onClick: () => handleAllApprovals(false),
-      hidden: !allItemsAreApproved || isCancelled || zeroItems,
-    },
-    {
-      label: (
-        <TranslatedText
-          stringId="invoice.editInvoice.markAllAsApproved"
-          fallback="Mark all as approved"
-          data-testid="translatedtext-95jh"
-        />
-      ),
-      onClick: () => handleAllApprovals(true),
-      hidden: allItemsAreApproved || isCancelled,
-    },
-    {
-      label: (
-        <TranslatedText
-          stringId="invoice.editInvoice.printInvoice"
-          fallback="Print invoice"
-          data-testid="translatedtext-31yh"
-        />
-      ),
-      onClick: () => setInvoiceModalType(INVOICE_MODAL_TYPES.PRINT),
-      hidden: !isInProgress,
     },
   ];
 


### PR DESCRIPTION
### Changes

Design tweaks to the invoicing screens from Felicity's review feedback, with values sourced from the linked Figma frames where possible. Nine small UI adjustments:

- **Add new** button restyled as a plain blue link (`Colours.primary`) with underline on hover — applies to both the invoice and the add-items modal (shared component)
- Added the missing light-grey outer stroke to the edit/add-new item table
- Reordered the main invoice overflow menu to match the design (Edit items → Mark all as approved → Remove all approvals → Print invoice → Cancel invoice → Delete invoice)
- **Remove all approvals** now appears when _one or more_ items are approved (previously only when _all_ items were approved)
- Widened the **Record payment** modal so the method field isn't clipped
- Gave the payments-table date column more room, taken from the flexible method column
- Insurance plan field is single-select when only one plan is available and multi-select when more than one; the submitted value is normalised to always be an array
- Widened the item cost field and changed its counter-arrow step to $1 (via a new optional `step` prop on `PriceField`, so all other usages keep 0.01)
- Added padding under the item table in the finalised invoice state

The item-level overflow menu already matched the design, so it was left unchanged.

**Notes for review:** a few spacing/width values (finalised padding, modal width, date-column and cost-field widths) are design-system-consistent estimates rather than pixel-measured from Figma — easy to nudge. The insurance single/multi change is the main behavioural one worth a manual check (that both a single-plan and a multi-plan patient save correctly). Not yet visually verified in a running stack.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->