### PR TITLE
db: no-issue: add partial index for unresolved fhir resources

### DIFF
--- a/packages/database/src/migrations/1786347983207-addUnresolvedFhirResourceIndex.ts
+++ b/packages/database/src/migrations/1786347983207-addUnresolvedFhirResourceIndex.ts
@@ -1,0 +1,41 @@
+import { QueryInterface } from 'sequelize';
+
+// FHIR resource tables (fhir.* schema) that carry the resolved/last_updated columns
+// the resolver job scans. Not sync-tracked (syncDirection: DO_NOT_SYNC), so no
+// sync_lookup rebuild is needed here.
+const TABLES = [
+  'encounters',
+  'immunizations',
+  'medication_requests',
+  'non_fhir_medici_report',
+  'organizations',
+  'patients',
+  'practitioners',
+  'service_requests',
+  'specimens',
+];
+
+const indexName = (table: string) => `${table}_unresolved_last_updated`;
+
+export async function up(query: QueryInterface): Promise<void> {
+  // The resolver job repeatedly scans for resolved = false (see
+  // FhirResource.resolveUpstreams); without this, every scan is a full sequential
+  // scan of the whole table. Partial on resolved = false so the index stays small
+  // even though most rows are resolved.
+  for (const table of TABLES) {
+    await query.addIndex(
+      { schema: 'fhir', tableName: table },
+      {
+        name: indexName(table),
+        fields: ['last_updated'],
+        where: { resolved: false },
+      },
+    );
+  }
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  for (const table of TABLES) {
+    await query.removeIndex({ schema: 'fhir', tableName: table }, indexName(table));
+  }
+}


### PR DESCRIPTION
### Changes

Adds a partial index (`WHERE resolved = false`) on `last_updated` for each FHIR resource table with a `resolved` column. `FhirResource.resolveUpstreams()` (used by the `fhir.resolver` job) scans for `resolved = false` rows every run with no supporting index, so it's currently a full sequential scan of the whole table. The index stays small even on large tables since it only covers the unresolved subset, which is normally a small fraction of rows.\n\nSplit out from a related resolver-hang investigation (see #10734) since it's an independent, standalone improvement.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->