### PR TITLE
feat(reporting): no-issue: re-apply reporting grants without a restart

### DIFF
--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -107,7 +107,7 @@ export class ApplicationContext {
       // rest of the server works without reporting, so degrade instead of
       // crash-looping the whole deployment.
       log.error(
-        'initReporting failed; reporting schemas unavailable until the db grants are fixed',
+        'initReporting failed; reporting schemas unavailable until the db grants are fixed and this server restarts. Grants wiped by a reporting schema script are re-applied by ReportingGrantRepair without a restart; this is a different failure.',
         { error },
       );
     }

--- a/packages/central-server/app/tasks/index.js
+++ b/packages/central-server/app/tasks/index.js
@@ -34,6 +34,7 @@ import { GenerateMedicationAdministrationRecords } from './GenerateMedicationAdm
 import { MedicationDiscontinuer } from './MedicationDiscontinuer';
 import { DHIS2IntegrationProcessor } from './DHIS2IntegrationProcessor';
 import { ProgramRegistryPltfuFlagger } from './ProgramRegistryPltfuFlagger';
+import { ReportingGrantRepair } from '@tamanu/database/tasks/ReportingGrantRepair';
 
 export { startFhirWorkerTasks } from '@tamanu/shared/tasks';
 
@@ -49,6 +50,7 @@ export async function startScheduledTasks(context) {
   /* eslint-enable require-atomic-updates */
 
   const taskClasses = [
+    ReportingGrantRepair,
     OutpatientDischarger,
     DeceasedPatientDischarger,
     PatientEmailCommunicationProcessor,

--- a/packages/database/src/services/reporting.js
+++ b/packages/database/src/services/reporting.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import config from 'config';
+import { QueryTypes } from 'sequelize';
 
 import {
   REPORT_DB_CONNECTION_ROLES,
@@ -90,6 +91,49 @@ const withCatalogRaceRetry = async (label, fn) => {
   }
 };
 
+// Everything a reporting schema script destroys when it runs
+// `DROP SCHEMA ... CASCADE`: the schema's own ACL and the default privileges keyed
+// to its oid both go with it. Re-applying needs no password, so the repair task
+// below can call this without touching the role's credentials.
+const applySchemaGrants = async (sequelize, connectionName) => {
+  const role = REPORT_DB_CONNECTION_ROLES[connectionName];
+  const schema = REPORT_DB_CONNECTION_SCHEMAS[connectionName];
+
+  if (schema !== 'public') {
+    await sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${schema}";`);
+  }
+
+  await sequelize.query(`GRANT USAGE ON SCHEMA "${schema}" TO "${role}";`);
+  await sequelize.query(`GRANT SELECT ON ALL TABLES IN SCHEMA "${schema}" TO "${role}";`);
+  // Covers tables created later (e.g. materialised reporting tables).
+  await sequelize.query(
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schema}" GRANT SELECT ON TABLES TO "${role}";`,
+  );
+
+  // The raw role reads all of `public` for reporting, but report SQL has no
+  // business reading credential/token tables: local_system_secrets holds the
+  // device private key and the reporting secret (encrypted, but still not for
+  // reports), and the rest hold auth tokens or certificate signing keys. Revoke
+  // SELECT on them.
+  // to_regclass skips any not present on this server (e.g. central-only ones).
+  if (schema === 'public') {
+    const sensitiveTablesArray = REPORTING_SENSITIVE_TABLES.map(table => `'${table}'`).join(', ');
+    await sequelize.query(`
+      DO $$
+      DECLARE
+        sensitive_table text;
+      BEGIN
+        FOREACH sensitive_table IN ARRAY ARRAY[${sensitiveTablesArray}] LOOP
+          IF to_regclass('public.' || sensitive_table) IS NOT NULL THEN
+            EXECUTE format('REVOKE SELECT ON public.%I FROM %I', sensitive_table, '${role}');
+          END IF;
+        END LOOP;
+      END
+      $$;
+    `);
+  }
+};
+
 const ensureReportingRole = async (existingStore, connectionName, password) => {
   const role = REPORT_DB_CONNECTION_ROLES[connectionName];
   const schema = REPORT_DB_CONNECTION_SCHEMAS[connectionName];
@@ -126,44 +170,89 @@ const ensureReportingRole = async (existingStore, connectionName, password) => {
       }
 
       if (schema !== 'public') {
-        await sequelize.query(`CREATE SCHEMA IF NOT EXISTS "${schema}";`);
-        // Lets reporting reports reference tables without the schema prefix.
+        // Role-level (survives a schema drop): lets reports skip the schema prefix.
         await sequelize.query(`ALTER ROLE "${role}" SET search_path TO "${schema}";`);
       }
 
-      await sequelize.query(`GRANT USAGE ON SCHEMA "${schema}" TO "${role}";`);
-      await sequelize.query(`GRANT SELECT ON ALL TABLES IN SCHEMA "${schema}" TO "${role}";`);
-      // Covers tables created later (e.g. materialised reporting tables).
-      await sequelize.query(
-        `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schema}" GRANT SELECT ON TABLES TO "${role}";`,
-      );
-
-      // The raw role reads all of `public` for reporting, but report SQL has no
-      // business reading credential/token tables: local_system_secrets holds the
-      // device private key and the reporting secret (encrypted, but still not for
-      // reports), and the rest hold auth tokens or certificate signing keys. Revoke
-      // SELECT on them.
-      // to_regclass skips any not present on this server (e.g. central-only ones).
-      if (schema === 'public') {
-        const sensitiveTablesArray = REPORTING_SENSITIVE_TABLES.map(table => `'${table}'`).join(
-          ', ',
-        );
-        await sequelize.query(`
-        DO $$
-        DECLARE
-          sensitive_table text;
-        BEGIN
-          FOREACH sensitive_table IN ARRAY ARRAY[${sensitiveTablesArray}] LOOP
-            IF to_regclass('public.' || sensitive_table) IS NOT NULL THEN
-              EXECUTE format('REVOKE SELECT ON public.%I FROM %I', sensitive_table, '${role}');
-            END IF;
-          END LOOP;
-        END
-        $$;
-      `);
-      }
+      await applySchemaGrants(sequelize, connectionName);
     }),
   );
