### PR TITLE
feat(blobs): P2: blob integrity scrub and self-heal

### DIFF
--- a/.agents/skills/draft-card-breakdown/SKILL.md
+++ b/.agents/skills/draft-card-breakdown/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: draft-card-breakdown
+description: "Workshop how to break this card into smaller spawned cards and capture entries in the card breakdown"
+label: "Draft card breakdown"
+pill-order:
+  not-started: 8
+  specifying: 13
+  implementing: 7
+  reviewing: 7
+surface: both
+jockey-hint: "Always available but low-traffic — surface as an available pill, not a top suggestion. Most cards are implemented as one PR; only suggest prominently when the conversation has already revealed the card is too large to ship in one piece."
+workhorse-version: 0.3.0
+---
+
+## Your task: Draft card breakdown
+
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
+Workshop how to slice this card into smaller spawned cards and capture the result in the card breakdown at `.workhorse/breakdowns/{card-id}/breakdown.md`.
+
+The breakdown is not the implementation plan. The breakdown lists the cards this card splits into; the plan at `.workhorse/plans/{card-id}/plan.md` describes how a single card gets built. You are editing the breakdown here. It has a strict shape:
+
+- An H1 title and an optional intro paragraph
+- A flat list of `## ` heading entries, one per spawned card
+- Each entry's body is a short description paragraph (and optionally a `<!-- mockups: ... -->` comment) — no checklists, no sub-headings, no nested H3s, no build-step bullets
+
+Once the user is ready, a bulk Create cards action turns each uncreated entry into a real spawned card based on this one. The parent stays as the umbrella while the children carry the implementation work.
+
+### How to run the workshop
+
+1. Read the card's specs in `specs/`, the card description, and any existing breakdown at `.workhorse/breakdowns/{card-id}/breakdown.md`
+2. Skim the target repo where it helps you reason about boundaries between the children
+3. Talk through how to slice the work — natural seams, dependency order, what each child should own. Ask focused questions one or two at a time
+4. As entries become clear, write them into `breakdown.md` as `## ` headings with a short description paragraph beneath. Edit in place as the conversation refines them — adding, splitting, merging, reordering entries is normal
+5. If `breakdown.md` does not yet exist, create it at the path above with an H1 title and the entries underneath. Do not create or edit any other file
+6. **Suggest mockup carry-forward.** Each entry has an inline Mockups picker for choosing which of the parent's mockups travel with the spawned card. As you write entries, populate the picker by inserting a structured comment line directly under the entry's `## ` heading: `<!-- mockups: slug-one, slug-two -->` (one comment per entry, comma-separated slugs from `.workhorse/design/mockups/{card-id}/`). Pick only the mockups that fit each entry — the user can adjust later
+7. Do not trigger bulk-create yourself. The user runs the Create cards action from the editor when they are ready
+
+### What each entry should look like
+
+- The `## ` heading is the spawned card's title — concise, action-oriented, no trailing punctuation, no code suffix (the editor stamps `· CODE` automatically once the card is created)
+- The body beneath is the spawned card's description — a short paragraph (or two) covering scope and boundaries. Do not write a checklist, sub-headings, or implementation steps; that detail belongs in each child card's own plan after it is created
+- Spawned cards inherit the parent's project and become "based on" the parent via dependencies, so don't restate that
+
+See `specs/card/breakdown.md` for the canonical shape.

