### PR TITLE
fix(cd): no-issue: windows esm migration loader

### DIFF
--- a/common.jest.config.mjs
+++ b/common.jest.config.mjs
@@ -1,4 +1,10 @@
+import { fileURLToPath } from 'node:url';
+
 export const isCI = !!process.env.CI;
+
+// Teaches jest's resolver to accept file:// URLs, which production code must pass to
+// `import()` for absolute paths to work on Windows. See jest.resolver.cjs.
+const fileUrlAwareResolver = fileURLToPath(new URL('./jest.resolver.cjs', import.meta.url));
 
 // ESM-only dependencies that ship no CommonJS entry, so jest (which runs CJS)
 // must transform them rather than ignore them with the rest of node_modules.
@@ -29,6 +35,8 @@ export function config(importMeta, overrides = {}, { transformNodeModules = [] }
     setupFiles: ['<rootDir>/__tests__/setup.js'],
     testRegex: '(\\.|/)(test|spec)\\.[jt]sx?$',
     collectCoverageFrom: ['src/**/*.[jt]sx?'],
+
+    resolver: fileUrlAwareResolver,
 
     maxWorkers: isCI ? '50%' : '25%',
 

--- a/jest.resolver.cjs
+++ b/jest.resolver.cjs
@@ -1,0 +1,12 @@
+const { fileURLToPath } = require('node:url');
+
+// jest resolves filesystem paths, but ESM specifiers may legitimately be file:// URLs — code
+// that dynamically imports an absolute path has to pass one, because on Windows a bare `C:\…`
+// is read as a URL with scheme `c:` (see the migration resolver in @tamanu/database). Under
+// jest those modules are transpiled to CommonJS, so the import becomes a require and lands
+// here; hand the default resolver the path it expects.
+module.exports = (request, options) =>
+  options.defaultResolver(
+    request.startsWith('file://') ? fileURLToPath(request) : request,
+    options,
+  );

--- a/packages/central-server/app/index.js
+++ b/packages/central-server/app/index.js
@@ -31,7 +31,7 @@ import { closeDatabase } from './database';
 const hiddenCommands = ['migrateNotePagesToNotesCommand', 'removeDuplicatedDischargesCommand'];
 
 async function run() {
-  program.version(version).description('Tamanu Central server').name('node dist');
+  program.version(version).description('Tamanu Central server').name('node --import tsx app');
 
   for (const [key, command] of Object.entries(cmd).filter(([k]) => /^\w+Command$/.test(k))) {
     const hidden = hiddenCommands.includes(key);

--- a/packages/database/src/services/migrations/migrations.js
+++ b/packages/database/src/services/migrations/migrations.js
@@ -1,5 +1,6 @@
 import { readdirSync } from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import Umzug from 'umzug';
 import { QueryTypes } from 'sequelize';
 import { runPostMigration, runPreMigration } from './hooks';
@@ -241,7 +242,9 @@ export async function createMigrationInterface(log, sequelize, options = {}) {
       },
 
       customResolver: async (sqlPath) => {
-        const migrationImport = await import(sqlPath);
+        // umzug hands us an absolute filesystem path, but ESM only imports file:// URLs: on
+        // Windows a bare `C:\…` is read as a URL with scheme `c:` and rejected outright.
+        const migrationImport = await import(pathToFileURL(sqlPath).href);
         const migration = 'default' in migrationImport ? migrationImport.default : migrationImport;
 
         if (!('up' in migration)) {

--- a/packages/facility-server/app/index.js
+++ b/packages/facility-server/app/index.js
@@ -30,7 +30,7 @@ import {
 } from './subCommands';
 
 async function run() {
-  program.version(version).description('Tamanu Facility server').name('node dist');
+  program.version(version).description('Tamanu Facility server').name('node --import tsx app');
 
   program.addCommand(startAllCommand, { isDefault: true });
   program.addCommand(startApiCommand);

--- a/packages/upgrade/src/listSteps.ts
+++ b/packages/upgrade/src/listSteps.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { basename, extname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import toposort from 'toposort';
 import type { MigrationStr, Step, Steps, StepStr } from './step.ts';
 import { START, END, MIGRATION_PREFIX, onlyMigrations } from './step.js';
@@ -115,7 +116,9 @@ export async function orderSteps(steps: ResolvedStep[], migrations: MigrationStr
 
 async function readStep(file: string) {
   const stepfile = basename(file, extname(file));
-  const { STEPS }: { STEPS: Steps } = await import(join(STEPS_DIR, file));
+  // file:// URL rather than the bare path, as ESM rejects a Windows `C:\…` path (see the
+  // migration resolver in @tamanu/database for the same constraint).
+  const { STEPS }: { STEPS: Steps } = await import(pathToFileURL(join(STEPS_DIR, file)).href);
   return STEPS.map((step, i) => ({
     id: `upgrade/${stepfile}/${i}` as StepStr,
     file,


### PR DESCRIPTION
* fix(migrations): no-issue: import migration and upgrade-step files by file URL (hotfix 2.60)

Both the umzug customResolver and the upgrade-step reader dynamically imported an absolute filesystem path. ESM only accepts file:// URLs, so on Windows a path like C:\Tamanu\release-v2.60.6\... is parsed as a URL with scheme `c:` and rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME, failing every migration on the first file.

This never surfaced before because the servers ran a built dist whose CommonJS half turned these into require() calls, which accept Windows paths; they now run from TypeScript source under tsx, so both call sites are genuine ESM.

Wrapping the path in pathToFileURL() is a no-op for the POSIX paths CI and Linux deployments pass today.



* fix(servers): no-issue: correct the CLI usage string after the build-less switch (hotfix 2.60)

Both servers still announced themselves as `node dist`, so every --help printed an invocation that no longer exists: they run from TypeScript source under tsx now, and `dist` is never built. Operators following the usage string reach for `node dist migrate` and get nothing.



---------

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