+};
+
+// A dropped-and-recreated schema leaves the role able to log in but unable to read
+// anything, so this checks exactly what `applySchemaGrants` sets. Catalog-only and
+// read-only, cheap enough to run on a short schedule.
+const reportingGrantsNeedRepair = async (sequelize, connectionName) => {
+  const role = REPORT_DB_CONNECTION_ROLES[connectionName];
+  const schema = REPORT_DB_CONNECTION_SCHEMAS[connectionName];
+
+  const [present] = await sequelize.query(
+    `SELECT to_regnamespace(:schema) IS NOT NULL AS "schemaExists",
+            EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :role) AS "roleExists";`,
+    { replacements: { schema, role }, type: QueryTypes.SELECT },
+  );
+  // Creating either is startup's job. Granting into a schema a reporting script has
+  // dropped but not yet recreated would also make that script's own CREATE SCHEMA fail.
+  if (!present.schemaExists || !present.roleExists) return false;
+
+  // The raw role is deliberately denied these, so their absence isn't drift.
+  const deliberatelyRevoked =
+    schema === 'public'
+      ? `AND cls.relname <> ALL (ARRAY[${REPORTING_SENSITIVE_TABLES.map(
+          table => `'${table}'`,
+        ).join(', ')}]::text[])`
+      : '';
+
+  const [state] = await sequelize.query(
+    `SELECT
+       has_schema_privilege(:role, :schema, 'USAGE') AS "hasUsage",
+       EXISTS (
+         SELECT 1
+         FROM pg_default_acl acl
+         JOIN pg_namespace nsp ON nsp.oid = acl.defaclnamespace
+         CROSS JOIN LATERAL aclexplode(acl.defaclacl) AS ace
+         WHERE nsp.nspname = :schema
+           AND acl.defaclobjtype = 'r'
+           AND ace.privilege_type = 'SELECT'
+           AND ace.grantee = (SELECT oid FROM pg_roles WHERE rolname = :role)
+       ) AS "hasDefaultPrivileges",
+       EXISTS (
+         SELECT 1
+         FROM pg_class cls
+         JOIN pg_namespace nsp ON nsp.oid = cls.relnamespace
+         WHERE nsp.nspname = :schema
+           AND cls.relkind IN ('r', 'v', 'm', 'f', 'p')
+           AND NOT has_table_privilege(:role, cls.oid, 'SELECT')
+           ${deliberatelyRevoked}
+       ) AS "hasUnreadableTable";`,
+    { replacements: { schema, role }, type: QueryTypes.SELECT },
+  );
+
+  return !state.hasUsage || !state.hasDefaultPrivileges || state.hasUnreadableTable;
+};
+
+/**
+ * Re-apply the schema grants that a reporting script's `DROP SCHEMA ... CASCADE`
+ * removes, so reporting recovers on its own instead of waiting for a server restart.
+ * Checks before granting: `GRANT ... ON ALL TABLES` locks every table it touches,
+ * which is not something to do on a schedule for no reason.
+ *
+ * Returns the connections it repaired.
+ */
+export const repairReportingGrants = async ({ sequelize }) => {
+  const repaired = [];
+  for (const connectionName of REPORT_DB_CONNECTION_VALUES) {
+    if (!(await reportingGrantsNeedRepair(sequelize, connectionName))) continue;
+
+    await withCatalogRaceRetry(`repairReportingGrants(${connectionName})`, () =>
+      sequelize.transaction(async () => {
+        await sequelize.query(`SELECT pg_advisory_xact_lock(${REPORTING_ROLES_LOCK_KEY}::bigint);`);
+        await applySchemaGrants(sequelize, connectionName);
+      }),
+    );
+    repaired.push(connectionName);
+  }
+  return repaired;
 };
 
 const initReportStore = async (existingStore, connectionName, secret) => {

--- a/packages/database/src/tasks/ReportingGrantRepair.js
+++ b/packages/database/src/tasks/ReportingGrantRepair.js
@@ -1,0 +1,31 @@
+import { ScheduledTask } from '@tamanu/shared/tasks';
+import { log } from '@tamanu/shared/services/logging';
+
+import { repairReportingGrants } from '../services/reporting';
+
+/**
+ * Reporting schema scripts open with `DROP SCHEMA reporting CASCADE`, which takes the
+ * reporting role's grants with it: the schema ACL and the default privileges keyed to
+ * that schema both go. Only startup re-applied them, so recovering meant restarting
+ * every facility server. This re-applies them in place instead.
+ */
+export class ReportingGrantRepair extends ScheduledTask {
+  getName() {
+    return 'ReportingGrantRepair';
+  }
+
+  constructor(context) {
+    const { schedule, jitterTime, enabled } = context.schedules.reportingGrantRepair;
+    super(schedule, log, jitterTime, enabled);
+    this.context = context;
+  }
+
+  async run() {
+    const repaired = await repairReportingGrants(this.context.store);
+    if (repaired.length === 0) return;
+
+    log.info('ReportingGrantRepair: re-applied reporting grants', {
+      connections: repaired.join(', '),
+    });
+  }
+}

--- a/packages/facility-server/__tests__/apiv1/ReportingGrantRepair.test.js
+++ b/packages/facility-server/__tests__/apiv1/ReportingGrantRepair.test.js
@@ -1,0 +1,82 @@
+import { QueryTypes } from 'sequelize';
+import { REPORT_DB_CONNECTION_ROLES, REPORT_DB_CONNECTION_SCHEMAS } from '@tamanu/constants';
+import { repairReportingGrants } from '@tamanu/database/services/reporting';
+import { createTestContext } from '../utilities';
+
+const ROLE = REPORT_DB_CONNECTION_ROLES.reporting;
+const SCHEMA = REPORT_DB_CONNECTION_SCHEMAS.reporting;
+const TEST_TABLE = `${SCHEMA}.grant_repair_test_table`;
+
+// A reporting schema script opens with `DROP SCHEMA reporting CASCADE`, which takes the
+// schema's ACL and its default privileges with it. Jest workers share a database, so
+// these revoke the grants directly rather than dropping the schema out from under
+// another suite; the state left behind is the same one the drop leaves.
+describe('repairReportingGrants', () => {
+  let ctx;
+  let sequelize;
+
+  beforeAll(async () => {
+    ctx = await createTestContext({ enableReportInstances: true });
+    sequelize = ctx.sequelize;
+    await sequelize.query(`CREATE TABLE ${TEST_TABLE} ("id" integer PRIMARY KEY);`);
+  });
+
+  afterAll(async () => {
+    await sequelize.query(`DROP TABLE IF EXISTS ${TEST_TABLE};`);
+    await ctx.close();
+  });
+
+  const reportingRoleCanRead = async () => {
+    const [privileges] = await sequelize.query(
+      `SELECT has_schema_privilege(:role, :schema, 'USAGE') AS "hasUsage",
+              has_table_privilege(:role, :table, 'SELECT') AS "canSelect";`,
+      {
+        replacements: { role: ROLE, schema: SCHEMA, table: TEST_TABLE },
+        type: QueryTypes.SELECT,
+      },
+    );
+    return privileges.hasUsage && privileges.canSelect;
+  };
+
+  const stripSchemaGrants = () =>
+    sequelize.query(`
+      REVOKE USAGE ON SCHEMA ${SCHEMA} FROM ${ROLE};
+      REVOKE SELECT ON ALL TABLES IN SCHEMA ${SCHEMA} FROM ${ROLE};
+      ALTER DEFAULT PRIVILEGES IN SCHEMA ${SCHEMA} REVOKE SELECT ON TABLES FROM ${ROLE};
+    `);
+
+  it('re-applies grants a schema rebuild removed', async () => {
+    await stripSchemaGrants();
+    expect(await reportingRoleCanRead()).toBe(false);
+
+    const repaired = await repairReportingGrants({ sequelize });
+
+    expect(repaired).toContain('reporting');
+    expect(await reportingRoleCanRead()).toBe(true);
+  });
+
+  it('covers tables created after the rebuild', async () => {
+    await stripSchemaGrants();
+    await repairReportingGrants({ sequelize });
+    await sequelize.query(`CREATE TABLE ${SCHEMA}.grant_repair_later_table ("id" integer);`);
+
+    const [privileges] = await sequelize.query(
+      `SELECT has_table_privilege(:role, :table, 'SELECT') AS "canSelect";`,
+      {
+        replacements: { role: ROLE, table: `${SCHEMA}.grant_repair_later_table` },
+        type: QueryTypes.SELECT,
+      },
+    );
+    await sequelize.query(`DROP TABLE ${SCHEMA}.grant_repair_later_table;`);
+
+    expect(privileges.canSelect).toBe(true);
+  });
+
+  it('does nothing when the grants are intact', async () => {
+    await repairReportingGrants({ sequelize });
+
+    // Not an empty-array assertion: suites sharing this database churn `public`, which
+    // the raw connection also covers.
+    expect(await repairReportingGrants({ sequelize })).not.toContain('reporting');
+  });
+});

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -93,7 +93,7 @@ export class ApplicationContext {
       // rest of the server works without reporting, so degrade instead of
       // crash-looping the whole deployment.
       log.error(
-        'initReporting failed; reporting schemas unavailable until the db grants are fixed',
+        'initReporting failed; reporting schemas unavailable until the db grants are fixed and this server restarts. Grants wiped by a reporting schema script are re-applied by ReportingGrantRepair without a restart; this is a different failure.',
         { error },
       );
     }

--- a/packages/facility-server/app/tasks/index.js
+++ b/packages/facility-server/app/tasks/index.js
@@ -14,10 +14,12 @@ import { mSupplyMedIntegrationProcessor } from './mSupplyMedIntegrationProcessor
 import { MSupplyStockOnHandProcessor } from './MSupplyStockOnHandProcessor';
 import { RefreshUpcomingVaccinations } from './RefreshMaterializedView';
 import { TimeSyncTask } from './TimeSyncTask';
+import { ReportingGrantRepair } from '@tamanu/database/tasks/ReportingGrantRepair';
 
 export { startFhirWorkerTasks };
 
 const DEFAULT_TASK_CLASSES = [
+  ReportingGrantRepair,
   RefreshUpcomingVaccinations,
   SendStatusToMetaServer,
   TimeSyncTask,

--- a/packages/settings/src/schema/central.ts
+++ b/packages/settings/src/schema/central.ts
@@ -822,6 +822,7 @@ export const centralSettings = {
       description: 'Cron schedules and tuning for central-server background tasks',
       requiresRestart: true,
       properties: {
+        reportingGrantRepair: scheduledTaskSchema({ schedule: '*/5 * * * *' }),
         outpatientDischarger: scheduledTaskSchema(
           { schedule: '0 2 * * *' },
           batchingProperties(1000, 50),

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -231,6 +231,7 @@ export const facilitySettings = {
           },
         ),
         sendStatusToMetaServer: scheduledTaskSchema({ schedule: '* * * * *', jitterTime: '30s' }),
+        reportingGrantRepair: scheduledTaskSchema({ schedule: '*/5 * * * *' }),
         timeSync: scheduledTaskSchema({ schedule: '0 * * * *', enabled: false }),
         mSupplyMedIntegrationProcessor: scheduledTaskSchema(
           { schedule: '0 2 * * *', enabled: false },


### PR DESCRIPTION
### Changes

Reporting schema scripts open with `DROP SCHEMA reporting CASCADE`. That takes the reporting role's schema ACL **and** the schema's default privileges with it (verified on PG 16: `nspacl` loses the role, and the `pg_default_acl` row for the schema disappears). Only `ensureReportingRole` re-applied them, and that runs at startup, so recovering meant restarting every facility server, a minute or two of downtime each.

`ReportingGrantRepair` is a scheduled task on central and facility (every 5 minutes by default) that checks whether the grants are intact and re-applies them only when they aren't. `applySchemaGrants` is extracted from `ensureReportingRole` so startup and the repair path share one definition of a correct grant state.

Four decisions worth a look:

- **Grants only, never the role or its password.** `getReportingSecret` can rotate, and re-deriving the password on a schedule would change it out from under the live connection pools. Roles are cluster-level and survive a schema drop anyway.
- **Check before granting.** `GRANT ... ON ALL TABLES` locks every table it touches, so the task does a catalog-only read first and issues DDL only on drift.
- **Skips when the schema is absent.** Otherwise a repair landing between a script's `DROP` and its `CREATE SCHEMA` would make the script's own `CREATE SCHEMA` fail.
- **On `public`, the sensitive tables the raw role is deliberately revoked from are excluded**, or the check would read permanent drift and re-grant every tick.

Also reworded the `initReporting` failure log. That path leaves the connection pools unopened, so it still needs a restart; the message now says so and points at the task for the case that doesn't.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
