### PR TITLE
fix(web): no-issue: classify API error toasts by error type

### DIFF
--- a/packages/errors/src/extractErrorFromFetchResponse.ts
+++ b/packages/errors/src/extractErrorFromFetchResponse.ts
@@ -10,7 +10,6 @@ import {
   NotFoundError,
   RemoteUnreachableError,
   UnknownError,
-  ValidationError,
 } from './errors';
 
 export function isRecoverable(error: Error) {
@@ -118,15 +117,26 @@ interface Logger {
   warn: (message: string, ...args: any[]) => void;
 }
 
+/**
+ * A body we can't read is the remote misbehaving, not the caller sending
+ * something invalid, so keep the response's own status: a reverse proxy serving
+ * an HTML 502 page has to stay a server error rather than looking like a
+ * validation failure the caller could fix. Mirrors the empty-body and
+ * unrecognised-shape branches of `readResponse`.
+ */
+function unreadableBody(response: Response, detail: string, cause: Error): Problem {
+  const problem = new Problem(ERROR_TYPE.REMOTE, 'Server error', response.status, detail);
+  problem.cause = cause;
+  return problem;
+}
+
 async function readResponse(response: Response, logger: Logger = console): Promise<Problem> {
   let data;
   try {
     data = await response.text();
   } catch (err) {
     logger.warn('readResponseError: Error decoding text', err);
-    return Problem.fromError(
-      new ValidationError('Invalid text encoding in response').withCause(err as Error),
-    );
+    return unreadableBody(response, 'Invalid text encoding in response', err as Error);
   }
 
   if (data.length === 0) {
@@ -138,9 +148,7 @@ async function readResponse(response: Response, logger: Logger = console): Promi
     json = JSON.parse(data);
   } catch (err) {
     logger.warn('readResponseError: Error parsing JSON', err);
-    return Problem.fromError(
-      new ValidationError('Invalid JSON in response').withCause(err as Error),
-    );
+    return unreadableBody(response, 'Invalid JSON in response', err as Error);
   }
 
   const problem = Problem.fromJSON(json);

--- a/packages/facility-server/__tests__/sync/CentralServerConnection.test.js
+++ b/packages/facility-server/__tests__/sync/CentralServerConnection.test.js
@@ -41,6 +41,19 @@ const fakeProblem = error => {
   const problem = Problem.fromError(error);
   return fakeResponse({ status: problem.status, ok: false }, problem.toJSON(), problem.headers);
 };
+// A reverse proxy answering for the central server with its own error page, so the
+// body is HTML rather than a problem document.
+const fakeGatewayFailure = status =>
+  Promise.resolve({
+    status,
+    ok: false,
+    json: () => Promise.reject(new Error('Unexpected token < in JSON at position 0')),
+    text: () => Promise.resolve(`<!doctype html><title>${status}</title><h1>${status}</h1>`),
+    headers: {
+      get: key => ({ 'content-type': 'text/html; charset=utf-8' })[key.toLowerCase()],
+      has: () => false,
+    },
+  });
 
 describe('CentralServerConnection', () => {
   // Create a valid JWT token for testing
@@ -196,6 +209,16 @@ describe('CentralServerConnection', () => {
     it('throws a RemoteCallError if no data is returned with the error', async () => {
       fetch.mockReturnValueOnce(authEmpty);
       await expect(centralServer.connect()).rejects.toBeProblemOfType(ERROR_TYPE.REMOTE);
+    });
+
+    it('throws a RemoteCallError if the error body is not a problem document', async () => {
+      // A gateway error page is the remote misbehaving, not a validation failure:
+      // keeping it as a remote error (with its real status) is what lets callers
+      // tell it apart from a problem the request itself caused.
+      fetch.mockReturnValueOnce(fakeGatewayFailure(502));
+      const problem = await centralServer.connect().catch(err => err);
+      expect(problem).toBeProblemOfType(ERROR_TYPE.REMOTE);
+      expect(problem.status).toBe(502);
     });
 
     it('retrieves server settings', async () => {

--- a/packages/web/__tests__/api/classifyApiError.test.js
+++ b/packages/web/__tests__/api/classifyApiError.test.js
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   EditConflictError,
   ERROR_TYPE,
+  extractErrorFromFetchResponse,
   ForbiddenError,
   NotFoundError,
+  Problem,
   RemoteUnreachableError,
   ValidationError,
 } from '@tamanu/errors';
@@ -12,6 +14,7 @@ import {
   API_ERROR_TOAST,
   classifyApiError,
   isErrorUnknownDefault,
+  resolveApiErrorToast,
 } from '../../app/api/classifyApiError';
 
 // The full taxonomy, so a newly added ERROR_TYPE has to be classified deliberately
@@ -94,9 +97,122 @@ describe('classifyApiError', () => {
   });
 
   it('covers every error type in the taxonomy', () => {
-    expect(Object.keys(EXPECTED_BY_TYPE).toSorted()).toEqual(
-      Object.values(ERROR_TYPE).toSorted(),
+    expect(Object.keys(EXPECTED_BY_TYPE).toSorted()).toEqual(Object.values(ERROR_TYPE).toSorted());
+  });
+});
+
+// The classifier sees whatever @tamanu/errors made of the response, so go through
+// the real extraction rather than hand-built error objects: an error body that
+// isn't a problem document at all is the case most likely to be misfiled.
+describe('errors extracted from a real response', () => {
+  const silentLogger = {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    log: () => {},
+    warn: () => {},
+  };
+
+  const extract = response =>
+    extractErrorFromFetchResponse(response, 'patient/all-of-them', silentLogger);
+
+  const htmlErrorPage = status =>
+    new Response(`<!doctype html><title>${status}</title><h1>${status}</h1>`, {
+      status,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+
+  it.each([502, 504, 500])(
+    'raises the server toast for a proxy-generated HTML %i page',
+    async status => {
+      // Caddy serves its own HTML error page for these, so the body never parses
+      // as a problem document. A gateway failure is the exact thing this toast
+      // exists to surface, so it must not be mistaken for a validation error the
+      // form it came from will report.
+      const problem = await extract(htmlErrorPage(status));
+
+      expect(problem.type).toBe(ERROR_TYPE.REMOTE);
+      expect(problem.status).toBe(status);
+      expect(classifyApiError(problem)).toBe(API_ERROR_TOAST.SERVER);
+    },
+  );
+
+  it('raises the server toast for an empty error body', async () => {
+    const problem = await extract(new Response('', { status: 502 }));
+
+    expect(classifyApiError(problem)).toBe(API_ERROR_TOAST.SERVER);
+  });
+
+  it('stays quiet for a validation problem the server really authored', async () => {
+    // The other half of the deliberate decision: a genuine validation problem
+    // belongs to the form that submitted it, so no global toast.
+    const problem = await extract(
+      Problem.fromError(new ValidationError('Date of birth is required')).intoResponse(),
     );
+
+    expect(problem.type).toBe(ERROR_TYPE.VALIDATION);
+    expect(classifyApiError(problem)).toBeNull();
+  });
+
+  it('raises the unreachable toast when the server responds with one', async () => {
+    const problem = await extract(Problem.fromError(new RemoteUnreachableError()).intoResponse());
+
+    expect(classifyApiError(problem)).toBe(API_ERROR_TOAST.UNREACHABLE);
+  });
+});
+
+describe('resolveApiErrorToast', () => {
+  describe('with no caller-supplied predicate', () => {
+    it.each(Object.entries(EXPECTED_BY_TYPE))('lets the classifier decide %s', (type, expected) => {
+      expect(resolveApiErrorToast({ type })).toBe(expected);
+    });
+
+    it('falls back to the server toast for an unrecognised error', () => {
+      expect(resolveApiErrorToast(new Error('boom'))).toBe(API_ERROR_TOAST.SERVER);
+    });
+  });
+
+  describe('with a caller-supplied predicate', () => {
+    it('raises the server toast for an error the classifier is quiet about', () => {
+      // The predicate is how a caller forces a toast the classifier wouldn't
+      // raise; the toast must have real copy rather than being empty.
+      expect(resolveApiErrorToast({ type: ERROR_TYPE.NOT_FOUND }, () => true)).toBe(
+        API_ERROR_TOAST.SERVER,
+      );
+      expect(resolveApiErrorToast({ type: ERROR_TYPE.VALIDATION }, () => true)).toBe(
+        API_ERROR_TOAST.SERVER,
+      );
+    });
+
+    it('keeps the specific toast kind when the classifier already picked one', () => {
+      expect(resolveApiErrorToast({ type: ERROR_TYPE.REMOTE_UNREACHABLE }, () => true)).toBe(
+        API_ERROR_TOAST.UNREACHABLE,
+      );
+      expect(resolveApiErrorToast({ type: ERROR_TYPE.EDIT_CONFLICT }, () => true)).toBe(
+        API_ERROR_TOAST.EDIT_CONFLICT,
+      );
+    });
+
+    it('suppresses a toast the classifier would have raised', () => {
+      expect(resolveApiErrorToast({ type: ERROR_TYPE.REMOTE_UNREACHABLE }, () => false)).toBeNull();
+      expect(resolveApiErrorToast(new Error('boom'), () => false)).toBeNull();
+    });
+
+    it('consults the predicate exactly once, with the error', () => {
+      const error = new RemoteUnreachableError('Failed to fetch');
+      const isErrorUnknown = vi.fn(() => false);
+      resolveApiErrorToast(error, isErrorUnknown);
+      expect(isErrorUnknown).toHaveBeenCalledTimes(1);
+      expect(isErrorUnknown).toHaveBeenCalledWith(error);
+    });
+  });
+
+  it('agrees with the default predicate on whether to toast at all', () => {
+    // isErrorUnknownDefault is no longer on the default path, so pin the two
+    // together: anything it calls unknown must still produce a toast.
+    for (const type of Object.keys(EXPECTED_BY_TYPE)) {
+      expect(resolveApiErrorToast({ type }) !== null).toBe(isErrorUnknownDefault({ type }));
+    }
   });
 });
 

--- a/packages/web/__tests__/api/classifyApiError.test.js
+++ b/packages/web/__tests__/api/classifyApiError.test.js
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EditConflictError,
+  ERROR_TYPE,
+  ForbiddenError,
+  NotFoundError,
+  RemoteUnreachableError,
+  ValidationError,
+} from '@tamanu/errors';
+
+import {
+  API_ERROR_TOAST,
+  classifyApiError,
+  isErrorUnknownDefault,
+} from '../../app/api/classifyApiError';
+
+// The full taxonomy, so a newly added ERROR_TYPE has to be classified deliberately
+// rather than falling through unnoticed (see the completeness test at the bottom).
+const EXPECTED_BY_TYPE = {
+  [ERROR_TYPE.AUTH]: null,
+  [ERROR_TYPE.AUTH_CREDENTIAL_INVALID]: null,
+  [ERROR_TYPE.AUTH_CREDENTIAL_MISSING]: null,
+  [ERROR_TYPE.AUTH_PERMISSION_REQUIRED]: null,
+  [ERROR_TYPE.AUTH_QUOTA_EXCEEDED]: null,
+  [ERROR_TYPE.AUTH_TOKEN_INVALID]: null,
+  [ERROR_TYPE.CLIENT_INCOMPATIBLE]: null,
+  [ERROR_TYPE.FORBIDDEN]: null,
+  [ERROR_TYPE.NOT_FOUND]: null,
+  [ERROR_TYPE.RATE_LIMITED]: null,
+  [ERROR_TYPE.VALIDATION]: null,
+  [ERROR_TYPE.VALIDATION_CONSTRAINT]: null,
+  [ERROR_TYPE.VALIDATION_DATABASE]: null,
+  [ERROR_TYPE.VALIDATION_DUPLICATE]: null,
+  [ERROR_TYPE.VALIDATION_OPERATION]: null,
+  [ERROR_TYPE.VALIDATION_PARAMETER]: null,
+  [ERROR_TYPE.VALIDATION_RELATION]: null,
+  [ERROR_TYPE.REMOTE_UNREACHABLE]: API_ERROR_TOAST.UNREACHABLE,
+  [ERROR_TYPE.EDIT_CONFLICT]: API_ERROR_TOAST.EDIT_CONFLICT,
+  [ERROR_TYPE.DATABASE]: API_ERROR_TOAST.SERVER,
+  [ERROR_TYPE.REMOTE]: API_ERROR_TOAST.SERVER,
+  [ERROR_TYPE.REMOTE_INCOMPATIBLE]: API_ERROR_TOAST.SERVER,
+  [ERROR_TYPE.STORAGE_INSUFFICIENT]: API_ERROR_TOAST.SERVER,
+  [ERROR_TYPE.UNIMPLEMENTED]: API_ERROR_TOAST.SERVER,
+  [ERROR_TYPE.UNKNOWN]: API_ERROR_TOAST.SERVER,
+};
+
+describe('classifyApiError', () => {
+  it.each(Object.entries(EXPECTED_BY_TYPE))('classifies %s', (type, expected) => {
+    expect(classifyApiError({ type })).toBe(expected);
+  });
+
+  it('shows the unreachable toast for a connectivity failure', () => {
+    // The single most important case: a real failure to reach the server must be
+    // distinguishable from the server responding with an error.
+    expect(classifyApiError(new RemoteUnreachableError('Failed to fetch'))).toBe(
+      API_ERROR_TOAST.UNREACHABLE,
+    );
+  });
+
+  it('shows the conflict toast for a concurrent edit', () => {
+    expect(classifyApiError(new EditConflictError())).toBe(API_ERROR_TOAST.EDIT_CONFLICT);
+  });
+
+  it('stays quiet for errors the caller handles itself', () => {
+    expect(classifyApiError(new ValidationError('Date of birth is required'))).toBeNull();
+    expect(classifyApiError(new NotFoundError())).toBeNull();
+    expect(classifyApiError(new ForbiddenError())).toBeNull();
+  });
+
+  describe('errors with no usable type', () => {
+    it.each([
+      ['no type at all', {}],
+      ['an undefined type', { type: undefined }],
+      ['a null type', { type: null }],
+      ['a non-string type', { type: 404 }],
+      ['an unrecognised type', { type: 'nonsense' }],
+      ['an unresolved problem URI', { type: '/problems/nonsense' }],
+      ['a plain Error', new Error('boom')],
+      ['no error object', undefined],
+    ])('falls back to the server toast for %s', (_label, error) => {
+      expect(classifyApiError(error)).toBe(API_ERROR_TOAST.SERVER);
+    });
+  });
+
+  it('ignores the HTTP status', () => {
+    // The old classifier keyed off status; a 404 or a 422 must stay quiet even
+    // though its status is a client error, and a 200-status validation problem
+    // must not become a toast.
+    expect(classifyApiError({ type: ERROR_TYPE.NOT_FOUND, status: 404 })).toBeNull();
+    expect(classifyApiError({ type: ERROR_TYPE.VALIDATION, status: 422 })).toBeNull();
+    expect(classifyApiError({ type: ERROR_TYPE.REMOTE_UNREACHABLE, status: 200 })).toBe(
+      API_ERROR_TOAST.UNREACHABLE,
+    );
+  });
+
+  it('covers every error type in the taxonomy', () => {
+    expect(Object.keys(EXPECTED_BY_TYPE).toSorted()).toEqual(
+      Object.values(ERROR_TYPE).toSorted(),
+    );
+  });
+});
+
+describe('isErrorUnknownDefault', () => {
+  it('is true only for the errors that raise a toast', () => {
+    expect(isErrorUnknownDefault({ type: ERROR_TYPE.REMOTE_UNREACHABLE })).toBe(true);
+    expect(isErrorUnknownDefault({ type: ERROR_TYPE.EDIT_CONFLICT })).toBe(true);
+    expect(isErrorUnknownDefault({ type: ERROR_TYPE.DATABASE })).toBe(true);
+    expect(isErrorUnknownDefault({})).toBe(true);
+
+    expect(isErrorUnknownDefault({ type: ERROR_TYPE.FORBIDDEN })).toBe(false);
+    expect(isErrorUnknownDefault({ type: ERROR_TYPE.NOT_FOUND })).toBe(false);
+    expect(isErrorUnknownDefault({ type: ERROR_TYPE.VALIDATION })).toBe(false);
+    expect(isErrorUnknownDefault({ type: ERROR_TYPE.RATE_LIMITED })).toBe(false);
+    expect(isErrorUnknownDefault({ type: ERROR_TYPE.AUTH_TOKEN_INVALID })).toBe(false);
+  });
+});

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -10,6 +10,7 @@ import { LOCAL_STORAGE_KEYS } from '../constants';
 import { getDeviceId, notifyError } from '../utils';
 import { TranslatedText } from '../components/Translation/TranslatedText';
 import { ERROR_TYPE } from '@tamanu/errors';
+import { API_ERROR_TOAST, classifyApiError, isErrorUnknownDefault } from './classifyApiError';
 
 const {
   TOKEN,
@@ -112,21 +113,69 @@ function clearLocalStorage() {
   window?.localStorage?.removeItem(SETTINGS);
 }
 
-export function isErrorUnknownDefault(error) {
-  const status = error?.status;
-  if (!status || typeof status !== 'number') {
-    return true;
-  }
-  // we don't want to show toast for 403 (no permission) errors
-  return status >= 400 && status != 403;
-}
+const TOAST_HEADINGS = {
+  [API_ERROR_TOAST.UNREACHABLE]: {
+    stringId: 'general.api.notification.serverUnreachable.title',
+    fallback: "Couldn't reach the server",
+  },
+  [API_ERROR_TOAST.EDIT_CONFLICT]: {
+    stringId: 'general.api.notification.editConflict.title',
+    fallback: 'This record was changed by someone else',
+  },
+  [API_ERROR_TOAST.SERVER]: {
+    stringId: 'general.api.notification.serverError.title',
+    fallback: 'Something went wrong on the server',
+  },
+};
 
-export function isErrorUnknownAllow404s(error) {
-  const status = error?.status;
-  if (status === 404) {
-    return false;
-  }
-  return isErrorUnknownDefault(error);
+const TOAST_DETAILS = {
+  [API_ERROR_TOAST.UNREACHABLE]: {
+    stringId: 'general.api.notification.serverUnreachable.detail',
+    fallback: 'Your last action may not have been saved. Please try again.',
+  },
+  [API_ERROR_TOAST.EDIT_CONFLICT]: {
+    stringId: 'general.api.notification.editConflict.detail',
+    fallback: 'Reload the page to see the latest version before saving again.',
+  },
+  [API_ERROR_TOAST.SERVER]: {
+    stringId: 'general.api.notification.serverError.detail',
+    fallback: 'Please try again. If this keeps happening, contact your IT support.',
+  },
+};
+
+function buildErrorToast(toastKind, error, endpoint) {
+  const heading = TOAST_HEADINGS[toastKind];
+  const detail = TOAST_DETAILS[toastKind];
+  const language = window?.localStorage?.getItem(LANGUAGE);
+
+  // The path and the raw server message only make sense for a server error, and
+  // only in English: they aren't translated, and a mixed-language toast is worse
+  // than none. Everything else gets the plain two-line message.
+  const isEnglish = !language || language === ENGLISH_LANGUAGE_CODE;
+  const showRequestDetail = toastKind === API_ERROR_TOAST.SERVER && isEnglish;
+
+  return [
+    <b key={heading.stringId}>
+      <TranslatedText stringId={heading.stringId} fallback={heading.fallback} />
+    </b>,
+    <TranslatedText key={detail.stringId} stringId={detail.stringId} fallback={detail.fallback} />,
+    ...(showRequestDetail
+      ? [
+          <TranslatedText
+            key="general.api.notification.path"
+            stringId="general.api.notification.path"
+            fallback="Path: :path"
+            replacements={{ path: error.path ?? endpoint }}
+          />,
+          <TranslatedText
+            key="general.api.notification.message"
+            stringId="general.api.notification.message"
+            fallback="Message: :message"
+            replacements={{ message: error?.title }}
+          />,
+        ]
+      : []),
+  ];
 }
 
 export class TamanuApi extends ApiClient {
@@ -304,35 +353,13 @@ export class TamanuApi extends ApiClient {
     try {
       return await super.fetch(endpoint, query, otherConfig);
     } catch (err) {
-      if (err.type.startsWith(ERROR_TYPE.AUTH)) {
+      if (err.type?.startsWith(ERROR_TYPE.AUTH)) {
         clearLocalStorage();
       } else if (showUnknownErrorToast && isErrorUnknown(err)) {
-        const language = window?.localStorage?.getItem(LANGUAGE);
-        notifyError([
-          <b key="general.api.notification.requestFailed">
-            <TranslatedText
-              stringId="general.api.notification.requestFailed"
-              fallback="Network request failed"
-            />
-          </b>,
-          // Only show full server messages in English
-          ...(!language || language === ENGLISH_LANGUAGE_CODE
-            ? [
-                <TranslatedText
-                  key="general.api.notification.path"
-                  stringId="general.api.notification.path"
-                  fallback="Path: :path"
-                  replacements={{ path: err.path ?? endpoint }}
-                />,
-                <TranslatedText
-                  key="general.api.notification.message"
-                  stringId="general.api.notification.message"
-                  fallback="Message: :message"
-                  replacements={{ message: err?.title }}
-                />,
-              ]
-            : []),
-        ]);
+        // A caller-supplied predicate can ask for a toast on an error the
+        // classifier stays quiet about; treat those as server errors.
+        const toastKind = classifyApiError(err) ?? API_ERROR_TOAST.SERVER;
+        notifyError(buildErrorToast(toastKind, err, endpoint));
       }
 
       throw err;

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -10,7 +10,7 @@ import { LOCAL_STORAGE_KEYS } from '../constants';
 import { getDeviceId, notifyError } from '../utils';
 import { TranslatedText } from '../components/Translation/TranslatedText';
 import { ERROR_TYPE } from '@tamanu/errors';
-import { API_ERROR_TOAST, classifyApiError, isErrorUnknownDefault } from './classifyApiError';
+import { API_ERROR_TOAST, resolveApiErrorToast } from './classifyApiError';
 
 const {
   TOKEN,
@@ -113,39 +113,43 @@ function clearLocalStorage() {
   window?.localStorage?.removeItem(SETTINGS);
 }
 
-const TOAST_HEADINGS = {
+// The heading and detail for each toast kind, together in one entry so a new
+// kind can't get a heading without a detail (or vice versa).
+const TOAST_COPY = {
   [API_ERROR_TOAST.UNREACHABLE]: {
-    stringId: 'general.api.notification.serverUnreachable.title',
-    fallback: "Couldn't reach the server",
+    heading: {
+      stringId: 'general.api.notification.serverUnreachable.title',
+      fallback: "Couldn't reach the server",
+    },
+    detail: {
+      stringId: 'general.api.notification.serverUnreachable.detail',
+      fallback: 'Your last action may not have been saved. Please try again.',
+    },
   },
   [API_ERROR_TOAST.EDIT_CONFLICT]: {
-    stringId: 'general.api.notification.editConflict.title',
-    fallback: 'This record was changed by someone else',
+    heading: {
+      stringId: 'general.api.notification.editConflict.title',
+      fallback: 'This record was changed by someone else',
+    },
+    detail: {
+      stringId: 'general.api.notification.editConflict.detail',
+      fallback: 'Reload the page to see the latest version before saving again.',
+    },
   },
   [API_ERROR_TOAST.SERVER]: {
-    stringId: 'general.api.notification.serverError.title',
-    fallback: 'Something went wrong on the server',
-  },
-};
-
-const TOAST_DETAILS = {
-  [API_ERROR_TOAST.UNREACHABLE]: {
-    stringId: 'general.api.notification.serverUnreachable.detail',
-    fallback: 'Your last action may not have been saved. Please try again.',
-  },
-  [API_ERROR_TOAST.EDIT_CONFLICT]: {
-    stringId: 'general.api.notification.editConflict.detail',
-    fallback: 'Reload the page to see the latest version before saving again.',
-  },
-  [API_ERROR_TOAST.SERVER]: {
-    stringId: 'general.api.notification.serverError.detail',
-    fallback: 'Please try again. If this keeps happening, contact your IT support.',
+    heading: {
+      stringId: 'general.api.notification.serverError.title',
+      fallback: 'Something went wrong on the server',
+    },
+    detail: {
+      stringId: 'general.api.notification.serverError.detail',
+      fallback: 'Please try again. If this keeps happening, contact your system administrator.',
+    },
   },
 };
 
 function buildErrorToast(toastKind, error, endpoint) {
-  const heading = TOAST_HEADINGS[toastKind];
-  const detail = TOAST_DETAILS[toastKind];
+  const { heading, detail } = TOAST_COPY[toastKind];
   const language = window?.localStorage?.getItem(LANGUAGE);
 
   // The path and the raw server message only make sense for a server error, and
@@ -344,22 +348,18 @@ export class TamanuApi extends ApiClient {
   }
 
   async fetch(endpoint, query, config) {
-    const {
-      isErrorUnknown = isErrorUnknownDefault,
-      showUnknownErrorToast = false,
-      ...otherConfig
-    } = config;
+    const { isErrorUnknown, showUnknownErrorToast = false, ...otherConfig } = config;
 
     try {
       return await super.fetch(endpoint, query, otherConfig);
     } catch (err) {
       if (err.type?.startsWith(ERROR_TYPE.AUTH)) {
         clearLocalStorage();
-      } else if (showUnknownErrorToast && isErrorUnknown(err)) {
-        // A caller-supplied predicate can ask for a toast on an error the
-        // classifier stays quiet about; treat those as server errors.
-        const toastKind = classifyApiError(err) ?? API_ERROR_TOAST.SERVER;
-        notifyError(buildErrorToast(toastKind, err, endpoint));
+      } else if (showUnknownErrorToast) {
+        const toastKind = resolveApiErrorToast(err, isErrorUnknown);
+        if (toastKind) {
+          notifyError(buildErrorToast(toastKind, err, endpoint));
+        }
       }
 
       throw err;

--- a/packages/web/app/api/classifyApiError.js
+++ b/packages/web/app/api/classifyApiError.js
@@ -70,8 +70,31 @@ export function classifyApiError(error) {
 }
 
 /**
- * The default `isErrorUnknown` predicate for `TamanuApi.fetch`. Callers can pass
- * their own to force or suppress a toast for a particular request.
+ * The toast an API error should raise, honouring a caller-supplied
+ * `isErrorUnknown` predicate.
+ *
+ * Without a predicate — the usual case — the classifier decides on its own. A
+ * predicate overrides it in both directions: it can force a toast for an error
+ * the classifier stays quiet about (shown as a server error), or suppress one
+ * the classifier would have raised.
+ *
+ * @returns {string | null} a value of `API_ERROR_TOAST`, or null for no toast.
+ */
+export function resolveApiErrorToast(error, isErrorUnknown) {
+  const toastKind = classifyApiError(error);
+
+  if (!isErrorUnknown) {
+    return toastKind;
+  }
+
+  return isErrorUnknown(error) ? (toastKind ?? API_ERROR_TOAST.SERVER) : null;
+}
+
+/**
+ * The predicate `resolveApiErrorToast` applies when a caller doesn't supply one.
+ * `TamanuApi.fetch` doesn't route the default path through it (the classifier
+ * result is enough), but it stays exported for callers that need to compose or
+ * wrap the default behaviour — it's re-exported from `web/app/api`.
  */
 export function isErrorUnknownDefault(error) {
   return classifyApiError(error) !== null;

--- a/packages/web/app/api/classifyApiError.js
+++ b/packages/web/app/api/classifyApiError.js
@@ -1,0 +1,78 @@
+import { ERROR_TYPE } from '@tamanu/errors';
+
+/**
+ * The toasts an API error can raise. Each one has its own copy, chosen so the
+ * user can tell a connectivity problem apart from a server problem.
+ */
+export const API_ERROR_TOAST = {
+  /** The server could not be reached at all. */
+  UNREACHABLE: 'unreachable',
+  /** Someone else changed the record between reading and saving it. */
+  EDIT_CONFLICT: 'edit-conflict',
+  /** Anything else the user cannot act on themselves. */
+  SERVER: 'server',
+};
+
+// `isKnownErrorType` in @tamanu/errors is marked @internal and isn't re-exported
+// from the package entry point, so recognise the types locally instead.
+const KNOWN_ERROR_TYPES = new Set(Object.values(ERROR_TYPE));
+
+// Error types that are already dealt with somewhere more specific, so a global
+// toast would be noise or a duplicate:
+//
+// - `auth*` logs the session out and shows a message on the login screen
+// - `forbidden` and `rate-limited` are surfaced by the view that hit them
+// - `validation*` belongs to the form that submitted the request
+// - `not-found` is a normal outcome for the many optional-resource queries
+// - `client-incompatible` already triggers the version-incompatible logout
+//   message from @tamanu/api-client (see `getVersionIncompatibleMessage`)
+const SILENT_ERROR_TYPES = new Set([
+  ERROR_TYPE.CLIENT_INCOMPATIBLE,
+  ERROR_TYPE.FORBIDDEN,
+  ERROR_TYPE.NOT_FOUND,
+  ERROR_TYPE.RATE_LIMITED,
+  ERROR_TYPE.VALIDATION,
+  ERROR_TYPE.VALIDATION_CONSTRAINT,
+  ERROR_TYPE.VALIDATION_DATABASE,
+  ERROR_TYPE.VALIDATION_DUPLICATE,
+  ERROR_TYPE.VALIDATION_OPERATION,
+  ERROR_TYPE.VALIDATION_PARAMETER,
+  ERROR_TYPE.VALIDATION_RELATION,
+]);
+
+/**
+ * Decides which toast (if any) an API error should raise, based on its
+ * `ERROR_TYPE`. An error with a missing or unrecognised type is treated as a
+ * server error, so nothing gets silently swallowed.
+ *
+ * @returns {string | null} a value of `API_ERROR_TOAST`, or null for no toast.
+ */
+export function classifyApiError(error) {
+  const type = error?.type;
+
+  if (typeof type !== 'string' || !KNOWN_ERROR_TYPES.has(type)) {
+    return API_ERROR_TOAST.SERVER;
+  }
+
+  if (type.startsWith(ERROR_TYPE.AUTH) || SILENT_ERROR_TYPES.has(type)) {
+    return null;
+  }
+
+  if (type === ERROR_TYPE.REMOTE_UNREACHABLE) {
+    return API_ERROR_TOAST.UNREACHABLE;
+  }
+
+  if (type === ERROR_TYPE.EDIT_CONFLICT) {
+    return API_ERROR_TOAST.EDIT_CONFLICT;
+  }
+
+  return API_ERROR_TOAST.SERVER;
+}
+
+/**
+ * The default `isErrorUnknown` predicate for `TamanuApi.fetch`. Callers can pass
+ * their own to force or suppress a toast for a particular request.
+ */
+export function isErrorUnknownDefault(error) {
+  return classifyApiError(error) !== null;
+}

--- a/packages/web/app/api/index.js
+++ b/packages/web/app/api/index.js
@@ -1,4 +1,4 @@
 export * from './suggesters';
 export * from './useApi';
 export * from './combineQueries';
-export { isErrorUnknownDefault, isErrorUnknownAllow404s } from './TamanuApi';
+export { isErrorUnknownDefault } from './classifyApiError';

--- a/packages/web/app/api/queries/useChartsVisualisationConfigsQuery.js
+++ b/packages/web/app/api/queries/useChartsVisualisationConfigsQuery.js
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useEncounter } from '../../contexts/Encounter';
-import { combineQueries, isErrorUnknownAllow404s, useApi } from '../index';
+import { combineQueries, useApi } from '../index';
 import { usePatientDataQuery } from './usePatientDataQuery';
 import { useSurveyQuery } from './useSurveyQuery';
 import { useChartData } from '../../contexts/ChartData';
@@ -18,12 +18,7 @@ export const useChartsVisualisationConfigsQuery = () => {
   // Fetch chart data to determine which historical questions have data
   const chartDataQuery = useQuery(
     ['encounterCharts', encounter?.id, selectedChartTypeId],
-    () =>
-      api.get(
-        `encounter/${encounter?.id}/charts/${selectedChartTypeId}`,
-        { rowsPerPage: 1 },
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+    () => api.get(`encounter/${encounter?.id}/charts/${selectedChartTypeId}`, { rowsPerPage: 1 }),
     { enabled: Boolean(encounter?.id) && Boolean(selectedChartTypeId) },
   );
 

--- a/packages/web/app/api/queries/useEncounterChartWithResponseQuery.js
+++ b/packages/web/app/api/queries/useEncounterChartWithResponseQuery.js
@@ -1,15 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
-import { isErrorUnknownAllow404s, useApi } from '../index';
+import { useApi } from '../index';
 
 // Gets the first alphabetically ordered chart survey that has any answer
 export const useEncounterChartWithResponseQuery = (encounterId) => {
   const api = useApi();
 
-  return useQuery(['encounterInitialChart', encounterId], () =>
-    api.get(
-      `encounter/${encounterId}/initialChart`,
-      { isErrorUnknown: isErrorUnknownAllow404s },
-      { enabled: Boolean(encounterId) },
-    ),
+  return useQuery(
+    ['encounterInitialChart', encounterId],
+    () => api.get(`encounter/${encounterId}/initialChart`),
+    // `enabled` was being passed to api.get as the query argument, so this query
+    // was never actually gated on having an encounter id.
+    { enabled: Boolean(encounterId) },
   );
 };

--- a/packages/web/app/api/queries/useEncounterChartsQuery.js
+++ b/packages/web/app/api/queries/useEncounterChartsQuery.js
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { CHARTING_DATA_ELEMENT_IDS, VISIBILITY_STATUSES } from '@tamanu/constants';
-import { combineQueries, isErrorUnknownAllow404s, useApi } from '../index';
+import { combineQueries, useApi } from '../index';
 import { getConfigObject } from '../../utils';
 import { useSurveyQuery } from './useSurveyQuery';
 
@@ -71,12 +71,7 @@ export const useEncounterChartsQuery = (encounterId, surveyId, instanceId) => {
   const api = useApi();
   const chartQuery = useQuery(
     ['encounterCharts', encounterId, surveyId, instanceId],
-    () =>
-      api.get(
-        `encounter/${encounterId}/charts/${surveyId}`,
-        { rowsPerPage: 50, instanceId },
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+    () => api.get(`encounter/${encounterId}/charts/${surveyId}`, { rowsPerPage: 50, instanceId }),
     { enabled: Boolean(surveyId) },
   );
   const surveyQuery = useSurveyQuery(surveyId);

--- a/packages/web/app/api/queries/useEncounterDischargeQuery.js
+++ b/packages/web/app/api/queries/useEncounterDischargeQuery.js
@@ -1,17 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import { isErrorUnknownAllow404s, useApi } from '../index';
+import { useApi } from '../index';
 
 export const useEncounterDischargeQuery = (encounter) => {
   const api = useApi();
 
   return useQuery(
     ['encounterDischarge', encounter?.id],
-    () =>
-      api.get(
-        `encounter/${encodeURIComponent(encounter?.id)}/discharge`,
-        {},
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+    () => api.get(`encounter/${encodeURIComponent(encounter?.id)}/discharge`),
     { enabled: !!encounter?.endDate && !!encounter?.id },
   );
 };

--- a/packages/web/app/api/queries/useGraphDataQuery.js
+++ b/packages/web/app/api/queries/useGraphDataQuery.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { isErrorUnknownAllow404s, useApi } from '../index';
+import { useApi } from '../index';
 
 const transformVitalDataToChartData = vitalQuery => {
   const { data: vitalDataAndCount = {} } = vitalQuery;
@@ -23,7 +23,6 @@ export const useGraphDataQuery = (encounterId, vitalDataElementId, dateRange, is
       api.get(
         `encounter/${encounterId}/graphData/${directory}/${vitalDataElementId}`,
         { startDate, endDate },
-        { isErrorUnknown: isErrorUnknownAllow404s },
       ),
     {
       enabled: Boolean(encounterId) && Boolean(startDate) && Boolean(endDate),

--- a/packages/web/app/api/queries/useInvoiceQuery.js
+++ b/packages/web/app/api/queries/useInvoiceQuery.js
@@ -1,14 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../useApi';
-import { isErrorUnknownAllow404s } from '../TamanuApi';
 
 export const useEncounterInvoiceQuery = (encounterId) => {
   const api = useApi();
 
   return useQuery(
     [`encounter/${encounterId}/invoice`],
-    () =>
-      api.get(`encounter/${encounterId}/invoice`, {}, { isErrorUnknown: isErrorUnknownAllow404s }),
+    () => api.get(`encounter/${encounterId}/invoice`),
     {
       enabled: !!encounterId,
     },
@@ -20,12 +18,7 @@ export const useInvoiceTotalOutstandingBalanceQuery = (patientId) => {
 
   return useQuery(
     [`patient/${patientId}/invoices/totalOutstandingBalance`],
-    () =>
-      api.get(
-        `patient/${patientId}/invoices/totalOutstandingBalance`,
-        {},
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+    () => api.get(`patient/${patientId}/invoices/totalOutstandingBalance`),
     {
       enabled: !!patientId,
     },

--- a/packages/web/app/api/queries/usePausePrescriptionQuery.js
+++ b/packages/web/app/api/queries/usePausePrescriptionQuery.js
@@ -1,18 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../useApi';
-import { isErrorUnknownAllow404s } from '../TamanuApi';
 
 export const usePausePrescriptionQuery = ({ prescriptionId, encounterId }, options) => {
   const api = useApi();
 
   return useQuery(
     [`medication/${prescriptionId}/pause`, encounterId],
-    () =>
-      api.get(
-        `medication/${prescriptionId}/pause`,
-        { encounterId },
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+    () => api.get(`medication/${prescriptionId}/pause`, { encounterId }),
     {
       ...options,
     },

--- a/packages/web/app/api/queries/usePausesPrescriptionQuery.js
+++ b/packages/web/app/api/queries/usePausesPrescriptionQuery.js
@@ -1,18 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../useApi';
-import { isErrorUnknownAllow404s } from '../TamanuApi';
 
 export const usePausesPrescriptionQuery = (prescriptionId, encounterId, fetchOptions) => {
   const api = useApi();
 
   return useQuery(
     [`medication/${prescriptionId}/pauses`, encounterId, fetchOptions],
-    () =>
-      api.get(
-        `medication/${prescriptionId}/pauses`,
-        { encounterId, ...fetchOptions },
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+    () => api.get(`medication/${prescriptionId}/pauses`, { encounterId, ...fetchOptions }),
     {
       enabled: !!prescriptionId && !!encounterId,
     },

--- a/packages/web/app/api/queries/useProgramRegistryChartsVisualisationConfigsQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryChartsVisualisationConfigsQuery.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { combineQueries, isErrorUnknownAllow404s, useApi } from '../index';
+import { combineQueries, useApi } from '../index';
 import { usePatientDataQuery } from './usePatientDataQuery';
 import { useSurveyQuery } from './useSurveyQuery';
 import { getVisualisationConfig } from '../../utils/getVisualisationConfig';
@@ -13,11 +13,7 @@ export const useProgramRegistryChartsVisualisationConfigsQuery = (patientId, cha
   const chartDataQuery = useQuery(
     ['programRegistryPatientCharts', patientId, chartSurveyId],
     () =>
-      api.get(
-        `programRegistry/patient/${patientId}/charts/${chartSurveyId}`,
-        { rowsPerPage: 1 },
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+      api.get(`programRegistry/patient/${patientId}/charts/${chartSurveyId}`, { rowsPerPage: 1 }),
     { enabled: Boolean(patientId) && Boolean(chartSurveyId) },
   );
 

--- a/packages/web/app/api/queries/useProgramRegistryGraphDataQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryGraphDataQuery.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { isErrorUnknownAllow404s, useApi } from '../index';
+import { useApi } from '../index';
 import { transformVitalDataToChartData } from './useGraphDataQuery';
 
 export const useProgramRegistryGraphDataQuery = (patientId, dataElementId, dateRange) => {
@@ -22,7 +22,6 @@ export const useProgramRegistryGraphDataQuery = (patientId, dataElementId, dateR
       api.get(
         `programRegistry/patient/${patientId}/graphData/${directory}/${dataElementId}`,
         { startDate, endDate },
-        { isErrorUnknown: isErrorUnknownAllow404s },
       ),
     {
       enabled: Boolean(patientId) && Boolean(startDate) && Boolean(endDate),

--- a/packages/web/app/api/queries/useProgramRegistryPatientChartsQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryPatientChartsQuery.js
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { CHARTING_DATA_ELEMENT_IDS, VISIBILITY_STATUSES } from '@tamanu/constants';
-import { combineQueries, isErrorUnknownAllow404s, useApi } from '../index';
+import { combineQueries, useApi } from '../index';
 import { getConfigObject } from '../../utils';
 import { useSurveyQuery } from './useSurveyQuery';
 
@@ -75,7 +75,6 @@ export const useProgramRegistryPatientChartsQuery = (patientId, surveyId, instan
       api.get(
         `programRegistry/patient/${patientId}/charts/${surveyId}`,
         { rowsPerPage: 50, instanceId },
-        { isErrorUnknown: isErrorUnknownAllow404s },
       ),
     { enabled: Boolean(patientId) && Boolean(surveyId) },
   );

--- a/packages/web/app/api/queries/useProgramRegistryPatientInitialChartQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryPatientInitialChartQuery.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { isErrorUnknownAllow404s, useApi } from '../index';
+import { useApi } from '../index';
 
 // Gets the first alphabetically ordered chart survey (for a specific program registry)
 // that has any answer for this patient
@@ -8,12 +8,7 @@ export const useProgramRegistryPatientInitialChartQuery = (patientId, programReg
 
   return useQuery(
     ['programRegistryPatientInitialChart', patientId, programRegistryId],
-    () =>
-      api.get(
-        `programRegistry/patient/${patientId}/initialChart`,
-        { programRegistryId },
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+    () => api.get(`programRegistry/patient/${patientId}/initialChart`, { programRegistryId }),
     { enabled: Boolean(patientId) && Boolean(programRegistryId) },
   );
 };

--- a/packages/web/app/api/queries/useSurveyQuery.js
+++ b/packages/web/app/api/queries/useSurveyQuery.js
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import { isErrorUnknownAllow404s, useApi } from '../index';
+import { useApi } from '../index';
 
 export const useSurveyQuery = surveyId => {
   const api = useApi();
   return useQuery(
     ['survey', surveyId],
-    () => api.get(`survey/${surveyId}`, {}, { isErrorUnknown: isErrorUnknownAllow404s }),
+    () => api.get(`survey/${surveyId}`),
     { enabled: Boolean(surveyId) },
   );
 };

--- a/packages/web/app/api/queries/useVitalsQuery.js
+++ b/packages/web/app/api/queries/useVitalsQuery.js
@@ -1,17 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { VITALS_DATA_ELEMENT_IDS } from '@tamanu/constants';
-import { combineQueries, isErrorUnknownAllow404s, useApi } from '../index';
+import { combineQueries, useApi } from '../index';
 import { useVitalsSurveyQuery } from './useVitalsSurveyQuery';
 import { getDatesAndRecords } from './useEncounterChartsQuery';
 
 export const useVitalsQuery = (encounterId) => {
   const api = useApi();
   const vitalsQuery = useQuery(['encounterVitals', encounterId], () =>
-    api.get(
-      `encounter/${encounterId}/vitals`,
-      { rowsPerPage: 50 },
-      { isErrorUnknown: isErrorUnknownAllow404s },
-    ),
+    api.get(`encounter/${encounterId}/vitals`, { rowsPerPage: 50 }),
   );
   const surveyQuery = useVitalsSurveyQuery();
 

--- a/packages/web/app/api/queries/useVitalsSurveyQuery.js
+++ b/packages/web/app/api/queries/useVitalsSurveyQuery.js
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { isErrorUnknownAllow404s, useApi } from '../index';
+import { useApi } from '../index';
 
 export const useVitalsSurveyQuery = () => {
   const api = useApi();
   const vitalsSurvey = useQuery(['survey', { type: 'vitals' }], () =>
-    api.get(`survey/vitals`, {}, { isErrorUnknown: isErrorUnknownAllow404s }),
+    api.get(`survey/vitals`),
   );
 
   return vitalsSurvey;

--- a/packages/web/app/components/Field/LinkedField.jsx
+++ b/packages/web/app/components/Field/LinkedField.jsx
@@ -8,10 +8,7 @@ const useLinkedFieldQuery = (endpoint, name, value) => {
   return useQuery(
     ['linkedField', name, value],
     () =>
-      api.get(
-        endpoint.includes(':id') ? endpoint.replace(':id', value) : `${endpoint}/${value}`,
-        {},
-      ),
+      api.get(endpoint.includes(':id') ? endpoint.replace(':id', value) : `${endpoint}/${value}`),
     {
       enabled: !!value,
     },

--- a/packages/web/app/components/Field/LinkedField.jsx
+++ b/packages/web/app/components/Field/LinkedField.jsx
@@ -2,7 +2,6 @@ import { Field, useField } from 'formik';
 import React, { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../../api/useApi';
-import { isErrorUnknownAllow404s } from '../../api';
 
 const useLinkedFieldQuery = (endpoint, name, value) => {
   const api = useApi();
@@ -12,7 +11,6 @@ const useLinkedFieldQuery = (endpoint, name, value) => {
       api.get(
         endpoint.includes(':id') ? endpoint.replace(':id', value) : `${endpoint}/${value}`,
         {},
-        { isErrorUnknown: isErrorUnknownAllow404s },
       ),
     {
       enabled: !!value,

--- a/packages/web/app/components/Field/SurveyAnswerField.jsx
+++ b/packages/web/app/components/Field/SurveyAnswerField.jsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { isErrorUnknownAllow404s, useApi } from '../../api';
+import { useApi } from '../../api';
 import { SurveyAnswerResult } from '../SurveyAnswerResult';
 
 function useLatestAnswerForPatientQuery(patientId, dataElementCode) {
@@ -15,7 +15,6 @@ function useLatestAnswerForPatientQuery(patientId, dataElementCode) {
       await api.get(
         `surveyResponseAnswer/latest-answer/${encodeURIComponent(dataElementCode)}`,
         { patientId },
-        { isErrorUnknown: isErrorUnknownAllow404s },
       ),
     {
       enabled: Boolean(patientId && dataElementCode),

--- a/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { Modal } from '../../Modal';
 import { useAuth } from '../../../contexts/Auth';
-import { isErrorUnknownAllow404s, useApi } from '../../../api';
+import { useApi } from '../../../api';
 import { useCertificate } from '../../../utils/useCertificate';
 import { usePatientAdditionalDataQuery } from '../../../api/queries';
 
@@ -110,12 +110,7 @@ export const BirthNotificationCertificateModal = React.memo(({ patient }) => {
 
   const { data: deathData, isLoading: isDeathDataLoading } = useQuery(
     ['deathData', patient.id],
-    () =>
-      api.get(
-        `patient/${encodeURIComponent(patient.id)}/death`,
-        {},
-        { isErrorUnknown: isErrorUnknownAllow404s },
-      ),
+    () => api.get(`patient/${encodeURIComponent(patient.id)}/death`),
   );
 
   const { data: facility, isLoading: isFacilityLoading } = useQuery(['facility', facilityId], () =>

--- a/packages/web/app/components/PatientPrinting/modals/PrintPatientDetailsModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/PrintPatientDetailsModal.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { ButtonBase, Typography } from '@material-ui/core';
 import { OutlinedButton, Modal, TranslatedText } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
-import { isErrorUnknownAllow404s, useApi } from '../../../api';
+import { useApi } from '../../../api';
 import { useAuth } from '../../../contexts/Auth';
 import { PatientIDCardPage } from './PatientIDCardPage';
 import { PatientStickerLabelPage } from './PatientStickerLabelPage';
@@ -363,11 +363,7 @@ const PrintOption = ({ label, caption, icon: Icon, onPress }) => (
 
 async function getPatientProfileImage(api, patientId) {
   try {
-    const { data } = await api.get(
-      `patient/${patientId}/profilePicture`,
-      {},
-      { isErrorUnknown: isErrorUnknownAllow404s },
-    );
+    const { data } = await api.get(`patient/${patientId}/profilePicture`);
     return data;
   } catch (e) {
     // 1x1 blank pixel

--- a/packages/web/app/components/ReferralTable.jsx
+++ b/packages/web/app/components/ReferralTable.jsx
@@ -8,7 +8,7 @@ import { DateDisplay } from './DateDisplay';
 
 import { EncounterModal } from './EncounterModal';
 import { useEncounter } from '../contexts/Encounter';
-import { isErrorUnknownAllow404s, useApi } from '../api';
+import { useApi } from '../api';
 import { SurveyResponseDetailsModal } from './SurveyResponseDetailsModal';
 import { ConfirmModal } from './ConfirmModal';
 import { TranslatedText, TranslatedEnum } from './Translation';
@@ -48,11 +48,7 @@ const ReferralBy = ({ surveyResponse: { survey, answers } }) => {
       }
 
       try {
-        const user = await api.get(
-          `user/${encodeURIComponent(referralByAnswer.body)}`,
-          {},
-          { isErrorUnknown: isErrorUnknownAllow404s },
-        );
+        const user = await api.get(`user/${encodeURIComponent(referralByAnswer.body)}`);
         setName(user.displayName);
       } catch (e) {
         if (e.message === 'Facility server error response: 404') {

--- a/packages/web/app/components/SurveyResponseDetailsModal.jsx
+++ b/packages/web/app/components/SurveyResponseDetailsModal.jsx
@@ -14,7 +14,6 @@ import {
   TranslatedText,
   ViewChangeLogButton,
 } from '@tamanu/ui-components';
-import { isErrorUnknownAllow404s } from '../api';
 import { useSurveyResponseChangesQuery, useSurveyResponseQuery } from '../api/queries';
 import { ModalCancelRow } from './ModalActionRow';
 import { SurveyAnswerResult } from './SurveyAnswerResult';
@@ -90,7 +89,7 @@ export const SurveyResponseDetailsModal = ({
     data: surveyDetails,
     isLoading,
     error,
-  } = useSurveyResponseQuery(surveyResponseId, { isErrorUnknown: isErrorUnknownAllow404s });
+  } = useSurveyResponseQuery(surveyResponseId);
   const isNotFound = error?.status === 404;
   const isPending = isLoading || !surveyDetails || error;
 

--- a/packages/web/app/views/programs/ProgramsView.jsx
+++ b/packages/web/app/views/programs/ProgramsView.jsx
@@ -20,7 +20,6 @@ import { PATIENT_TABS } from '../../constants/patientPaths';
 import { ENCOUNTER_TAB_NAMES } from '../../constants/encounterTabNames';
 import { TranslatedText } from '../../components/Translation/TranslatedText';
 import { useApi } from '../../api';
-import { isErrorUnknownAllow404s } from '../../api/index.js';
 import { useProgramRegistryContext } from '../../contexts/ProgramRegistry';
 import { useAuth } from '../../contexts/Auth';
 import { SurveyResponseChangelogModal } from '../../components/SurveyResponseChangelogModal';
@@ -160,10 +159,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
     isLoading: isLoadingSurveyResponse,
     isError: isSurveyResponseError,
     error: surveyResponseError,
-  } = useSurveyResponseQuery(surveyResponseId, {
-    enabled: Boolean(surveyResponseId),
-    isErrorUnknown: isErrorUnknownAllow404s,
-  });
+  } = useSurveyResponseQuery(surveyResponseId, { enabled: Boolean(surveyResponseId) });
 
   const surveyForEdit = useMemo(() => {
     if (!existingSurveyResponse) return null;

--- a/packages/web/app/views/programs/ProgramsView.jsx
+++ b/packages/web/app/views/programs/ProgramsView.jsx
@@ -159,7 +159,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
     isLoading: isLoadingSurveyResponse,
     isError: isSurveyResponseError,
     error: surveyResponseError,
-  } = useSurveyResponseQuery(surveyResponseId, { enabled: Boolean(surveyResponseId) });
+  } = useSurveyResponseQuery(surveyResponseId);
 
   const surveyForEdit = useMemo(() => {
     if (!existingSurveyResponse) return null;


### PR DESCRIPTION
### Changes

🤖 Every failed API call showed the same toast: **"Network request failed"**. `isErrorUnknownDefault` keyed off `error.status`, treating anything ≥400 except 403 — plus anything with no status at all — as an unknown error. So a 404, a 422 validation failure, a 500 and a genuine connectivity failure all produced the same network-shaped message.

Users at a live deployment repeatedly reported that the message was wrong and their connection was fine. They were right on both counts: most of what they saw was not a network problem, and the one case that genuinely was gave them no useful action.

Classification now branches on `err.type` instead, which `packages/errors` already populates and which the auth branch two lines above already trusted:

- `remote-unreachable` — connectivity copy, warning that the last action may not have been saved
- `conflict` — dedicated edit-conflict copy
- `validation*` (all seven), `not-found`, `rate-limited`, `forbidden`, `auth*` — no toast; still thrown, so forms and callers handle them locally
- everything else, **including missing or unrecognised types** — server-error copy, retaining the `Path:`/`Message:` diagnostic lines that made this investigation possible

`client-incompatible` is excluded because it is already handled upstream via `getVersionIncompatibleMessage`. `remote-incompatible` has no web handling and falls through to the server-error message, which is the right advice for a facility↔central version mismatch.

`RemoteUnreachableError` already carried `type === 'remote-unreachable'` via `BaseError` — connectivity failures were always distinguishable, the classifier simply was not looking.

Most of the diff is the removal of `isErrorUnknownAllow404s` and its 22 call sites, now redundant since 404 no longer toasts. Classification is extracted to `packages/web/app/api/classifyApiError.js` as pure logic with table-driven tests, including a completeness assertion so any newly added error type must be classified deliberately rather than defaulting silently.

Two incidental fixes fell out of the call-site removal. `useEncounterChartWithResponseQuery` was passing `{ isErrorUnknown }` as query params and `{ enabled }` as fetch config, so the option was being serialised into the query string and the query was never gated on `encounterId`. A similar misplacement in `useSurveyResponseQuery` is left alone — it is a no-op there because the hook gates internally on the same condition.

The old `general.api.notification.requestFailed` string ID is retired in favour of new IDs, since the meaning changed substantially. Deployments with stored translations for the old ID will have three new untranslated strings.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
