### PR TITLE
chore(docs): no-issue: Caddy access logs now live in /var/log/caddy

### DIFF
--- a/docs/reference/maintain-tamanu-on-linux.md
+++ b/docs/reference/maintain-tamanu-on-linux.md
@@ -48,10 +48,14 @@ Canopy's `get_check_documentation`.
 ## Read logs
 
 ```bash
-journalctl -fu tamanu-central-api        # a Tamanu service
-journalctl -fu caddy -o cat | jq -c '.ts = (.ts | todate)'   # Caddy (UTC)
+bestool tamanu logs caddy -f             # Caddy, preferred: both streams (UTC)
+bestool tamanu logs api -f               # a Tamanu service
 journalctl -u postgresql                 # Postgres
 ```
+
+Raw paths, for filtering or reading history: the Caddy access log is
+`/var/log/caddy/access.log*`, and Caddy's runtime events are in
+`journalctl -u caddy`.
 
 More detail and filtering in `../sops/read-logs.md`.
 

--- a/docs/reference/query-cookbook.md
+++ b/docs/reference/query-cookbook.md
@@ -456,9 +456,13 @@ Linux (grep in place — do **not** copy the log off the server; that is
 **sensitive-data**, see `../ruled-out-actions.md`):
 
 ```bash
-journalctl -u caddy -o cat \
-  | jq -c 'select(.request.uri | test("/fhir/mat/ServiceRequest")) | {ts:(.ts|todate), status, uri:.request.uri, ip:.request.remote_ip, ua:(.request.headers["User-Agent"]|first)}'
+jq -c 'select(.request.uri | test("/fhir/mat/ServiceRequest")) | {ts:(.ts|todate), status, uri:.request.uri, ip:.request.remote_ip, ua:(.request.headers["User-Agent"]|first)}' \
+  /var/log/caddy/access.log*
 ```
+
+On a host that has not yet moved its access log to a file, read the same entries
+from the journal instead (`journalctl -u caddy -o cat | jq -Rr 'fromjson? | …'`) —
+see `../sops/read-logs.md` for which applies where.
 
 Windows: search `C:\caddy\logs\server.log` for `/fhir/mat/ServiceRequest` and
 inspect the `status` field (see the PowerShell snippet in `../sops/read-logs.md`).

--- a/docs/ruled-out-actions.md
+++ b/docs/ruled-out-actions.md
@@ -77,8 +77,10 @@ These actions may be read-only, but they touch PII or secrets. Tag them with the
 **sensitive-data** flag on top of their normal class, and prefer the safer
 alternative.
 
-- **Copying `caddy/server.log` (or any patient-data log) to a laptop** — PII
-  egress. Prefer grep-in-place on the server and redact before sharing. See
+- **Copying a Caddy access log (or any patient-data log) to a laptop** — PII
+  egress. That is `/var/log/caddy/access.log` on Linux and
+  `C:\caddy\logs\server.log` on Windows; request URIs can carry patient
+  identifiers. Prefer grep-in-place on the server and redact before sharing. See
   `sops/read-logs.md` for reading logs without exfiltrating them. If a raw log
   must leave the server, that is a decision for a lead, not a default.
 - **Mailgun API-key generation** — secret creation (also ruled-out above).

--- a/docs/sops/read-logs.md
+++ b/docs/sops/read-logs.md
@@ -17,9 +17,50 @@ grep-in-place and redact before sharing (see `../ruled-out-actions.md`).
 
 ## Caddy logs
 
-Caddy access logs are the record of what integrations and clients actually hit.
+Caddy produces two streams and they live in different places on Linux:
+
+- the **access log** — what integrations and clients actually hit;
+- Caddy's **runtime events** — TLS/certificate failures, upstream errors,
+  startup. Always in the journal.
+
 Times are in **UTC** — convert using the deployment's derived offset
