### PR TITLE
chore: no-issue: close config to new keys in the agent rules

### DIFF
--- a/llm/project-rules/coding-rules.md
+++ b/llm/project-rules/coding-rules.md
@@ -34,6 +34,12 @@ Readability is the highest priority. Every line of code is read many times over 
 - Schema changes (added/removed/changed tables or columns) require updating the dbt source models in `database/model/` — see `packages/database/CLAUDE.md`
 - Adding a new **importable reference-data type** (a new `reference_data` type, or anything added to `OTHER_REFERENCE_TYPES` that flows into `GENERAL_IMPORTABLE_DATA_TYPES`) makes it **required by the provisioning completeness check** (`validateFullReferenceDataImport` in `provision.js`). You must either add a matching `packages/central-server/app/subCommands/defaultProvisioningData/<Sheet>.json5` (with at least one data row) **or** add it to `EXCLUDED_FROM_FULL_IMPORT_CHECK` if it's optional — otherwise `provision` throws and the deploy's central-provisioner job fails (central-api never starts).
 
+### Config
+
+- Never add a key to `config/*.json5`. New configurable values are settings; see
+  @llm/project-rules/settings.md for the decision procedure and the short list of bootstrap
+  concerns that are still config.
+
 ### Sync
 
 - Never modify `updated_at_sync_tick` manually

--- a/llm/project-rules/important-project-rules.md
+++ b/llm/project-rules/important-project-rules.md
@@ -17,6 +17,12 @@ This file contains essential Tamanu-specific information for LLM agents.
 
 We use **managed transactions** with `sequelize.transaction(async () => { ... })` and **Sequelize.useCLS()**, so the transaction object is not passed to inner calls. See `llm/project-rules/sequelize-transactions.md` for details.
 
+## Config Change Detection
+
+**Load `llm/project-rules/settings.md` before editing any `config/*.json5`**, or when adding a
+value a deployment or operator would set. `config/*.json5` is closed to new keys; that rule has
+the decision procedure.
+
 ## Copy Change Detection
 
 **Load `llm/project-rules/update-copy.md` when the user mentions:**

--- a/llm/project-rules/settings.md
+++ b/llm/project-rules/settings.md
@@ -89,11 +89,12 @@ Work through these in order:
    everything: anything an operator might tune, anything per-facility, anything the admin
    panel should show.
 2. **A secret?** It is a `secret: true` setting, encrypted at rest and masked in the UI.
-3. **Needed synchronously at boot, before the database is up?** Only then is it config, and
-   only if it is genuinely one of the bootstrap concerns already there: database connection,
-   `serverFacilityId`, crypto key paths, ports. A deploy-supplied value also needs a mapping
-   in `custom-environment-variables.json5`; the env var is how a deployment sets the key, not
-   a way around adding one.
+3. **Needed synchronously at boot, before the database is up?** It is bootstrap. Prefer reading
+   it straight from `process.env`, the way `resolveDbConfig` reads `DATABASE_URL`: that needs no
+   config key and no mapping. Add a config key only when the value genuinely needs a committed
+   default or must be settable from a config file, and then map it in
+   `custom-environment-variables.json5` so deployments can set it. The keys already there are
+   database connection, `serverFacilityId`, crypto key paths and ports.
 4. **Anything else:** stop. Do not add the key. Name the value, say why you think it cannot be
    a setting, and let a reviewer decide.
 

--- a/llm/project-rules/settings.md
+++ b/llm/project-rules/settings.md
@@ -78,11 +78,24 @@ only has `models` and can't reasonably be threaded a reader.
 `get()` is async and reads from the DB, so settings can only be read from async
 code that runs after startup — not from bootstrap/module-load code.
 
-## Settings, not config files
+## Settings and env, not config files
 
-New configurable values belong in the settings schema, **not** in the
-`config/*.json5` files. Config is reserved for deployment/bootstrap concerns
-that must be read synchronously before settings are available — DB connection,
-`serverFacilityId`, crypto key paths, ports. Anything an operator might tune at
-runtime should be a setting: it's DB-backed, admin-editable, and per-facility
-where needed, none of which a config file can do.
+**`config/*.json5` is closed to new keys.** New configurable values go in the settings
+schema. Adding a config key is a call a human makes, not one an agent makes on judgement.
+
+Work through these in order:
+
+1. **Readable after startup, from async code?** It is a **setting**. That covers almost
+   everything: anything an operator might tune, anything per-facility, anything the admin
+   panel should show.
+2. **A secret?** It is a `secret: true` setting, encrypted at rest and masked in the UI.
+3. **Needed synchronously at boot, before the database is up?** Only then is it config, and
+   only if it is genuinely one of the bootstrap concerns already there: database connection,
+   `serverFacilityId`, crypto key paths, ports. A deploy-supplied value also needs a mapping
+   in `custom-environment-variables.json5`; the env var is how a deployment sets the key, not
+   a way around adding one.
+4. **Anything else:** stop. Do not add the key. Name the value, say why you think it cannot be
+   a setting, and let a reviewer decide.
+
+Nothing lints this, so it holds only if you apply it, and a config key that should have been a
+setting is expensive to undo once deployments have set it.


### PR DESCRIPTION
### Changes

The config-vs-settings rule existed only as prose in `llm/project-rules/settings.md`, referenced from `AGENTS.md` as a see-also about settings. So an agent adding a key to `config/*.json5` had no reason to load it, and the rule only bit if someone already suspected settings were relevant. That is how a root config key got added without being weighed against it.

Three changes, because hardening the wording alone would not have helped:

- **The rule is now hard.** `settings.md` opens with "`config/*.json5` is closed to new keys" and gives a four-step decision procedure. Step 4 is "stop, do not add the key, name the value and say why you think it cannot be a setting". That turns a judgement call into an escalation.
- **A load trigger**, mirroring the existing Copy Change Detection pattern: load `settings.md` *before editing any `config/*.json5`*. This is the actual fix. It fires on the file being touched rather than on the agent already thinking about settings.
- **An antipattern entry** in `coding-rules.md`, which is the file read during review.

Two calls worth a look:

- Bootstrap values should prefer a direct `process.env` read, the way `resolveDbConfig` reads `DATABASE_URL` with no config key and no mapping entry. Step 3 points at that first and treats a new config key plus a `custom-environment-variables.json5` mapping as the fallback, for when a committed default is genuinely needed.
- The list of legitimate config concerns stays as the four already present (database connection, `serverFacilityId`, crypto key paths, ports). Deliberately not widened, since whether a given new key belongs there is the question the rule exists to force.

No lint sits behind this, and the rule says so. Real enforcement would need a test diffing new keys in `config/*.json5` against an allowlist and failing on anything else, since "should this be a setting?" cannot be fully inferred. Happy to add that separately if wanted.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

