### PR TITLE
fix(medications): no-issue: show updated pharmacy note after a dispense modification

### DIFF
--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -1,4 +1,5 @@
 import { DataTypes, Op } from 'sequelize';
+import { keyBy } from 'es-toolkit/compat';
 import {
   type DrugUnit,
   NOTIFICATION_TYPES,
@@ -16,6 +17,13 @@ import { dateTimeType, type InitOptions, type Models } from '../types/model';
 import { EncounterPrescription } from './EncounterPrescription';
 import { isInpatientFeeBundled } from '../utils/isInpatientFeeBundled';
 import { buildEncounterLinkedLookupSelect } from '../sync/buildEncounterLinkedLookupFilter';
+
+export interface LatestModifiedDispense {
+  id: string;
+  pharmacyNotes: string | null;
+  displayPharmacyNotesInMar: boolean;
+  modifiedAt: string;
+}
 
 // Earliest time the encounter was an admission, from its history: the initial snapshot if it was
 // created as an admission, or the admit-in-place transition otherwise. Null if never an admission.
@@ -200,6 +208,35 @@ export class Prescription extends Model {
 
   static getListReferenceAssociations() {
     return ['medication', 'prescriber', 'discontinuingClinician'];
+  }
+
+  static async getLatestModifiedDispensesByPrescriptionId(
+    prescriptionIds: string[],
+  ): Promise<Record<string, LatestModifiedDispense>> {
+    if (!prescriptionIds.length) return {};
+
+    const [rows] = await this.sequelize!.query(
+      `
+      SELECT DISTINCT ON (pop.prescription_id)
+        pop.prescription_id,
+        md.id,
+        md.pharmacy_notes AS "pharmacyNotes",
+        md.display_pharmacy_notes_in_mar AS "displayPharmacyNotesInMar",
+        md.modified_at AS "modifiedAt"
+      FROM medication_dispenses md
+      INNER JOIN pharmacy_order_prescriptions pop ON pop.id = md.pharmacy_order_prescription_id
+      WHERE pop.prescription_id IN (:prescriptionIds)
+        AND md.modified_at IS NOT NULL
+        AND md.deleted_at IS NULL
+        AND pop.deleted_at IS NULL
+      ORDER BY pop.prescription_id, md.dispensed_at DESC
+      `,
+      { replacements: { prescriptionIds } },
+    );
+    return keyBy(
+      rows as (LatestModifiedDispense & { prescription_id: string })[],
+      'prescription_id',
+    );
   }
 
   static buildPatientSyncFilter(patientCount: number, markedForSyncPatientsTable: string) {

--- a/packages/facility-server/__tests__/apiv1/Medication.test.js
+++ b/packages/facility-server/__tests__/apiv1/Medication.test.js
@@ -856,6 +856,48 @@ describe('Medication', () => {
       expect(afterRow.latestModifiedDispense.displayPharmacyNotesInMar).toBe(true);
     });
 
+    it('should expose the latest modified fill on the single medication endpoint', async () => {
+      const { pharmacyOrderPrescription, prescription } =
+        await createPharmacyOrderWithPrescription({ patientId: patient.id });
+      const modifyReason = await models.ReferenceData.create(
+        fake(models.ReferenceData, { type: REFERENCE_TYPES.MEDICATION_DISPENSE_MODIFY_REASON }),
+      );
+
+      const before = await app.get(`/api/medication/${prescription.id}`);
+      expect(before).toHaveSucceeded();
+      expect(before.body.latestModifiedDispense).toBeNull();
+
+      const dispenseResult = await app.post('/api/medication/dispense').send({
+        dispensedByUserId: app.user.id,
+        facilityId,
+        items: [
+          {
+            pharmacyOrderPrescriptionId: pharmacyOrderPrescription.id,
+            quantity: 10,
+            instructions: 'Modified label',
+            modification: buildModification({
+              medicationId: prescription.medicationId,
+              modifiedReasonId: modifyReason.id,
+              modifiedById: app.user.id,
+            }),
+          },
+        ],
+      });
+      expect(dispenseResult).toHaveSucceeded();
+
+      const after = await app.get(`/api/medication/${prescription.id}`);
+      expect(after).toHaveSucceeded();
+      expect(after.body.latestModifiedDispense.id).toBe(dispenseResult.body[0].id);
+      expect(after.body.latestModifiedDispense.pharmacyNotes).toBe(
+        'This prescription has been modified by pharmacy when dispensing.',
+      );
+      expect(after.body.latestModifiedDispense.displayPharmacyNotesInMar).toBe(true);
+
+      // The prescription's own pharmacyNotes must remain untouched
+      const reloaded = await models.Prescription.findByPk(prescription.id);
+      expect(reloaded.pharmacyNotes ?? null).toBe(prescription.pharmacyNotes ?? null);
+    });
+
     it('should reject a modification with a duration value but no unit', async () => {
       const { pharmacyOrderPrescription, prescription } =
         await createPharmacyOrderWithPrescription({ patientId: patient.id });

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -543,28 +543,9 @@ encounterRelations.get(
       );
       const lastOrderedAts = keyBy(lastOrderedRows, 'prescription_id');
 
-      // The most recent pharmacy-modified fill per prescription, so the MAR can show the
-      // modification's pharmacy note and a "View change" link. The original prescription is
-      // never altered by dispensing modifications; the modified details live on the dispense.
-      const [latestModifiedDispenseRows] = await db.query(
-        `
-        SELECT DISTINCT ON (pop.prescription_id)
-          pop.prescription_id,
-          md.id,
-          md.pharmacy_notes AS "pharmacyNotes",
-          md.display_pharmacy_notes_in_mar AS "displayPharmacyNotesInMar",
-          md.modified_at AS "modifiedAt"
-        FROM medication_dispenses md
-        INNER JOIN pharmacy_order_prescriptions pop ON pop.id = md.pharmacy_order_prescription_id
-        WHERE pop.prescription_id IN (:prescriptionIds)
-          AND md.modified_at IS NOT NULL
-          AND md.deleted_at IS NULL
-          AND pop.deleted_at IS NULL
-        ORDER BY pop.prescription_id, md.dispensed_at DESC
-      `,
-        { replacements: { prescriptionIds } },
+      const latestModifiedDispenses = await Prescription.getLatestModifiedDispensesByPrescriptionId(
+        prescriptionIds,
       );
-      const latestModifiedDispenses = keyBy(latestModifiedDispenseRows, 'prescription_id');
 
       responseData = responseData.map(p => ({
         ...p,

--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -2757,7 +2757,12 @@ const buildDispensedDetails = (item, prescription, unitsByMedicationId, dispense
 // Notifies the original prescriber about modified fills (the pharmacy note hint in the modal
 // promises this). With the prescription untouched, the Prescription.afterUpdate pharmacy-note hook
 // never fires, so push the notification explicitly.
-const notifyPrescriberOfModifications = async (items, prescriptionsByPopId, models, transaction) => {
+const notifyPrescriberOfModifications = async (
+  items,
+  prescriptionsByPopId,
+  models,
+  transaction,
+) => {
   for (const item of items) {
     if (!item.modification) continue;
     const prescription = prescriptionsByPopId.get(item.pharmacyOrderPrescriptionId);
@@ -3063,6 +3068,13 @@ medication.get(
       });
     }
 
-    res.send(object);
+    const latestModifiedDispenses = await Prescription.getLatestModifiedDispensesByPrescriptionId([
+      object.id,
+    ]);
+
+    res.send({
+      ...object.forResponse(),
+      latestModifiedDispense: latestModifiedDispenses[object.id] ?? null,
+    });
   }),
 );

--- a/packages/web/app/components/Medication/MedicationDetails.jsx
+++ b/packages/web/app/components/Medication/MedicationDetails.jsx
@@ -24,9 +24,9 @@ import {
   Field,
   Form,
   FormGrid,
+  MultilineTextField,
   NumberField,
   OutlinedButton,
-  TextField,
   TimeDisplay,
   TimeRangeDisplay,
   TranslatedEnum,
@@ -41,6 +41,7 @@ import { Colors } from '../../constants/styles';
 import { useAuth } from '../../contexts/Auth';
 import { useEncounter } from '../../contexts/Encounter';
 import { singularize } from '../../utils';
+import { getDisplayedPharmacyNote } from '../../utils/medications';
 import { preventInvalidRepeatsInput } from '../../utils/utils';
 import { CheckField } from '../Field';
 import { FormModal } from '../FormModal';
@@ -48,6 +49,7 @@ import { NoteModalActionBlocker } from '../NoteModalActionBlocker';
 import { MedicationDiscontinueModal } from './MedicationDiscontinueModal';
 import { MedicationPauseModal } from './MedicationPauseModal';
 import { MedicationResumeModal } from './MedicationResumeModal';
+import { PrescriptionChangeHistoryModal } from './PrescriptionChangeHistoryModal';
 
 const StyledFormModal = styled(FormModal)`
   .MuiPaper-root {
@@ -95,6 +97,19 @@ const PausedText = styled(Box)`
   color: ${Colors.primary};
 `;
 
+const ChangeLogLink = styled.a`
+  color: ${Colors.primary};
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 export const MedicationDetails = ({
   initialMedication,
   onClose,
@@ -115,7 +130,10 @@ export const MedicationDetails = ({
   const [openDiscontinueModal, setOpenDiscontinueModal] = useState(false);
   const [openPauseModal, setOpenPauseModal] = useState(false);
   const [openResumeModal, setOpenResumeModal] = useState(false);
+  const [showChangeHistoryModal, setShowChangeHistoryModal] = useState(false);
   const [medication, setMedication] = useState(initialMedication);
+
+  const { modifiedPharmacyNote } = getDisplayedPharmacyNote(medication);
 
   const { data, refetch: refetchPauseData } = usePausePrescriptionQuery(
     {
@@ -277,8 +295,10 @@ export const MedicationDetails = ({
         formType={FORM_TYPES.EDIT_FORM}
         validationSchema={validationSchema}
         initialValues={{
-          pharmacyNotes: medication.pharmacyNotes,
-          displayPharmacyNotesInMar: medication.displayPharmacyNotesInMar,
+          pharmacyNotes: modifiedPharmacyNote ?? medication.pharmacyNotes,
+          displayPharmacyNotesInMar: modifiedPharmacyNote
+            ? medication.latestModifiedDispense.displayPharmacyNotesInMar
+            : medication.displayPharmacyNotesInMar,
           repeats: medication.repeats ?? 0,
         }}
         render={values => (
@@ -454,7 +474,7 @@ export const MedicationDetails = ({
                           fallback="Pharmacy notes"
                         />
                       }
-                      component={TextField}
+                      component={MultilineTextField}
                       disabled={
                         !canCreateMedicationPharmacyNote ||
                         (!canUpdateMedicationPharmacyNote && values.pharmacyNotes) ||
@@ -466,22 +486,34 @@ export const MedicationDetails = ({
                   </NoteModalActionBlocker>
                 </div>
                 {!medication.discontinued && !isPausing && !isOngoingPrescription && (
-                  <div style={{ gridColumn: '1/-1', marginTop: '-12px' }}>
-                    <NoteModalActionBlocker>
-                      <Field
-                        name="displayPharmacyNotesInMar"
-                        label={
-                          <MidText color={`${Colors.darkText} !important`}>
-                            <TranslatedText
-                              stringId="medication.details.displayInMarInstructions"
-                              fallback="Display pharmacy notes on MAR"
-                            />
-                          </MidText>
-                        }
-                        component={CheckField}
-                        disabled={!canCreateMedicationPharmacyNote}
-                      />
-                    </NoteModalActionBlocker>
+                  <div style={{ gridColumn: '1/-1', marginTop: '-16px' }}>
+                    <Box display="flex" justifyContent="space-between" alignItems="center">
+                      <NoteModalActionBlocker>
+                        <Field
+                          name="displayPharmacyNotesInMar"
+                          label={
+                            <MidText color={`${Colors.darkText} !important`}>
+                              <TranslatedText
+                                stringId="medication.details.displayInMarInstructions"
+                                fallback="Display pharmacy notes on MAR"
+                              />
+                            </MidText>
+                          }
+                          component={CheckField}
+                          disabled={
+                            !canCreateMedicationPharmacyNote || Boolean(modifiedPharmacyNote)
+                          }
+                        />
+                      </NoteModalActionBlocker>
+                      {modifiedPharmacyNote && (
+                        <ChangeLogLink onClick={() => setShowChangeHistoryModal(true)}>
+                          <TranslatedText
+                            stringId="medication.mar.viewChange"
+                            fallback="View change"
+                          />
+                        </ChangeLogLink>
+                      )}
+                    </Box>
                   </div>
                 )}
               </FormGrid>
@@ -663,6 +695,12 @@ export const MedicationDetails = ({
                 onClose={() => setOpenResumeModal(false)}
               />
             )}
+
+            <PrescriptionChangeHistoryModal
+              open={showChangeHistoryModal}
+              dispenseId={medication.latestModifiedDispense?.id}
+              onClose={() => setShowChangeHistoryModal(false)}
+            />
           </>
         )}
       />


### PR DESCRIPTION
### Changes

When a prescription is modified during dispensing, the up-to-date pharmacy note is stored on the dispense rather than the prescription (which is deliberately never altered by a dispensing modification). Neither the ''Pharmacy note'' notification-click flow nor opening ''Medication details'' from the encounter medications table surfaced this to the original prescriber:\n- GET /medication/:id (used by the notification-click flow) never fetched the modification data at all.\n- The Medication details modal only ever read the prescription'''s own (stale) pharmacyNotes field, even when the encounter medications list endpoint already returned the modification data correctly.\n\nThis PR pre-fills the pharmacy notes field and its ''Display on MAR'' checkbox from the latest modified dispense when one exists, disables that checkbox in that case (mirroring the pharmacist'''s own modify-during-dispense form, where it'''s always true and read-only), and adds a ''View change'' link to see the full modification history (medication substitution, dose, frequency, etc.) via the existing PrescriptionChangeHistoryModal.\n\nAlso extracted the latest-modified-dispense SQL query, previously duplicated between the encounter medications list and the single medication endpoint, into a shared Prescription.getLatestModifiedDispensesByPrescriptionId model method.\n\nAdded a backend test confirming GET /medication/:id now exposes latestModifiedDispense correctly.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows VHDX; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->