-(`../deployment-context.md`).
+(`../deployment-context.md`). Grep in place; do not copy a log off the server
+(**sensitive-data**, `../ruled-out-actions.md`).
+
+**For live logs, use bestool** — it is the preferred tool on both Linux and
+Windows, covers both streams, and saves you knowing which paths a given host
+uses:
+
+```bash
+bestool tamanu logs caddy -f
+```
+
+Reach for the raw paths below when you need to filter, read across rotations, or
+go back through history.
+
+### Access log
+
+- **Linux:** `/var/log/caddy/access.log`, rolled at 100 MiB keeping 10 files
+  (older rotations sit beside it). One file covers every vhost — each entry
+  carries `request.host` if you need to separate them.
+
+  ```bash
+  tail -f /var/log/caddy/access.log | jq -c '.ts = (.ts | todate)'
+  ```
+
+  Filter for a route, across rotations:
+
+  ```bash
+  jq -c 'select(.request.uri | test("/api/integration/fhir/mat")) | .ts = (.ts | todate)' /var/log/caddy/access.log*
+  ```
+
+- **Linux, hosts not yet updated:** access entries went to the journal before
+  this split and stay there until a host takes the change. If
+  `/var/log/caddy/access.log` does not exist, use:
+
+  ```bash
+  journalctl -fu caddy -o cat | jq -Rr 'fromjson? | select(.status != null) | .ts = (.ts | todate)'
+  ```
 
 - **Windows:** the log file is `C:\caddy\logs\server.log`. Tail it readably in
   PowerShell:
@@ -30,23 +71,19 @@ Times are in **UTC** — convert using the deployment's derived offset
   }
   ```
 
-- **Linux:** Caddy logs to the journal:
-
-  ```bash
-  journalctl -fu caddy -o cat | jq -c '.ts = (.ts | todate)'
-  ```
-
-  Filter for a particular route (grep-in-place, no copy):
-
-  ```bash
-  journalctl -fu caddy -o cat | jq -c '.ts = (.ts | todate) | select(.request.uri | test("/api/integration/fhir/mat"))'
-  ```
-
 - **Kubernetes:** read the Caddy/ingress pod logs via Headlamp or
   `kubectl logs`.
 
-To read historical Caddy log files on Linux without journald, point `jq`/grep at
-the rotated file in place; do not copy the file to a laptop.
+### Runtime events (Linux)
+
+Certificate renewal failures, upstream errors and startup problems never appear
+in the access log. They are the journal entries with no `status` field:
+
+```bash
+journalctl -u caddy -o cat | jq -Rr 'fromjson? | select(.status == null) | [(.ts|todate), .level, .logger, .msg] | @tsv'
+```
+
+`fromjson?` skips the plain-text environment block Caddy prints at startup.
 
 ## Postgres logs
 


### PR DESCRIPTION
### Changes

🤖 Ops has moved the Tamanu vhost access log out of the systemd journal and into `/var/log/caddy/access.log` (rolled at 100 MiB, keeping 10 files). The journal now carries only Caddy's runtime events. The support pack said Linux Caddy logs were in the journal, full stop, so following it on an updated host finds an empty result and no hint why.

Four files updated, no new ones created:

- **`docs/sops/read-logs.md`** — the Caddy section now splits **access log** from **runtime events**, which the pack did not distinguish before. That split matters in practice: certificate renewal failures and upstream errors never appear in the access log, so someone grepping the access log for a TLS problem finds nothing. Linux access log is the file, with the `journalctl` route kept explicitly for hosts that have not taken the change (keyed on whether `/var/log/caddy/access.log` exists, so it is self-checking rather than requiring you to know a host's state).
- **`docs/reference/query-cookbook.md`** — the "Is the integration polling?" check now reads the file, globbed across rotations so a poll from before the last roll is still found. One-line pointer to the journal fallback rather than a duplicated snippet.
- **`docs/reference/maintain-tamanu-on-linux.md`** — the quick-reference block distinguishes the two streams instead of implying one journal command covers both.
- **`docs/ruled-out-actions.md`** — the sensitive-data item named only `caddy/server.log`, which is the Windows path. Now names both, and says why it is sensitive (request URIs can carry patient identifiers) rather than leaving the reader to infer it.

Dedup: the standalone trailing sentence in `read-logs.md` about reading historical rotated Caddy files on Linux is gone — it was describing the file-based path as an aside, and that is now the main path with rotation covered inline. Nothing else was removed. The journal commands are retained rather than dropped, since both topologies are live simultaneously during the rollout.

Verified against the ops source rather than assumed: path, roll size and retention come from `roles/tamanu-single-install/templates/caddy/common.j2`, and the single-file-for-all-vhosts detail (entries carry `request.host`) from the same snippet.

The `fromjson?` in the journal snippets is deliberate — Caddy prints a plain-text environment block at startup that otherwise breaks the jq pipeline.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
