### PR TITLE
fix(fhir): no-issue: use settings reader for resolver lock timeout

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/resolver.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/resolver.test.js
@@ -269,9 +269,9 @@ describe(`FHIR reference resolution`, () => {
           transaction: blockingTransaction,
         });
 
-        await expect(
-          FhirServiceRequest.resolveUpstreams({ lockTimeoutMs: 100 }),
-        ).rejects.toThrow(/lock timeout/i);
+        await expect(FhirServiceRequest.resolveUpstreams({ lockTimeoutMs: 100 })).rejects.toThrow(
+          /lock timeout/i,
+        );
       } finally {
         await blockingTransaction.rollback();
       }

--- a/packages/central-server/__tests__/tasks/fhir/resolver.test.js
+++ b/packages/central-server/__tests__/tasks/fhir/resolver.test.js
@@ -1,11 +1,21 @@
 /**
- * Tests for sortResourcesInDependencyOrder (source: @tamanu/shared/tasks).
- * Run here in central-server so we avoid a circular devDependency between shared and database.
+ * Tests for sortResourcesInDependencyOrder and the resolver job entrypoint
+ * (source: @tamanu/shared/tasks). Run here in central-server so we avoid a
+ * circular devDependency between shared and database.
  */
+import { fake } from '@tamanu/fake-data/fake';
+import { log } from '@tamanu/shared/services/logging';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
-import { sortResourcesInDependencyOrder } from '@tamanu/shared/tasks';
+import { resolver, sortResourcesInDependencyOrder } from '@tamanu/shared/tasks';
 import { createTestContext } from '../../utilities';
+import { fakeResourcesOfFhirServiceRequest } from '../../fake/fhir';
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
+
+// Mock out sleepAsync so we don't have to wait for the resolver's built-in delay.
+const sleepAsyncMock = jest.fn();
+jest.mock('@tamanu/utils/sleepAsync', () => ({
+  sleepAsync: ms => sleepAsyncMock(ms),
+}));
 
 describe('sortResourcesInDependencyOrder', () => {
   let ctx;
@@ -36,5 +46,45 @@ describe('sortResourcesInDependencyOrder', () => {
       'FhirServiceRequest',
       'FhirMedicationRequest',
     ]);
+  });
+});
+
+describe('resolver job', () => {
+  let ctx;
+  let resources;
+
+  beforeAll(async () => {
+    ctx = await createTestContext({ initFhir: true });
+    resources = await fakeResourcesOfFhirServiceRequest(ctx.store.models);
+  });
+
+  afterAll(() => ctx.close());
+
+  it('runs end-to-end using the settings reader, resolving materialised resources', async () => {
+    const {
+      FhirServiceRequest,
+      FhirEncounter,
+      FhirOrganization,
+      FhirPractitioner,
+      ImagingRequest,
+    } = ctx.store.models;
+
+    const ir = await ImagingRequest.create(
+      fake(ImagingRequest, {
+        requestedById: resources.practitioner.id,
+        encounterId: resources.encounter.id,
+        locationGroupId: resources.locationGroup.id,
+      }),
+    );
+    const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+    await FhirOrganization.materialiseFromUpstream(resources.facility.id);
+    await FhirEncounter.materialiseFromUpstream(resources.encounter.id);
+    await FhirPractitioner.materialiseFromUpstream(resources.practitioner.id);
+    expect(mat.resolved).toBe(false);
+
+    await resolver(undefined, { log, models: ctx.store.models, settings: ctx.settings });
+
+    await mat.reload();
+    expect(mat.resolved).toBe(true);
   });
 });

--- a/packages/shared/src/tasks/fhir/FhirTopicQueueProcessor.js
+++ b/packages/shared/src/tasks/fhir/FhirTopicQueueProcessor.js
@@ -118,6 +118,7 @@ export class FhirTopicQueueProcessor {
                   log: this.manager.log.child({ topic: this.topic, jobId: job.id }),
                   models: this.manager.models,
                   sequelize: this.manager.sequelize,
+                  settings: this.manager.settings,
                 }),
               );
             } catch (workErr) {

--- a/packages/shared/src/tasks/fhir/resolver.js
+++ b/packages/shared/src/tasks/fhir/resolver.js
@@ -39,7 +39,7 @@ export const sortResourcesInDependencyOrder = resources => {
   return sorted;
 };
 
-export async function resolver(_, { log, models }) {
+export async function resolver(_, { log, models, settings }) {
   await sleepAsync(3000); // sleep for 3 seconds to allow materialisation jobs to complete
 
   const materialisableResources = resourcesThatCanDo(
@@ -51,7 +51,7 @@ export async function resolver(_, { log, models }) {
   // bulk update) would otherwise sit in 'Started' forever: its worker keeps
   // heartbeating, so no other worker reclaims the job and it never errors. Bound
   // each record's lock waits so the job fails (and retries) instead of stalling.
-  const lockTimeoutMs = ms(await models.Setting.get('fhir.worker.resolverLockTimeout'));
+  const lockTimeoutMs = ms(await settings.get('fhir.worker.resolverLockTimeout'));
 
   log.debug('Starting resolve');
   // Resources are resolved in dependency order so referenced resources are


### PR DESCRIPTION
### Changes

The fhir.resolver job could sit in `Started` for hours when blocked on a lock held elsewhere (e.g. a sync session or another FHIR job touching the same row). A prior fix bounded that wait with a configurable `fhir.worker.resolverLockTimeout` lock_timeout, but it read the setting via `models.Setting.get()` — a raw DB lookup that does not fall back to the settings schema default. Since that setting is never seeded, every resolver run got `undefined` and `ms(undefined)` threw immediately, so the lock-timeout protection never actually took effect.\n\nThis threads the proper settings reader (the one already used correctly for `fhir.worker.heartbeat`/`concurrency`) through to FHIR job handlers, and switches resolver.js to use it. Adds a regression test that runs the resolver job entrypoint end-to-end (previously untested) plus a test confirming the lock-timeout error path.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->