--- a/.agents/skills/review-testing-notes/SKILL.md
+++ b/.agents/skills/review-testing-notes/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: review-testing-notes
+description: "Review the product engineer's post-implementation testing notes for how thoroughly they cover the card's requirements and risk, and whether regression-worthy cases are automated at the right level of the test hierarchy"
+label: "Review testing notes"
+pill-order:
+  reviewing: 6
+  complete: 5
+jockey-hint: "Surface in the reviewing and complete phases once code changes exist on the branch and testing is underway — it reviews testing notes that follow implementation. Keep it out of the earlier phases."
+workhorse-version: 0.3.0
+---
+
+## Your task: Review testing notes
+
+If you don't already have this card's context (title, identifier, description) — for instance when running outside Workhorse — establish it first by following `.agents/docs/card-context.md`.
+
+Once a card is implemented, the assigned product engineer tests it — manual testing plus the three classes of automated test (end-to-end, integration, unit) — and writes up their testing notes on the card. Review those notes: judge how thoroughly they cover the card's requirements and the risk around them, and whether what belongs in an ongoing regression suite has been automated at the right level. Produce a written review the user can cross-post to Linear.
+
+Use the card's branch as the source of truth for the code and its end-to-end tests throughout.
+
+### 1. Settle the source of truth first
+
+Before reviewing anything, work out what the card is required to do. By this stage the committed specs are the authoritative statement of behaviour.
+
+- Reconcile three inputs: the latest Linear card description, any Linear comments that update the requirements in a way that drifts from that description, and the committed spec changes on the card's branch (diff the branch against its upstream base, scoped to `specs/`)
+- Treat the committed specs as the source of truth. Specs that have moved *ahead* of the Linear description are fine — they are simply more current
+- Where Linear describes behaviour that is **missing from the specs**, the silence is ambiguous — ask the user which case applies, then act on it:
+- **If the missing behaviour was deliberately dropped or superseded** — the specs are already correct (they don't document absences); only Linear is stale. Treat the specs as the source of truth and carry on. If another spec relied on the dropped behaviour, raise that as a finding — it doesn't block the review
+- **If the missing behaviour is still required** — the specs need to catch up. For a small, scoped gap, reconcile it inline (pin down the intended behaviour with the user): treat the confirmed behaviour as part of the source of truth (reviewed for coverage and automation in steps 3 and 4 like any spec criterion), raise the spec update as a top finding, offer to draft it, and continue. For a substantial gap, pause and ask for the specs to be brought up to date first and implemented/tested/reviewed again — there's no sound baseline otherwise
+- A single run should deliver a full review wherever possible; stopping is the exception
+
+### 2. Find the testing notes
+
+Testing notes live in card comments, which span the transition from Linear-hosted to Workhorse-hosted cards.
+
+- Read them from the linked Linear card's comments (via the Linear MCP read tools) and from the Workhorse card's comments — review whatever is found in either or both
+- Comments are not in your session context, so fetch them explicitly through the comment-reading tools rather than expecting them to be present
+- If no testing notes exist in either place, say so and point the user at where notes are expected — don't review an empty set
+
+### 3. Review how thoroughly the notes cover the work
+
+- **Acceptance criteria** — every criterion in the source-of-truth specs, plus any behaviour confirmed as still-required while settling the source of truth in step 1
+- **Edge cases** — cases you can identify from the specs and code that the notes don't address
+- **Interactions** — existing functionality the change touches
+- **Regressions** — the potential-risk blast radius, the areas the change could break beyond its own surface
+
+Ground every gap you raise in the committed specs and the source code, so a suggestion speaks to behaviour the product actually has — not a case that isn't relevant to it. Check before you raise it.
+
+### 4. Verify automated coverage and test-hierarchy balance
+
+Anything that would previously have gone into a manual regression suite is expected to be an automated test now. Confirm this against the actual tests on the branch, not the notes' claims alone.
+
+- For each case the notes describe as covered, confirm a matching automated test exists on the branch at the class claimed (end-to-end, integration, or unit)
+- Every workflow is covered in full by at least some end-to-end tests
+- Where a range of specific or edge cases could be covered more cheaply, they belong pushed down to integration or unit tests rather than left as end-to-end tests — e2e tests are slower in CI and more brittle
+- Flag a regression-worthy case that is only manually tested, so it can be automated
+- Flag imbalance in either direction: a workflow with no end-to-end coverage, or edge cases carried by end-to-end tests that belong lower in the hierarchy
+
+### 5. Feed classes of gap back upstream
+
+If a gap is not a one-off miss but a **class or pattern** of test case that scenario design should have caught before implementation reached testing-notes review, suggest the user add that class or pattern to the Draft test cases skill — or to whichever skill they used to set up this card's test cases — so future cards catch it earlier. Frame this as a process improvement, separate from the card's own findings.
+
+### 6. Write it up
+
+- Post the review as a structured written message the user can cross-post to Linear — clear enough to stand on its own for a reader who wasn't in the conversation
+- You cannot post to Linear or to the Workhorse card yourself; deliver the write-up in chat for the user to place where they want it
+- Offer to act on the findings: automate missing test cases (see the Automate test cases skill) or fix inadequate or broken automated tests
+- Do not edit the testing notes

--- a/.workhorse/plans/p2/plan.md
+++ b/.workhorse/plans/p2/plan.md
@@ -1,0 +1,80 @@
+# Blob integrity scrub and self-heal
+
+Implements `specs/blob-storage/integrity.md` (SCRUB) over the store primitive (E2),
+the transfer channel (F2), access control (H2) and the facility cache tiers (G2),
+all of which are already merged into the epic branch.
+
+## Shape
+
+Detection and repair are separated. A `BlobScrubber` in the database package owns
+detection — it is the same on every server — and is handed a `heal` policy by the
+server that constructs it, because what a fault means and how it is repaired
+differ between central and a facility. The scrubber never decides severity.
+
+Three passes make up one scrub:
+
+- **Verification** walks the registry least-recently-scrubbed first, re-hashes each
+  blob, and stamps `last_scrubbed_at`.
+- **Reconciliation** walks the store's own fan-out directories to find bytes no
+  registry entry names.
+- **Referential integrity** asks the server for content that must be durably
+  present but is not held.
+
+Rate limiting is per pass, by blob count and byte volume, so a pass on a large
+store is bounded and the target cycle is met across many passes rather than one.
+
+## Registry state
+
+`integrity_state` gains `absent`, so a registry row naming bytes the store does not
+hold is distinguishable from a corrupt one. Scrub time is a new
+`last_scrubbed_at` column; the scrub *result* is the integrity state as of that
+time, so no second column is needed.
+
+## Severity grading
+
+The tier column already carries the distinction the spec grades on, so the healer
+reads it rather than inferring anything:
+
+- Facility, `cache`, corrupt: delete the blob so the next read refetches it. Low
+  severity, self-correcting, logged at warn.
+- Facility, `cache`, missing: not a fault. Evicted content is expected to be absent.
+- Facility, `outbox`: the only durable copy. Quarantine or mark absent, escalate,
+  and try central as a peer (it may hold content whose demotion was interrupted).
+- Central: every copy is authoritative. Quarantine or mark absent, escalate. Peer
+  repair is opportunistic rather than driven from here.
+
+## Opportunistic peer healing on central
+
+Central cannot reach a facility on demand, so healing happens on the connection a
+facility already makes. The offer route answers `wanted` rather than
+`already-stored` when the copy it holds is quarantined, and a commit over a
+quarantined copy replaces it. This needs no index of what facilities hold, which
+the spec explicitly rules out.
+
+## Referential integrity and the consumer cards
+
+The central referential check runs over the blob reference sources registered in
+`blobReferences.js`. That list is empty until J2 (attachments) and K2 (assets)
+land, so the check is wired and tested but finds nothing today. The facility side
+is complete now, since an outbox row with missing bytes is found by the
+verification pass.
+
+## Deferred
+
+Error correction is the first rung of the ladder but belongs to R2; the healer
+leaves the seam for it rather than stubbing a hook that does nothing. Bao-style
+per-range verification stays deferred, and the ranged-read carve-out in the spec
+is what makes that acceptable.
+
+## Steps
+
+- [x] Add the `absent` integrity state and scrub tuning constants
+- [x] Migration for `blobs.last_scrubbed_at` and dbt models. No mobile counterpart:
+  a device runs no scrub (see `facility-cache.md` via L2), so the column would be dead there
+- [x] `BlobStore.verify()` and full-read verification on the serving path
+- [x] `BlobStore` store walk for reconciliation, and replacement of a quarantined copy
+- [x] `BlobScrubber` with the three passes and rate limiting
+- [x] Facility healer, scrub task, and settings
+- [x] Central healer, scrub task, settings, and opportunistic peer healing
+- [x] Runbook, healthcheck map entry, and query cookbook entries
+- [x] Tests across store, scrubber, and both servers

--- a/.workhorse/plans/p2/plan.md
+++ b/.workhorse/plans/p2/plan.md
@@ -66,6 +66,27 @@ leaves the seam for it rather than stubbing a hook that does nothing. Bao-style
 per-range verification stays deferred, and the ranged-read carve-out in the spec
 is what makes that acceptable.
 
+## Review follow-ups
+
+Triage of a stashed reviewer finder-pass (2026-08-10, unverified findings from a
+cancelled review):
+
+- **Fixed — scrub flush un-quarantine race.** `recordVerified` batch-stamped
+  VERIFIED with no state guard, so a read-path quarantine landing between a blob's
+  verify() and the end-of-pass flush was overwritten and the known-bad bytes served
+  again until the next pass. Now guarded with `integrityState != quarantined`, the
+  same guard `commitStaged` already uses. Regression test added.
+- **Confirmed, deferred — rollback halted by one corrupt blob.** In the M2 backfill,
+  `rollbackReferenceRows`/`rollbackChangelogEntries` read through the verifying
+  `get()` stream; a single `BlobHashMismatchError` throws out of the batch loop, and
+  because batches are `ORDER BY id` the corrupt row sits at the front of every rerun,
+  so rows after it never restore. Real data-loss, but in the rollback subcommand
+  (dev-OTS, rare) and the right fix needs a product decision on what rollback does
+  with a corrupt blob (skip-and-report vs abort). Belongs to M2, not this card.
+- **Ruled out — ranged reads serving corrupt bytes.** `get()` refuses any
+  quarantined blob up front regardless of range; ranged reads skip only the re-hash,
+  which is the documented carve-out. Not a bug.
+
 ## Steps
 
 - [x] Add the `absent` integrity state and scrub tuning constants

--- a/.workhorse/test-cases/p2/overview.md
+++ b/.workhorse/test-cases/p2/overview.md
@@ -60,6 +60,8 @@ Automated coverage lives in `packages/database/__tests__/blobStore/`,
 - [x] An offer for content central holds and has no fault with is still declined
 - [x] A quarantined blob is never served, and the channel does not disclose the
   quarantine
+- [x] An absent blob is withheld the same way: not held on availability and fetch,
+  wanted on offer (verifies spec: BLAC, SCRUB)
 
 ## Referential integrity
 

--- a/.workhorse/test-cases/p2/overview.md
+++ b/.workhorse/test-cases/p2/overview.md
@@ -1,0 +1,79 @@
+# Blob integrity scrub and self-heal — test cases
+
+Scenarios that verify the store detects corruption on every path the spec names,
+grades it by whether the copy is authoritative, and repairs it where it can.
+
+Automated coverage lives in `packages/database/__tests__/blobStore/`,
+`packages/facility-server/__tests__/blobIntegrity/`, and the quarantine block of
+`packages/central-server/__tests__/blobTransfer.test.js`.
+
+## Verification
+
+- [x] A whole-blob read of content whose stored bytes no longer match its hash
+  fails rather than serving the bytes as complete (verifies spec: SCRUB)
+- [x] A whole-blob read of intact content succeeds and reports no fault
+- [x] A ranged read of corrupt content is not failed, since part of a blob cannot
+  be checked against a hash of the whole (verifies spec: SCRUB)
+- [x] Corruption found on the read path runs the same self-heal as the scrub
+- [x] Content received over the transfer channel is verified before it is stored
+  (covered by F2's channel tests, which this card leaves intact)
+
+## Scrub
+
+- [x] A scheduled pass verifies stored blobs and records when each was checked
+- [x] Never-scrubbed blobs are taken ahead of ones scrubbed long ago
+- [x] A pass stops on its blob-count limit and on its byte limit
+- [x] Successive passes cover the whole store
+- [x] An already-quarantined blob is not re-reported on every pass
+- [x] A blob the healer cannot repair does not stop the rest of the pass
+- [ ] A scrub pass on a store of realistic size stays within its byte budget and
+  does not starve clinical IO — needs a volume test, not a unit test
+
+## Registry reconciliation
+
+- [x] Bytes on disk that no registry entry names are verified and registered
+- [x] Bytes whose content does not match the hash their location encodes are
+  quarantined rather than adopted as good content
+- [x] Content left by an admission interrupted between placing the file and
+  recording it is recovered on the next pass
+- [x] A registry entry naming bytes the store does not hold is recorded absent
+- [ ] A server restored from a backup whose store and database were captured at
+  different moments converges after a scrub cycle (verifies spec: SCRUB) — needs
+  a restore fixture spanning both captures
+
+## Severity grading
+
+- [x] A corrupt facility cache copy is dropped so the next read refetches it
+- [x] A corrupt facility outbox blob is quarantined, not dropped, since it may be
+  the only copy (verifies spec: SCRUB)
+- [x] A facility outbox blob whose bytes have gone is recorded absent
+- [x] An outbox blob is repaired from central where central turns out to hold it,
+  and demotes to cache once it is
+- [x] An outbox blob central cannot supply stays quarantined and is escalated
+- [x] Quarantined bytes are retained on disk, not deleted
+
+## Central peer healing
+
+- [x] An offer for a hash whose held copy is quarantined is wanted, not declined
+- [x] A pushed replacement that verifies replaces the quarantined copy, and the
+  blob serves again
+- [x] An offer for content central holds and has no fault with is still declined
+- [x] A quarantined blob is never served, and the channel does not disclose the
+  quarantine
+
+## Referential integrity
+
+- [x] Hashes reported as undeliverable by the server are raised as faults
+- [x] The pass is skipped where a server supplies no reference check
+- [ ] A reference whose record synced longer ago than the delivery grace, with no
+  bytes held, is reported (verifies spec: SCRUB) — needs J2 or K2 to register a
+  real reference source before it can be exercised
+- [ ] A reference still within the delivery grace is treated as content-pending
+  rather than reported — same dependency
+
+## Operations
+
+- [ ] The `blob_integrity` Canopy check reads the documented queries and reports
+  the states they distinguish — Canopy-side, outside this repo
+- [ ] The runbook's outbox-restore path works end to end: a blob placed in its
+  fan-out path by hand is adopted by the next scrub pass

--- a/.workhorse/test-cases/p2/overview.md
+++ b/.workhorse/test-cases/p2/overview.md
@@ -26,6 +26,9 @@ Automated coverage lives in `packages/database/__tests__/blobStore/`,
 - [x] Successive passes cover the whole store
 - [x] An already-quarantined blob is not re-reported on every pass
 - [x] A blob the healer cannot repair does not stop the rest of the pass
+- [x] A blob quarantined on the read path mid-pass stays quarantined when the
+  end-of-pass verified batch flushes, so known-bad bytes are never re-served
+  (verifies spec: SCRUB)
 - [ ] A scrub pass on a store of realistic size stays within its byte budget and
   does not starve clinical IO — needs a volume test, not a unit test
 

--- a/.workhorse/test-cases/p2/overview.md
+++ b/.workhorse/test-cases/p2/overview.md
@@ -65,11 +65,11 @@ Automated coverage lives in `packages/database/__tests__/blobStore/`,
 
 - [x] Hashes reported as undeliverable by the server are raised as faults
 - [x] The pass is skipped where a server supplies no reference check
-- [ ] A reference whose record synced longer ago than the delivery grace, with no
-  bytes held, is reported (verifies spec: SCRUB) — needs J2 or K2 to register a
-  real reference source before it can be exercised
-- [ ] A reference still within the delivery grace is treated as content-pending
-  rather than reported — same dependency
+- [x] A reference whose record synced longer ago than the delivery grace, with no
+  bytes held, is reported (verifies spec: SCRUB) — covered against a scratch
+  reference source; a real consumer source arrives with J2 or K2
+- [x] A reference still within the delivery grace is treated as content-pending
+  rather than reported
 
 ## Operations
 

--- a/database/model/public/blobs.md
+++ b/database/model/public/blobs.md
@@ -21,7 +21,8 @@ Size of the blob's content in bytes.
 {% docs blobs__integrity_state %}
 The blob's integrity state: `verified` when its content matched its hash at the
 last check, `quarantined` when verification failed and the blob is retained for
-investigation but never served.
+investigation but never served, `absent` when the store no longer holds the
+bytes this entry names and the server needs to acquire them again.
 {% enddocs %}
 
 {% docs blobs__tier %}
@@ -36,6 +37,14 @@ When the blob's content was last read (or admitted, whichever is later), used
 for least-recently-used eviction ordering on facility and mobile servers.
 Recency updates may be coalesced, so this is a lower bound on the true last
 access.
+{% enddocs %}
+
+{% docs blobs__last_scrubbed_at %}
+When the scheduled integrity scrub last verified this blob's content against its
+hash; the result of that verification is the integrity state as at this time.
+The scrub takes the least-recently-scrubbed blobs first, so how far this lags
+behind the present is how far behind a full cycle of the store the scrub is.
+Null means never scrubbed.
 {% enddocs %}
 
 {% docs blobs__eligible_since_tick %}

--- a/database/model/public/blobs.yml
+++ b/database/model/public/blobs.yml
@@ -52,6 +52,9 @@ sources:
             description: "{{ doc('blobs__last_accessed_at') }}"
             data_tests:
               - not_null
+          - name: last_scrubbed_at
+            data_type: timestamp with time zone
+            description: "{{ doc('blobs__last_scrubbed_at') }}"
           - name: eligible_since_tick
             data_type: bigint
             description: "{{ doc('blobs__eligible_since_tick') }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,7 @@ treated as a hard pre-filter on any suggested action.
 | [facility-restored-from-backup](runbooks/facility-restored-from-backup.md) | Facility restored from backup: sync fkey conflicts, and checking the blob store | Complete |
 | [fhir-queue-backlog](runbooks/fhir-queue-backlog.md) | FHIR job queue backed up or blocked (`fhir_jobs` check) | Complete |
 | [report-and-error-rows](runbooks/report-and-error-rows.md) | Report / IPS / communication / certificate error-row checks | Complete |
+| [blob-integrity](runbooks/blob-integrity.md) | Attachment or asset bytes corrupt or missing (`blob_integrity` check) | Complete |
 
 ## SOPs
 

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -35,6 +35,7 @@ marked planned are not written yet; use the Canopy solve in the meantime.
 | `sync_sessions`, `sync_session_errors`, `sync_lookup` | [runbooks/sync-facility-stale.md](runbooks/sync-facility-stale.md) / [runbooks/sync-restart-loop.md](runbooks/sync-restart-loop.md); for backup-restore fkey conflicts, [runbooks/facility-restored-from-backup.md](runbooks/facility-restored-from-backup.md) |
 | `sync_snapshot_tables` | [runbooks/sync-facility-stale.md](runbooks/sync-facility-stale.md) |
 | `report_errors`, `ips_errors`, `patient_communication_errors`, `certificate_notification_errors` | [runbooks/report-and-error-rows.md](runbooks/report-and-error-rows.md) |
+| `blob_integrity` | [runbooks/blob-integrity.md](runbooks/blob-integrity.md) |
 | `db_connect`, `pg_tuning` | Canopy solve, then `reference/maintain-tamanu-on-linux.md` for the frontline host steps |
 | `disk_free`, `btrfs`, `inodes`, `load`, `memory` | Canopy solve; deep disk work is in `beyondessential/ops` |
 | `caddy_certs`, `caddy_version`, `http_errors`, `tailscale_config`, `time_sync` | Canopy solve; see `sops/read-logs.md` and `sops/restart-services.md` |

--- a/docs/reference/query-cookbook.md
+++ b/docs/reference/query-cookbook.md
@@ -553,10 +553,49 @@ repair path is not working. On central it is an authoritative copy needing repai
 from a peer or a backup, and is an escalation.
 
 ```sql
-SELECT id, hash, size, created_at
+SELECT id, hash, size, tier, created_at, last_scrubbed_at
 FROM blobs
 WHERE deleted_at IS NULL AND integrity_state = 'quarantined'
 ORDER BY created_at;
+```
+
+On a facility, `tier` decides how urgent this is: a `cache` row is self-correcting,
+an `outbox` row may be the only copy of its content. See
+`../runbooks/blob-integrity.md`.
+
+### Integrity state summary
+
+The shape of the store's health in one row, and the basis of the `blob_integrity`
+check. `absent` is a registry entry whose bytes the store no longer holds, as
+distinct from `quarantined` bytes that are held but no longer match their hash.
+
+```sql
+SELECT integrity_state,
+       tier,
+       count(*) AS blobs,
+       pg_size_pretty(sum(size)) AS bytes
+FROM blobs
+WHERE deleted_at IS NULL
+GROUP BY integrity_state, tier
+ORDER BY integrity_state, tier;
+```
+
+### Scrub coverage
+
+The scrub verifies least-recently-scrubbed blobs first, in rate-limited passes, so
+the oldest scrub time is how far behind a full cycle it is. A figure that keeps
+growing means the store is being added to faster than the per-pass limits cover
+it: raise `maxBlobsPerPass` / `maxGigabytesPerPass`, or run the scrub more often
+(central `schedules.blobIntegrityScrub`, or the same path in facility settings).
+A never-scrubbed count that never falls means the scrub is not running at all.
+
+```sql
+SELECT count(*) AS blobs,
+       count(*) FILTER (WHERE last_scrubbed_at IS NULL) AS never_scrubbed,
+       min(last_scrubbed_at) AS oldest_scrub,
+       max(last_scrubbed_at) AS newest_scrub
+FROM blobs
+WHERE deleted_at IS NULL;
 ```
 
 ## DHIS2 push log

--- a/docs/runbooks/blob-integrity.md
+++ b/docs/runbooks/blob-integrity.md
@@ -1,0 +1,131 @@
+# Runbook: blob integrity (corrupt or missing attachment bytes)
+
+A server reports that stored attachment or asset bytes no longer match the hash
+that names them, or that content it should hold is not there. This surfaces as
+the `blob_integrity` healthcheck, as a failed download for a specific file, or as
+quarantined rows found while triaging something else.
+
+Every action is tagged with its class from the ladder in `../README.md`. Check
+`../ruled-out-actions.md` before running anything mutating.
+
+## 1. When this applies
+
+Use this when any of the following is true:
+
+- The `blob_integrity` check is failing on central or a facility.
+- A user reports a specific attachment that fails to download, and the server log
+  shows the content hashed to something other than its name on read.
+- A scrub pass logged an unrecoverable blob.
+
+Most blob problems are **not** this. Content that is merely awaiting its bytes is
+normal and self-resolving: see the content-pending checks in
+`facility-restored-from-backup.md` §5 before treating an absence as corruption.
+
+## 2. What the store does on its own
+
+The store verifies content at three points, so by the time a fault reaches you
+the automatic repair has usually already been tried:
+
+- On receipt, before the bytes are stored.
+- On a full read, by re-hashing as the content streams.
+- On a scheduled incremental scrub, which is what covers content nobody reads.
+
+What happens next depends on whether the copy was the only durable one, and this
+is the distinction that decides how urgent the report is:
+
+| Where | What the server does | How urgent |
+| --- | --- | --- |
+| Facility, `cache` tier | Drops the bad copy; the next read refetches it from central | Self-correcting. Only a concern if it persists |
+| Facility, `outbox` tier | Quarantines, tries central, then escalates | Urgent: may be the only copy |
+| Central, any blob | Quarantines and escalates; waits for a facility to re-offer the content | Urgent: authoritative copy |
+
+A quarantined blob is **retained, never served, and never deleted automatically**,
+so the bad bytes stay available for investigation.
+
+## 3. Establish context
+
+Which deployment and server — see `../deployment-context.md`. Then, on the
+affected server, get the shape of the problem from the "Blob store" queries in
+`../reference/query-cookbook.md`: the quarantined-blob list, the store size by
+tier, and (on a facility) outbox depth. **[diagnose]**
+
+The two things worth establishing before anything else:
+
+- **Is it one blob or many?** A single corrupt blob is a bad sector or an
+  interrupted write. Many at once is the storage substrate failing, and the blob
+  problem is a symptom of a host problem — go to `disk_free` / `btrfs` / the host
+  disk checks, and treat this runbook as secondary.
+- **Which tier?** On a facility, `tier` in the query output decides whether this
+  is self-correcting or data loss, per the table above.
+
+## 4. Resolve: facility cache blob
+
+Nothing to do. The server drops the copy and refetches on demand, and the count
+should return to zero without help. **[diagnose]** Re-run the quarantined-blob
+query after the next scrub pass to confirm it cleared.
+
+If the count does **not** clear, the refetch path is the problem, not the storage:
+work the facility's sync and transfer health (`sync-facility-stale.md`) instead.
+
+## 5. Resolve: facility outbox blob
+
+An outbox blob has not been acknowledged by central, so this facility holds the
+only copy. The server has already tried central (which occasionally does hold it,
+where a push succeeded but the demotion did not land). If that failed, the
+content exists only in this facility's backups.
+
+**[diagnose]** Confirm the blob is genuinely outbox tier and genuinely unheld,
+using the quarantined and outbox queries.
+
+Restoring a single blob from a facility backup is a **[dev-OTS]** action: it means
+extracting one file from the store capture of a backup cycle and placing it in the
+running store. Hand this to a developer with the hash, the facility, and the
+backup cycle to draw from. The scrub's reconciliation pass is what makes it work:
+a file placed in its correct fan-out path is verified and registered on the next
+pass, so the restore does not need a database change.
+
+If no backup holds it, the content is lost. Say so plainly to the deployment
+contact rather than leaving a quarantined row to be rediscovered later.
+
+## 6. Resolve: central blob
+
+Every blob central holds is authoritative, so this is the escalation case.
+
+Central repairs itself from a facility **opportunistically**: it cannot reach out
+to a facility on demand, so it accepts a replacement when some facility next
+offers that content on a connection it makes anyway. This means a central
+quarantine can clear on its own, but only if a facility still holds the blob and
+has reason to offer it. Do not wait on this if the content matters.
+
+**[diagnose]** Establish whether the content is referenced by a live record, and
+by how many. An unreferenced quarantined blob is a curiosity; a referenced one is
+a file a clinician cannot open.
+
+The dependable repair is a restore from central's backup, which is
+**[dev-OTS]** and follows the same shape as §5: extract the blob from the store
+capture, place it in its fan-out path, let the scrub adopt it.
+
+## 7. Escalate
+
+Escalate immediately, without waiting for a scrub cycle, when:
+
+- A facility outbox blob is unrecoverable, or
+- A central blob is quarantined and referenced, or
+- The quarantined count is rising across successive scrub passes, which means the
+  underlying storage is failing rather than having failed once.
+
+Include the server, the tier, the hashes, the quarantined count over time, and
+whether the host disk checks are also failing. Use the structured payload from
+`senaite-integration-delay.md` §6.
+
+## 8. Do not
+
+- Do **not** delete quarantined rows or store files to "clear" the check. The
+  bytes are the evidence, and on an outbox blob they may be a partially
+  recoverable copy of content held nowhere else.
+- Do **not** copy blob files between servers by hand as routine repair. It works
+  only because the scrub adopts correctly placed files, and a file put in the
+  wrong path is invisible and unreclaimable. Restores go through a developer.
+- Do **not** disable the scrub to quiet the check. It is what finds the next
+  fault, and a store with the scrub off looks healthy right up until someone
+  needs the file.

--- a/docs/runbooks/facility-restored-from-backup.md
+++ b/docs/runbooks/facility-restored-from-backup.md
@@ -103,7 +103,11 @@ Two failure modes here are worse than content-pending and do warrant escalation:
   absent one. A facility cache copy repairs itself by refetching, so a corruption
   report that persists means the repair path is not working.
 
+Both are covered by `blob-integrity.md`, which also explains how the store grades
+and repairs these on its own.
+
 Do **not** hand-copy blob files between servers, or delete store files to "reset"
-the facility. The store is content-addressed and its registry lives in the
-database, so files placed on disk by hand are not visible to the server, and
-deleting outbox files destroys the only copy of that content.
+the facility. Deleting outbox files destroys the only copy of that content. A file
+placed by hand is picked up only if it lands in the exact fan-out path its hash
+dictates, which the scrub then verifies and registers; anywhere else it is
+invisible to the server and never reclaimed.

--- a/packages/central-server/__tests__/blobReferentialIntegrity.test.js
+++ b/packages/central-server/__tests__/blobReferentialIntegrity.test.js
@@ -1,0 +1,138 @@
+import { createHash } from 'node:crypto';
+import { Readable } from 'node:stream';
+
+import { registerBlobReferenceSource, findUndeliverableReferences } from '../app/blobReferences';
+import { createTestContext } from './utilities';
+
+const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+// spec: SCRUB
+// The central referential-integrity query behind the scrub's referential pass:
+// which synchronised references point at bytes central does not hold, once they
+// are past the delivery grace. Exercised against a real database and a scratch
+// reference source, since the query's load-bearing parts — the grace-time
+// filter and the missing-bytes join — cannot be covered by mocking it.
+describe('findUndeliverableReferences', () => {
+  let ctx;
+  let sequelize;
+  let unregister;
+
+  // A reference standing in for a consumer record: a row in the scratch table
+  // with an update time, plus the sync_lookup entry that marks it synchronised.
+  let seq = 0;
+  const reference = async (hash, { updatedAt }) => {
+    const recordId = `undeliverable-ref-${seq++}`;
+    await sequelize.query(
+      'INSERT INTO test_undeliverable_refs (id, blob_hash, updated_at) VALUES (:recordId, :hash, :updatedAt)',
+      { replacements: { recordId, hash, updatedAt } },
+    );
+    await sequelize.query(
+      `INSERT INTO sync_lookup
+        (record_id, record_type, data, updated_at_sync_tick, patient_id, facility_id, is_lab_request, is_deleted)
+       VALUES (:recordId, 'test_undeliverable_refs', '{}', 1, NULL, NULL, FALSE, FALSE)`,
+      { replacements: { recordId } },
+    );
+    return recordId;
+  };
+
+  const holdBytes = async content => {
+    await ctx.blobStore.put(Readable.from(content));
+  };
+
+  const DELIVERED_BEFORE = new Date('2026-01-02T00:00:00Z');
+  const BEFORE_GRACE = new Date('2026-01-01T00:00:00Z'); // old enough to be undelivered
+  const WITHIN_GRACE = new Date('2026-01-03T00:00:00Z'); // still content-pending
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    sequelize = ctx.store.sequelize;
+    await sequelize.query(
+      `CREATE TABLE test_undeliverable_refs (
+         id TEXT PRIMARY KEY,
+         blob_hash TEXT NOT NULL,
+         updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+       )`,
+    );
+    unregister = registerBlobReferenceSource({
+      recordType: 'test_undeliverable_refs',
+      hashColumn: 'blob_hash',
+    });
+  });
+
+  afterAll(async () => {
+    unregister();
+    await sequelize.query('DROP TABLE IF EXISTS test_undeliverable_refs');
+    await ctx.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.query(
+      `DELETE FROM sync_lookup WHERE record_type = 'test_undeliverable_refs'`,
+    );
+    await sequelize.query('DELETE FROM test_undeliverable_refs');
+    await ctx.store.models.Blob.destroy({ where: {}, force: true });
+  });
+
+  it('reports a past-grace reference whose bytes central does not hold', async () => {
+    const hash = hashOf('undelivered content');
+    await reference(hash, { updatedAt: BEFORE_GRACE });
+
+    const result = await findUndeliverableReferences(sequelize, {
+      limit: 100,
+      deliveredBefore: DELIVERED_BEFORE,
+    });
+
+    expect(result).toEqual([hash]);
+  });
+
+  it('leaves a reference still within the delivery grace as content-pending', async () => {
+    const hash = hashOf('freshly referenced content');
+    await reference(hash, { updatedAt: WITHIN_GRACE });
+
+    const result = await findUndeliverableReferences(sequelize, {
+      limit: 100,
+      deliveredBefore: DELIVERED_BEFORE,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not report a reference whose bytes central holds', async () => {
+    const content = Buffer.from('content central holds');
+    await reference(hashOf(content), { updatedAt: BEFORE_GRACE });
+    await holdBytes(content);
+
+    const result = await findUndeliverableReferences(sequelize, {
+      limit: 100,
+      deliveredBefore: DELIVERED_BEFORE,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('reports a hash once even when several references point at it', async () => {
+    const hash = hashOf('content referenced twice');
+    await reference(hash, { updatedAt: BEFORE_GRACE });
+    await reference(hash, { updatedAt: BEFORE_GRACE });
+
+    const result = await findUndeliverableReferences(sequelize, {
+      limit: 100,
+      deliveredBefore: DELIVERED_BEFORE,
+    });
+
+    expect(result).toEqual([hash]);
+  });
+
+  it('bounds the batch to the requested limit', async () => {
+    for (let i = 0; i < 3; i++) {
+      await reference(hashOf(`undelivered ${i}`), { updatedAt: BEFORE_GRACE });
+    }
+
+    const result = await findUndeliverableReferences(sequelize, {
+      limit: 2,
+      deliveredBefore: DELIVERED_BEFORE,
+    });
+
+    expect(result).toHaveLength(2);
+  });
+});

--- a/packages/central-server/__tests__/blobTransfer.test.js
+++ b/packages/central-server/__tests__/blobTransfer.test.js
@@ -464,6 +464,44 @@ describe('Blob transfer channel', () => {
     });
   });
 
+  // spec: BLAC, SCRUB
+  // Only verified content is servable, so an absent copy is withheld on the
+  // channel exactly as a quarantined one is: availability and fetch answer as
+  // for content central does not hold, and an offer is wanted so the bytes can
+  // be restored.
+  describe('absent content', () => {
+    it('answers an absent hash as not held on availability and fetch', async () => {
+      const content = Buffer.from('absent content');
+      const hash = await seedHeldBlob(content);
+      await reference(hash);
+      await models.Blob.update(
+        { integrityState: BLOB_INTEGRITY_STATES.ABSENT },
+        { where: { hash } },
+      );
+
+      const probe = await availability(hash);
+      expect(probe.body).toEqual({ availability: BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD });
+
+      const fetched = await getBlob(hash);
+      expect(fetched.status).toBe(404);
+      expect(fetched.body.availability).toBe(BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD);
+    });
+
+    it('wants a hash whose held copy is absent, rather than declining it', async () => {
+      const content = Buffer.from('content whose bytes central lost');
+      const hash = await seedHeldBlob(content);
+      await reference(hash);
+      await models.Blob.update(
+        { integrityState: BLOB_INTEGRITY_STATES.ABSENT },
+        { where: { hash } },
+      );
+
+      const offered = await offer(hash, content.length);
+      expect(offered).toHaveSucceeded();
+      expect(offered.body.status).toBe(BLOB_OFFER_STATUSES.WANTED);
+    });
+  });
+
   // spec: BLAC
   // The scope is the declared facility set, not the user's entitlement. With
   // facility restriction off, the sync user may access every facility, yet a

--- a/packages/central-server/__tests__/blobTransfer.test.js
+++ b/packages/central-server/__tests__/blobTransfer.test.js
@@ -1,4 +1,6 @@
 import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { Readable } from 'node:stream';
 
 import { fake } from '@tamanu/fake-data/fake';
@@ -113,6 +115,18 @@ describe('Blob transfer channel', () => {
 
   // Bytes held by central without going through the push gate.
   const seedHeldBlob = async content => (await ctx.blobStore.put(Readable.from(content))).hash;
+
+  // Where the store keeps a hash's bytes, for tests that need to damage them.
+  const storedPath = hash => {
+    const digest = hash.split(':')[1];
+    return path.join(
+      ctx.blobStore.root,
+      'sha256',
+      digest.slice(0, 2),
+      digest.slice(2, 4),
+      digest.slice(4),
+    );
+  };
 
   // Responses must be identical modulo the hash they were asked about. The
   // stack is dropped before comparing: it is a debug field that production
@@ -393,6 +407,60 @@ describe('Blob transfer channel', () => {
       expect(fetched.body.availability).toBe(BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD);
       // and does not disclose the quarantine in the message
       expect(JSON.stringify(fetched.body)).not.toContain('quarantine');
+    });
+
+    // spec: SCRUB
+    // Central's peer healing. It cannot reach a facility on demand and keeps no
+    // index of what facilities hold, so a replacement is taken on a connection
+    // the facility makes anyway, whenever one happens to offer the content.
+    it('wants a hash whose held copy is quarantined, rather than declining it', async () => {
+      const content = Buffer.from('content central found to be bad');
+      const hash = await seedHeldBlob(content);
+      await reference(hash);
+      await models.Blob.update(
+        { integrityState: BLOB_INTEGRITY_STATES.QUARANTINED },
+        { where: { hash } },
+      );
+
+      const offered = await offer(hash, content.length);
+      expect(offered).toHaveSucceeded();
+      expect(offered.body.status).toBe(BLOB_OFFER_STATUSES.WANTED);
+    });
+
+    it('replaces the quarantined copy once the pushed content verifies', async () => {
+      const content = Buffer.from('content central found to be bad, replaced');
+      const hash = await seedHeldBlob(content);
+      await reference(hash);
+      // Corrupt the stored bytes as the scrub would have found them, so the
+      // replacement is a real repair rather than a no-op over good content.
+      await fs.writeFile(storedPath(hash), Buffer.from('rotted'));
+      await models.Blob.update(
+        { integrityState: BLOB_INTEGRITY_STATES.QUARANTINED },
+        { where: { hash } },
+      );
+
+      const offered = await offer(hash, content.length);
+      expect(offered.body.status).toBe(BLOB_OFFER_STATUSES.WANTED);
+      const put = await putChunk(hash, content, 0, content.length);
+      expect(put).toHaveSucceeded();
+      expect(put.body.acknowledged).toBe(true);
+
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.VERIFIED);
+      expect(await fs.readFile(storedPath(hash))).toEqual(content);
+
+      // and it serves again
+      const fetched = await getBlob(hash);
+      expect(fetched).toHaveSucceeded();
+    });
+
+    it('still declines content it holds and has no fault with', async () => {
+      const content = Buffer.from('content central is happy with');
+      const hash = await seedHeldBlob(content);
+      await reference(hash);
+
+      const offered = await offer(hash, content.length);
+      expect(offered.body.status).toBe(BLOB_OFFER_STATUSES.ALREADY_STORED);
     });
   });
 

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -114,7 +114,11 @@ export class ApplicationContext {
       // spec: SCRUB — a whole-blob read that fails verification heals by the
       // same ladder the scrub uses.
       onCorruptionDetected: async hash => {
-        await this.blobHealer?.heal({ hash, fault: BLOB_FAULTS.CORRUPT });
+        await this.blobHealer?.heal({
+          hash,
+          fault: BLOB_FAULTS.CORRUPT,
+          blob: await this.store.models.Blob.findOne({ where: { hash } }),
+        });
       },
       log,
     });

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -3,7 +3,7 @@ import { omit } from 'es-toolkit/compat';
 import { Timesimp } from 'timesimp';
 
 import { ReadSettings } from '@tamanu/settings';
-import { BlobStore } from '@tamanu/database/blobStore';
+import { BLOB_FAULTS, BlobScrubber, BlobStore } from '@tamanu/database/blobStore';
 import { isSyncTriggerDisabled } from '@tamanu/database/dataMigrations';
 import { initBugsnag, log } from '@tamanu/shared/services/logging';
 import { initReporting } from '@tamanu/database/services/reporting';
@@ -13,9 +13,10 @@ import {
 } from '@tamanu/shared/utils/fhir/fhirSettings';
 import { setFhirRefreshTriggers } from '@tamanu/database';
 
+import { CentralBlobHealer } from './blobIntegrity';
+import { findUndeliverableReferences, registerBlobReferenceSource } from './blobReferences';
 import { EmailService } from './services/EmailService';
 
-import { registerBlobReferenceSource } from './blobReferences';
 import { closeDatabase, initDatabase } from './database';
 import { initIntegrations } from './integrations';
 import { AIService } from './services/AIService';
@@ -23,6 +24,12 @@ import { defineSingletonTelegramBotService } from './services/TelegramBotService
 import { VERSION } from './middleware/versionCompatibility';
 import { initDeviceId } from '@tamanu/shared/utils';
 import { DEVICE_TYPES } from '@tamanu/constants';
+
+// spec: SCRUB
+// How long after a record syncs its blob is still expected to be on its way.
+// Push is sync-first, so every reference is briefly ahead of its bytes; only a
+// reference older than this counts as content central should already hold.
+const UNDELIVERED_REFERENCE_GRACE_MS = 24 * 60 * 60 * 1000;
 
 export const CENTRAL_SERVER_APP_TYPES = {
   API: 'api',
@@ -61,6 +68,12 @@ export class ApplicationContext {
   /** @type {BlobStore | null} */
   blobStore = null;
 
+  /** @type {CentralBlobHealer | null} */
+  blobHealer = null;
+
+  /** @type {BlobScrubber | null} */
+  blobScrubber = null;
+
   /** @type {string | null} */
   deviceId = null;
 
@@ -98,6 +111,39 @@ export class ApplicationContext {
       models: this.store.models,
       getFreeDiskReserveBytes: async () =>
         (await this.settings.get('blobStorage.freeDiskReserveGB')) * 1024 ** 3,
+      // spec: SCRUB — a whole-blob read that fails verification heals by the
+      // same ladder the scrub uses.
+      onCorruptionDetected: async hash => {
+        await this.blobHealer?.heal({ hash, fault: BLOB_FAULTS.CORRUPT });
+      },
+      log,
+    });
+
+    // spec: SCRUB
+    // Every copy central holds is authoritative, so the healer has no
+    // low-severity case: it quarantines and escalates, and repair arrives
+    // either opportunistically from a facility or from a backup.
+    this.blobHealer = new CentralBlobHealer({ blobStore: this.blobStore });
+    this.blobScrubber = new BlobScrubber({
+      blobStore: this.blobStore,
+      models: this.store.models,
+      getLimits: async () => {
+        const scrub = await this.settings.get('schedules.blobIntegrityScrub');
+        return {
+          maxBlobs: scrub.maxBlobsPerPass,
+          maxBytes: scrub.maxGigabytesPerPass * 1024 ** 3,
+        };
+      },
+      heal: report => this.blobHealer.heal(report),
+      findUndeliverableReferences: async limit =>
+        await findUndeliverableReferences(this.store.sequelize, {
+          limit,
+          // A reference is only undelivered once its record has been synced
+          // long enough for the push to have happened; before that it is
+          // ordinary content-pending, since push is sync-first.
+          deliveredBefore: new Date(Date.now() - UNDELIVERED_REFERENCE_GRACE_MS),
+        }),
+      log,
     });
     // spec: ATCH
     // Model and shared route code admits attachment content through this, so it

--- a/packages/central-server/app/blobIntegrity/CentralBlobHealer.js
+++ b/packages/central-server/app/blobIntegrity/CentralBlobHealer.js
@@ -1,0 +1,32 @@
+import { BLOB_FAULTS } from '@tamanu/database/blobStore';
+import { BLOB_INTEGRITY_STATES } from '@tamanu/constants';
+import { log } from '@tamanu/shared/services/logging';
+
+// spec: SCRUB
+// Central's response to a blob that fails verification. Every copy central
+// holds is authoritative, so there is no low-severity case here as there is on
+// a facility: a fault is content the deployment may have lost. The copy is
+// quarantined (retained, never served) and escalated, and repair comes either
+// from a facility that still holds the content — opportunistically, as it
+// connects and offers the hash, which the transfer routes handle — or from a
+// backup, which is a human action the runbook covers.
+export class CentralBlobHealer {
+  #blobStore;
+
+  constructor({ blobStore }) {
+    this.#blobStore = blobStore;
+  }
+
+  async heal({ hash, fault }) {
+    await this.#blobStore.recordIntegrityState(
+      hash,
+      fault === BLOB_FAULTS.CORRUPT
+        ? BLOB_INTEGRITY_STATES.QUARANTINED
+        : BLOB_INTEGRITY_STATES.ABSENT,
+    );
+    log.error('CentralBlobHealer: authoritative blob failed verification and needs repair', {
+      hash,
+      fault,
+    });
+  }
+}

--- a/packages/central-server/app/blobIntegrity/index.js
+++ b/packages/central-server/app/blobIntegrity/index.js
@@ -1,0 +1,1 @@
+export { CentralBlobHealer } from './CentralBlobHealer';

--- a/packages/central-server/app/blobReferences.js
+++ b/packages/central-server/app/blobReferences.js
@@ -46,6 +46,48 @@ export function registerBlobReferenceSource({ recordType, hashColumn }) {
   };
 }
 
+// spec: SCRUB
+// Referential integrity in the direction the verification pass cannot see. That
+// pass walks the registry, so it finds rows whose bytes have gone; this finds
+// synchronised records referencing a hash the registry does not name at all,
+// which is central advertising content it cannot serve.
+//
+// `deliveredBefore` is what separates a fault from ordinary content-pending:
+// push is sync-first, so every reference is briefly ahead of its bytes, and
+// only a reference whose record synced long enough ago for the upload to have
+// happened counts as undelivered.
+export async function findUndeliverableReferences(sequelize, { limit, deliveredBefore }) {
+  if (BLOB_REFERENCE_SOURCES.length === 0) {
+    return [];
+  }
+
+  const replacements = { limit, deliveredBefore };
+  const perSource = BLOB_REFERENCE_SOURCES.map(({ recordType, hashColumn }, index) => {
+    replacements[`recordType${index}`] = recordType;
+    return `
+      SELECT record.${hashColumn} AS hash
+      FROM ${recordType} record
+      JOIN sync_lookup
+        ON sync_lookup.record_type = :recordType${index}
+        AND sync_lookup.record_id = record.id::text
+      WHERE record.${hashColumn} IS NOT NULL
+      AND sync_lookup.data IS NOT NULL
+      AND record.updated_at < :deliveredBefore`;
+  });
+
+  const [rows] = await sequelize.query(
+    `
+      SELECT DISTINCT referenced.hash
+      FROM (${perSource.join(' UNION ALL ')}) referenced
+      LEFT JOIN blobs ON blobs.hash = referenced.hash AND blobs.deleted_at IS NULL
+      WHERE blobs.id IS NULL
+      LIMIT :limit
+    `,
+    { replacements },
+  );
+  return rows.map(({ hash }) => hash);
+}
+
 // spec: BLAC
 // Whether a hash is referenced by a record within the given facility scope.
 // `facilityIds` is the set of facilities the requesting server operates as —

--- a/packages/central-server/app/blobTransfer.js
+++ b/packages/central-server/app/blobTransfer.js
@@ -105,7 +105,10 @@ export const buildBlobTransferRoutes = ctx => {
   // discloses the quarantine.
   const servableStat = async hash => {
     const held = await blobStore.stat(hash);
-    if (!held || held.integrityState === BLOB_INTEGRITY_STATES.QUARANTINED) {
+    // Only verified content is servable. Stated as an allow-list rather than a
+    // list of states to exclude, so a state added later is withheld until it is
+    // deliberately allowed rather than served by omission.
+    if (!held || held.integrityState !== BLOB_INTEGRITY_STATES.VERIFIED) {
       return null;
     }
     return held;

--- a/packages/central-server/app/blobTransfer.js
+++ b/packages/central-server/app/blobTransfer.js
@@ -159,11 +159,13 @@ export const buildBlobTransferRoutes = ctx => {
       if (!(await hashInScope(req, hash))) {
         throw pushNotExpected(hash);
       }
-      // Plain stat, not servableStat: a quarantined copy still occupies the
-      // hash, so re-pushing it would no-op against the retained bytes. Pushing
-      // a good replacement over a quarantined copy is the self-heal path, which
-      // belongs to the integrity spec (see specs/blob-storage/integrity.md).
-      if (await blobStore.stat(hash)) {
+      // spec: SCRUB
+      // servableStat, so a quarantined copy is wanted rather than declined.
+      // This is central's peer healing: it cannot reach a facility on demand
+      // and keeps no index of what facilities hold, so it takes a replacement
+      // on the connection a facility makes anyway, whenever one happens to
+      // offer content central has found to be bad.
+      if (await servableStat(hash)) {
         res.send({ status: BLOB_OFFER_STATUSES.ALREADY_STORED });
         return;
       }
@@ -193,7 +195,9 @@ export const buildBlobTransferRoutes = ctx => {
         throw pushNotExpected(hash);
       }
 
-      if (await blobStore.stat(hash)) {
+      // spec: SCRUB — matches the offer: a quarantined copy is being replaced,
+      // so the bytes are accepted rather than acknowledged against bad content.
+      if (await servableStat(hash)) {
         res.send({ acknowledged: true, existed: true });
         return;
       }

--- a/packages/central-server/app/tasks/BlobIntegrityScrubTask.js
+++ b/packages/central-server/app/tasks/BlobIntegrityScrubTask.js
@@ -1,0 +1,26 @@
+import { ScheduledTask } from '@tamanu/shared/tasks';
+import { log } from '@tamanu/shared/services/logging';
+
+// spec: SCRUB
+// Central's scheduled blob integrity scrub. Central holds the authoritative
+// copy of every blob in the deployment, so this is the scrub that finds loss
+// which no other server can make good.
+export class BlobIntegrityScrubTask extends ScheduledTask {
+  getName() {
+    return 'BlobIntegrityScrubTask';
+  }
+
+  constructor(context) {
+    const { schedule, jitterTime, enabled } = context.schedules.blobIntegrityScrub;
+    super(schedule, log, jitterTime, enabled);
+    this.context = context;
+  }
+
+  async run() {
+    const { blobScrubber } = this.context;
+    if (!blobScrubber) {
+      return;
+    }
+    await blobScrubber.run();
+  }
+}

--- a/packages/central-server/app/tasks/index.js
+++ b/packages/central-server/app/tasks/index.js
@@ -1,6 +1,7 @@
 import { log } from '@tamanu/shared/services/logging';
 import { SendStatusToMetaServer } from '@tamanu/shared/tasks/SendStatusToMetaServer';
 
+import { BlobIntegrityScrubTask } from './BlobIntegrityScrubTask';
 import { PatientEmailCommunicationProcessor } from './PatientEmailCommunicationProcessor';
 import { PortalCommunicationProcessor } from './PortalCommunicationProcessor';
 import { PatientMergeMaintainer } from './PatientMergeMaintainer';
@@ -79,6 +80,7 @@ export async function startScheduledTasks(context) {
     DHIS2IntegrationProcessor,
     ProgramRegistryPltfuFlagger,
     BlobBackfillTask,
+    BlobIntegrityScrubTask,
     SendStatusToMetaServer,
   ];
 

--- a/packages/constants/src/blobs.ts
+++ b/packages/constants/src/blobs.ts
@@ -10,9 +10,15 @@ export type BlobHashAlgorithm = (typeof BLOB_HASH_ALGORITHMS)[keyof typeof BLOB_
 // not a migration of stored content.
 export const CURRENT_BLOB_HASH_ALGORITHM: BlobHashAlgorithm = BLOB_HASH_ALGORITHMS.SHA256;
 
+// spec: SCRUB
+// A blob's standing against its hash. `verified` content matched when it was
+// last checked; `quarantined` content failed and is retained for investigation
+// but never served; `absent` is a registry entry whose bytes the store does not
+// hold, which the server acquires rather than offers.
 export const BLOB_INTEGRITY_STATES = {
   VERIFIED: 'verified',
   QUARANTINED: 'quarantined',
+  ABSENT: 'absent',
 } as const;
 
 export type BlobIntegrityState = (typeof BLOB_INTEGRITY_STATES)[keyof typeof BLOB_INTEGRITY_STATES];

--- a/packages/database/__tests__/blobStore/BlobScrubber.test.ts
+++ b/packages/database/__tests__/blobStore/BlobScrubber.test.ts
@@ -231,17 +231,34 @@ describe('BlobScrubber', () => {
       expect(healed).toEqual([]);
     });
 
-    it('leaves an absent blob alone rather than re-reporting it each pass', async () => {
-      // A registry row whose bytes are gone: recorded absent by an earlier
-      // pass, and terminal until a repair re-admits it.
+    it('re-checks an absent blob without re-reporting it while it stays missing', async () => {
+      // A registry row whose bytes are gone, recorded absent by an earlier pass.
+      // The scrub still looks at it (that is how it would notice recovery) but
+      // does not re-escalate or re-heal, and re-stamps it so it yields its slot.
       const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
       await removeStoredBytes(hash);
       fakeBlob.rows.get(hash)!.integrityState = 'absent';
+      fakeBlob.rows.get(hash)!.lastScrubbedAt = new Date(1000);
 
       const result = await makeScrubber().run();
 
       expect(result.faults).toBe(0);
       expect(healed).toEqual([]);
+      expect(fakeBlob.rows.get(hash)!.integrityState).toBe('absent');
+      expect(fakeBlob.rows.get(hash)!.lastScrubbedAt!.getTime()).toBeGreaterThan(1000);
+    });
+
+    it('restores an absent blob to verified once its bytes return', async () => {
+      // The bytes come back (e.g. a backup restore drops the file into place)
+      // while the registry row still stands absent; the scrub flips it back.
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      fakeBlob.rows.get(hash)!.integrityState = 'absent';
+
+      const result = await makeScrubber().run();
+
+      expect(result.faults).toBe(0);
+      expect(result.verified).toBe(1);
+      expect(fakeBlob.rows.get(hash)!.integrityState).toBe('verified');
     });
 
     it('takes least-recently-scrubbed blobs first', async () => {

--- a/packages/database/__tests__/blobStore/BlobScrubber.test.ts
+++ b/packages/database/__tests__/blobStore/BlobScrubber.test.ts
@@ -29,13 +29,20 @@ function makeFakeBlobModel() {
 
   const matches = (row: FakeRow, where: Record<string, unknown> = {}) =>
     Object.entries(where).every(([field, expected]) => {
-      if (expected && typeof expected === 'object') {
-        const excluded = Object.getOwnPropertySymbols(expected).map(
-          symbol => (expected as Record<symbol, unknown>)[symbol],
-        );
-        return !excluded.includes(row[field as keyof FakeRow]);
+      const value = row[field as keyof FakeRow];
+      // An array value is an IN check (the batched existence lookup).
+      if (Array.isArray(expected)) {
+        return expected.includes(value);
       }
-      return row[field as keyof FakeRow] === expected;
+      if (expected && typeof expected === 'object') {
+        // The store and scrubber use Op.ne (a scalar) and Op.notIn (an array);
+        // flatten both to the set of excluded values.
+        const excluded = Object.getOwnPropertySymbols(expected)
+          .map(symbol => (expected as Record<symbol, unknown>)[symbol])
+          .flat();
+        return !excluded.includes(value);
+      }
+      return value === expected;
     });
 
   return {
@@ -204,6 +211,19 @@ describe('BlobScrubber', () => {
       expect(healed).toEqual([]);
     });
 
+    it('leaves an absent blob alone rather than re-reporting it each pass', async () => {
+      // A registry row whose bytes are gone: recorded absent by an earlier
+      // pass, and terminal until a repair re-admits it.
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await removeStoredBytes(hash);
+      fakeBlob.rows.get(hash)!.integrityState = 'absent';
+
+      const result = await makeScrubber().run();
+
+      expect(result.faults).toBe(0);
+      expect(healed).toEqual([]);
+    });
+
     it('takes least-recently-scrubbed blobs first', async () => {
       const stale = await store.put(Readable.from(Buffer.from('stale content')));
       const fresh = await store.put(Readable.from(Buffer.from('fresh content')));
@@ -287,6 +307,41 @@ describe('BlobScrubber', () => {
 
       expect(result.adopted).toBe(0);
       expect(result.faults).toBe(0);
+    });
+
+    it('partitions a batch of stored hashes into registered and orphan', async () => {
+      // A registered blob and two orphans interleaved: the batched existence
+      // check must reconcile only the orphans and leave the registered one.
+      const registered = await store.put(Readable.from(Buffer.from('registered content')));
+      const orphanA = await store.put(Readable.from(Buffer.from('orphan a')));
+      const orphanB = await store.put(Readable.from(Buffer.from('orphan b')));
+      fakeBlob.rows.delete(orphanA.hash);
+      fakeBlob.rows.delete(orphanB.hash);
+
+      const result = await makeScrubber().run();
+
+      expect(result.adopted).toBe(2);
+      expect(fakeBlob.rows.get(orphanA.hash)!.integrityState).toBe('verified');
+      expect(fakeBlob.rows.get(orphanB.hash)!.integrityState).toBe('verified');
+      // The registered blob was verified by the verification pass, not adopted.
+      expect(fakeBlob.rows.get(registered.hash)!.integrityState).toBe('verified');
+    });
+
+    it('stops reconciling orphans on the blob limit, leaving the rest for a later pass', async () => {
+      const orphans = [];
+      for (let i = 0; i < 3; i++) {
+        orphans.push((await store.put(Readable.from(Buffer.from(`orphan ${i}`)))).hash);
+      }
+      fakeBlob.rows.clear();
+
+      const result = await makeScrubber({ maxBlobs: 2 }).run();
+
+      // Two adopted this pass; the third stays unregistered on disk and is found
+      // again next pass, so coverage is not lost.
+      expect(result.adopted).toBe(2);
+      expect(result.ratelimited).toBe(true);
+      const stillOrphan = orphans.filter(hash => !fakeBlob.rows.has(hash));
+      expect(stillOrphan).toHaveLength(1);
     });
   });
 

--- a/packages/database/__tests__/blobStore/BlobScrubber.test.ts
+++ b/packages/database/__tests__/blobStore/BlobScrubber.test.ts
@@ -1,0 +1,310 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { BLOB_FAULTS, BlobScrubber } from '../../src/blobStore/BlobScrubber';
+import { BlobStore } from '../../src/blobStore/BlobStore';
+import type { Blob } from '../../src/models/Blob';
+
+const HELLO_HASH = 'sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9';
+
+interface FakeRow {
+  id: string;
+  hash: string;
+  size: number;
+  integrityState: string;
+  tier: string;
+  lastScrubbedAt: Date | null;
+  createdAt: Date;
+}
+
+// In-memory Blob registry covering what the store and the scrubber ask of it:
+// findOne, findAll with the least-recently-scrubbed ordering, update, destroy,
+// and the raw upsert.
+function makeFakeBlobModel() {
+  const rows = new Map<string, FakeRow>();
+  let inserted = 0;
+
+  const matches = (row: FakeRow, where: Record<string, unknown> = {}) =>
+    Object.entries(where).every(([field, expected]) => {
+      if (expected && typeof expected === 'object') {
+        const excluded = Object.getOwnPropertySymbols(expected).map(
+          symbol => (expected as Record<symbol, unknown>)[symbol],
+        );
+        return !excluded.includes(row[field as keyof FakeRow]);
+      }
+      return row[field as keyof FakeRow] === expected;
+    });
+
+  return {
+    rows,
+    async findOne({ where }: { where: Record<string, unknown> }) {
+      return [...rows.values()].find(row => matches(row, where)) ?? null;
+    },
+    async findAll({ where, limit }: { where?: Record<string, unknown>; limit?: number } = {}) {
+      const found = [...rows.values()]
+        .filter(row => matches(row, where))
+        // Mirrors the scrubber's order: never-scrubbed first, then oldest scrub,
+        // then oldest row.
+        .sort((a, b) => {
+          const left = a.lastScrubbedAt?.getTime() ?? -Infinity;
+          const right = b.lastScrubbedAt?.getTime() ?? -Infinity;
+          return left - right || a.createdAt.getTime() - b.createdAt.getTime();
+        });
+      return limit === undefined ? found : found.slice(0, limit);
+    },
+    async update(values: Partial<FakeRow>, { where }: { where: Record<string, unknown> }) {
+      for (const row of rows.values()) {
+        if (matches(row, where)) {
+          Object.assign(row, values);
+        }
+      }
+    },
+    async destroy({ where: { hash } }: { where: { hash: string } }) {
+      rows.delete(hash as string);
+    },
+    sequelize: {
+      async query(
+        _sql: string,
+        { bind }: { bind: { id: string; hash: string; size: number; integrityState: string; tier: string } },
+      ) {
+        if (!rows.has(bind.hash)) {
+          inserted += 1;
+          rows.set(bind.hash, {
+            id: bind.id,
+            hash: bind.hash,
+            size: bind.size,
+            integrityState: bind.integrityState,
+            tier: bind.tier,
+            lastScrubbedAt: new Date(),
+            // Distinct and increasing, so createdAt is a stable tiebreak.
+            createdAt: new Date(inserted * 1000),
+          });
+        }
+      },
+    },
+  };
+}
+
+describe('BlobScrubber', () => {
+  let root: string;
+  let fakeBlob: ReturnType<typeof makeFakeBlobModel>;
+  let store: BlobStore;
+  let healed: Array<{ hash: string; fault: string; tier?: string }>;
+
+  const makeScrubber = ({
+    maxBlobs = 100,
+    maxBytes = 1_000_000,
+    findUndeliverableReferences,
+    heal,
+  }: {
+    maxBlobs?: number;
+    maxBytes?: number;
+    findUndeliverableReferences?: (limit: number) => Promise<string[]>;
+    heal?: (report: { hash: string; fault: string }) => Promise<void>;
+  } = {}) =>
+    new BlobScrubber({
+      blobStore: store,
+      models: { Blob: fakeBlob as unknown as typeof Blob },
+      getLimits: async () => ({ maxBlobs, maxBytes }),
+      heal:
+        heal ??
+        (async ({ hash, fault, blob }) => {
+          healed.push({ hash, fault, tier: blob?.tier });
+        }),
+      findUndeliverableReferences,
+      log: { info: () => {}, warn: () => {} },
+    });
+
+  const corruptStoredBytes = async (hash: string, replacement: string) => {
+    const digest = hash.split(':')[1];
+    await fs.writeFile(
+      path.join(root, 'sha256', digest.slice(0, 2), digest.slice(2, 4), digest.slice(4)),
+      replacement,
+    );
+  };
+
+  const removeStoredBytes = async (hash: string) => {
+    const digest = hash.split(':')[1];
+    await fs.rm(
+      path.join(root, 'sha256', digest.slice(0, 2), digest.slice(2, 4), digest.slice(4)),
+      { force: true },
+    );
+  };
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-scrubber-test-'));
+    fakeBlob = makeFakeBlobModel();
+    healed = [];
+    store = new BlobStore({
+      root,
+      models: { Blob: fakeBlob as unknown as typeof Blob },
+      getFreeDiskReserveBytes: async () => 0,
+      statfs: async () => ({ bavail: 1_000_000, bsize: 1 }),
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  describe('verification pass', () => {
+    it('verifies stored blobs and records when it did', async () => {
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      fakeBlob.rows.get(hash)!.lastScrubbedAt = null;
+
+      const result = await makeScrubber().run();
+
+      expect(result.verified).toBe(1);
+      expect(result.faults).toBe(0);
+      expect(fakeBlob.rows.get(hash)!.lastScrubbedAt).toBeInstanceOf(Date);
+    });
+
+    it('reports content whose bytes no longer match its hash as corrupt', async () => {
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await corruptStoredBytes(hash, 'goodbye wo');
+
+      const result = await makeScrubber().run();
+
+      expect(result.faults).toBe(1);
+      expect(healed).toEqual([{ hash, fault: BLOB_FAULTS.CORRUPT, tier: 'cache' }]);
+    });
+
+    it('reports a registry entry whose bytes are gone as missing', async () => {
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await removeStoredBytes(hash);
+
+      const result = await makeScrubber().run();
+
+      expect(result.faults).toBe(1);
+      expect(healed).toEqual([{ hash, fault: BLOB_FAULTS.MISSING, tier: 'cache' }]);
+    });
+
+    it('passes the registry row through, so the healer can grade on tier', async () => {
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')), {
+        tier: 'outbox',
+      });
+      await corruptStoredBytes(hash, 'goodbye wo');
+
+      await makeScrubber().run();
+
+      expect(healed).toEqual([{ hash, fault: BLOB_FAULTS.CORRUPT, tier: 'outbox' }]);
+    });
+
+    it('leaves an already-quarantined blob alone rather than re-reporting it each pass', async () => {
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await corruptStoredBytes(hash, 'goodbye wo');
+      fakeBlob.rows.get(hash)!.integrityState = 'quarantined';
+
+      const result = await makeScrubber().run();
+
+      expect(result.faults).toBe(0);
+      expect(healed).toEqual([]);
+    });
+
+    it('takes least-recently-scrubbed blobs first', async () => {
+      const stale = await store.put(Readable.from(Buffer.from('stale content')));
+      const fresh = await store.put(Readable.from(Buffer.from('fresh content')));
+      fakeBlob.rows.get(stale.hash)!.lastScrubbedAt = new Date(1000);
+      fakeBlob.rows.get(fresh.hash)!.lastScrubbedAt = new Date(9000);
+
+      const result = await makeScrubber({ maxBlobs: 1 }).run();
+
+      expect(result.verified).toBe(1);
+      expect(fakeBlob.rows.get(stale.hash)!.lastScrubbedAt!.getTime()).toBeGreaterThan(1000);
+      expect(fakeBlob.rows.get(fresh.hash)!.lastScrubbedAt!.getTime()).toBe(9000);
+    });
+
+    it('takes a never-scrubbed blob ahead of a stale one', async () => {
+      const stale = await store.put(Readable.from(Buffer.from('stale content')));
+      const never = await store.put(Readable.from(Buffer.from('never scrubbed')));
+      fakeBlob.rows.get(stale.hash)!.lastScrubbedAt = new Date(1000);
+      fakeBlob.rows.get(never.hash)!.lastScrubbedAt = null;
+
+      await makeScrubber({ maxBlobs: 1 }).run();
+
+      expect(fakeBlob.rows.get(never.hash)!.lastScrubbedAt).toBeInstanceOf(Date);
+      expect(fakeBlob.rows.get(stale.hash)!.lastScrubbedAt!.getTime()).toBe(1000);
+    });
+
+    it('stops on the byte limit so one pass cannot read the whole store', async () => {
+      await store.put(Readable.from(Buffer.from('a'.repeat(50))));
+      await store.put(Readable.from(Buffer.from('b'.repeat(50))));
+      await store.put(Readable.from(Buffer.from('c'.repeat(50))));
+
+      const result = await makeScrubber({ maxBytes: 60 }).run();
+
+      expect(result.verified).toBe(2);
+      expect(result.ratelimited).toBe(true);
+    });
+
+    it('carries on past a blob the healer cannot fix', async () => {
+      const first = await store.put(Readable.from(Buffer.from('first content')));
+      const second = await store.put(Readable.from(Buffer.from('second content')));
+      await corruptStoredBytes(first.hash, 'x'.repeat(13));
+      await corruptStoredBytes(second.hash, 'y'.repeat(14));
+
+      const result = await makeScrubber({
+        heal: async () => {
+          throw new Error('healer unavailable');
+        },
+      }).run();
+
+      expect(result.faults).toBe(2);
+    });
+  });
+
+  describe('reconciliation pass', () => {
+    it('registers bytes on disk that no registry entry names', async () => {
+      const { hash, size } = await store.put(Readable.from(Buffer.from('hello world')));
+      fakeBlob.rows.clear();
+
+      const result = await makeScrubber().run();
+
+      expect(result.adopted).toBe(1);
+      expect(fakeBlob.rows.get(hash)).toMatchObject({ hash, size, integrityState: 'verified' });
+    });
+
+    it('quarantines unregistered bytes that do not match the hash their location encodes', async () => {
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await corruptStoredBytes(hash, 'goodbye wo');
+      fakeBlob.rows.clear();
+
+      const result = await makeScrubber().run();
+
+      expect(result.adopted).toBe(0);
+      expect(result.faults).toBe(1);
+      expect(fakeBlob.rows.get(hash)!.integrityState).toBe('quarantined');
+      expect(healed).toEqual([{ hash, fault: BLOB_FAULTS.CORRUPT, tier: 'cache' }]);
+    });
+
+    it('leaves registered content alone', async () => {
+      await store.put(Readable.from(Buffer.from('hello world')));
+
+      const result = await makeScrubber().run();
+
+      expect(result.adopted).toBe(0);
+      expect(result.faults).toBe(0);
+    });
+  });
+
+  describe('referential pass', () => {
+    it('reports content that must be durably present but is not held at all', async () => {
+      const result = await makeScrubber({
+        findUndeliverableReferences: async () => [HELLO_HASH],
+      }).run();
+
+      expect(result.faults).toBe(1);
+      expect(healed).toEqual([
+        { hash: HELLO_HASH, fault: BLOB_FAULTS.MISSING, tier: undefined },
+      ]);
+    });
+
+    it('is skipped where the server supplies no reference check', async () => {
+      const result = await makeScrubber().run();
+      expect(result.faults).toBe(0);
+    });
+  });
+});

--- a/packages/database/__tests__/blobStore/BlobScrubber.test.ts
+++ b/packages/database/__tests__/blobStore/BlobScrubber.test.ts
@@ -169,6 +169,26 @@ describe('BlobScrubber', () => {
       expect(fakeBlob.rows.get(hash)!.lastScrubbedAt).toBeInstanceOf(Date);
     });
 
+    it('stamps a whole batch of verified blobs in a single write', async () => {
+      for (let i = 0; i < 5; i++) {
+        await store.put(Readable.from(Buffer.from(`verified content ${i}`)));
+      }
+      const calls: string[][] = [];
+      const original = store.recordVerified.bind(store);
+      store.recordVerified = async hashes => {
+        calls.push(hashes);
+        return original(hashes);
+      };
+
+      const result = await makeScrubber().run();
+
+      expect(result.verified).toBe(5);
+      // One stamp call carrying all five, not one write per blob.
+      const stampCalls = calls.filter(hashes => hashes.length > 0);
+      expect(stampCalls).toHaveLength(1);
+      expect(stampCalls[0]).toHaveLength(5);
+    });
+
     it('reports content whose bytes no longer match its hash as corrupt', async () => {
       const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
       await corruptStoredBytes(hash, 'goodbye wo');

--- a/packages/database/__tests__/blobStore/BlobScrubber.test.ts
+++ b/packages/database/__tests__/blobStore/BlobScrubber.test.ts
@@ -189,6 +189,28 @@ describe('BlobScrubber', () => {
       expect(stampCalls[0]).toHaveLength(5);
     });
 
+    it('leaves a blob quarantined mid-pass quarantined, not stamped verified by the flush', async () => {
+      // Two intact blobs, so the first has verified and is sitting in the
+      // pending batch while the second is still being read.
+      const { hash: first } = await store.put(Readable.from(Buffer.from('first content')));
+      const { hash: second } = await store.put(Readable.from(Buffer.from('second content')));
+      const original = store.verify.bind(store);
+      store.verify = async hash => {
+        const outcome = await original(hash);
+        if (hash === second) {
+          // A read-path corruption on the first blob lands between its verify()
+          // and the end-of-pass flush.
+          fakeBlob.rows.get(first)!.integrityState = 'quarantined';
+        }
+        return outcome;
+      };
+
+      await makeScrubber().run();
+
+      expect(fakeBlob.rows.get(first)!.integrityState).toBe('quarantined');
+      expect(fakeBlob.rows.get(second)!.integrityState).toBe('verified');
+    });
+
     it('reports content whose bytes no longer match its hash as corrupt', async () => {
       const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
       await corruptStoredBytes(hash, 'goodbye wo');

--- a/packages/database/__tests__/blobStore/BlobStore.test.ts
+++ b/packages/database/__tests__/blobStore/BlobStore.test.ts
@@ -39,22 +39,24 @@ function makeFakeBlobModel() {
     },
     async update(
       values: Partial<FakeRow>,
-      { where }: { where: { hash: string; integrityState?: { [key: symbol]: string } } },
+      { where }: { where: { hash: string | string[]; integrityState?: { [key: symbol]: string } } },
     ) {
-      const row = rows.get(where.hash);
-      if (!row) {
-        return;
-      }
+      // The store updates a single hash on the heal paths and a batch of them
+      // from the scrub's end-of-pass flush.
+      const hashes = Array.isArray(where.hash) ? where.hash : [where.hash];
       // The only operator the store uses here is Op.ne on integrityState.
       const excluded = where.integrityState
         ? Object.getOwnPropertySymbols(where.integrityState).map(
             symbol => (where.integrityState as Record<symbol, string>)[symbol],
           )
         : [];
-      if (excluded.includes(row.integrityState)) {
-        return;
+      for (const hash of hashes) {
+        const row = rows.get(hash);
+        if (!row || excluded.includes(row.integrityState)) {
+          continue;
+        }
+        Object.assign(row, values);
       }
-      Object.assign(row, values);
     },
     async destroy({ where: { hash } }: { where: { hash: string } }) {
       rows.delete(hash);

--- a/packages/database/__tests__/blobStore/BlobStore.test.ts
+++ b/packages/database/__tests__/blobStore/BlobStore.test.ts
@@ -363,6 +363,31 @@ describe('BlobStore', () => {
   });
 
   // spec: SCRUB
+  describe('recordVerified', () => {
+    it('stamps a batch of blobs verified', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      fakeBlob.rows.get(hash)!.integrityState = 'absent';
+
+      await store.recordVerified([hash]);
+
+      expect(fakeBlob.rows.get(hash)!.integrityState).toBe('verified');
+    });
+
+    it('never overwrites a concurrently quarantined blob, so known-bad bytes stay unserved', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      // A read-path quarantine lands after this blob verified earlier in the
+      // pass but before the end-of-pass flush.
+      fakeBlob.rows.get(hash)!.integrityState = 'quarantined';
+
+      await store.recordVerified([hash]);
+
+      expect(fakeBlob.rows.get(hash)!.integrityState).toBe('quarantined');
+    });
+  });
+
+  // spec: SCRUB
   describe('storedHashes', () => {
     const collect = async (store: BlobStore) => {
       const found: string[] = [];

--- a/packages/database/__tests__/blobStore/BlobStore.test.ts
+++ b/packages/database/__tests__/blobStore/BlobStore.test.ts
@@ -24,16 +24,37 @@ interface FakeRow {
   hash: string;
   size: number;
   integrityState: string;
+  lastScrubbedAt: Date | null;
 }
 
 // In-memory stand-in for the Blob registry model, covering the calls the
-// store makes: findOne, destroy, and the raw upsert via sequelize.query.
+// store makes: findOne, update, destroy, and the raw upsert via
+// sequelize.query.
 function makeFakeBlobModel() {
   const rows = new Map<string, FakeRow>();
   return {
     rows,
     async findOne({ where: { hash } }: { where: { hash: string } }) {
       return rows.get(hash) ?? null;
+    },
+    async update(
+      values: Partial<FakeRow>,
+      { where }: { where: { hash: string; integrityState?: { [key: symbol]: string } } },
+    ) {
+      const row = rows.get(where.hash);
+      if (!row) {
+        return;
+      }
+      // The only operator the store uses here is Op.ne on integrityState.
+      const excluded = where.integrityState
+        ? Object.getOwnPropertySymbols(where.integrityState).map(
+            symbol => (where.integrityState as Record<symbol, string>)[symbol],
+          )
+        : [];
+      if (excluded.includes(row.integrityState)) {
+        return;
+      }
+      Object.assign(row, values);
     },
     async destroy({ where: { hash } }: { where: { hash: string } }) {
       rows.delete(hash);
@@ -49,6 +70,7 @@ function makeFakeBlobModel() {
             hash: bind.hash,
             size: bind.size,
             integrityState: bind.integrityState,
+            lastScrubbedAt: new Date(),
           });
         }
       },
@@ -72,17 +94,31 @@ describe('BlobStore', () => {
   const makeStore = ({
     reserveBytes = 0,
     evictCache,
+    onCorruptionDetected,
   }: {
     reserveBytes?: number;
     evictCache?: (bytesNeeded: number) => Promise<void>;
+    onCorruptionDetected?: (hash: string) => Promise<void>;
   } = {}) =>
     new BlobStore({
       root,
       models: { Blob: fakeBlob as unknown as typeof Blob },
       getFreeDiskReserveBytes: async () => reserveBytes,
       evictCache,
+      onCorruptionDetected,
+      log: { error: () => {} },
       statfs: async () => ({ bavail: volumeFreeBytes, bsize: 1 }),
     });
+
+  // Rewrite a stored blob's bytes in place, leaving its registry row and its
+  // path untouched: bit rot as the store would meet it.
+  const corruptStoredBytes = async (hash: string, replacement: string) => {
+    const digest = hash.split(':')[1];
+    await fs.writeFile(
+      path.join(root, 'sha256', digest.slice(0, 2), digest.slice(2, 4), digest.slice(4)),
+      replacement,
+    );
+  };
 
   beforeEach(async () => {
     root = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-store-test-'));
@@ -223,6 +259,139 @@ describe('BlobStore', () => {
       await expect(
         store.get(hash, { stat: { size: 11, integrityState: 'quarantined' } }),
       ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  // spec: SCRUB
+  describe('read verification', () => {
+    it('fails a whole-blob read whose stored bytes no longer match the hash', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await corruptStoredBytes(hash, 'goodbye wo');
+
+      await expect(readAll(await store.get(hash))).rejects.toThrow(BlobHashMismatchError);
+    });
+
+    it('reports the corruption to the healer', async () => {
+      const detected: string[] = [];
+      const store = makeStore({
+        onCorruptionDetected: async hash => {
+          detected.push(hash);
+        },
+      });
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await corruptStoredBytes(hash, 'goodbye wo');
+
+      await expect(readAll(await store.get(hash))).rejects.toThrow(BlobHashMismatchError);
+      expect(detected).toEqual([hash]);
+    });
+
+    it('serves intact content without complaint', async () => {
+      const detected: string[] = [];
+      const store = makeStore({
+        onCorruptionDetected: async hash => {
+          detected.push(hash);
+        },
+      });
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+
+      expect((await readAll(await store.get(hash))).toString()).toBe('hello world');
+      expect(detected).toEqual([]);
+    });
+
+    it('leaves a ranged read unverified, since part of a blob cannot match a hash of the whole', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await corruptStoredBytes(hash, 'goodbye wo');
+
+      const content = await readAll(await store.get(hash, { start: 0, end: 4 }));
+      expect(content.toString()).toBe('goodb');
+    });
+
+    it('can be opted out of, for callers that are themselves the verification', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await corruptStoredBytes(hash, 'goodbye wo');
+
+      const content = await readAll(await store.get(hash, { verify: false }));
+      expect(content.toString()).toBe('goodbye wo');
+    });
+  });
+
+  // spec: SCRUB
+  describe('verify', () => {
+    it('confirms intact content and reports its size', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+
+      expect(await store.verify(hash)).toEqual({
+        held: true,
+        matches: true,
+        size: 11,
+        actualHash: hash,
+      });
+    });
+
+    it('reports what corrupt bytes actually hash to', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      await corruptStoredBytes(hash, 'goodbye wo');
+
+      const result = await store.verify(hash);
+      expect(result.matches).toBe(false);
+      expect(result.held).toBe(true);
+      expect(result.actualHash).not.toBe(hash);
+    });
+
+    it('reports bytes the store does not hold as unheld rather than throwing', async () => {
+      const store = makeStore();
+      expect(await store.verify(HELLO_HASH)).toEqual({
+        held: false,
+        matches: false,
+        size: 0,
+        actualHash: null,
+      });
+    });
+
+    it('verifies quarantined content, so a repair can re-check what it replaced', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      fakeBlob.rows.get(hash)!.integrityState = 'quarantined';
+
+      expect((await store.verify(hash)).matches).toBe(true);
+    });
+  });
+
+  // spec: SCRUB
+  describe('storedHashes', () => {
+    const collect = async (store: BlobStore) => {
+      const found: string[] = [];
+      for await (const hash of store.storedHashes()) {
+        found.push(hash);
+      }
+      return found.sort();
+    };
+
+    it('yields nothing for an empty store', async () => {
+      expect(await collect(makeStore())).toEqual([]);
+    });
+
+    it('finds bytes on disk whether or not the registry names them', async () => {
+      const store = makeStore();
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+      const { hash: emptyHash } = await store.put(Readable.from([]));
+      fakeBlob.rows.clear();
+
+      expect(await collect(store)).toEqual([hash, emptyHash].sort());
+    });
+
+    it('skips staging and temp files, which are not content', async () => {
+      const store = makeStore();
+      await store.stage(HELLO_HASH, Readable.from(Buffer.from('hel')), { offset: 0 });
+      await fs.mkdir(path.join(root, 'tmp'), { recursive: true });
+      await fs.writeFile(path.join(root, 'tmp', 'leftover'), 'x');
+
+      expect(await collect(store)).toEqual([]);
     });
   });
 

--- a/packages/database/__tests__/blobStore/BlobStore.test.ts
+++ b/packages/database/__tests__/blobStore/BlobStore.test.ts
@@ -387,7 +387,7 @@ describe('BlobStore', () => {
 
     it('skips staging and temp files, which are not content', async () => {
       const store = makeStore();
-      await store.stage(HELLO_HASH, Readable.from(Buffer.from('hel')), { offset: 0 });
+      await store.stage(HELLO_HASH, Readable.from(Buffer.from('hello')), { offset: 0 });
       await fs.mkdir(path.join(root, 'tmp'), { recursive: true });
       await fs.writeFile(path.join(root, 'tmp', 'leftover'), 'x');
 

--- a/packages/database/src/blobStore/BlobScrubber.ts
+++ b/packages/database/src/blobStore/BlobScrubber.ts
@@ -17,6 +17,11 @@ export const BLOB_FAULTS = {
 
 export type BlobFault = (typeof BLOB_FAULTS)[keyof typeof BLOB_FAULTS];
 
+// Hashes checked for registration per query while reconciling the store against
+// the registry, so a store with many files costs a query per batch rather than
+// one per file.
+const RECONCILE_EXISTENCE_BATCH = 500;
+
 export interface BlobFaultReport {
   hash: string;
   fault: BlobFault;
@@ -121,9 +126,17 @@ export class BlobScrubber {
   // Least-recently-scrubbed first, never-scrubbed ahead of all: a blob admitted
   // today is verified before one checked last week, and the whole population is
   // covered within the target cycle without tracking a cursor across passes.
+  // Blobs already in a recorded fault state are skipped: quarantined and absent
+  // are terminal until a repair, and a repair comes through admission (which
+  // resets the state to verified), never through re-verifying the same fault and
+  // re-escalating it every pass.
   async #verificationPass(limits: ScrubPassLimits, result: ScrubResult): Promise<void> {
     const candidates = await this.#models.Blob.findAll({
-      where: { integrityState: { [Op.ne]: BLOB_INTEGRITY_STATES.QUARANTINED } },
+      where: {
+        integrityState: {
+          [Op.notIn]: [BLOB_INTEGRITY_STATES.QUARANTINED, BLOB_INTEGRITY_STATES.ABSENT],
+        },
+      },
       order: [
         ['lastScrubbedAt', 'ASC NULLS FIRST'],
         ['createdAt', 'ASC'],
@@ -160,48 +173,88 @@ export class BlobScrubber {
   // The store's own contents, so bytes no registry entry names are found. Such
   // a blob is otherwise permanent: never served, and never reclaimed, since a
   // facility evicts against a budget derived from the registry.
+  //
+  // The walk covers the whole store each pass, because an orphan can sit under
+  // any fan-out prefix and a bounded walk without a cursor would only ever see
+  // the same slice. What is kept off the clinical path is the cost that scales:
+  // registration is checked a batch of hashes at a time rather than one query
+  // per file, and the expensive part — re-hashing an orphan's content — is
+  // bounded by the same blob and byte budget as verification, with the rest
+  // deferred to a later pass (an unregistered blob stays found until adopted).
   async #reconciliationPass(limits: ScrubPassLimits, result: ScrubResult): Promise<void> {
-    let examined = 0;
-    for await (const hash of this.#blobStore.storedHashes()) {
-      if (examined >= limits.maxBlobs || result.bytesRead >= limits.maxBytes) {
-        result.ratelimited = true;
+    let batch: string[] = [];
+    let orphansExamined = 0;
+    let stop = false;
+
+    const drainBatch = async (): Promise<void> => {
+      if (batch.length === 0) {
         return;
       }
-      if (await this.#models.Blob.findOne({ where: { hash }, attributes: ['id'] })) {
-        continue;
+      const hashes = batch;
+      batch = [];
+      const registered = new Set(
+        (
+          await this.#models.Blob.findAll({ where: { hash: hashes }, attributes: ['hash'] })
+        ).map(row => row.hash),
+      );
+      for (const hash of hashes) {
+        if (registered.has(hash)) {
+          continue;
+        }
+        if (orphansExamined >= limits.maxBlobs || result.bytesRead >= limits.maxBytes) {
+          // Budget spent on found orphans; the rest stay unregistered on disk
+          // and are found again next pass, so coverage is not lost.
+          result.ratelimited = true;
+          stop = true;
+          return;
+        }
+        orphansExamined += 1;
+        await this.#reconcileOrphan(hash, result);
       }
-      examined += 1;
+    };
 
-      // Verified against the hash its own location encodes: bytes that match
-      // are usable content whatever left them unregistered, and bytes that do
-      // not are corrupt in the ordinary way.
-      const outcome = await this.#blobStore.verify(hash);
-      result.bytesRead += outcome.size;
-      if (!outcome.held) {
-        // Removed between the walk and the read; nothing to reconcile.
-        continue;
+    for await (const hash of this.#blobStore.storedHashes()) {
+      batch.push(hash);
+      if (batch.length >= RECONCILE_EXISTENCE_BATCH) {
+        await drainBatch();
+        if (stop) {
+          return;
+        }
       }
-      // Registered either way. Bytes that match become usable content; bytes
-      // that do not need a registry row before they can be quarantined, which
-      // is what retains them for investigation and keeps them from being
-      // served. Both beat leaving them stranded on disk, where nothing serves
-      // them and nothing reclaims them.
-      await this.#blobStore.adopt(hash, outcome.size);
-      if (!outcome.matches) {
-        await this.#blobStore.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.QUARANTINED);
-        result.faults += 1;
-        await this.#reportFault({
-          hash,
-          fault: BLOB_FAULTS.CORRUPT,
-          blob: await this.#models.Blob.findOne({ where: { hash } }),
-        });
-        continue;
-      }
-
-      await this.#blobStore.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.VERIFIED);
-      result.adopted += 1;
-      this.#log.info('BlobScrubber: adopted an unregistered blob', { hash, size: outcome.size });
     }
+    await drainBatch();
+  }
+
+  async #reconcileOrphan(hash: string, result: ScrubResult): Promise<void> {
+    // Verified against the hash its own location encodes: bytes that match are
+    // usable content whatever left them unregistered, and bytes that do not are
+    // corrupt in the ordinary way.
+    const outcome = await this.#blobStore.verify(hash);
+    result.bytesRead += outcome.size;
+    if (!outcome.held) {
+      // Removed between the walk and the read; nothing to reconcile.
+      return;
+    }
+    // Registered either way. Bytes that match become usable content; bytes that
+    // do not need a registry row before they can be quarantined, which is what
+    // retains them for investigation and keeps them from being served. Both beat
+    // leaving them stranded on disk, where nothing serves them and nothing
+    // reclaims them.
+    await this.#blobStore.adopt(hash, outcome.size);
+    if (!outcome.matches) {
+      await this.#blobStore.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.QUARANTINED);
+      result.faults += 1;
+      await this.#reportFault({
+        hash,
+        fault: BLOB_FAULTS.CORRUPT,
+        blob: await this.#models.Blob.findOne({ where: { hash } }),
+      });
+      return;
+    }
+
+    await this.#blobStore.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.VERIFIED);
+    result.adopted += 1;
+    this.#log.info('BlobScrubber: adopted an unregistered blob', { hash, size: outcome.size });
   }
 
   // spec: SCRUB

--- a/packages/database/src/blobStore/BlobScrubber.ts
+++ b/packages/database/src/blobStore/BlobScrubber.ts
@@ -1,0 +1,235 @@
+import { Op } from 'sequelize';
+
+import { BLOB_INTEGRITY_STATES } from '@tamanu/constants';
+
+import type { BlobStore } from './BlobStore';
+import type { Blob } from '../models/Blob';
+
+// spec: SCRUB
+// What a scrub found wrong with a blob. `corrupt` bytes are held but no longer
+// hash to their name; `missing` bytes are named by a registry entry the store
+// cannot satisfy. Both are faults only where the content must be durably
+// present, which is the healer's judgement, not the scrubber's.
+export const BLOB_FAULTS = {
+  CORRUPT: 'corrupt',
+  MISSING: 'missing',
+} as const;
+
+export type BlobFault = (typeof BLOB_FAULTS)[keyof typeof BLOB_FAULTS];
+
+export interface BlobFaultReport {
+  hash: string;
+  fault: BlobFault;
+  /** The registry row as it stood when the fault was found, where there is one. */
+  blob: Blob | null;
+}
+
+export interface ScrubPassLimits {
+  /** Registry rows verified in one pass. */
+  maxBlobs: number;
+  /** Bytes read in one pass; the last blob may take the total past it. */
+  maxBytes: number;
+}
+
+export interface ScrubResult {
+  verified: number;
+  faults: number;
+  adopted: number;
+  bytesRead: number;
+  /** True when the pass stopped on a limit rather than exhausting its work. */
+  ratelimited: boolean;
+}
+
+export interface BlobScrubberOptions {
+  blobStore: BlobStore;
+  models: { Blob: typeof Blob };
+  getLimits: () => Promise<ScrubPassLimits>;
+  /**
+   * Severity grading and the repair ladder, supplied by the server: what a
+   * fault means differs between an authoritative copy and a refetchable one.
+   */
+  heal: (report: BlobFaultReport) => Promise<void>;
+  /**
+   * Hashes that must be durably present on this server but are not held —
+   * central's referenced-and-delivered blobs. A facility's equivalent is its
+   * outbox, which the verification pass already covers, so it supplies none.
+   */
+  findUndeliverableReferences?: (limit: number) => Promise<string[]>;
+  log: {
+    info: (message: string, meta?: object) => void;
+    warn: (message: string, meta?: object) => void;
+  };
+}
+
+// spec: SCRUB
+// The scheduled integrity scrub: verify stored blobs against their hashes,
+// covering content that is never read, and reconcile the registry against the
+// store in both directions. Detection only — grading a fault and repairing it
+// belong to the healer this is constructed with, because an authoritative copy
+// and a refetchable cache copy warrant different responses to identical bytes.
+export class BlobScrubber {
+  #blobStore: BlobStore;
+  #models: { Blob: typeof Blob };
+  #getLimits: () => Promise<ScrubPassLimits>;
+  #heal: (report: BlobFaultReport) => Promise<void>;
+  #findUndeliverableReferences?: (limit: number) => Promise<string[]>;
+  #log: BlobScrubberOptions['log'];
+
+  constructor({
+    blobStore,
+    models,
+    getLimits,
+    heal,
+    findUndeliverableReferences,
+    log,
+  }: BlobScrubberOptions) {
+    this.#blobStore = blobStore;
+    this.#models = models;
+    this.#getLimits = getLimits;
+    this.#heal = heal;
+    this.#findUndeliverableReferences = findUndeliverableReferences;
+    this.#log = log;
+  }
+
+  // spec: SCRUB
+  /**
+   * One incremental pass: verify a bounded batch of the least-recently-scrubbed
+   * blobs, reconcile the store against the registry, and check the referential
+   * integrity of content that must be durably present. Bounded by both blob
+   * count and bytes read, so every blob is covered across successive passes
+   * rather than in one sweep of the whole store.
+   */
+  async run(): Promise<ScrubResult> {
+    const limits = await this.#getLimits();
+    const result: ScrubResult = {
+      verified: 0,
+      faults: 0,
+      adopted: 0,
+      bytesRead: 0,
+      ratelimited: false,
+    };
+
+    await this.#verificationPass(limits, result);
+    await this.#reconciliationPass(limits, result);
+    await this.#referentialPass(limits, result);
+
+    this.#log.info('BlobScrubber: pass complete', { ...result });
+    return result;
+  }
+
+  // spec: SCRUB
+  // Least-recently-scrubbed first, never-scrubbed ahead of all: a blob admitted
+  // today is verified before one checked last week, and the whole population is
+  // covered within the target cycle without tracking a cursor across passes.
+  async #verificationPass(limits: ScrubPassLimits, result: ScrubResult): Promise<void> {
+    const candidates = await this.#models.Blob.findAll({
+      where: { integrityState: { [Op.ne]: BLOB_INTEGRITY_STATES.QUARANTINED } },
+      order: [
+        ['lastScrubbedAt', 'ASC NULLS FIRST'],
+        ['createdAt', 'ASC'],
+      ],
+      limit: limits.maxBlobs,
+    });
+
+    for (const blob of candidates) {
+      if (result.bytesRead >= limits.maxBytes) {
+        result.ratelimited = true;
+        return;
+      }
+      const outcome = await this.#blobStore.verify(blob.hash);
+      result.bytesRead += outcome.size;
+
+      if (outcome.held && outcome.matches) {
+        await this.#blobStore.recordIntegrityState(blob.hash, BLOB_INTEGRITY_STATES.VERIFIED);
+        result.verified += 1;
+        continue;
+      }
+
+      result.faults += 1;
+      await this.#reportFault({
+        hash: blob.hash,
+        fault: outcome.held ? BLOB_FAULTS.CORRUPT : BLOB_FAULTS.MISSING,
+        blob,
+      });
+    }
+
+    result.ratelimited ||= candidates.length === limits.maxBlobs;
+  }
+
+  // spec: SCRUB
+  // The store's own contents, so bytes no registry entry names are found. Such
+  // a blob is otherwise permanent: never served, and never reclaimed, since a
+  // facility evicts against a budget derived from the registry.
+  async #reconciliationPass(limits: ScrubPassLimits, result: ScrubResult): Promise<void> {
+    let examined = 0;
+    for await (const hash of this.#blobStore.storedHashes()) {
+      if (examined >= limits.maxBlobs || result.bytesRead >= limits.maxBytes) {
+        result.ratelimited = true;
+        return;
+      }
+      if (await this.#models.Blob.findOne({ where: { hash }, attributes: ['id'] })) {
+        continue;
+      }
+      examined += 1;
+
+      // Verified against the hash its own location encodes: bytes that match
+      // are usable content whatever left them unregistered, and bytes that do
+      // not are corrupt in the ordinary way.
+      const outcome = await this.#blobStore.verify(hash);
+      result.bytesRead += outcome.size;
+      if (!outcome.held) {
+        // Removed between the walk and the read; nothing to reconcile.
+        continue;
+      }
+      // Registered either way. Bytes that match become usable content; bytes
+      // that do not need a registry row before they can be quarantined, which
+      // is what retains them for investigation and keeps them from being
+      // served. Both beat leaving them stranded on disk, where nothing serves
+      // them and nothing reclaims them.
+      await this.#blobStore.adopt(hash, outcome.size);
+      if (!outcome.matches) {
+        await this.#blobStore.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.QUARANTINED);
+        result.faults += 1;
+        await this.#reportFault({
+          hash,
+          fault: BLOB_FAULTS.CORRUPT,
+          blob: await this.#models.Blob.findOne({ where: { hash } }),
+        });
+        continue;
+      }
+
+      await this.#blobStore.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.VERIFIED);
+      result.adopted += 1;
+      this.#log.info('BlobScrubber: adopted an unregistered blob', { hash, size: outcome.size });
+    }
+  }
+
+  // spec: SCRUB
+  // Content the server is expected to be able to serve but does not hold at
+  // all — no registry row, so the verification pass cannot see it. Reported the
+  // same way as corruption, since the consequence is identical.
+  async #referentialPass(limits: ScrubPassLimits, result: ScrubResult): Promise<void> {
+    if (!this.#findUndeliverableReferences) {
+      return;
+    }
+    const hashes = await this.#findUndeliverableReferences(limits.maxBlobs);
+    for (const hash of hashes) {
+      result.faults += 1;
+      await this.#reportFault({ hash, fault: BLOB_FAULTS.MISSING, blob: null });
+    }
+  }
+
+  async #reportFault(report: BlobFaultReport): Promise<void> {
+    try {
+      await this.#heal(report);
+    } catch (error) {
+      // One blob that cannot be healed must not end the pass: the rest of the
+      // store still needs checking, and the fault stays recorded for the next.
+      this.#log.warn('BlobScrubber: self-heal failed', {
+        hash: report.hash,
+        fault: report.fault,
+        error: (error as Error).message,
+      });
+    }
+  }
+}

--- a/packages/database/src/blobStore/BlobScrubber.ts
+++ b/packages/database/src/blobStore/BlobScrubber.ts
@@ -126,17 +126,18 @@ export class BlobScrubber {
   // Least-recently-scrubbed first, never-scrubbed ahead of all: a blob admitted
   // today is verified before one checked last week, and the whole population is
   // covered within the target cycle without tracking a cursor across passes.
-  // Blobs already in a recorded fault state are skipped: quarantined and absent
-  // are terminal until a repair, and a repair comes through admission (which
-  // resets the state to verified), never through re-verifying the same fault and
-  // re-escalating it every pass.
+  //
+  // Quarantined blobs are skipped: their bytes are known-bad and on disk, so
+  // re-hashing them every pass would burn the byte budget to re-learn what is
+  // already recorded. Absent blobs are kept in the scan but treated specially:
+  // re-checking one is cheap (its bytes are missing, so there is nothing to
+  // hash) and it is how the scrub notices the bytes coming back — a backup
+  // restore, say. While an absent blob stays missing it is neither re-reported
+  // nor re-repaired, only re-stamped so it yields its slot to unchecked blobs;
+  // once its bytes return and verify, it flips back to verified.
   async #verificationPass(limits: ScrubPassLimits, result: ScrubResult): Promise<void> {
     const candidates = await this.#models.Blob.findAll({
-      where: {
-        integrityState: {
-          [Op.notIn]: [BLOB_INTEGRITY_STATES.QUARANTINED, BLOB_INTEGRITY_STATES.ABSENT],
-        },
-      },
+      where: { integrityState: { [Op.ne]: BLOB_INTEGRITY_STATES.QUARANTINED } },
       order: [
         ['lastScrubbedAt', 'ASC NULLS FIRST'],
         ['createdAt', 'ASC'],
@@ -148,20 +149,36 @@ export class BlobScrubber {
     // the end rather than one write each, since a pass verifies up to maxBlobs.
     // A fault is rarer and its state is written through the heal path per blob.
     const verified: string[] = [];
-    const stampVerified = () => this.#blobStore.recordVerified(verified);
+    // Absent blobs that are still missing: their state does not change, but
+    // their scrub time does, so they don't monopolise the next pass's scan.
+    const stillAbsent: string[] = [];
+    const flush = async () => {
+      await this.#blobStore.recordVerified(verified);
+      await this.#blobStore.touchScrubbed(stillAbsent);
+    };
 
     for (const blob of candidates) {
       if (result.bytesRead >= limits.maxBytes) {
         result.ratelimited = true;
-        await stampVerified();
+        await flush();
         return;
       }
       const outcome = await this.#blobStore.verify(blob.hash);
       result.bytesRead += outcome.size;
 
       if (outcome.held && outcome.matches) {
+        // Covers recovery: an absent blob whose bytes have returned verifies
+        // here and is stamped back to verified along with the happy path.
         verified.push(blob.hash);
         result.verified += 1;
+        continue;
+      }
+
+      if (!outcome.held && blob.integrityState === BLOB_INTEGRITY_STATES.ABSENT) {
+        // Already recorded absent and still missing: re-checking found no
+        // change, so don't re-escalate or re-attempt a repair — just note it
+        // was looked at.
+        stillAbsent.push(blob.hash);
         continue;
       }
 
@@ -173,7 +190,7 @@ export class BlobScrubber {
       });
     }
 
-    await stampVerified();
+    await flush();
     result.ratelimited ||= candidates.length === limits.maxBlobs;
   }
 

--- a/packages/database/src/blobStore/BlobScrubber.ts
+++ b/packages/database/src/blobStore/BlobScrubber.ts
@@ -144,16 +144,23 @@ export class BlobScrubber {
       limit: limits.maxBlobs,
     });
 
+    // The happy path is that a blob verifies; stamp those as a single batch at
+    // the end rather than one write each, since a pass verifies up to maxBlobs.
+    // A fault is rarer and its state is written through the heal path per blob.
+    const verified: string[] = [];
+    const stampVerified = () => this.#blobStore.recordVerified(verified);
+
     for (const blob of candidates) {
       if (result.bytesRead >= limits.maxBytes) {
         result.ratelimited = true;
+        await stampVerified();
         return;
       }
       const outcome = await this.#blobStore.verify(blob.hash);
       result.bytesRead += outcome.size;
 
       if (outcome.held && outcome.matches) {
-        await this.#blobStore.recordIntegrityState(blob.hash, BLOB_INTEGRITY_STATES.VERIFIED);
+        verified.push(blob.hash);
         result.verified += 1;
         continue;
       }
@@ -166,6 +173,7 @@ export class BlobScrubber {
       });
     }
 
+    await stampVerified();
     result.ratelimited ||= candidates.length === limits.maxBlobs;
   }
 

--- a/packages/database/src/blobStore/BlobStore.ts
+++ b/packages/database/src/blobStore/BlobStore.ts
@@ -1,12 +1,16 @@
 import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import type { Readable } from 'node:stream';
+import { Transform, type Readable } from 'node:stream';
+
+import { Op } from 'sequelize';
 
 import {
+  BLOB_HASH_ALGORITHMS,
   BLOB_INTEGRITY_STATES,
   BLOB_TIERS,
   CURRENT_BLOB_HASH_ALGORITHM,
+  type BlobIntegrityState,
   type BlobTier,
 } from '@tamanu/constants';
 import {
@@ -15,7 +19,12 @@ import {
   InvalidParameterError,
   NotFoundError,
 } from '@tamanu/errors';
-import { blobPathSegments, formatBlobHash, parseBlobHash } from '@tamanu/utils/blobs';
+import {
+  blobHashFromPathSegments,
+  blobPathSegments,
+  formatBlobHash,
+  parseBlobHash,
+} from '@tamanu/utils/blobs';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import type { Blob } from '../models/Blob';
@@ -57,6 +66,13 @@ export interface BlobStoreOptions {
    * on servers with nothing evictable.
    */
   evictCache?: (bytesNeeded: number) => Promise<void>;
+  /**
+   * Self-heal hook (spec: SCRUB): called with the hash of a blob whose bytes
+   * failed verification on the read path. Supplied by the server, which owns
+   * severity grading and the repair ladder.
+   */
+  onCorruptionDetected?: (hash: string) => Promise<void>;
+  log?: { error: (message: string, meta?: object) => void };
   /** Injectable for tests; defaults to fs.statfs on the store root. */
   statfs?: (root: string) => Promise<VolumeStats>;
 }
@@ -73,6 +89,15 @@ export interface BlobStat {
   integrityState: string;
 }
 
+export interface VerifyResult {
+  /** Whether the store holds bytes for the hash at all. */
+  held: boolean;
+  matches: boolean;
+  size: number;
+  /** What the held bytes actually hash to, or null when none are held. */
+  actualHash: string | null;
+}
+
 // spec: CAS, CAP
 // The content-addressed blob store primitive: bytes on disk under an
 // algorithm-namespaced two-level fan-out, and a row per blob in the local
@@ -85,14 +110,26 @@ export class BlobStore {
   readonly #models: { Blob: typeof Blob };
   readonly #getFreeDiskReserveBytes: () => Promise<number>;
   readonly #evictCache?: (bytesNeeded: number) => Promise<void>;
+  readonly #onCorruptionDetected?: (hash: string) => Promise<void>;
+  readonly #log?: { error: (message: string, meta?: object) => void };
   readonly #statfs: (root: string) => Promise<VolumeStats>;
   readonly #stagingLocks = new Map<string, Promise<unknown>>();
 
-  constructor({ root, models, getFreeDiskReserveBytes, evictCache, statfs }: BlobStoreOptions) {
+  constructor({
+    root,
+    models,
+    getFreeDiskReserveBytes,
+    evictCache,
+    onCorruptionDetected,
+    log,
+    statfs,
+  }: BlobStoreOptions) {
     this.root = root;
     this.#models = models;
     this.#getFreeDiskReserveBytes = getFreeDiskReserveBytes;
     this.#evictCache = evictCache;
+    this.#onCorruptionDetected = onCorruptionDetected;
+    this.#log = log;
     this.#statfs = statfs ?? (r => fs.statfs(r));
   }
 
@@ -110,9 +147,24 @@ export class BlobStore {
     return await fileExists(filePath);
   }
 
+  /**
+   * Stream a blob's bytes.
+   *
+   * spec: SCRUB — a read of the whole blob re-verifies it: the bytes are hashed
+   * as they stream and the stream fails at the end if they do not match, so
+   * corrupt content is never served as complete. A ranged read cannot be
+   * verified this way and relies on receipt verification and the scrub instead.
+   * `verify: false` opts out for callers that are themselves the verification
+   * (the scrub) or that must read quarantined bytes.
+   */
   async get(
     hash: string,
-    { start, end, stat }: { start?: number; end?: number; stat?: BlobStat | null } = {},
+    {
+      start,
+      end,
+      stat,
+      verify = true,
+    }: { start?: number; end?: number; stat?: BlobStat | null; verify?: boolean } = {},
   ): Promise<Readable> {
     const filePath = this.#pathFor(hash);
     // A caller that has just run stat() for this hash (the serving path, which
@@ -136,7 +188,111 @@ export class BlobStore {
       }
       throw error;
     }
-    return handle.createReadStream({ start, end });
+    const stream = handle.createReadStream({ start, end });
+    // A read bounded at either end covers part of the content, so its bytes
+    // cannot be checked against a hash of the whole.
+    const isWholeBlob = (start ?? 0) === 0 && end === undefined;
+    if (!verify || !isWholeBlob) {
+      return stream;
+    }
+    return verifyingStream(stream, hash, () => this.#onReadCorruption(hash));
+  }
+
+  async #onReadCorruption(hash: string): Promise<void> {
+    // The read path detects; the healer decides severity and repair, since that
+    // differs between an authoritative copy and a refetchable cache one.
+    if (!this.#onCorruptionDetected) {
+      return;
+    }
+    try {
+      await this.#onCorruptionDetected(hash);
+    } catch (error) {
+      // A failed heal must not replace the mismatch error the reader is about
+      // to see with one about the repair attempt.
+      this.#log?.error('BlobStore: self-heal after a failed read verification threw', {
+        hash,
+        error: (error as Error).message,
+      });
+    }
+  }
+
+  // spec: SCRUB
+  /**
+   * Re-hash the stored bytes for a hash and report whether they still match it.
+   * Reads the file directly, so it verifies quarantined content too — a repair
+   * needs to be able to re-check what it replaced.
+   */
+  async verify(hash: string): Promise<VerifyResult> {
+    const { algorithm } = parseBlobHash(hash);
+    let handle;
+    try {
+      handle = await fs.open(this.#pathFor(hash), 'r');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { held: false, matches: false, size: 0, actualHash: null };
+      }
+      throw error;
+    }
+
+    const hasher = createHash(algorithm);
+    let size = 0;
+    try {
+      for await (const chunk of handle.createReadStream({ autoClose: false })) {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        hasher.update(buffer);
+        size += buffer.length;
+      }
+    } finally {
+      await handle.close();
+    }
+
+    const actualHash = formatBlobHash(algorithm, hasher.digest('hex'));
+    return { held: true, matches: actualHash === hash, size, actualHash };
+  }
+
+  // spec: SCRUB
+  /**
+   * Every hash the store holds bytes for, read from the fan-out layout rather
+   * than the registry, so bytes no registry entry names are found. Yields as it
+   * walks: a store with a very large population is never materialised whole.
+   * Paths that do not parse as a hash are skipped — the staging and temp
+   * directories live under the same root, and neither is content.
+   */
+  async *storedHashes(): AsyncGenerator<string> {
+    for (const algorithm of Object.values(BLOB_HASH_ALGORITHMS)) {
+      const algorithmRoot = path.join(this.root, algorithm);
+      for await (const filePath of walkFiles(algorithmRoot)) {
+        const segments = path.relative(this.root, filePath).split(path.sep);
+        const hash = blobHashFromPathSegments(segments);
+        if (hash) {
+          yield hash;
+        }
+      }
+    }
+  }
+
+  // spec: SCRUB
+  /**
+   * Record a blob's standing against its hash, stamping the scrub time. The
+   * result of a scrub is the state it leaves behind, so the two are written
+   * together and never drift.
+   */
+  async recordIntegrityState(hash: string, integrityState: BlobIntegrityState): Promise<void> {
+    await this.#models.Blob.update(
+      { integrityState, lastScrubbedAt: new Date() },
+      { where: { hash } },
+    );
+  }
+
+  // spec: SCRUB
+  /**
+   * Register bytes already sitting in their fan-out path — content admitted by
+   * a process that died between placing the file and recording it, or restored
+   * from a store backup taken after its database. The caller has verified the
+   * bytes against the hash their location encodes.
+   */
+  async adopt(hash: string, size: number): Promise<void> {
+    await this.#register(hash, size);
   }
 
   /** The registry's record of a held blob, or null when the blob is not held. */
@@ -324,7 +480,10 @@ export class BlobStore {
 
   async #commitStagedLocked(hash: string): Promise<PutResult> {
     const existing = await this.stat(hash);
-    if (existing) {
+    // spec: SCRUB — a quarantined copy is exactly what an incoming good copy is
+    // there to replace, so it does not count as content already held. The bad
+    // bytes are dropped only once the replacement has verified below.
+    if (existing && existing.integrityState !== BLOB_INTEGRITY_STATES.QUARANTINED) {
       await this.#removeStagingFile(hash);
       return { hash, size: existing.size, existed: true };
     }
@@ -361,8 +520,22 @@ export class BlobStore {
       );
     }
 
+    if (existing) {
+      // spec: SCRUB — the replacement has verified, so the quarantined bytes go
+      // now. Removing them first is what lets the rename below land, since
+      // placement treats an occupied destination as content already won.
+      await fs.rm(this.#pathFor(hash), { force: true });
+    }
     await this.#placeAtFinalPath(stagingPath, this.#pathFor(hash));
     await this.#register(hash, size);
+    // spec: SCRUB — these bytes just verified, so a row still standing as
+    // quarantined or absent is now out of date. Covers both self-heal arrivals:
+    // a replacement for a corrupt copy, and a refetch of one whose bytes had
+    // gone. A row already verified is left alone.
+    await this.#models.Blob.update(
+      { integrityState: BLOB_INTEGRITY_STATES.VERIFIED, size, lastScrubbedAt: new Date() },
+      { where: { hash, integrityState: { [Op.ne]: BLOB_INTEGRITY_STATES.VERIFIED } } },
+    );
     return { hash, size, existed: false };
   }
 
@@ -509,14 +682,19 @@ export class BlobStore {
     // outbox re-admission must not stay evictable cache) and reset recency to
     // now (so it is not instantly the oldest LRU victim). Live rows are left
     // untouched.
+    //
+    // Admission hashes the content it stores, so the blob is verified as at
+    // now: stamping the scrub time here keeps freshly admitted content from
+    // going straight to the front of the scrub queue ahead of colder blobs.
     await this.#models.Blob.sequelize.query(
       `
-        INSERT INTO blobs (id, hash, size, integrity_state, tier)
-        VALUES ($id, $hash, $size, $integrityState, $tier)
+        INSERT INTO blobs (id, hash, size, integrity_state, tier, last_scrubbed_at)
+        VALUES ($id, $hash, $size, $integrityState, $tier, now())
         ON CONFLICT (hash) DO UPDATE
           SET deleted_at = NULL,
               updated_at = now(),
               last_accessed_at = now(),
+              last_scrubbed_at = now(),
               tier = EXCLUDED.tier
           WHERE blobs.deleted_at IS NOT NULL
       `,
@@ -583,5 +761,65 @@ async function fileExists(filePath: string): Promise<boolean> {
     return true;
   } catch {
     return false;
+  }
+}
+
+// spec: SCRUB
+// Hash the bytes as they pass and fail the stream at the end if they do not
+// match, so a reader either gets content that verified or gets an error — never
+// a clean end-of-stream over corrupt bytes. The mismatch surfaces after the
+// bytes have gone out, which is unavoidable when verification is of the whole:
+// what it protects is the reader's ability to tell a complete blob from a
+// corrupt one.
+function verifyingStream(source: Readable, hash: string, onMismatch: () => Promise<void>): Readable {
+  const { algorithm } = parseBlobHash(hash);
+  const hasher = createHash(algorithm);
+  const verifier = new Transform({
+    transform(chunk, _encoding, callback) {
+      hasher.update(chunk);
+      callback(null, chunk);
+    },
+    flush(callback) {
+      const actualHash = formatBlobHash(algorithm, hasher.digest('hex'));
+      if (actualHash === hash) {
+        callback();
+        return;
+      }
+      // Heal in the background: the reader's error must not wait on a repair,
+      // and the repair must not be skipped because the reader gave up.
+      void onMismatch();
+      callback(
+        new BlobHashMismatchError(`Stored content for ${hash} hashed to ${actualHash} on read`),
+      );
+    },
+  });
+  // The file handle must close whether the reader finished, errored, or walked
+  // away, and a read error on the file must reach the reader rather than ending
+  // the stream cleanly and failing verification instead.
+  verifier.on('close', () => source.destroy());
+  source.on('error', error => verifier.destroy(error));
+  return source.pipe(verifier);
+}
+
+// Every file beneath a directory, depth-first, yielded as it goes. A missing
+// directory is empty rather than an error: an algorithm's tree only exists once
+// content has been stored under it.
+async function* walkFiles(directory: string): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkFiles(entryPath);
+    } else if (entry.isFile()) {
+      yield entryPath;
+    }
   }
 }

--- a/packages/database/src/blobStore/BlobStore.ts
+++ b/packages/database/src/blobStore/BlobStore.ts
@@ -286,6 +286,22 @@ export class BlobStore {
 
   // spec: SCRUB
   /**
+   * Stamp a batch of blobs as verified as of now, in one statement. The scrub's
+   * common case is that most blobs pass, so this keeps a pass to a single write
+   * for the verified set rather than one per blob.
+   */
+  async recordVerified(hashes: string[]): Promise<void> {
+    if (hashes.length === 0) {
+      return;
+    }
+    await this.#models.Blob.update(
+      { integrityState: BLOB_INTEGRITY_STATES.VERIFIED, lastScrubbedAt: new Date() },
+      { where: { hash: hashes } },
+    );
+  }
+
+  // spec: SCRUB
+  /**
    * Register bytes already sitting in their fan-out path — content admitted by
    * a process that died between placing the file and recording it, or restored
    * from a store backup taken after its database. The caller has verified the

--- a/packages/database/src/blobStore/BlobStore.ts
+++ b/packages/database/src/blobStore/BlobStore.ts
@@ -302,6 +302,20 @@ export class BlobStore {
 
   // spec: SCRUB
   /**
+   * Record that a batch of blobs was scrubbed just now without changing their
+   * integrity state — for a fault the scrub re-checked and found unchanged, so
+   * it moves to the back of the least-recently-scrubbed queue rather than being
+   * re-examined every pass.
+   */
+  async touchScrubbed(hashes: string[]): Promise<void> {
+    if (hashes.length === 0) {
+      return;
+    }
+    await this.#models.Blob.update({ lastScrubbedAt: new Date() }, { where: { hash: hashes } });
+  }
+
+  // spec: SCRUB
+  /**
    * Register bytes already sitting in their fan-out path — content admitted by
    * a process that died between placing the file and recording it, or restored
    * from a store backup taken after its database. The caller has verified the
@@ -496,10 +510,12 @@ export class BlobStore {
 
   async #commitStagedLocked(hash: string): Promise<PutResult> {
     const existing = await this.stat(hash);
-    // spec: SCRUB — a quarantined copy is exactly what an incoming good copy is
-    // there to replace, so it does not count as content already held. The bad
-    // bytes are dropped only once the replacement has verified below.
-    if (existing && existing.integrityState !== BLOB_INTEGRITY_STATES.QUARANTINED) {
+    // spec: SCRUB — only a copy already verified counts as content held; the
+    // commit is a no-op against it. A quarantined or absent copy is exactly what
+    // an incoming good copy is there to replace or restore, so it falls through
+    // and its bytes and state are only settled once the replacement verifies
+    // below.
+    if (existing && existing.integrityState === BLOB_INTEGRITY_STATES.VERIFIED) {
       await this.#removeStagingFile(hash);
       return { hash, size: existing.size, existed: true };
     }

--- a/packages/database/src/blobStore/BlobStore.ts
+++ b/packages/database/src/blobStore/BlobStore.ts
@@ -289,6 +289,11 @@ export class BlobStore {
    * Stamp a batch of blobs as verified as of now, in one statement. The scrub's
    * common case is that most blobs pass, so this keeps a pass to a single write
    * for the verified set rather than one per blob.
+   *
+   * spec: SCRUB — a read-path quarantine landing between a blob's verify() and
+   * this end-of-pass flush must win: its bytes are known-bad now, whatever they
+   * hashed to earlier in the pass. So this never overwrites a quarantined row,
+   * only the verified/absent ones the scrub actually re-checked.
    */
   async recordVerified(hashes: string[]): Promise<void> {
     if (hashes.length === 0) {
@@ -296,7 +301,12 @@ export class BlobStore {
     }
     await this.#models.Blob.update(
       { integrityState: BLOB_INTEGRITY_STATES.VERIFIED, lastScrubbedAt: new Date() },
-      { where: { hash: hashes } },
+      {
+        where: {
+          hash: hashes,
+          integrityState: { [Op.ne]: BLOB_INTEGRITY_STATES.QUARANTINED },
+        },
+      },
     );
   }
 

--- a/packages/database/src/blobStore/index.ts
+++ b/packages/database/src/blobStore/index.ts
@@ -1,2 +1,3 @@
 export * from './BlobStore';
 export * from './backfill/BlobBackfill';
+export * from './BlobScrubber';

--- a/packages/database/src/migrations/1785850000000-addBlobScrubColumns.ts
+++ b/packages/database/src/migrations/1785850000000-addBlobScrubColumns.ts
@@ -1,0 +1,27 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+const TABLE = { tableName: 'blobs', schema: 'public' };
+const INDEX = 'blobs_last_scrubbed_at';
+
+// spec: SCRUB
+// Scrub state for the blob registry. `last_scrubbed_at` is when the blob was
+// last verified against its hash; the result of that verification is the
+// integrity state as of that moment, so it needs no column of its own. Null
+// means never scrubbed, which the scrub takes first.
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn(TABLE, 'last_scrubbed_at', {
+    type: DataTypes.DATE,
+    allowNull: true,
+  });
+  // Written out rather than through addIndex: the scan orders NULLS FIRST so a
+  // never-scrubbed blob is taken ahead of a stale one, and a default (NULLS
+  // LAST) index does not serve that ordering.
+  await query.sequelize.query(
+    `CREATE INDEX ${INDEX} ON blobs (last_scrubbed_at ASC NULLS FIRST)`,
+  );
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`DROP INDEX ${INDEX}`);
+  await query.removeColumn(TABLE, 'last_scrubbed_at');
+}

--- a/packages/database/src/models/Blob.ts
+++ b/packages/database/src/models/Blob.ts
@@ -23,6 +23,7 @@ export class Blob extends Model {
   declare integrityState: BlobIntegrityState;
   declare tier: BlobTier;
   declare lastAccessedAt: Date;
+  declare lastScrubbedAt: Date | null;
   declare eligibleSinceTick: number | null;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
@@ -63,6 +64,15 @@ export class Blob extends Model {
           type: DataTypes.DATE,
           allowNull: false,
           defaultValue: DataTypes.NOW,
+        },
+        // spec: SCRUB
+        // When the scrub last verified this blob against its hash. Null until
+        // first scrubbed, which the scrub's least-recently-scrubbed-first scan
+        // takes ahead of any stamped row. The result of that verification is
+        // the integrity state above, as at this time.
+        lastScrubbedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
         },
         // spec: CAP
         // The push cursor at the moment this blob was first observed eligible

--- a/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
+++ b/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
@@ -205,6 +205,23 @@ describe('facility blob integrity', () => {
       expect(blob.size).toBe(content.length);
       expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.VERIFIED);
     });
+
+    it('retains a corrupt orphan rather than the cache healer deleting it', async () => {
+      // A corrupt orphan has no reference and no known provenance, so it cannot
+      // be assumed a refetchable replica: quarantine must retain it, not let the
+      // cache path drop it.
+      const { hash } = await put(BLOB_TIERS.CACHE);
+      await corrupt(hash);
+      await models.Blob.destroy({ where: { hash }, force: true });
+
+      const result = await makeScrubber().run();
+
+      expect(result.faults).toBe(1);
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.QUARANTINED);
+      // The bytes are retained on disk for investigation, not deleted.
+      await expect(fs.access(pathOf(hash))).resolves.toBeUndefined();
+    });
   });
 
   // The application context resolves the scrub's per-pass bounds through this

--- a/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
+++ b/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
@@ -1,0 +1,238 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import { BLOB_INTEGRITY_STATES, BLOB_TIERS } from '@tamanu/constants';
+import { BlobScrubber, BlobStore } from '@tamanu/database/blobStore';
+import { BlobHashMismatchError } from '@tamanu/errors';
+
+import { createTestContext } from '../utilities';
+import { FacilityBlobHealer } from '../../app/blobIntegrity/FacilityBlobHealer';
+
+const uniqueContent = () => Buffer.from(`blob content ${randomUUID()}`);
+
+async function readAll(stream) {
+  const chunks = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function waitFor(predicate, { timeoutMs = 5000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) return;
+    if (Date.now() > deadline) throw new Error('waitFor timed out');
+    await new Promise(resolve => {
+      setTimeout(resolve, 10);
+    });
+  }
+}
+
+describe('facility blob integrity', () => {
+  let ctx;
+  let models;
+  let root;
+  let blobStore;
+  let blobHealer;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await models.Blob.destroy({ where: {}, force: true });
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-integrity-test-'));
+    blobStore = new BlobStore({
+      root,
+      models,
+      getFreeDiskReserveBytes: async () => 0,
+      onCorruptionDetected: async hash => {
+        await blobHealer.heal({
+          hash,
+          fault: 'corrupt',
+          blob: await models.Blob.findOne({ where: { hash } }),
+        });
+      },
+    });
+    blobHealer = new FacilityBlobHealer({ blobStore, models });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const makeScrubber = ({ maxBlobs = 100, maxBytes = 1024 ** 3 } = {}) =>
+    new BlobScrubber({
+      blobStore,
+      models,
+      getLimits: async () => ({ maxBlobs, maxBytes }),
+      heal: report => blobHealer.heal(report),
+      log: { info: () => {}, warn: () => {} },
+    });
+
+  const put = async (tier, content = uniqueContent()) => {
+    const { hash } = await blobStore.put(Readable.from(content), { tier });
+    return { hash, content };
+  };
+
+  const pathOf = hash => {
+    const digest = hash.split(':')[1];
+    return path.join(root, 'sha256', digest.slice(0, 2), digest.slice(2, 4), digest.slice(4));
+  };
+
+  const corrupt = async hash => fs.writeFile(pathOf(hash), uniqueContent());
+
+  // spec: SCRUB
+  describe('grading by tier', () => {
+    it('drops a corrupt cache blob so the next read refetches it', async () => {
+      const { hash } = await put(BLOB_TIERS.CACHE);
+      await corrupt(hash);
+
+      await makeScrubber().run();
+
+      expect(await models.Blob.findOne({ where: { hash } })).toBeNull();
+      await expect(fs.access(pathOf(hash))).rejects.toThrow();
+    });
+
+    it('quarantines a corrupt outbox blob rather than dropping the only copy', async () => {
+      const { hash } = await put(BLOB_TIERS.OUTBOX);
+      await corrupt(hash);
+
+      await makeScrubber().run();
+
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.QUARANTINED);
+      // Retained for investigation, per the spec: the bytes are still there.
+      await expect(fs.access(pathOf(hash))).resolves.toBeUndefined();
+    });
+
+    it('marks an outbox blob whose bytes have gone as absent', async () => {
+      const { hash } = await put(BLOB_TIERS.OUTBOX);
+      await fs.rm(pathOf(hash));
+
+      await makeScrubber().run();
+
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.ABSENT);
+    });
+
+    it('repairs an outbox blob from central where central turns out to hold it', async () => {
+      const { hash, content } = await put(BLOB_TIERS.OUTBOX);
+      await corrupt(hash);
+      blobHealer.setTransferChannel({
+        fetchFromCentral: async fetched => {
+          await blobStore.stage(fetched, Readable.from(content), { offset: 0 });
+          return await blobStore.commitStaged(fetched);
+        },
+      });
+
+      await makeScrubber().run();
+
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.VERIFIED);
+      // Central had it, so it is a replica now rather than the only copy.
+      expect(blob.tier).toBe(BLOB_TIERS.CACHE);
+      expect((await readAll(await blobStore.get(hash))).equals(content)).toBe(true);
+    });
+
+    it('leaves an outbox blob quarantined when central cannot supply it', async () => {
+      const { hash } = await put(BLOB_TIERS.OUTBOX);
+      await corrupt(hash);
+      blobHealer.setTransferChannel({
+        fetchFromCentral: async () => {
+          throw new Error('central does not hold it');
+        },
+      });
+
+      await makeScrubber().run();
+
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.QUARANTINED);
+    });
+  });
+
+  // spec: SCRUB
+  describe('scrub scheduling against the real registry', () => {
+    it('takes never-scrubbed blobs before ones scrubbed long ago', async () => {
+      const stale = await put(BLOB_TIERS.CACHE);
+      const never = await put(BLOB_TIERS.CACHE);
+      await models.Blob.update(
+        { lastScrubbedAt: new Date('2020-01-01T00:00:00Z') },
+        { where: { hash: stale.hash } },
+      );
+      await models.Blob.update({ lastScrubbedAt: null }, { where: { hash: never.hash } });
+
+      await makeScrubber({ maxBlobs: 1 }).run();
+
+      const neverRow = await models.Blob.findOne({ where: { hash: never.hash } });
+      const staleRow = await models.Blob.findOne({ where: { hash: stale.hash } });
+      expect(neverRow.lastScrubbedAt).not.toBeNull();
+      expect(staleRow.lastScrubbedAt.toISOString()).toBe('2020-01-01T00:00:00.000Z');
+    });
+
+    it('covers the whole store across successive passes', async () => {
+      const hashes = [];
+      for (let i = 0; i < 3; i++) {
+        hashes.push((await put(BLOB_TIERS.CACHE)).hash);
+      }
+      await models.Blob.update({ lastScrubbedAt: null }, { where: {} });
+
+      const scrubber = makeScrubber({ maxBlobs: 1 });
+      await scrubber.run();
+      await scrubber.run();
+      await scrubber.run();
+
+      const unscrubbed = await models.Blob.count({ where: { lastScrubbedAt: null } });
+      expect(unscrubbed).toBe(0);
+    });
+
+    it('registers bytes left on disk by an interrupted admission', async () => {
+      const { hash, content } = await put(BLOB_TIERS.CACHE);
+      // Exactly what a crash between placing the file and recording it leaves.
+      await models.Blob.destroy({ where: { hash }, force: true });
+
+      const result = await makeScrubber().run();
+
+      expect(result.adopted).toBe(1);
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.size).toBe(content.length);
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.VERIFIED);
+    });
+  });
+
+  // The application context resolves the scrub's per-pass bounds through this
+  // settings path, and a typo in it would only surface when a scheduled pass
+  // first ran on a real server.
+  describe('scrub settings', () => {
+    it('resolves the per-pass bounds the context reads', async () => {
+      const [facilityId] = Object.keys(ctx.settings).filter(key => key !== 'global');
+      const scrub = await ctx.settings[facilityId].get('schedules.blobIntegrityScrub');
+
+      expect(scrub.maxBlobsPerPass).toBeGreaterThan(0);
+      expect(scrub.maxGigabytesPerPass).toBeGreaterThan(0);
+      expect(scrub.schedule).toEqual(expect.any(String));
+    });
+  });
+
+  // spec: SCRUB
+  describe('read verification', () => {
+    it('fails the read and heals when stored bytes no longer match', async () => {
+      const { hash } = await put(BLOB_TIERS.CACHE);
+      await corrupt(hash);
+
+      await expect(readAll(await blobStore.get(hash))).rejects.toThrow(BlobHashMismatchError);
+      // The cache grading applies on the read path too, so it is gone and will
+      // refetch rather than being served corrupt a second time. Healing runs
+      // clear of the read, so the reader gets its error without waiting on the
+      // repair — hence waiting for it here rather than asserting immediately.
+      await waitFor(async () => (await models.Blob.findOne({ where: { hash } })) === null);
+    });
+  });
+});

