### PR TITLE
fix(fhir): no-issue: stop resolver stalling on lock waits (hotfix 2.55)

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/resolver.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/resolver.test.js
@@ -243,6 +243,40 @@ describe(`FHIR reference resolution`, () => {
       );
     });
 
+    it('fails fast when a row lock is held elsewhere, rather than stalling indefinitely', async () => {
+      // arrange: an unresolved resource that resolveUpstreams will try to rematerialise
+      const { FhirServiceRequest, ImagingRequest } = ctx.store.models;
+      const { sequelize } = ctx.store;
+      const ir = await ImagingRequest.create(
+        fake(ImagingRequest, {
+          requestedById: resources.practitioner.id,
+          encounterId: resources.encounter.id,
+          locationGroupId: resources.locationGroup.id,
+        }),
+      );
+      const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+      expect(mat.resolved).toBe(false);
+
+      // Hold a row lock on the materialised resource from a separate transaction so
+      // the rematerialisation UPDATE inside resolveUpstreams cannot acquire it. This
+      // simulates a resolver blocked on a lock held elsewhere (e.g. a long sync
+      // session). Without a lock timeout the job would sit in 'Started' forever; with
+      // one it errors and is retried instead.
+      const blockingTransaction = await sequelize.transaction();
+      try {
+        await sequelize.query('SELECT id FROM fhir.service_requests WHERE id = $id FOR UPDATE', {
+          bind: { id: mat.id },
+          transaction: blockingTransaction,
+        });
+
+        await expect(
+          FhirServiceRequest.resolveUpstreams({ lockTimeoutMs: 100 }),
+        ).rejects.toThrow(/lock timeout/i);
+      } finally {
+        await blockingTransaction.rollback();
+      }
+    });
+
     describe('circular dependencies', () => {
       it('can resolve resources with a circular dependency for merged patients', async () => {
         // arrange

--- a/packages/central-server/__tests__/tasks/fhir/resolver.test.js
+++ b/packages/central-server/__tests__/tasks/fhir/resolver.test.js
@@ -1,7 +1,16 @@
+import { fake } from '@tamanu/fake-data/fake';
+import { log } from '@tamanu/shared/services/logging';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
-import { sortResourcesInDependencyOrder } from '../../../dist/tasks/fhir/resolver';
+import { resolver, sortResourcesInDependencyOrder } from '../../../dist/tasks/fhir/resolver';
 import { createTestContext } from '../../utilities';
+import { fakeResourcesOfFhirServiceRequest } from '../../fake/fhir';
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
+
+// Mock out sleepAsync so we don't have to wait for the resolver's built-in delay.
+const sleepAsyncMock = jest.fn();
+jest.mock('@tamanu/utils/sleepAsync', () => ({
+  sleepAsync: ms => sleepAsyncMock(ms),
+}));
 
 describe('sortResourcesInDependencyOrder', () => {
   let ctx;
@@ -31,5 +40,45 @@ describe('sortResourcesInDependencyOrder', () => {
       'FhirImmunization',
       'FhirServiceRequest',
     ]);
+  });
+});
+
+describe('resolver job', () => {
+  let ctx;
+  let resources;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    resources = await fakeResourcesOfFhirServiceRequest(ctx.store.models);
+  });
+
+  afterAll(() => ctx.close());
+
+  it('runs end-to-end, defaulting the lock timeout when unset, resolving materialised resources', async () => {
+    const {
+      FhirServiceRequest,
+      FhirEncounter,
+      FhirOrganization,
+      FhirPractitioner,
+      ImagingRequest,
+    } = ctx.store.models;
+
+    const ir = await ImagingRequest.create(
+      fake(ImagingRequest, {
+        requestedById: resources.practitioner.id,
+        encounterId: resources.encounter.id,
+        locationGroupId: resources.locationGroup.id,
+      }),
+    );
+    const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+    await FhirOrganization.materialiseFromUpstream(resources.facility.id);
+    await FhirEncounter.materialiseFromUpstream(resources.encounter.id);
+    await FhirPractitioner.materialiseFromUpstream(resources.practitioner.id);
+    expect(mat.resolved).toBe(false);
+
+    await resolver(undefined, { log, models: ctx.store.models });
+
+    await mat.reload();
+    expect(mat.resolved).toBe(true);
   });
 });

