### PR TITLE
fix(sync): batch changelog insertion, avoiding OOM during persist phase

### DIFF
--- a/packages/database/src/utils/audit/insertChangelogRecords.ts
+++ b/packages/database/src/utils/audit/insertChangelogRecords.ts
@@ -1,25 +1,43 @@
+import config from 'config';
+import type { BulkCreateOptions, InferAttributes } from 'sequelize';
+
+import { runFunctionInBatches } from '@tamanu/utils/runFunctionInBatches';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
 import type { ChangeLog } from 'models/ChangeLog';
 import type { Models } from 'types/model';
 
-export const insertChangelogRecords = async (models: Models, changelogRecords: ChangeLog[]) => {
+type ChangeLogAttributes = InferAttributes<ChangeLog>;
+
+const { pauseBetweenPersistedCacheBatchesInMilliseconds, persistedCacheBatchSize } = config.sync;
+
+const bulkCreateOptions = {
+  /** Entries are immutable, so re-delivered records are skipped rather than merged */
+  ignoreDuplicates: true,
+  returning: false,
+} as const satisfies BulkCreateOptions<ChangeLogAttributes>;
+
+/**
+ * `logs.changes` records carry a full copy of the record in `record_data`. Keep batches small to
+ * small to avoid building one enormous `INSERT` query in memory.
+ */
+export const insertChangelogRecords = async (
+  models: Models,
+  changelogRecords: ChangeLogAttributes[],
+  batchSize = persistedCacheBatchSize,
+) => {
+  if (!changelogRecords.length) return;
+
   const { ChangeLog } = models;
 
-  if (!changelogRecords.length) {
-    return;
-  }
-
-  const existingRecords = await ChangeLog.findAll({
-    where: {
-      id: changelogRecords.map(({ id }) => id),
+  await runFunctionInBatches(
+    changelogRecords,
+    async batch => {
+      await ChangeLog.bulkCreate(batch, bulkCreateOptions);
+      await sleepAsync(pauseBetweenPersistedCacheBatchesInMilliseconds);
+      // Result of this `runFunctionInBatches` is unused anyway; let the `bulkCreate` results get
+      // garbage collected. Returning empty array simply for type safety.
+      return [];
     },
-  });
-
-  const existingIds = existingRecords.map(({ id }) => id);
-  const recordsToInsert = changelogRecords
-    .filter(({ id }) => !existingIds.includes(id))
-    .map((changelogRecord) => ({
-      ...changelogRecord,
-    }));
-
-  await ChangeLog.bulkCreate(recordsToInsert);
+    batchSize,
+  );
 };

--- a/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
+++ b/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
@@ -117,4 +117,56 @@ describe('insertChangelogRecords', () => {
       version: '1.0.3',
     });
   });
+
+  const buildChangelogRecord = n => ({
+    id: `00000000-0000-4000-8000-${`${n}`.padStart(12, '0')}`,
+    tableOid: 1234,
+    tableSchema: 'public',
+    tableName: 'patients',
+    loggedAt: new Date(),
+    recordCreatedAt: new Date(),
+    recordUpdatedAt: new Date(),
+    updatedByUserId: SYSTEM_USER_UUID,
+    recordId: `${n}`,
+    recordData: { first_name: `Patient ${n}` },
+    deviceId: `test-device-id-${n}`,
+    version: '1.0.0',
+  });
+
+  it('should insert all records when they span multiple batches', async () => {
+    // Arrange - 5 records with a batch size of 2 means 3 insert batches
+    const changelogRecords = [1, 2, 3, 4, 5].map(buildChangelogRecord);
+
+    // Act
+    await insertChangelogRecords(models, changelogRecords, 2);
+
+    // Assert
+    const results = await models.ChangeLog.findAll({ order: [['recordId', 'ASC']] });
+    expect(results).toHaveLength(5);
+    expect(results.map(r => r.recordId)).toEqual(['1', '2', '3', '4', '5']);
+  });
+
+  it('should skip duplicates in any batch while inserting the rest', async () => {
+    // Arrange - existing records that will fall into different insert batches
+    await models.ChangeLog.bulkCreate([buildChangelogRecord(1), buildChangelogRecord(4)]);
+
+    const changelogRecords = [1, 2, 3, 4, 5].map(n => ({
+      ...buildChangelogRecord(n),
+      recordData: { first_name: `Patient ${n} Updated` },
+    }));
+
+    // Act
+    await insertChangelogRecords(models, changelogRecords, 2);
+
+    // Assert
+    const results = await models.ChangeLog.findAll({ order: [['recordId', 'ASC']] });
+    expect(results).toHaveLength(5);
+    // Existing entries are immutable so the re-delivered versions are skipped
+    expect(results.find(r => r.recordId === '1').recordData).toEqual({ first_name: 'Patient 1' });
+    expect(results.find(r => r.recordId === '4').recordData).toEqual({ first_name: 'Patient 4' });
+    // New entries are inserted as delivered
+    expect(results.find(r => r.recordId === '2').recordData).toEqual({
+      first_name: 'Patient 2 Updated',
+    });
+  });
 });


### PR DESCRIPTION
### Changes

Cherry-pick of #10702 onto release\/2.55. Batches changelog insertion during the sync persist phase to avoid out-of-memory errors on large syncs.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->