--- a/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
+++ b/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
@@ -206,6 +206,40 @@ describe('facility blob integrity', () => {
       expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.VERIFIED);
     });
 
+    it('restores an absent blob to verified once its bytes return', async () => {
+      // A registry row left absent by an earlier loss, whose bytes are then
+      // back on disk (a backup restore). The scrub notices and flips it back
+      // rather than leaving usable content marked absent forever.
+      const { hash } = await put(BLOB_TIERS.CACHE);
+      await models.Blob.update(
+        { integrityState: BLOB_INTEGRITY_STATES.ABSENT },
+        { where: { hash } },
+      );
+
+      const result = await makeScrubber().run();
+
+      expect(result.verified).toBe(1);
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.VERIFIED);
+    });
+
+    it('re-checks a still-absent blob without re-escalating it', async () => {
+      const { hash } = await put(BLOB_TIERS.CACHE);
+      await fs.rm(pathOf(hash));
+      await models.Blob.update(
+        { integrityState: BLOB_INTEGRITY_STATES.ABSENT, lastScrubbedAt: new Date('2020-01-01T00:00:00Z') },
+        { where: { hash } },
+      );
+
+      const result = await makeScrubber().run();
+
+      expect(result.faults).toBe(0);
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.ABSENT);
+      // Re-stamped so it doesn't monopolise the next pass's scan.
+      expect(blob.lastScrubbedAt.getTime()).toBeGreaterThan(new Date('2020-01-01T00:00:00Z').getTime());
+    });
+
     it('retains a corrupt orphan rather than the cache healer deleting it', async () => {
       // A corrupt orphan has no reference and no known provenance, so it cannot
       // be assumed a refetchable replica: quarantine must retain it, not let the

--- a/packages/facility-server/__tests__/blobTransfer/BlobTransferChannel.test.js
+++ b/packages/facility-server/__tests__/blobTransfer/BlobTransferChannel.test.js
@@ -20,6 +20,16 @@ function makeFakeBlobModel() {
     async findOne({ where: { hash } }) {
       return rows.get(hash) ?? null;
     },
+    async update(values, { where }) {
+      const row = rows.get(where.hash);
+      if (!row) return;
+      // The only operator the store uses here is Op.ne on integrityState.
+      const excluded = where.integrityState
+        ? Object.getOwnPropertySymbols(where.integrityState).map(s => where.integrityState[s])
+        : [];
+      if (excluded.includes(row.integrityState)) return;
+      Object.assign(row, values);
+    },
     async destroy({ where: { hash } }) {
       rows.delete(hash);
     },

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -1,7 +1,7 @@
 import config from 'config';
 import { omit } from 'es-toolkit/compat';
 
-import { BlobStore } from '@tamanu/database/blobStore';
+import { BLOB_FAULTS, BlobScrubber, BlobStore } from '@tamanu/database/blobStore';
 import { initReporting } from '@tamanu/database/services/reporting';
 import { initBugsnag, log } from '@tamanu/shared/services/logging';
 import { facilityDefaults } from '@tamanu/settings';
@@ -13,6 +13,7 @@ import {
 import { setFhirRefreshTriggers } from '@tamanu/database';
 
 import { FacilityBlobCache, makeSyncedReferenceResolver } from './blobCache';
+import { FacilityBlobHealer } from './blobIntegrity';
 import { closeDatabase, initDatabase } from './database';
 import { getServerFacilityIds, initServerConfig } from './serverConfig';
 import { VERSION } from './middleware/versionCompatibility.js';
@@ -41,6 +42,12 @@ export class ApplicationContext {
 
   /** @type {FacilityBlobCache | null} */
   blobCache = null;
+
+  /** @type {FacilityBlobHealer | null} */
+  blobHealer = null;
+
+  /** @type {BlobScrubber | null} */
+  blobScrubber = null;
 
   reportSchemaStores = null;
 
@@ -93,6 +100,16 @@ export class ApplicationContext {
       evictCache: async bytesNeeded => {
         await this.blobCache?.evictBytes(bytesNeeded);
       },
+      // spec: SCRUB — a whole-blob read that fails verification heals by the
+      // same ladder the scrub uses. Late-bound for the same reason as above.
+      onCorruptionDetected: async hash => {
+        await this.blobHealer?.heal({
+          hash,
+          fault: BLOB_FAULTS.CORRUPT,
+          blob: await this.models.Blob.findOne({ where: { hash } }),
+        });
+      },
+      log,
     });
 
     // spec: CACHE
@@ -118,6 +135,27 @@ export class ApplicationContext {
     // delivers it once the referencing record has synchronised.
     this.sequelize.admitAttachmentBlob = (source, options) =>
       this.blobCache.putOutbox(source, options);
+
+    // spec: SCRUB
+    // Detection is server-agnostic; grading and repair are not. The facility
+    // grades on the cache/outbox tier, since that already records whether a
+    // copy is the only durable one.
+    this.blobHealer = new FacilityBlobHealer({ blobStore: this.blobStore, models: this.models });
+    this.blobScrubber = new BlobScrubber({
+      blobStore: this.blobStore,
+      models: this.models,
+      getLimits: async () => {
+        const scrub = primaryFacilityId
+          ? await this.settings[primaryFacilityId].get('schedules.blobIntegrityScrub')
+          : facilityDefaults.schedules.blobIntegrityScrub;
+        return {
+          maxBlobs: scrub.maxBlobsPerPass,
+          maxBytes: scrub.maxGigabytesPerPass * 1024 ** 3,
+        };
+      },
+      heal: report => this.blobHealer.heal(report),
+      log,
+    });
 
     // spec: CACHE — consumers (attachments, assets) append their synced-record
     // resolvers here so their blobs become eligible for push.

--- a/packages/facility-server/app/blobIntegrity/FacilityBlobHealer.js
+++ b/packages/facility-server/app/blobIntegrity/FacilityBlobHealer.js
@@ -29,6 +29,17 @@ export class FacilityBlobHealer {
    * hash repeatedly and concurrently.
    */
   async heal({ hash, fault, blob }) {
+    // spec: SCRUB — a quarantined blob is retained, never deleted. Reconciliation
+    // quarantines a corrupt orphan (unknown provenance, so not assumed to be a
+    // refetchable replica) before handing it here; the cache path below would
+    // otherwise delete the very evidence the quarantine is meant to keep.
+    if (blob?.integrityState === BLOB_INTEGRITY_STATES.QUARANTINED) {
+      log.warn('FacilityBlobHealer: retaining a quarantined corrupt blob for investigation', {
+        hash,
+        fault,
+      });
+      return;
+    }
     const tier = blob?.tier ?? BLOB_TIERS.CACHE;
     if (tier === BLOB_TIERS.OUTBOX) {
       await this.#healOutbox({ hash, fault });

--- a/packages/facility-server/app/blobIntegrity/FacilityBlobHealer.js
+++ b/packages/facility-server/app/blobIntegrity/FacilityBlobHealer.js
@@ -1,0 +1,103 @@
+import { BLOB_FAULTS } from '@tamanu/database/blobStore';
+import { BLOB_INTEGRITY_STATES, BLOB_TIERS } from '@tamanu/constants';
+import { log } from '@tamanu/shared/services/logging';
+
+// spec: SCRUB
+// The facility's response to a blob that fails verification. Severity is graded
+// by the tier, which already records whether the copy is the only durable one:
+// a cache copy is durable on central, so losing it costs a refetch, while an
+// outbox copy is the only copy its content has anywhere.
+export class FacilityBlobHealer {
+  #blobStore;
+  #models;
+  #transferChannel = null;
+
+  constructor({ blobStore, models }) {
+    this.#blobStore = blobStore;
+    this.#models = models;
+  }
+
+  /** Wired once the sync runtime is up; without it there is no peer to heal from. */
+  setTransferChannel(transferChannel) {
+    this.#transferChannel = transferChannel;
+  }
+
+  // spec: SCRUB
+  /**
+   * Repair a faulty blob, or escalate where it cannot be repaired here. Called
+   * by the scrub and by the read path, so it must be safe to call for the same
+   * hash repeatedly and concurrently.
+   */
+  async heal({ hash, fault, blob }) {
+    const tier = blob?.tier ?? BLOB_TIERS.CACHE;
+    if (tier === BLOB_TIERS.OUTBOX) {
+      await this.#healOutbox({ hash, fault });
+      return;
+    }
+    await this.#healCache({ hash, fault });
+  }
+
+  // spec: SCRUB
+  // A cache copy is a replica: the content is durable on central, so the repair
+  // is to stop holding the bad bytes and let the next read fetch them again.
+  // Low-severity and self-correcting, so it is logged but not escalated.
+  async #healCache({ hash, fault }) {
+    await this.#blobStore.delete(hash);
+    log.warn('FacilityBlobHealer: dropped a faulty cache blob, it will refetch on demand', {
+      hash,
+      fault,
+    });
+  }
+
+  // spec: SCRUB
+  // An outbox copy is the only durable copy of its content, so a fault here is
+  // real data loss unless a source can be found. Central is worth trying even
+  // though the blob is un-pushed: a push that was acknowledged but whose
+  // demotion did not land leaves exactly this state, and then the content is
+  // there to be had.
+  async #healOutbox({ hash, fault }) {
+    await this.#blobStore.recordIntegrityState(
+      hash,
+      fault === BLOB_FAULTS.CORRUPT
+        ? BLOB_INTEGRITY_STATES.QUARANTINED
+        : BLOB_INTEGRITY_STATES.ABSENT,
+    );
+
+    if (await this.#refetchFromCentral(hash)) {
+      // Central held it after all, so the content was never at risk and the
+      // local copy is now a verified replica rather than an outbox blob.
+      await this.#models.Blob.update(
+        { tier: BLOB_TIERS.CACHE, eligibleSinceTick: null },
+        { where: { hash } },
+      );
+      log.warn('FacilityBlobHealer: repaired a faulty outbox blob from central', { hash, fault });
+      return;
+    }
+
+    // Nothing left below error correction and a backup, neither of which this
+    // server can do unattended. Surfaced for the integrity healthcheck to pick
+    // up (see docs/runbooks/blob-integrity.md).
+    log.error('FacilityBlobHealer: outbox blob is unrecoverable here and needs restoring', {
+      hash,
+      fault,
+    });
+  }
+
+  async #refetchFromCentral(hash) {
+    if (!this.#transferChannel) {
+      return false;
+    }
+    try {
+      // ignoreLocal, or the fetch would see the quarantined copy still occupying
+      // the hash and report the content already held.
+      await this.#transferChannel.fetchFromCentral(hash, { ignoreLocal: true });
+      return true;
+    } catch (error) {
+      log.debug('FacilityBlobHealer: central could not supply a replacement', {
+        hash,
+        error: error.message,
+      });
+      return false;
+    }
+  }
+}

--- a/packages/facility-server/app/blobIntegrity/index.js
+++ b/packages/facility-server/app/blobIntegrity/index.js
@@ -1,0 +1,1 @@
+export { FacilityBlobHealer } from './FacilityBlobHealer';

--- a/packages/facility-server/app/blobTransfer/BlobTransferChannel.js
+++ b/packages/facility-server/app/blobTransfer/BlobTransferChannel.js
@@ -97,9 +97,13 @@ export class BlobTransferChannel {
    * download resumes from the bytes already staged, including across calls
    * and restarts, and the complete content is verified against the hash
    * before it is admitted.
+   *
+   * spec: SCRUB — `ignoreLocal` fetches even though the hash is occupied, for
+   * the self-heal path replacing a copy that failed verification. The bad bytes
+   * are only dropped once the replacement has verified.
    */
-  async fetchFromCentral(hash) {
-    const held = await this.#blobStore.stat(hash);
+  async fetchFromCentral(hash, { ignoreLocal = false } = {}) {
+    const held = ignoreLocal ? null : await this.#blobStore.stat(hash);
     if (held) {
       return { hash, size: held.size, existed: true };
     }

--- a/packages/facility-server/app/setupSyncRuntime.js
+++ b/packages/facility-server/app/setupSyncRuntime.js
@@ -49,6 +49,9 @@ export async function setupSyncRuntime(context, { syncManager } = {}) {
     facilityIds: getServerFacilityIds() ?? [],
   });
   context.blobCache.setTransferChannel(context.blobTransferChannel);
+  // spec: SCRUB — central is the peer rung of the self-heal ladder, so the
+  // healer can only reach it once the sync runtime is up.
+  context.blobHealer.setTransferChannel(context.blobTransferChannel);
   context.blobOutboxPusher = new BlobOutboxPusher({
     models: context.models,
     transferChannel: context.blobTransferChannel,

--- a/packages/facility-server/app/tasks/BlobIntegrityScrubTask.js
+++ b/packages/facility-server/app/tasks/BlobIntegrityScrubTask.js
@@ -1,0 +1,26 @@
+import { ScheduledTask } from '@tamanu/shared/tasks';
+import { log } from '@tamanu/shared/services/logging';
+
+// spec: SCRUB
+// The facility's scheduled blob integrity scrub. Reads cold content that no
+// clinical workflow would otherwise touch, so corruption is found before the
+// day someone needs the file rather than on that day.
+export class BlobIntegrityScrubTask extends ScheduledTask {
+  getName() {
+    return 'BlobIntegrityScrubTask';
+  }
+
+  constructor(context) {
+    const { schedule, jitterTime, enabled } = context.schedules.blobIntegrityScrub;
+    super(schedule, log, jitterTime, enabled);
+    this.context = context;
+  }
+
+  async run() {
+    const { blobScrubber } = this.context;
+    if (!blobScrubber) {
+      return;
+    }
+    await blobScrubber.run();
+  }
+}

--- a/packages/facility-server/app/tasks/index.js
+++ b/packages/facility-server/app/tasks/index.js
@@ -12,6 +12,7 @@ import { getServerFacilityIds } from '../serverConfig';
 
 import { BedFeeCharger } from './BedFeeCharger';
 import { BlobCacheEvictorTask } from './BlobCacheEvictorTask';
+import { BlobIntegrityScrubTask } from './BlobIntegrityScrubTask';
 import { BlobOutboxPusherTask } from './BlobOutboxPusherTask';
 import { mSupplyMedIntegrationProcessor } from './mSupplyMedIntegrationProcessor';
 import { MSupplyStockOnHandProcessor } from './MSupplyStockOnHandProcessor';
@@ -26,6 +27,7 @@ const DEFAULT_TASK_CLASSES = [
   TimeSyncTask,
   BlobOutboxPusherTask,
   BlobCacheEvictorTask,
+  BlobIntegrityScrubTask,
   FhirMissingResources,
   FhirJobWorkerCleaner,
   FhirErroredJobCleaner,

--- a/packages/settings/src/schema/central.ts
+++ b/packages/settings/src/schema/central.ts
@@ -4,6 +4,7 @@ import { SETTING_EDITORS } from '@tamanu/constants';
 
 import {
   batchingProperties,
+  blobScrubProperties,
   cronExpressionSchema,
   durationStringSchema,
   dhis2IdSchemeSchema,
@@ -859,6 +860,12 @@ export const centralSettings = {
         surveyCompletionNotifierProcessor: scheduledTaskSchema(
           { schedule: '*/30 * * * * *' },
           limitProperty(100),
+        ),
+        // spec: SCRUB — central holds the authoritative copy of every blob, so
+        // its scrub is the one that finds loss nothing else can recover from
+        blobIntegrityScrub: scheduledTaskSchema(
+          { schedule: '17 * * * *', jitterTime: '5m' },
+          blobScrubProperties(),
         ),
         vaccinationReminderProcessor: scheduledTaskSchema({ schedule: '0 1 * * *' }),
         patientMergeMaintainer: scheduledTaskSchema({ schedule: '12 * * * *' }),

--- a/packages/settings/src/schema/definitions/index.ts
+++ b/packages/settings/src/schema/definitions/index.ts
@@ -7,6 +7,7 @@ export {
   cronExpressionSchema,
   scheduledTaskSchema,
   batchingProperties,
+  blobScrubProperties,
   limitProperty,
 } from './scheduledTask';
 export { LOCALISED_FIELD_TYPES, generateFieldSchema, displayIdFieldProperties } from './fields';

--- a/packages/settings/src/schema/definitions/scheduledTask.ts
+++ b/packages/settings/src/schema/definitions/scheduledTask.ts
@@ -71,6 +71,29 @@ export const batchingProperties = (
   },
 });
 
+// spec: SCRUB
+// Per-pass bounds for the blob integrity scrub. The scrub is incremental, so
+// these decide how quickly the store is covered rather than whether it is: a
+// pass takes the least-recently-scrubbed blobs until it hits either bound, and
+// the next pass carries on from wherever that left the population.
+export const blobScrubProperties = (): Record<string, Setting> => ({
+  maxBlobsPerPass: {
+    name: 'Blobs per pass',
+    description:
+      'Most blobs one scrub pass verifies. Together with the schedule this sets how long a full cycle of the store takes',
+    type: yup.number().integer().positive(),
+    defaultValue: 500,
+  },
+  maxGigabytesPerPass: {
+    name: 'Gigabytes per pass',
+    description:
+      'Most content one scrub pass reads. Verification is disk-read bound, so this is what keeps the scrub off the same IO the clinical workload needs',
+    type: yup.number().positive(),
+    defaultValue: 2,
+    unit: 'GB',
+  },
+});
+
 export const limitProperty = (limit: number): Record<string, Setting> => ({
   limit: {
     name: 'Limit',

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -8,6 +8,7 @@ import {
 import { extractDefaults } from './utils';
 import {
   batchingProperties,
+  blobScrubProperties,
   emailSchema,
   letterheadProperties,
   nationalityIdSchema,
@@ -241,6 +242,12 @@ export const facilitySettings = {
         // periodic backstop for the cache size budget; admission-time
         // enforcement does the routine work
         blobCacheEvictor: scheduledTaskSchema({ schedule: '23 * * * *' }),
+        // hourly and incremental: each pass takes the least-recently-scrubbed
+        // blobs, so the store is covered over many passes rather than one sweep
+        blobIntegrityScrub: scheduledTaskSchema(
+          { schedule: '41 * * * *', jitterTime: '5m' },
+          blobScrubProperties(),
+        ),
         fhirMissingResources: scheduledTaskSchema({ schedule: '48 1 * * *', enabled: false }),
         // Enabled even where the FHIR worker is not: a facility that once ran one
         // has rows to prune, and where none ever ran there is nothing to match.

--- a/packages/utils/src/blobs.ts
+++ b/packages/utils/src/blobs.ts
@@ -48,3 +48,26 @@ export function blobPathSegments(hash: string): [string, string, string, string]
   const { algorithm, digest } = parseBlobHash(hash);
   return [algorithm, digest.slice(0, 2), digest.slice(2, 4), digest.slice(4)];
 }
+
+// spec: SCRUB
+// The inverse of blobPathSegments, for walking the store's own contents: the
+// hash a stored file's location encodes, or null where the path is not a blob's.
+// The store root also holds the staging and temp directories, so anything that
+// does not reconstruct into a valid hash is simply not content.
+export function blobHashFromPathSegments(segments: string[]): string | null {
+  if (segments.length !== 4) {
+    return null;
+  }
+  const [algorithm, firstByte, secondByte, remainder] = segments;
+  try {
+    const hash = formatBlobHash(algorithm, `${firstByte}${secondByte}${remainder}`);
+    // Round-trip rather than trusting the parse alone: it confirms the fan-out
+    // split itself is right, so a file misplaced under another blob's
+    // directories is rejected instead of being adopted under a hash its
+    // location does not actually encode.
+    parseBlobHash(hash);
+    return blobPathSegments(hash).join('/') === segments.join('/') ? hash : null;
+  } catch {
+    return null;
+  }
+}

--- a/specs/blob-storage/integrity.md
+++ b/specs/blob-storage/integrity.md
@@ -35,6 +35,10 @@ be found.
   proactively repaired: a blob still awaiting upload or fetch (content-pending, see
   `transfer.md`), or a cache blob that has been evicted (durable on central and
   refetched on demand, see `facility-cache.md`).
+- [ ] Central separates the two by how long the reference has stood: push is
+  sync-first, so every reference is briefly ahead of its bytes, and a reference is
+  undelivered only once its record has been synchronised long enough that the
+  upload should have followed. Within that window it is content-pending.
 
 ## Registry reconciliation
 


### PR DESCRIPTION
### Changes

Implements the blob integrity spec (SCRUB) over the store, transfer and cache tiers already on `workhorse/b2`.

Bit rot on bare metal and NTFS is silent: nothing under the store notices a flipped bit, so a corrupt attachment is found the day a clinician opens it. This adds detection on every path and repair where a good copy exists.

**Detection.** A `BlobScrubber` runs three passes: verification (least-recently-scrubbed first, bounded per pass by blob count and bytes), reconciliation (walks the fan-out for bytes no registry row names), and referential integrity. `BlobStore.get()` now hashes while streaming and fails a whole-blob read that does not match.

**Repair.** The scrubber only detects; each server supplies a healer, because identical bytes mean different things. A facility grades on the existing tier: cache is dropped and refetched, outbox is quarantined and escalated since it may be the only copy. Central treats every copy as authoritative.

Two decisions worth a look:

- **Ranged reads are not verified.** Part of a blob cannot be checked against a hash of the whole, so they rely on receipt verification and the scrub. That is what keeps Bao deferred.
- **Central's peer healing is the offer route answering `wanted` for a quarantined hash**, not central fetching. It cannot reach a facility on demand and the spec rules out indexing what facilities hold, so repair rides a connection the facility makes anyway.

The spec left "delivered" undefined for central's referential check; this defines it as a reference standing longer than a delivery grace, since push is sync-first. It finds nothing until J2 or K2 register a reference source.

Migration is numbered clear of J2 (`1785830000000`) and K2 (`1785860000000`). No mobile migration: a device runs no scrub.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


