### PR TITLE
fix(labs): no-issue: show historical lab categories and panels a patient has results for

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -13,6 +13,7 @@ import {
   buildDiagnosis,
   createDummyEncounter,
   createDummyPatient,
+  createLabTestTypes,
   randomRecords,
   randomLabRequest,
   splitIds,
@@ -438,6 +439,75 @@ describe('Suggestions', () => {
       expect(result).toHaveSucceeded();
       expect(result.body.length).toEqual(1);
       expect(result.body[0].name).toEqual('AA-used');
+    });
+
+    it('should still include a historical (no longer current) category if the patient has a published lab request against it', async () => {
+      const { id: historicalCategoryId } = await models.ReferenceData.create({
+        ...fake(models.ReferenceData),
+        name: 'AA-historical',
+        type: 'labTestCategory',
+        visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
+      });
+      await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          categoryId: historicalCategoryId,
+          status: LAB_REQUEST_STATUSES.PUBLISHED,
+          encounterId,
+        }),
+      );
+
+      const result = await userApp.get('/v1/suggestions/patientLabTestCategories').query({
+        patientId,
+        status: LAB_REQUEST_STATUSES.PUBLISHED,
+      });
+      expect(result).toHaveSucceeded();
+      expect(result.body.map(({ name }) => name).sort()).toEqual(['AA-historical', 'AA-used']);
+    });
+  });
+
+  describe('patientLabTestPanelTypes', () => {
+    let patientId;
+    let encounterId;
+
+    beforeAll(async () => {
+      patientId = (await models.Patient.create(await createDummyPatient(models))).id;
+      const encounter = await models.Encounter.create(
+        await createDummyEncounter(models, { patientId }),
+      );
+      encounterId = encounter.id;
+    });
+
+    it('should still include a historical (no longer current) panel if the patient has a published lab request against a test in it', async () => {
+      const { id: categoryId } = await models.ReferenceData.create({
+        ...fake(models.ReferenceData),
+        type: 'labTestCategory',
+      });
+      const [labTestType] = await createLabTestTypes(models, categoryId);
+
+      const { id: panelId } = await models.LabTestPanel.create({
+        ...fake(models.LabTestPanel),
+        visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
+      });
+      await models.LabTestPanelLabTestTypes.create({
+        labTestPanelId: panelId,
+        labTestTypeId: labTestType.id,
+      });
+
+      await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          categoryId,
+          labTestTypeIds: [labTestType.id],
+          status: LAB_REQUEST_STATUSES.PUBLISHED,
+          encounterId,
+        }),
+      );
+
+      const result = await userApp.get('/v1/suggestions/patientLabTestPanelTypes').query({
+        patientId,
+        status: LAB_REQUEST_STATUSES.PUBLISHED,
+      });
+      expect(result).toHaveSucceeded();
+      expect(result.body.map(({ id }) => id)).toEqual([panelId]);
     });
   });
 

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -1020,11 +1020,16 @@ createSuggester(
   'patientLabTestCategories',
   'ReferenceData',
   ({ endpoint, modelName, query, req }) => {
-    const baseWhere = DEFAULT_WHERE_BUILDER({ endpoint, modelName });
-
     if (!query.patientId) {
+      const baseWhere = DEFAULT_WHERE_BUILDER({ endpoint, modelName });
       return { ...baseWhere, type: REFERENCE_TYPES.LAB_TEST_CATEGORY };
     }
+
+    // A category that's no longer active (visibilityStatus !== current) should still be
+    // selectable here as long as the patient actually has a published lab request against
+    // it — skip the usual "current only" visibility filter and rely on the patient-scoped
+    // id filter below to do the real gating instead.
+    const baseWhere = DEFAULT_WHERE_BUILDER({ endpoint, modelName, skipVisibilityFilter: true });
 
     const idBaseFilter = {
       [Op.in]: Sequelize.literal(
@@ -1080,11 +1085,15 @@ createSuggester(
   'patientLabTestPanelTypes',
   'LabTestPanel',
   ({ endpoint, modelName, query }) => {
-    const baseWhere = DEFAULT_WHERE_BUILDER({ endpoint, modelName });
-
     if (!query.patientId) {
-      return baseWhere;
+      return DEFAULT_WHERE_BUILDER({ endpoint, modelName });
     }
+
+    // A panel that's no longer active (visibilityStatus !== current) should still be
+    // selectable here as long as the patient actually has a published lab request against
+    // it — skip the usual "current only" visibility filter and rely on the patient-scoped
+    // id filter below to do the real gating instead.
+    const baseWhere = DEFAULT_WHERE_BUILDER({ endpoint, modelName, skipVisibilityFilter: true });
 
     return {
       ...baseWhere,


### PR DESCRIPTION
### Changes

The ''Test category''/''Test panel'' dropdowns on a patient'''s lab results search bar already scoped their options to categories/panels the patient has a published lab request against, but also applied the default current only visibility filter on top of that scoping - so a historical (deactivated) category or panel would never show, even when the patient had real results for it.\n\nThis PR skips that visibility filter for both the patientLabTestCategories and patientLabTestPanelTypes suggesters when scoped to a patient, relying solely on the existing patient-scoped subquery (which already requires an actual published lab request) to gate inclusion - so a historical category/panel now shows if and only if the patient has results for it.\n\nAdded tests for both suggesters confirming this.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->