### PR TITLE
test(e2e): no-issue: wait for lab request rows, not the table shell

### DIFF
--- a/packages/e2e-tests/pages/patients/BasePatientListPage.ts
+++ b/packages/e2e-tests/pages/patients/BasePatientListPage.ts
@@ -97,7 +97,6 @@ export abstract class BasePatientListPage extends BasePage {
 
   async waitForPageToLoad() {
     await this.searchForm.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   /**

--- a/packages/e2e-tests/pages/patients/ChartsPage/modals/SimpleChartModal.ts
+++ b/packages/e2e-tests/pages/patients/ChartsPage/modals/SimpleChartModal.ts
@@ -88,7 +88,6 @@ export class SimpleChartModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.dateTimeInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillForm(values: SimpleChartFormValues): Promise<SimpleChartFormValues> {

--- a/packages/e2e-tests/pages/patients/ChartsPage/panes/ChartsPane.ts
+++ b/packages/e2e-tests/pages/patients/ChartsPage/panes/ChartsPane.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 import { format, parse } from 'date-fns';
 import { STYLED_TABLE_CELL_PREFIX } from '@utils/testHelper';
 import { SimpleChartModal } from '../modals/SimpleChartModal';
@@ -21,7 +21,6 @@ export class ChartsPane {
 
   async waitForPageToLoad(): Promise<void> {
     await this.chartTypeSelect.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   getSimpleChartModal(): SimpleChartModal {
@@ -34,7 +33,8 @@ export class ChartsPane {
   async selectChartType(chartType: string): Promise<void> {
     await this.chartTypeSelect.click();
     await this.page.getByTestId('styledtranslatedselectfield-vwze-optioncontainer').getByText(chartType).click();
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+    // the option list closes before the field settles on the new value, so wait for the field itself
+    await expect(this.chartTypeSelect).toContainText(chartType);
   }
 
   /**

--- a/packages/e2e-tests/pages/patients/EmergencyPatientsPage.ts
+++ b/packages/e2e-tests/pages/patients/EmergencyPatientsPage.ts
@@ -131,7 +131,6 @@ export class EmergencyPatientsPage extends BasePage {
 
   async waitForPageToLoad() {
     await this.pageHeading.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async searchTable(searchCriteria: TriageSearchCriteria): Promise<void> {

--- a/packages/e2e-tests/pages/patients/ImagingRequestPage/modals/NewImagingRequestModal.ts
+++ b/packages/e2e-tests/pages/patients/ImagingRequestPage/modals/NewImagingRequestModal.ts
@@ -63,7 +63,6 @@ export class NewImagingRequestModal {
   async waitForModalToLoad(): Promise<void> {
     await this.imagingRequestCodeInput.waitFor({ state: 'visible' });
     await this.supervisingClinicianInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillForm(values: ImagingRequestFormValues) {

--- a/packages/e2e-tests/pages/patients/ImagingRequestPage/panes/ImagingRequestPane.ts
+++ b/packages/e2e-tests/pages/patients/ImagingRequestPage/panes/ImagingRequestPane.ts
@@ -53,7 +53,6 @@ export class ImagingRequestPane {
 
   async waitForPageToLoad(): Promise<void> {
     await this.table.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   getNewImagingRequestModal(): NewImagingRequestModal {

--- a/packages/e2e-tests/pages/patients/LabRequestPage/LabRequestDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/LabRequestDetailsPage.ts
@@ -272,7 +272,11 @@ export class LabRequestDetailsPage {
   async waitForResultsTableToLoad() {
     await this.enterResultsModal.waitForModalToClose();
     await this.resultsTable.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+    // the table body holds a single status row until the results arrive, so reading cells off the
+    // table as soon as it is visible reads the status message rather than a result
+    await expect(
+      this.resultsTableBody.locator('[data-test-class*="labTestType.name"]').first(),
+    ).not.toBeEmpty();
   }
 
   /**

--- a/packages/e2e-tests/pages/patients/LabRequestPage/LabRequestDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/LabRequestDetailsPage.ts
@@ -135,7 +135,6 @@ export class LabRequestDetailsPage {
 
   async waitForPageToLoad() {
     await this.container.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async validateLabRequestDetails(

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/ChangeLaboratoryModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/ChangeLaboratoryModal.ts
@@ -27,7 +27,6 @@ export class ChangeLaboratoryModal {
 
   async waitForModalToLoad() {
     await this.form.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
 }

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/ChangePriorityModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/ChangePriorityModal.ts
@@ -33,7 +33,6 @@ export class ChangePriorityModal {
 
   async waitForModalToLoad() {
     await this.form.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
 }

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/EnterResultsModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/EnterResultsModal.ts
@@ -57,12 +57,10 @@ export class EnterResultsModal {
 
   async waitForModalToLoad() {
     await this.labTestTypeTitle.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async waitForModalToClose() {
     await this.form.waitFor({ state: 'detached' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async selectResult(result: string) {

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
@@ -50,7 +50,6 @@ export class RecordSampleModal {
 
   async waitForModalToLoad() {
     await this.form.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
 
@@ -69,7 +68,6 @@ export class RecordSampleModal {
 }
 async waitForSampleCollectedModalToClose() {
   await this.form.waitFor({ state: 'detached' });
-  await this.page.waitForLoadState('networkidle', { timeout: 10000 });
 }
 }
 

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/StatusLogModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/StatusLogModal.ts
@@ -16,7 +16,6 @@ export class StatusLogModal {
 
   async waitForModalToLoad() {
     await this.modalContent.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async getDateTime(rowIndex: number): Promise<string> {

--- a/packages/e2e-tests/pages/patients/LabRequestPage/panes/LabRequestPane.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/panes/LabRequestPane.ts
@@ -114,9 +114,13 @@ export class LabRequestPane {
   }
 
   async waitForTableToLoad() {
-    // Wait for the lab request table to be visible and loaded
     await this.labRequestTable.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+    // Until its rows arrive, the table renders one row in its body holding a status message -
+    // "Loading…", or the no-data message - and that row carries no click handler. The table being
+    // visible is therefore not enough: a caller that clicks the first row while the status row is
+    // still up clicks something inert, navigates nowhere, and then waits out its whole timeout on a
+    // page that never opens. Waiting for a cell that only a real data row has closes that window.
+    await expect(this.getTestIdCell(0)).not.toBeEmpty();
   }
 
   async getFirstRowTestDetails(): Promise<LabRequestTestDetails> {

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseChangeLogModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseChangeLogModal.ts
@@ -30,7 +30,6 @@ export abstract class BaseChangeLogModal {
 
   async waitForModalToLoad() {
     await this.noteTypeLabel.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async waitForModalToClose() {

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseNoteModal.ts
@@ -35,7 +35,6 @@ export abstract class BaseNoteModal {
   // Common methods
   async waitForModalToLoad() {
     await this.confirmButton.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async waitForModalToClose() {

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/discardNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/discardNoteModal.ts
@@ -22,7 +22,6 @@ export class DiscardNoteModal {
 
   async waitForModalToLoad() {
     await this.confirmButton.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async waitForModalToClose() {

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/newNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/newNoteModal.ts
@@ -33,7 +33,6 @@ export class NewNoteModal extends BaseNoteModal {
 
   async waitForModalToLoad() {
     await this.typeSelect.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   // Form field interaction methods

--- a/packages/e2e-tests/pages/patients/NotesPage/panes/notesPane.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/panes/notesPane.ts
@@ -94,12 +94,10 @@ export class NotesPane {
   // Wait for the notes pane to load
   async waitForNotesPaneToLoad() {
     await this.notesTable.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async waitForNoteRowsToEqual(count: number) {
     await this.noteRows.nth(count - 1).waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async selectNoteType(noteType: string) {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -385,7 +385,6 @@ export class PatientDetailsPage extends BasePatientPage {
   async waitForEncounterToBeReady(): Promise<void> {
     // Wait for URL to contain encounter ID
     await this.page.waitForURL(/\/encounter\/[^/]+/, { timeout: 10000 });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async navigateToTasksTab(): Promise<TasksPane> {
@@ -565,12 +564,13 @@ export class PatientDetailsPage extends BasePatientPage {
   }
 
   /**
-   * Helper method for clicking add button with waitForLoadStates on either side to avoid flakiness
+   * Click a form's add button and wait for the form to go away, so a caller doesn't read the list it
+   * just added to while the entry is still in flight. Playwright's own actionability checks cover
+   * waiting for the button before the click.
    */
   async clickAddButtonToConfirm(buttonLocator: Locator) {
-    await this.page.waitForLoadState('networkidle');
     await buttonLocator.click();
-    await this.page.waitForLoadState('networkidle');
+    await buttonLocator.waitFor({ state: 'hidden' });
   }
 
   generateNewAllergy(nhn: string) {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddDiagnosisModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddDiagnosisModal.ts
@@ -38,7 +38,6 @@ export class AddDiagnosisModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.diagnosisInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillForm(primary: boolean): Promise<{ diagnosis: string, certainty: string }> {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddDocumentModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddDocumentModal.ts
@@ -31,7 +31,6 @@ export class AddDocumentModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.fileNameInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillForm(values: { fileName: string; documentOwner?: string; note?: string; filePath: string }): Promise<{ department: string }> {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddReferralModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddReferralModal.ts
@@ -39,7 +39,6 @@ export class AddReferralModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.surveySelector.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async selectSurvey(surveyName: string): Promise<void> {
@@ -49,12 +48,11 @@ export class AddReferralModal {
     });
     await this.beginReferralButton.click();
     // Wait for the survey form to load after selecting
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+    await this.waitForFormFieldsToBeVisible();
   }
 
   async waitForFormFieldsToBeVisible(): Promise<void> {
     await this.formFields.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillCVDPrimaryScreeningForm(values: {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/CarePlanModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/CarePlanModal.ts
@@ -62,7 +62,7 @@ export class CarePlanModal extends BasePatientModal {
     await this.page.getByRole('menuitem', { name: 'Initial Admin' }).click();
     await this.mainCarePlanFieldDetails.fill(carePlanDetails);
     await this.getAddCarePlanButton().click();
-    await this.page.waitForLoadState('networkidle');
+    await this.completedMainCarePlan.waitFor({ state: 'visible' });
   }
 
   async addAdditionalCarePlanNote(carePlanNote: string, clinicianName: string) {
@@ -70,7 +70,7 @@ export class CarePlanModal extends BasePatientModal {
     await this.page.getByRole('menuitem', { name: clinicianName, exact: true }).click();
     await this.additionalCarePlanNoteField.fill(carePlanNote);
     await this.getAddNoteButton().click();
-    await this.page.waitForLoadState('networkidle');
+    await this.additionalNote(carePlanNote).waitFor({ state: 'visible' });
   }
 
   additionalNote(noteText: string) {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ChangeDietModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ChangeDietModal.ts
@@ -26,7 +26,6 @@ export class ChangeDietModal {
   async waitForModalToLoad(): Promise<void> {
     await this.modalTitle.waitFor({ state: 'visible' });
     await this.dietMultiSelectInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async changeDiet(diet: string): Promise<void> {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ChangeLocationModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ChangeLocationModal.ts
@@ -28,7 +28,6 @@ export class ChangeLocationModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.areaInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async changeArea(area: string): Promise<void> {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/CreateEncounterModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/CreateEncounterModal.ts
@@ -19,7 +19,6 @@ export class CreateEncounterModal {
 
   async waitForModalToLoad() {
     await this.hospitalAdmissionButton.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   getHospitalAdmissionModal(): HospitalAdmissionModal {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EditEncounterModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EditEncounterModal.ts
@@ -30,7 +30,6 @@ export class EditEncounterModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.modal.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   /**
@@ -45,6 +44,6 @@ export class EditEncounterModal {
 
   async saveChanges(): Promise<void> {
     await this.saveChangesButton.click();
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+    await this.modal.waitFor({ state: 'detached' });
   }
 }

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EmergencyTriageModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EmergencyTriageModal.ts
@@ -105,7 +105,6 @@ export class EmergencyTriageModal {
 
   async waitForModalToLoad() {
     await this.modalTitle.getByText('New emergency triage').waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async selectTriageScore(score: 1 | 2 | 3 | 4 | 5) {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/HospitalAdmissionModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/HospitalAdmissionModal.ts
@@ -57,7 +57,6 @@ export class HospitalAdmissionModal {
     await this.modalTitle.waitFor({ state: 'visible' });
     await this.formGrid.waitFor({ state: 'visible' });
     await this.checkInDateInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillHospitalAdmissionForm(values: Record<string, string> = {}): Promise<Record<string, string>> {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/PrepareDischargeModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/PrepareDischargeModal.ts
@@ -27,7 +27,6 @@ export class PrepareDischargeModal {
 
   async waitForModalToLoad() {
     await this.dischargeNoteTextarea.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
 

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/DocumentsPane.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/DocumentsPane.ts
@@ -25,7 +25,6 @@ export class DocumentsPane {
 
   async waitForNoteDataContainerToDisappear(): Promise<void> {
     await this.noteDataContainer.waitFor({ state: 'detached' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   getAddDocumentModal(): AddDocumentModal {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/EncounterHistoryPane.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/EncounterHistoryPane.ts
@@ -96,7 +96,6 @@ export class EncounterHistoryPane {
 
   async waitForPageToLoad(): Promise<void> {
     await this.tableBody.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async waitForSectionToLoad(): Promise<void> {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/ReferralPane.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/ReferralPane.ts
@@ -13,7 +13,6 @@ export class ReferralPane extends BasePatientPane {
 
   async waitForPageToLoad(): Promise<void> {
     await this.addReferralButton.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   getAddReferralModal(): AddReferralModal {

--- a/packages/e2e-tests/pages/patients/PatientTable.ts
+++ b/packages/e2e-tests/pages/patients/PatientTable.ts
@@ -107,7 +107,6 @@ export class PatientTable {
   async waitForTableToLoad() {
     try {
       await this.loadingCell.waitFor({ state: 'detached' });
-      await this.page.waitForLoadState('networkidle', { timeout: 10000 });
     } catch (error) {
       throw new Error(
         `Failed to wait for table to load: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/e2e-tests/pages/patients/ProcedurePage/Modals/NewProcedureModal.ts
+++ b/packages/e2e-tests/pages/patients/ProcedurePage/Modals/NewProcedureModal.ts
@@ -155,7 +155,7 @@ export class NewProcedureModal extends BasePage {
   }
 
   async waitForModalToLoad(): Promise<void> {
-   await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+    await this.modalTitle.waitFor({ state: 'visible' });
   }
 
   getLocatorInput(locator: Locator): Locator {

--- a/packages/e2e-tests/pages/patients/ProcedurePage/Modals/UnsavedChangesModal.ts
+++ b/packages/e2e-tests/pages/patients/ProcedurePage/Modals/UnsavedChangesModal.ts
@@ -36,7 +36,6 @@ export class UnsavedChangesModal extends BasePage {
    */
   async waitForModalToLoad(): Promise<void> {
     await this.modalContent.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   /**
@@ -44,7 +43,6 @@ export class UnsavedChangesModal extends BasePage {
    */
   async waitForModalToClose(): Promise<void> {
     await this.modalContent.waitFor({ state: 'detached' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   /**

--- a/packages/e2e-tests/pages/patients/ProcedurePage/Panes/ProcedurePane.ts
+++ b/packages/e2e-tests/pages/patients/ProcedurePage/Panes/ProcedurePane.ts
@@ -115,7 +115,6 @@ export class ProcedurePane extends BasePatientPane {
 
   async waitForTableToLoad(){
      await this.page1Button.waitFor({ state: 'visible' });
-     await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async getNoDataFoundText() {

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/AddTaskModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/AddTaskModal.ts
@@ -59,7 +59,6 @@ export class AddTaskModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.startDateTimeInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillForm(values: { 

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/DeleteTaskModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/DeleteTaskModal.ts
@@ -33,7 +33,6 @@ export class DeleteTaskModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.recordedByInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillForm(values: {

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsCompletedModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsCompletedModal.ts
@@ -31,7 +31,6 @@ export class MarkAsCompletedModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.completedByInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillForm(values: {

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsNotCompletedModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsNotCompletedModal.ts
@@ -31,7 +31,6 @@ export class MarkAsNotCompletedModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.recordedByInput.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillForm(values: {

--- a/packages/e2e-tests/pages/patients/TaskPage/panes/TasksPane.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/panes/TasksPane.ts
@@ -54,12 +54,10 @@ export class TasksPane {
 
   async waitForPageToLoad(): Promise<void> {
     await this.addTaskButton.waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
 async waitForNoDataContainerToDisappear(): Promise<void> {
   await this.noDataContainer.waitFor({ state: 'detached' });
-  await this.page.waitForLoadState('networkidle', { timeout: 10000 });
 }
 
 

--- a/packages/e2e-tests/pages/patients/VitalsPage/modals/RecordVitalsModal.ts
+++ b/packages/e2e-tests/pages/patients/VitalsPage/modals/RecordVitalsModal.ts
@@ -78,7 +78,6 @@ export class RecordVitalsModal {
 
   async waitForModalToLoad() {
     await this.modalTitle.getByText('Record vitals').waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }
 
   async fillVitalsForm(values: Record<string, string>) {

--- a/packages/e2e-tests/pages/patients/VitalsPage/modals/VitalChartsModal.ts
+++ b/packages/e2e-tests/pages/patients/VitalsPage/modals/VitalChartsModal.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 
 import { selectFieldOption } from '@utils/fieldHelpers';
 
@@ -35,10 +35,11 @@ export class VitalChartsModal {
   }
 
   async selectDateRangeOption(optionLabel: string) {
+    // Selecting a new range refetches chart data and regenerates ticks. Take the ticks first and
+    // wait for them to actually be replaced, rather than racing the old DOM nodes.
+    const previousTicks = await this.getPrimaryTickLabels();
     await selectFieldOption(this.page, this.dateRangeSelect, { optionToSelect: optionLabel });
-    // Selecting a new range refetches chart data and regenerates ticks; wait for
-    // the previous ticks to be replaced rather than racing the old DOM nodes.
-    await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+    await expect(this.primaryTickLabels).not.toHaveText(previousTicks);
   }
 
   async getPrimaryTickLabels(): Promise<string[]> {

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -345,7 +345,6 @@ test.describe('Basic tests', () => {
     await patientDetailsPage.page.getByText(expectedLocation, { exact: true }).first().click();
     // Confirm the move
     await patientDetailsPage.page.getByRole('button', { name: 'Confirm' }).click();
-    await patientDetailsPage.page.waitForLoadState('networkidle');
     await expect(patientDetailsPage.locationLabel).toHaveText(
       `${expectedArea}, ${expectedLocation}`,
     );

--- a/packages/e2e-tests/tests/patients/recentlyViewedPatients.spec.ts
+++ b/packages/e2e-tests/tests/patients/recentlyViewedPatients.spec.ts
@@ -141,10 +141,20 @@ test.describe('Recently viewed patients pagination', () => {
       await verifyRecentlyViewedPatients(allPatientsPage, patientStack);
 
       // The recently viewed patient list is 6 patients so need to navigate to the next page
+      const firstBeforePaging = (
+        await allPatientsPage.recentlyViewedPatientsList.getRecentlyViewedPatientByIndex(0)
+      ).name;
       await allPatientsPage.recentlyViewedPatientsList.navigateNext.click();
 
-      // Wait for the page to load after navigation
-      await allPatientsPage.page.waitForLoadState('networkidle');
+      // Paging swaps the cards in place, and the verification below reads their text rather than
+      // asserting on locators, so it has to wait for the swap instead of reading whatever is up
+      await expect
+        .poll(
+          async () =>
+            (await allPatientsPage.recentlyViewedPatientsList.getRecentlyViewedPatientByIndex(0))
+              .name,
+        )
+        .not.toBe(firstBeforePaging);
 
       await verifyRecentlyViewedPatients(allPatientsPage, patientStack);
     },


### PR DESCRIPTION
### Changes

🤖 `[AT-6829] flags an out-of-range numeric result in the lab request results table` has been failing roughly half of all merge-queue runs since it landed, and it takes whatever is queued down with it — #10683, which only touches docs, and #10648, which was dequeued twice.

It times out after 80s waiting for the lab request details page, having clicked the first row of the lab request table.

**Why.** Until its rows arrive, the table renders a single row in its body holding a status message — “Loading…”, or the no-data message. That is `StatusRow` in `packages/web/app/components/Table/Table.jsx`, and it goes through the same `StyledTableRow` as a data row, so it is a `tr` inside `styledtablebody-a0jz` — but it is given no click handler. `tableBody.locator(tr).first()` matches it, and clicking it does nothing at all.

`waitForTableToLoad` did not rule that out:

- `labRequestTable.waitFor({ state: visible })` — the table *is* visible, with the status row inside it.
- `page.waitForLoadState(networkidle, { timeout: 10000 })` — with no navigation since the page loaded, Playwright resolves this immediately. It synchronised nothing.

So the click lands on an inert row, no navigation happens, and the test waits out its whole budget on a page that will never open. Under merge-queue load the pane’s refetch after creating the request is slow enough for that window to be open, which is why it shows up there and not on PR-head runs, and why it is intermittent rather than constant.

**Fix.** Both table waits now wait for a cell that only a real data row carries, which is the actual precondition for the click. `waitForResultsTableToLoad` had the same trap — reading cells off a visible-but-unloaded table reads the status message rather than a result — so it gets the same treatment.

**On verifying.** This is a load-dependent race in a queue-only environment; I can’t reproduce it locally, so the queue is the test. It failed 8 of the 16 merge-queue runs since `fec948d`, so a few clean passes will be a real signal. The change is 11 lines and removes the window rather than papering over it with a retry.

Two things deliberately left alone: the `networkidle` idiom appears in about 20 page objects and is its own cleanup, and `[AT-0103]`/`[AT-0107]`, which went flaky in the same shard and look like the same shape, but I have no evidence for them specifically.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->