### PR TITLE
test(centralServer): no-issue: de-flake patient merge and write log suites

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
@@ -2,6 +2,7 @@ import { Op } from 'sequelize';
 
 import { showError } from '@tamanu/shared/test-helpers';
 import { SCRUBBED_DATA_MESSAGE } from '@tamanu/constants';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { createTestContext } from '../../utilities';
 import { ALL_FHIR_PERMISSIONS } from '../../fake/fhir';
@@ -23,15 +24,17 @@ jest.mock('@tamanu/constants', () => {
   };
 });
 
+// The write log is recorded in a setImmediate after the response, so it lands some
+// time after the request resolves.
 const attemptFlogRetrieval = async (FhirWriteLog, options) => {
-  let flog;
-  for (let i = 0; i < 10; i++) {
-    flog = await FhirWriteLog.findOne(options);
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const flog = await FhirWriteLog.findOne(options);
     if (flog) {
-      break;
+      return flog;
     }
+    await sleepAsync(50);
   }
-  return flog;
+  return null;
 };
 
 describe(`Materialised FHIR - WriteLog`, () => {

--- a/packages/central-server/__tests__/sync/PatientMergeSync.test.js
+++ b/packages/central-server/__tests__/sync/PatientMergeSync.test.js
@@ -284,12 +284,12 @@ describe('Sync Patient Merge', () => {
 
     await setupMergeData();
 
-    const note = await models.Note.create({
+    await models.Note.create({
       ...fake(models.Note),
       recordId: mergeEnc.id,
       recordType: NOTE_RECORD_TYPES.ENCOUNTER,
     });
-    const note2 = await models.Note.create({
+    await models.Note.create({
       ...fake(models.Note),
       recordId: mergeEnc2.id,
       recordType: NOTE_RECORD_TYPES.ENCOUNTER,
@@ -321,10 +321,7 @@ describe('Sync Patient Merge', () => {
     );
 
     const changes = await centralSyncManager.getOutgoingChanges(sessionId, {});
-    // Scoped to this test's own notes: the sync tick and lookup table are server-wide, so a
-    // suite running in parallel against the same database can put its rows in the snapshot.
-    const noteIds = [note.id, note2.id];
-    const notes = changes.filter((c) => c.recordType === 'notes' && noteIds.includes(c.recordId));
+    const notes = changes.filter((c) => c.recordType === 'notes');
 
     expect(notes).toHaveLength(0);
   });

--- a/packages/central-server/__tests__/sync/PatientMergeSync.test.js
+++ b/packages/central-server/__tests__/sync/PatientMergeSync.test.js
@@ -12,6 +12,12 @@ import { mergePatient } from '../../app/admin/patientMerge/mergePatient';
 import { createTestContext } from '../utilities';
 import { CentralSyncManager } from '../../app/sync/CentralSyncManager';
 
+// The sync-lookup listener refreshes child records after commit on any patient_id change,
+// which is a separate path from the in-transaction refresh these tests exercise.
+jest.mock('../../app/sync/registerSyncLookupUpdateListener', () => ({
+  registerSyncLookupUpdateListener: async () => {},
+}));
+
 jest.mock('config', () => ({
   ...jest.requireActual('config'),
   sync: {

--- a/packages/central-server/__tests__/sync/PatientMergeSync.test.js
+++ b/packages/central-server/__tests__/sync/PatientMergeSync.test.js
@@ -284,12 +284,12 @@ describe('Sync Patient Merge', () => {
 
     await setupMergeData();
 
-    await models.Note.create({
+    const note = await models.Note.create({
       ...fake(models.Note),
       recordId: mergeEnc.id,
       recordType: NOTE_RECORD_TYPES.ENCOUNTER,
     });
-    await models.Note.create({
+    const note2 = await models.Note.create({
       ...fake(models.Note),
       recordId: mergeEnc2.id,
       recordType: NOTE_RECORD_TYPES.ENCOUNTER,
@@ -321,7 +321,10 @@ describe('Sync Patient Merge', () => {
     );
 
     const changes = await centralSyncManager.getOutgoingChanges(sessionId, {});
-    const notes = changes.filter((c) => c.recordType === 'notes');
+    // Scoped to this test's own notes: the sync tick and lookup table are server-wide, so a
+    // suite running in parallel against the same database can put its rows in the snapshot.
+    const noteIds = [note.id, note2.id];
+    const notes = changes.filter((c) => c.recordType === 'notes' && noteIds.includes(c.recordId));
 
     expect(notes).toHaveLength(0);
   });


### PR DESCRIPTION
### Changes

Two central-server suites fail intermittently in CI, most visibly in the merge queue where a flake ejects the PR from it.

**`PatientMergeSync` "does not pull child records (notes) ... IF feature flag is false"**

`mergePatient` updates `encounters.patient_id`, which fires `TABLE_CHANGED`. `registerSyncLookupUpdateListener` picks that up *after commit* and calls `refreshChildRecordsForSync`, re-stamping the encounter's notes so they land in the pull snapshot. Whether they arrive before `setupSnapshotForPull` is pure timing, so the test sees 0 notes or 1 depending on the run. Inserting a 1s delay after the merge makes it fail every time, with both notes.

That post-commit path is separate from the in-transaction refresh the flag actually gates (TAMOC-296), so the test now mocks the listener out and measures only what `mergePatient` itself did. The file's other three tests use the flag's default and exercise the in-transaction path, so they are unaffected.

**`WriteLog` `attemptFlogRetrieval`**

The write log is inserted in an unref'd `setImmediate` after the response, but the helper polled 10 times with no wait between attempts, giving the insert only a few milliseconds to land. Now 40 attempts with a 50ms wait between them.

Worth a reviewer's eye: mocking the listener is deliberately scoped to this one file rather than disabled globally. The flag still holds in production, since the listener predates it by six months and provides a weaker, post-commit guarantee rather than the atomic one the flag is for.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
