### PR TITLE
ci(seedSnapshot): no-issue: surface a failing pod lookup in the seed watch

### DIFF
--- a/.github/workflows/seed-snapshot.yml
+++ b/.github/workflows/seed-snapshot.yml
@@ -184,6 +184,7 @@ jobs:
           }
 
           settle_deadline=
+          list_errors=0
           hard_deadline=$((SECONDS + START_TIMEOUT_SECONDS + SETTLE_SECONDS))
           while (( SECONDS < hard_deadline )); do
             if [[ "$(kubectl get job "$JOB_NAME" -n "$SEED_NAMESPACE" \
@@ -193,10 +194,20 @@ jobs:
             fi
 
             # `items[*]` rather than `items[0]`: the latter errors while the Job is still
-            # suspended and no pod exists.
-            pod=$(kubectl get pods -n "$SEED_NAMESPACE" \
+            # suspended and no pod exists. A query that cannot run at all must not read as
+            # "no pod yet", or the watch sits here for the whole timeout saying nothing.
+            if ! pod=$(kubectl get pods -n "$SEED_NAMESPACE" \
               -l "batch.kubernetes.io/job-name=$JOB_NAME" \
-              -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | awk '{print $1}')
+              -o jsonpath='{.items[*].metadata.name}'); then
+              list_errors=$((list_errors + 1))
+              if (( list_errors >= 3 )); then
+                fail "" "Cannot list pods in $SEED_NAMESPACE; no snapshot for $VERSION."
+              fi
+              sleep 10
+              continue
+            fi
+            list_errors=0
+            pod=${pod%% *}
 
             status=
             if [[ -n "$pod" ]]; then


### PR DESCRIPTION
### Changes

The seed watch polls for the Job's pod with `kubectl get pods -l ... 2>/dev/null`. A query that cannot run at all is indistinguishable from "no pod yet", so at the 2.62 cut it spun silently for the full 21 minutes and reported "had not started in time" while the seed had in fact been running since 51 seconds in. CI has no pods permission in `tamanu-seed` (ops#: separate RoleBinding fix), and the error went to /dev/null.

Errors are no longer suppressed. Three consecutive failed lookups fail the step with the underlying kubectl message, so a permission or connectivity problem shows up in ~30s instead of at the timeout, while a single API blip still rides through. `${pod%% *}` replaces the awk for picking the first match.

The step is still `continue-on-error`, so this can only ever add an annotation, never fail a release cut.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->