--- a/packages/central-server/app/tasks/fhir/resolver.js
+++ b/packages/central-server/app/tasks/fhir/resolver.js
@@ -1,3 +1,5 @@
+import ms from 'ms';
+
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
@@ -37,7 +39,7 @@ export const sortResourcesInDependencyOrder = resources => {
   return sorted;
 };
 
-export async function resolver(_, { log, sequelize, models }) {
+export async function resolver(_, { log, models }) {
   await sleepAsync(3000); // sleep for 3 seconds to allow materialisation jobs to complete
 
   const materialisableResources = resourcesThatCanDo(
@@ -45,13 +47,23 @@ export async function resolver(_, { log, sequelize, models }) {
     FHIR_INTERACTIONS.INTERNAL.MATERIALISE,
   );
 
+  // A resolver that blocks on a lock held elsewhere (e.g. a long sync session or a
+  // bulk update) would otherwise sit in 'Started' forever: its worker keeps
+  // heartbeating, so no other worker reclaims the job and it never errors. Bound
+  // each record's lock waits so the job fails (and retries) instead of stalling.
+  const lockTimeoutMs = ms(await models.Setting.get('fhir.worker.resolverLockTimeout'));
+
   log.debug('Starting resolve');
-  await sequelize.transaction(async () => {
-    const sortedResources = sortResourcesInDependencyOrder(materialisableResources);
-    for (const resource of sortedResources) {
-      await resource.resolveUpstreams();
-    }
-  });
+  // Resources are resolved in dependency order so referenced resources are
+  // materialised before the resources that reference them. Each resource resolves
+  // its upstreams in its own per-record transactions (see
+  // FhirResource.resolveUpstreams) rather than one transaction spanning every
+  // resource, which keeps lock holds short and preserves progress if a later
+  // record fails.
+  const sortedResources = sortResourcesInDependencyOrder(materialisableResources);
+  for (const resource of sortedResources) {
+    await resource.resolveUpstreams({ lockTimeoutMs });
+  }
 
   log.debug('Done resolving');
 }

--- a/packages/central-server/app/tasks/fhir/resolver.js
+++ b/packages/central-server/app/tasks/fhir/resolver.js
@@ -51,7 +51,13 @@ export async function resolver(_, { log, models }) {
   // bulk update) would otherwise sit in 'Started' forever: its worker keeps
   // heartbeating, so no other worker reclaims the job and it never errors. Bound
   // each record's lock waits so the job fails (and retries) instead of stalling.
-  const lockTimeoutMs = ms(await models.Setting.get('fhir.worker.resolverLockTimeout'));
+  //
+  // models.Setting.get() reads the settings table directly and returns undefined
+  // when the value has never been explicitly set - apply the same default (2
+  // minutes) the settings schema declares, inline.
+  const lockTimeoutMs = ms(
+    (await models.Setting.get('fhir.worker.resolverLockTimeout')) || '2 minutes',
+  );
 
   log.debug('Starting resolve');
   // Resources are resolved in dependency order so referenced resources are

--- a/packages/database/src/models/fhir/Resource.ts
+++ b/packages/database/src/models/fhir/Resource.ts
@@ -1,6 +1,13 @@
 /* eslint-disable no-unused-vars */
 import { snakeCase } from 'lodash';
-import { DataTypes, Sequelize, Utils, type InitOptions, type ModelAttributes } from 'sequelize';
+import {
+  DataTypes,
+  QueryTypes,
+  Sequelize,
+  Utils,
+  type InitOptions,
+  type ModelAttributes,
+} from 'sequelize';
 import { subMinutes } from 'date-fns';
 
 import {
@@ -11,6 +18,7 @@ import {
 } from '@tamanu/constants';
 import type { Ability } from '@casl/ability';
 import { formatFhirDate } from '@tamanu/shared/utils/fhir';
+import { log } from '@tamanu/shared/services/logging';
 import { objectAsFhir } from '../../utils/fhir/utils';
 import { Model } from '../Model';
 import type { FhirTransactionBundle } from '@tamanu/shared/services/fhirTypes/bundle';
@@ -213,17 +221,37 @@ export class FhirResource extends Model {
     return upstream as T | undefined;
   }
 
-  static async resolveUpstreams() {
+  static async resolveUpstreams({ lockTimeoutMs }: { lockTimeoutMs?: number } = {}) {
     const unresolvedResources = await this.findAll({
       where: {
         resolved: false,
       },
     });
 
-    for (const unresolvedResource of unresolvedResources) {
+    for (const [index, unresolvedResource] of unresolvedResources.entries()) {
       try {
-        await this.materialiseFromUpstream(unresolvedResource.upstreamId);
+        // Resolve each record in its own transaction so lock holds stay short and
+        // progress is preserved if a later record fails. When a lock timeout is
+        // configured, a record that can't acquire its locks in time fails fast
+        // (rather than blocking indefinitely) so the resolver job errors and retries.
+        await this.sequelize.transaction(async () => {
+          if (lockTimeoutMs) {
+            await this.sequelize.query("SELECT set_config('lock_timeout', $lockTimeoutMs, true)", {
+              type: QueryTypes.SELECT,
+              bind: { lockTimeoutMs: String(lockTimeoutMs) },
+            });
+          }
+          await this.materialiseFromUpstream(unresolvedResource.upstreamId);
+        });
       } catch (error) {
+        // We rethrow rather than skip so the resolver job errors and retries instead
+        // of silently completing with records left unresolved. Records already
+        // committed above are kept; the rest stay resolved: false and are retried on
+        // the next run, so surface how many were left for operational visibility.
+        const unprocessedCount = unresolvedResources.length - index;
+        log.warn(
+          `resolveUpstreams: ${unprocessedCount} of ${unresolvedResources.length} ${this.fhirName} record(s) left unresolved after a failure; resolver will error and retry`,
+        );
         if (error instanceof Error) {
           // Rethrowing like this to preserve stacktrace while logging which resource failed to resolve
           const errorMessage = `Error resolving upstreams for ${this.fhirName}/${unresolvedResource.id}: ${error.message ?? error.toString() ?? ''}`;

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -449,6 +449,13 @@ export const globalSettings = {
               type: yup.string(),
               defaultValue: '10 minutes',
             },
+            resolverLockTimeout: {
+              name: 'Resolver lock timeout',
+              description:
+                'How long the FHIR resolver waits to acquire row locks before failing the job, so a resolver blocked on locks held elsewhere errors and retries instead of stalling the queue indefinitely',
+              type: yup.string(),
+              defaultValue: '2 minutes',
+            },
           },
         },
       },


### PR DESCRIPTION
### Changes

Hotfix backport to release/2.55, which never had any lock-timeout protection on the fhir.resolver job. Bundles two changes together since neither is safe alone on this branch:\n\n1. 845e4e6a2d (originally #10088): bounds the resolver job's lock waits with a configurable lock_timeout so a resolver blocked on a lock held elsewhere (a sync session, another FHIR job, a bulk update) errors and retries instead of sitting in Started for hours.\n2. A follow-up fix (main #10734) for a bug in (1): it read the lock timeout via models.Setting.get(), which returns undefined since that setting is never seeded, so ms(undefined) threw on every run. On main this is fixed by threading a settings-with-defaults reader through; that reader does not exist yet on this branch (fhir.worker.concurrency is still config-only here), so this instead applies the same default (2 minutes) inline in resolver.js.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->