### PR TITLE
fix(web): no-issue: don't request patient data with a null patient id

### DIFF
--- a/packages/web/app/components/PatientInfoPane/InfoPaneList.jsx
+++ b/packages/web/app/components/PatientInfoPane/InfoPaneList.jsx
@@ -96,8 +96,11 @@ export const InfoPaneList = ({
   const [addEditState, setAddEditState] = useState({ adding: false, editKey: null });
   const { adding, editKey } = addEditState;
   const api = useApi();
-  const { data, error } = useQuery([`infoPaneListItem-${paneId}`, patient.id], () =>
-    api.get(getEndpoint),
+  const { data, error } = useQuery(
+    [`infoPaneListItem-${paneId}`, patient.id],
+    () => api.get(getEndpoint),
+    // getEndpoint interpolates patient.id, which is null until the patient is loaded into the store
+    { enabled: Boolean(patient.id) },
   );
 
   const isIssuesPane = paneId === PANE_SECTION_IDS.ISSUES;

--- a/packages/web/app/views/patients/EncounterView.jsx
+++ b/packages/web/app/views/patients/EncounterView.jsx
@@ -185,7 +185,10 @@ export const EncounterView = () => {
     fallbackEncounterTab,
   );
 
+  // The patient is loaded into the store asynchronously, so patient.id is null on the first
+  // render when this view is opened directly by URL. Only record the view once we have an id.
   useEffect(() => {
+    if (!patient.id) return;
     api.post(`user/recently-viewed-patients/${patient.id}`);
   }, [api, patient.id]);
 

--- a/packages/web/app/views/patients/PatientView.jsx
+++ b/packages/web/app/views/patients/PatientView.jsx
@@ -192,6 +192,7 @@ export const PatientView = () => {
   const { data: birthData, isLoading: isLoadingBirthData } = useQuery(
     ['birthData', patient.id],
     () => api.get(`patient/${patient.id}/birthData`),
+    { enabled: Boolean(patient.id) },
   );
   const {
     data: insurancePlans = [],


### PR DESCRIPTION
### Changes

🤖 Production logs at a facility server showed `POST /api/user/recently-viewed-patients/null` returning 422 — the literal string `null` interpolated into the URL path.

Root cause: the redux patient slice starts as `{ loading: true, id: null }`, and within the `/patients/:category/:patientId/*` route tree only `PatientView` (the index route) loads the patient from the URL param. `EncounterView` is a **sibling** route, so deep-linking or refreshing an encounter URL mounts it with the store still at its default and its effect fires with `patient.id === null`.

`PatientView`'s equivalent effect was already guarded — both were added unguarded in the same change, and the guard was added to `PatientView` later in an e2e PR (deep-linking being exactly what surfaced it) while `EncounterView` was missed. This completes that half-applied fix.

Two more instances of the same defect on the same route are fixed here: `PatientView`'s inline `birthData` query, whose two immediate neighbours already had `enabled` guards, and `InfoPaneList`, which is mounted for every patient route and fired six null-id GETs (`conditions`, `allergies`, `familyHistory`, `issues`, `carePlans`, `programRegistration`) on any deep link.

A guard rather than an upstream data load is the correct fix here: React runs child effects before parent effects, so an ancestor's load always lands after descendants' first-render requests have gone out. The consumer has to be keyed on the id.

Server behaviour is correct and untouched — the literal `'null'` violates the foreign key to `patients`, which maps to a 422 with no bad row written.

Not fixed, and worth a separate ticket: opening an encounter URL directly leaves `EncounterView` on a permanent loading indicator, because its render guard includes `patient.loading`, which defaults true and never clears since nothing dispatches `reloadPatient` on that route. That is the underlying reason the null id occurs at all.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
