### PR TITLE
fix(blobs): TAM-7037: surface content-pending on web reads, count dropped cache blobs

### DIFF
--- a/docs/reference/query-cookbook.md
+++ b/docs/reference/query-cookbook.md
@@ -563,6 +563,24 @@ On a facility, `tier` decides how urgent this is: a `cache` row is self-correcti
 an `outbox` row may be the only copy of its content. See
 `../runbooks/blob-integrity.md`.
 
+Note the query above does not show most facility cache faults. Dropping the bad
+copy is what makes them self-correcting, and the drop takes the row with it, so
+they are counted instead (below).
+
+### Dropped cache blobs (facility)
+
+How many cache blobs this server has dropped for failing verification, and when it
+last did. A dropped blob leaves no row, so this counter is the only record that it
+happened. It never resets, so the number matters relative to the last one seen for
+this server rather than on its own: one drop is a bad sector the refetch already
+corrected, a count climbing between visits is failing media.
+
+```sql
+SELECT key, value
+FROM local_system_facts
+WHERE key IN ('blobCacheFaults', 'blobCacheFaultAt');
+```
+
 ### Return a restored blob to the scrub (dev-OTS)
 
 **[dev-OTS]** The one mutating statement in this section, and only as step 2 of the

--- a/docs/runbooks/blob-integrity.md
+++ b/docs/runbooks/blob-integrity.md
@@ -49,6 +49,12 @@ is the distinction that decides how urgent the report is:
 A corrupt blob is **retained, never served, and never deleted automatically**,
 so the bad bytes stay available for investigation.
 
+The facility cache row is the exception, and it changes where you look. Dropping
+the bad copy is the repair, so the row goes with it and the corrupt-blob query
+below will not show it. Whether it persists is read from the dropped-cache count
+in `../reference/query-cookbook.md` instead, which is also what `blob_integrity`
+grades that tier on.
+
 Recording a blob corrupt also takes it out of the scrub's verification pass, which is
 deliberate: re-hashing bytes already known to be bad every pass would spend the
 scrub's budget re-learning what is recorded. The consequence matters for the

--- a/packages/constants/src/facts.ts
+++ b/packages/constants/src/facts.ts
@@ -47,5 +47,13 @@ export const FACT_REPORTING_ROLE_SECRET = 'reportingRoleSecret';
 // When that secret was last (re)generated, for automatic age-based rotation.
 export const FACT_REPORTING_SECRET_ROTATED_AT = 'reportingSecretRotatedAt';
 
+// spec: SCRUB
+// How many cache blobs this server has dropped for failing verification, and
+// when it last did. A dropped cache blob leaves no registry row, so these are
+// the only durable record that it happened: one drop is a bad sector the refetch
+// already corrected, a climbing count is failing media.
+export const FACT_BLOB_CACHE_FAULTS = 'blobCacheFaults';
+export const FACT_BLOB_CACHE_FAULT_AT = 'blobCacheFaultAt';
+
 // Materialised views
 export const FACT_MV_UPCOMING_VACCINATIONS = `${MATERIALIZED_VIEW_LAST_REFRESHED_AT_KEY_NAMESPACE}:${MATERIALIZED_VIEWS.UPCOMING_VACCINATIONS}`;

--- a/packages/database/src/models/Attachment.ts
+++ b/packages/database/src/models/Attachment.ts
@@ -57,8 +57,8 @@ export class Attachment extends Model {
     return { ...restOfValues, data: Buffer.from(data, 'base64') };
   }
 
-  // Mobile still uploads by carrying its bytes in the synchronised record; those
-  // arrive base64-encoded and are stored as a legacy in-database attachment.
+  // A record carrying base64 bytes rather than a hash is a legacy in-database
+  // attachment and is stored as one.
   static sanitizeForCentralServer(
     values: ModelSanitizeArgs<{ data?: string; type?: string; size?: number }>,
   ) {

--- a/packages/facility-server/__tests__/apiv1/PatientProfilePicture.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientProfilePicture.test.js
@@ -143,6 +143,22 @@ describe('Patient profile picture', () => {
     expect(result.body.data).toBeUndefined();
   });
 
+  // A legacy attachment holds its bytes on central and has no hash, so it is read
+  // through rather than resolved locally. Central answering with no data is the
+  // same awaiting-content state, and used to reach the client as a 200 carrying
+  // an undefined `data`.
+  it('should present a legacy attachment central cannot supply as awaiting its content', async () => {
+    const attachment = await models.Attachment.create(
+      fake(models.Attachment, { hash: null, data: null, type: 'image/jpeg', size: 0 }),
+    );
+    const patient = await models.Patient.create(await createDummyPatient(models));
+    await uploadDummyProfilePicture(models, patient.id, attachment.id);
+
+    const result = await app.get(`/api/patient/${patient.id}/profilePicture`);
+    expect(result).toHaveStatus(202);
+    expect(result.body.data).toBeUndefined();
+  });
+
   it('should send a placeholder picture when no real one is available', async () => {
     const otherPatient = await models.Patient.create(await createDummyPatient(models));
 

--- a/packages/facility-server/__tests__/apiv1/PatientProfilePicture.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientProfilePicture.test.js
@@ -1,7 +1,14 @@
+import { Readable } from 'node:stream';
+import { createHash } from 'node:crypto';
+
+import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
 import { createDummyEncounter, createDummyPatient } from '@tamanu/database/demoData/patients';
+import { fake } from '@tamanu/fake-data/fake';
 import { createTestContext } from '../utilities';
 
-async function uploadDummyProfilePicture(models, patientId) {
+const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+async function uploadDummyProfilePicture(models, patientId, attachmentId) {
   const program = await models.Program.create({ name: 'pfp-program' });
 
   const survey = await models.Survey.create({
@@ -35,7 +42,7 @@ async function uploadDummyProfilePicture(models, patientId) {
       encounterId: encounter.id,
       surveyId: survey.id,
       answers: {
-        [dataElement.id]: '12345',
+        [dataElement.id]: attachmentId,
       },
     }),
   );
@@ -48,6 +55,38 @@ describe('Patient profile picture', () => {
   let baseApp = null;
   let models = null;
   let ctx;
+  let uniqueSuffix = 0;
+
+  const uniqueContent = () =>
+    Buffer.from(`a profile photo captured on the facility ${(uniqueSuffix += 1)}`, 'utf8');
+
+  // Stands in for central: local content is available without consulting it,
+  // mirroring the real channel, so only the remote half is faked here.
+  const setCentral = ({ holds = null } = {}) => {
+    ctx.blobCache.setTransferChannel({
+      availability: async (hash, { stat } = {}) => {
+        const local = stat === undefined ? await ctx.blobStore.servableStat(hash) : stat;
+        if (local) {
+          return { availability: BLOB_AVAILABILITY_STATES.AVAILABLE, size: local.size };
+        }
+        if (holds && hashOf(holds) === hash) {
+          return { availability: BLOB_AVAILABILITY_STATES.AWAITING_FETCH, size: holds.length };
+        }
+        return { availability: BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD };
+      },
+      fetchFromCentral: async hash => {
+        if (!holds || hashOf(holds) !== hash) {
+          throw new Error(`central does not hold ${hash}`);
+        }
+        return await ctx.blobStore.put(Readable.from([holds]));
+      },
+    });
+  };
+
+  const makeAttachment = async (hash, size) =>
+    await models.Attachment.create(
+      fake(models.Attachment, { hash, data: null, type: 'image/jpeg', size }),
+    );
 
   beforeAll(async () => {
     ctx = await createTestContext();
@@ -57,16 +96,51 @@ describe('Patient profile picture', () => {
   });
   afterAll(() => ctx.close());
 
-  // Disabling this as the endpoint currently expects a real central server to exist
-  xit('should retrieve a profile picture where one exists', async () => {
+  // spec: ATCH
+  // A profile picture is a survey photo answer, so it reads from the facility's
+  // own store like any other attachment rather than through central.
+  it('should retrieve a profile picture where one exists', async () => {
+    const image = uniqueContent();
+    const { hash } = await ctx.blobStore.put(Readable.from([image]));
+    const attachment = await makeAttachment(hash, image.length);
     const patient = await models.Patient.create(await createDummyPatient(models));
-    await uploadDummyProfilePicture(models, patient.id);
+    await uploadDummyProfilePicture(models, patient.id, attachment.id);
+    setCentral();
 
     const result = await app.get(`/api/patient/${patient.id}/profilePicture`);
     expect(result).toHaveSucceeded();
 
-    expect(result.body).toHaveProperty('data');
-    expect(result.body).toHaveProperty('mimeType');
+    expect(result.body.data).toBe(image.toString('base64'));
+    expect(result.body.mimeType).toBe('image/jpeg');
+  });
+
+  it('should resolve the bytes from central on a local miss and serve them', async () => {
+    const image = uniqueContent();
+    const attachment = await makeAttachment(hashOf(image), image.length);
+    const patient = await models.Patient.create(await createDummyPatient(models));
+    await uploadDummyProfilePicture(models, patient.id, attachment.id);
+    setCentral({ holds: image });
+
+    expect(await ctx.blobStore.stat(hashOf(image))).toBeNull();
+
+    const result = await app.get(`/api/patient/${patient.id}/profilePicture`);
+    expect(result).toHaveSucceeded();
+    expect(result.body.data).toBe(image.toString('base64'));
+  });
+
+  // spec: ATCH — an existing file awaiting its content, rather than a response
+  // that carries no data and says nothing about why.
+  it('should present content neither server holds as awaiting its content', async () => {
+    const image = uniqueContent();
+    const attachment = await makeAttachment(hashOf(image), image.length);
+    const patient = await models.Patient.create(await createDummyPatient(models));
+    await uploadDummyProfilePicture(models, patient.id, attachment.id);
+    setCentral();
+
+    const result = await app.get(`/api/patient/${patient.id}/profilePicture`);
+    expect(result).toHaveStatus(202);
+    expect(result.body.availability).toBe(BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD);
+    expect(result.body.data).toBeUndefined();
   });
 
   it('should send a placeholder picture when no real one is available', async () => {

--- a/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
+++ b/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
@@ -5,7 +5,12 @@ import path from 'node:path';
 import { Readable } from 'node:stream';
 
 import { FACILITY_PARITY_TIERS, parityGeometry } from '@tamanu/blobs';
-import { BLOB_INTEGRITY_STATES, BLOB_TIERS } from '@tamanu/constants';
+import {
+  BLOB_INTEGRITY_STATES,
+  BLOB_TIERS,
+  FACT_BLOB_CACHE_FAULTS,
+  FACT_BLOB_CACHE_FAULT_AT,
+} from '@tamanu/constants';
 import { BlobScrubber, BlobStore } from '@tamanu/database/blobStore';
 import { BlobHashMismatchError } from '@tamanu/errors';
 
@@ -109,6 +114,19 @@ describe('facility blob integrity', () => {
 
       expect(await models.Blob.findOne({ where: { hash } })).toBeNull();
       await expect(fs.access(pathOf(hash))).rejects.toThrow();
+    });
+
+    // spec: SCRUB — the dropped row is indistinguishable from an eviction, so
+    // the count is the only thing left that says the fault happened.
+    it('counts a dropped cache blob, since its row is gone', async () => {
+      const before = Number((await models.LocalSystemFact.get(FACT_BLOB_CACHE_FAULTS)) ?? 0);
+      const { hash } = await put(BLOB_TIERS.CACHE);
+      await corrupt(hash);
+
+      await makeScrubber().run();
+
+      expect(Number(await models.LocalSystemFact.get(FACT_BLOB_CACHE_FAULTS))).toBe(before + 1);
+      expect(await models.LocalSystemFact.get(FACT_BLOB_CACHE_FAULT_AT)).toEqual(expect.any(String));
     });
 
     it('retains a corrupt outbox blob rather than dropping the only copy', async () => {

--- a/packages/facility-server/app/blobIntegrity/FacilityBlobHealer.js
+++ b/packages/facility-server/app/blobIntegrity/FacilityBlobHealer.js
@@ -1,6 +1,12 @@
 import { BLOB_FAULTS } from '@tamanu/database/blobStore';
-import { BLOB_INTEGRITY_STATES, BLOB_TIERS } from '@tamanu/constants';
+import {
+  BLOB_INTEGRITY_STATES,
+  BLOB_TIERS,
+  FACT_BLOB_CACHE_FAULTS,
+  FACT_BLOB_CACHE_FAULT_AT,
+} from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
+import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 // spec: SCRUB
 // The facility's response to a blob that fails verification. Severity is graded
@@ -71,10 +77,23 @@ export class FacilityBlobHealer {
   // Low-severity and self-correcting, so it is logged but not escalated.
   async #healCache({ hash, fault }) {
     await this.#blobStore.delete(hash);
+    await this.#countCacheFault();
     log.warn('FacilityBlobHealer: dropped a faulty cache blob, it will refetch on demand', {
       hash,
       fault,
     });
+  }
+
+  // spec: SCRUB
+  // Dropping the row is what makes the repair self-correcting, and it is also
+  // what leaves the registry with nothing to report: the drop is indistinguishable
+  // from an eviction, which deletes the row the same way. So the fault is counted
+  // here, where "only a concern if it persists" has something to read.
+  async #countCacheFault() {
+    const { LocalSystemFact } = this.#models;
+    await LocalSystemFact.setIfAbsent(FACT_BLOB_CACHE_FAULTS, '0');
+    await LocalSystemFact.incrementValue(FACT_BLOB_CACHE_FAULTS);
+    await LocalSystemFact.set(FACT_BLOB_CACHE_FAULT_AT, getCurrentDateTimeString());
   }
 
   // spec: SCRUB

--- a/packages/facility-server/app/blobServing.js
+++ b/packages/facility-server/app/blobServing.js
@@ -1,5 +1,13 @@
-import { BLOB_SCANNERS } from '@tamanu/constants';
+import { BLOB_AVAILABILITY_STATES, BLOB_SCANNERS } from '@tamanu/constants';
 import { blobWithholdReason } from '@tamanu/database/blobStore';
+
+import { BlobTransferChannel } from './blobTransfer';
+import { getServerFacilityIds } from './serverConfig';
+import { CentralServerConnection } from './sync';
+
+// The availability states a read can be satisfied from: content this server
+// holds, and content central holds and is willing to serve.
+const SERVES_FROM = [BLOB_AVAILABILITY_STATES.AVAILABLE, BLOB_AVAILABILITY_STATES.AWAITING_FETCH];
 
 // spec: AV
 /**
@@ -22,4 +30,59 @@ export async function blobServeGate({ settings, models }, hash, stat) {
     // The quarantine still applies, naming the hash rather than any copy of it.
     scans: Boolean(stat) && scanner !== BLOB_SCANNERS.NONE,
   });
+}
+
+// Content this server does not hold is resolved from central on demand. The API
+// process runs no sync runtime and so has no channel of its own; it builds one
+// from the same kind of connection a legacy attachment is read through.
+const transferChannelFor = ({ blobCache, blobHealer, blobStore, deviceId }) => {
+  if (!blobCache.transferChannel) {
+    const channel = new BlobTransferChannel({
+      blobStore,
+      centralServer: new CentralServerConnection({ deviceId }),
+      facilityIds: getServerFacilityIds(),
+    });
+    blobCache.setTransferChannel(channel);
+    // spec: SCRUB — a read here can detect corruption, and the healer grades
+    // that fault in this process too. Without the channel it would reach the
+    // escalation rung with the peer rung untried.
+    blobHealer.setTransferChannel(channel);
+  }
+  return blobCache.transferChannel;
+};
+
+// spec: ATCH
+/**
+ * Resolve a hash-backed reference for a read on this facility: the servable
+ * gate, then the antivirus gate, then central's view of the hash.
+ *
+ * Returns `{ availability }` for an existing file this server will not serve,
+ * or `{ size }` for content the caller may go on to read through the cache.
+ */
+export async function resolveBlobForRead(req, hash) {
+  // spec: SCRUB — a copy the store will not serve reads as not held, so the read
+  // resolves a replacement from central rather than judging bad bytes.
+  const stat = await req.blobStore.servableStat(hash);
+
+  // spec: AV
+  // Asked of this server before central, so a facility with the link down still
+  // withholds content the deployment has found to be malware: the quarantine
+  // record reached it by sync and does not need central to be reachable to apply.
+  const withheldLocally = await blobServeGate(
+    { settings: req.settings[getServerFacilityIds()[0]], models: req.models },
+    hash,
+    stat,
+  );
+  if (withheldLocally) {
+    return { availability: withheldLocally };
+  }
+
+  const { availability, size } = await transferChannelFor(req).availability(hash, { stat });
+
+  // spec: ATCH, AV
+  // Available is held here and awaiting-fetch is held by central, which the read
+  // resolves. Every other state is an existing file that is not being served,
+  // and carries which: awaiting upload from its origin, awaiting a scan central
+  // has not run, or withheld as infected.
+  return SERVES_FROM.includes(availability) ? { size } : { availability };
 }

--- a/packages/facility-server/app/routes/apiv1/attachment.js
+++ b/packages/facility-server/app/routes/apiv1/attachment.js
@@ -2,20 +2,10 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 import * as yup from 'yup';
 
-import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
 import { readBlobAsBase64, serveBlob } from '@tamanu/shared/utils/serveBlob';
 
-import { blobServeGate } from '../../blobServing';
-import { BlobTransferChannel } from '../../blobTransfer';
-import { getServerFacilityIds } from '../../serverConfig';
+import { resolveBlobForRead } from '../../blobServing';
 import { CentralServerConnection } from '../../sync';
-
-// The availability states a read can be satisfied from: content this server
-// holds, and content central holds and is willing to serve.
-const SERVES_FROM = [
-  BLOB_AVAILABILITY_STATES.AVAILABLE,
-  BLOB_AVAILABILITY_STATES.AWAITING_FETCH,
-];
 
 const SAFE_ID_REGEX = /^[A-Za-z0-9-]+$/;
 const ID_SCHEMA = yup
@@ -23,26 +13,6 @@ const ID_SCHEMA = yup
   .matches(SAFE_ID_REGEX, 'id must not have spaces or punctuation other than -');
 
 export const attachment = express.Router();
-
-// Content this server does not hold is resolved from central on demand. The API
-// process runs no sync runtime and so has no channel of its own; it builds one
-// from the same kind of connection this route already opens to read a legacy
-// attachment through.
-const transferChannelFor = ({ blobCache, blobHealer, blobStore, deviceId }) => {
-  if (!blobCache.transferChannel) {
-    const channel = new BlobTransferChannel({
-      blobStore,
-      centralServer: new CentralServerConnection({ deviceId }),
-      facilityIds: getServerFacilityIds(),
-    });
-    blobCache.setTransferChannel(channel);
-    // spec: SCRUB — a read here can detect corruption, and the healer grades
-    // that fault in this process too. Without the channel it would reach the
-    // escalation rung with the peer rung untried.
-    blobHealer.setTransferChannel(channel);
-  }
-  return blobCache.transferChannel;
-};
 
 attachment.get(
   '/:id',
@@ -63,34 +33,8 @@ attachment.get(
     if (localAttachment?.hash) {
       const { hash, type } = localAttachment;
 
-      // spec: SCRUB — a copy the store will not serve reads as not held, so the
-      // read resolves a replacement from central rather than judging bad bytes.
-      const stat = await req.blobStore.servableStat(hash);
-
-      // spec: AV
-      // Asked of this server before central, so a facility with the link down
-      // still withholds content the deployment has found to be malware: the
-      // quarantine record reached it by sync and does not need central to be
-      // reachable to apply.
-      const withheldLocally = await blobServeGate(
-        { settings: req.settings[getServerFacilityIds()[0]], models: req.models },
-        hash,
-        stat,
-      );
-      if (withheldLocally) {
-        res.status(202).send({ attachmentId: id, availability: withheldLocally });
-        return;
-      }
-
-      const channel = transferChannelFor(req);
-      const { availability, size } = await channel.availability(hash, { stat });
-
-      // spec: ATCH, AV
-      // Available is held here and awaiting-fetch is held by central, which the
-      // read below resolves. Every other state is an existing file that is not
-      // being served, and carries which: awaiting upload from its origin,
-      // awaiting a scan central has not run, or withheld as infected.
-      if (!SERVES_FROM.includes(availability)) {
+      const { availability, size } = await resolveBlobForRead(req, hash);
+      if (availability) {
         res.status(202).send({ attachmentId: id, availability });
         return;
       }

--- a/packages/facility-server/app/routes/apiv1/patient/patientProfilePicture.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientProfilePicture.js
@@ -1,6 +1,10 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { QueryTypes } from 'sequelize';
+
+import { readBlobAsBase64 } from '@tamanu/shared/utils/serveBlob';
+
+import { resolveBlobForRead } from '../../../blobServing';
 import { CentralServerConnection } from '../../../sync';
 
 export const patientProfilePicture = express.Router();
@@ -8,7 +12,7 @@ export const patientProfilePicture = express.Router();
 patientProfilePicture.get(
   '/:id/profilePicture',
   asyncHandler(async (req, res) => {
-    const { params, deviceId } = req;
+    const { params, deviceId, blobCache } = req;
 
     // what we want is:
     // - the answer body
@@ -53,14 +57,40 @@ patientProfilePicture.get(
 
     // the body of a ProfilePhoto survey answer is an attachment id
     const attachmentId = result[0].body;
+    const localAttachment = await req.models.Attachment.findByPk(attachmentId);
 
-    // load the attachment from the central server
+    // spec: ATCH
+    // A hash-backed attachment reads from the local store, resolving the bytes
+    // from central on a miss, so a picture the facility already holds displays
+    // without connectivity.
+    if (localAttachment?.hash) {
+      const { hash } = localAttachment;
+      const { availability, size } = await resolveBlobForRead(req, hash);
+      if (availability) {
+        res.status(202).send({ attachmentId, availability });
+        return;
+      }
+
+      res.send({
+        mimeType: 'image/jpeg',
+        data: await readBlobAsBase64({ size, open: () => blobCache.open(hash) }),
+      });
+      return;
+    }
+
+    // spec: ATCH
+    // Legacy attachments reside only on the central server, so one with no local
+    // hash is read through it.
     const centralServer = new CentralServerConnection({ deviceId });
     const response = await centralServer.fetch(`attachment/${attachmentId}?base64=true`, {
       method: 'GET',
     });
 
-    // send the data along
+    if (!response?.data) {
+      res.status(202).send({ attachmentId, availability: response?.availability });
+      return;
+    }
+
     res.send({
       mimeType: 'image/jpeg',
       data: response.data,

--- a/packages/facility-server/app/routes/apiv1/patient/patientProfilePicture.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientProfilePicture.js
@@ -86,7 +86,9 @@ patientProfilePicture.get(
       method: 'GET',
     });
 
-    if (!response?.data) {
+    // Absence, not falsiness: a zero-byte attachment reads back as an empty
+    // string and is forwarded rather than reported as pending.
+    if (response?.data == null) {
       res.status(202).send({ attachmentId, availability: response?.availability });
       return;
     }

--- a/packages/web/__tests__/utils/attachments.test.jsx
+++ b/packages/web/__tests__/utils/attachments.test.jsx
@@ -15,6 +15,12 @@ describe('getAttachmentUnavailableMessage', () => {
     expect(getAttachmentUnavailableMessage({ data: 'aGVsbG8=' })).toBeNull();
   });
 
+  // spec: CAS — zero-byte content has a defined hash and is stored like any
+  // other blob, so an empty string is content rather than an absent response.
+  it('treats zero-byte content as served', () => {
+    expect(getAttachmentUnavailableMessage({ data: '' })).toBeNull();
+  });
+
   // spec: ATCH — one awaiting-content message whichever way it is pending
   it('gives the same pending message for every awaiting state', () => {
     const pending = [

--- a/packages/web/__tests__/utils/attachments.test.jsx
+++ b/packages/web/__tests__/utils/attachments.test.jsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
+
+import { getAttachmentUnavailableMessage } from '../../app/utils/attachments';
+
+// The attachment routes answer 202 with an availability state in place of the
+// bytes, and 202 is an ok response, so a caller that reads `data` alone gets
+// undefined and shows nothing. Every state that carries no data has to resolve
+// to a message.
+const stringIdFor = availability =>
+  getAttachmentUnavailableMessage({ availability })?.props?.stringId;
+
+describe('getAttachmentUnavailableMessage', () => {
+  it('has no message for a response carrying content', () => {
+    expect(getAttachmentUnavailableMessage({ data: 'aGVsbG8=' })).toBeNull();
+  });
+
+  // spec: ATCH — one awaiting-content message whichever way it is pending
+  it('gives the same pending message for every awaiting state', () => {
+    const pending = [
+      BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD,
+      BLOB_AVAILABILITY_STATES.AWAITING_FETCH,
+      BLOB_AVAILABILITY_STATES.AWAITING_SCAN,
+    ].map(stringIdFor);
+
+    expect(new Set(pending)).toEqual(new Set(['attachment.unavailable.pending']));
+  });
+
+  // spec: AV — a reader is told the content is not coming rather than left
+  // waiting on it, so this cannot share the pending message
+  it('distinguishes content withheld as infected', () => {
+    expect(stringIdFor(BLOB_AVAILABILITY_STATES.WITHHELD_INFECTED)).toBe(
+      'attachment.unavailable.withheld',
+    );
+  });
+
+  // A response shape the client does not recognise still carries no bytes, so it
+  // gets the pending message rather than rendering an empty file.
+  it('falls back to the pending message for an unrecognised state', () => {
+    expect(stringIdFor(undefined)).toBe('attachment.unavailable.pending');
+  });
+
+  it('covers every availability state that is not available', () => {
+    const withheld = Object.values(BLOB_AVAILABILITY_STATES).filter(
+      state => state !== BLOB_AVAILABILITY_STATES.AVAILABLE,
+    );
+
+    for (const state of withheld) {
+      expect(stringIdFor(state)).toBeTruthy();
+    }
+  });
+});

--- a/packages/web/app/components/DocumentPreview/PDFPreview.jsx
+++ b/packages/web/app/components/DocumentPreview/PDFPreview.jsx
@@ -3,6 +3,7 @@ import * as pdfjsLib from 'pdfjs-dist';
 
 import styled from 'styled-components';
 import { useApi } from '../../api';
+import { getAttachmentUnavailableMessage } from '../../utils';
 import { PDFPage } from './PDFPage';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
@@ -37,6 +38,7 @@ export default function PDFPreview({
 }) {
   const api = useApi();
   const [pages, setPages] = useState([]);
+  const [unavailableMessage, setUnavailableMessage] = useState(null);
 
   const scrollRef = useRef(null);
 
@@ -47,8 +49,13 @@ export default function PDFPreview({
       if (!attachmentId) {
         return;
       }
-      const { data } = await api.get(`attachment/${attachmentId}`, { base64: true });
-      const raw = Uint8Array.from(atob(data), (c) => c.charCodeAt(0));
+      const response = await api.get(`attachment/${attachmentId}`, { base64: true });
+      const unavailable = getAttachmentUnavailableMessage(response);
+      setUnavailableMessage(unavailable);
+      if (unavailable) {
+        return;
+      }
+      const raw = Uint8Array.from(atob(response.data), (c) => c.charCodeAt(0));
       const loadingTask = pdfjsLib.getDocument(raw);
       loadingTask.promise.then(
         async (loadedPdf) => {
@@ -88,10 +95,11 @@ export default function PDFPreview({
 
   return (
     <PDFDocument ref={scrollRef} data-testid="pdfdocument-qcy9">
-      {pages.map((p, i) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <PDFPage page={p} key={i} parentRef={scrollRef} data-testid={`pdfpage-l9ek-${i}`} />
-      ))}
+      {unavailableMessage ??
+        pages.map((p, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <PDFPage page={p} key={i} parentRef={scrollRef} data-testid={`pdfpage-l9ek-${i}`} />
+        ))}
     </PDFDocument>
   );
 }

--- a/packages/web/app/components/DocumentPreview/PhotoPreview.jsx
+++ b/packages/web/app/components/DocumentPreview/PhotoPreview.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useApi } from '../../api';
+import { getAttachmentUnavailableMessage } from '../../utils';
 
 const Image = styled.img`
   max-width: 35vw;
@@ -14,20 +15,24 @@ const ImageContainer = styled.div`
 export default function PhotoPreview({ attachmentId }) {
   const api = useApi();
   const [imageData, setImageData] = useState();
+  const [unavailableMessage, setUnavailableMessage] = useState(null);
 
   useEffect(() => {
     (async () => {
       if (!attachmentId) {
         return;
       }
-      const { data } = await api.get(`attachment/${attachmentId}`, { base64: true });
-      setImageData(data);
+      const response = await api.get(`attachment/${attachmentId}`, { base64: true });
+      setUnavailableMessage(getAttachmentUnavailableMessage(response));
+      setImageData(response.data);
     })();
   }, [api, attachmentId, setImageData]);
 
   return (
     <ImageContainer data-testid="imagecontainer-ag5w">
-      <Image src={`data:image/jpeg;base64,${imageData}`} alt="" data-testid="image-znla" />
+      {unavailableMessage ?? (
+        <Image src={`data:image/jpeg;base64,${imageData}`} alt="" data-testid="image-znla" />
+      )}
     </ImageContainer>
   );
 }

--- a/packages/web/app/components/DocumentPreview/PhotoPreview.jsx
+++ b/packages/web/app/components/DocumentPreview/PhotoPreview.jsx
@@ -23,7 +23,11 @@ export default function PhotoPreview({ attachmentId }) {
         return;
       }
       const response = await api.get(`attachment/${attachmentId}`, { base64: true });
-      setUnavailableMessage(getAttachmentUnavailableMessage(response));
+      const unavailable = getAttachmentUnavailableMessage(response);
+      setUnavailableMessage(unavailable);
+      if (unavailable) {
+        return;
+      }
       setImageData(response.data);
     })();
   }, [api, attachmentId, setImageData]);

--- a/packages/web/app/components/PatientPrinting/modals/PrintPatientDetailsModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/PrintPatientDetailsModal.jsx
@@ -361,13 +361,18 @@ const PrintOption = ({ label, caption, icon: Icon, onPress }) => (
   </PrintOptionButton>
 );
 
+const BLANK_PIXEL =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
 async function getPatientProfileImage(api, patientId) {
   try {
     const { data } = await api.get(`patient/${patientId}/profilePicture`);
-    return data;
+    // The route answers with an availability state and no data when the picture
+    // exists but its bytes have not arrived; an ID card prints without it, the
+    // same as for a patient who has none.
+    return data ?? BLANK_PIXEL;
   } catch (e) {
-    // 1x1 blank pixel
-    return 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+    return BLANK_PIXEL;
   }
 }
 

--- a/packages/web/app/components/ViewPhotoLink.jsx
+++ b/packages/web/app/components/ViewPhotoLink.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { subject } from '@casl/ability';
 import { useApi } from '../api';
-import { getImageSourceFromData } from '../utils';
+import { getAttachmentUnavailableMessage, getImageSourceFromData } from '../utils';
 import {
   Button,
   ButtonRow,
@@ -102,9 +102,10 @@ export const ViewPhotoLink = ({ answerId, surveyId, imageId, chartTitle = null }
     }
 
     try {
-      const { data } = await api.get(`attachment/${imageId}`, { base64: true });
-      setImageData(data);
-      setErrorMessage(null);
+      const response = await api.get(`attachment/${imageId}`, { base64: true });
+      const unavailableMessage = getAttachmentUnavailableMessage(response);
+      setImageData(response.data);
+      setErrorMessage(unavailableMessage);
     } catch (error) {
       setImageData(null);
       const genericErrorMessage = getTranslation(

--- a/packages/web/app/hooks/useDocumentActions.jsx
+++ b/packages/web/app/hooks/useDocumentActions.jsx
@@ -3,7 +3,13 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { TranslatedText } from '@tamanu/ui-components';
 import { useApi } from '../api';
-import { getAttachmentUnavailableMessage, notify, notifyError, notifySuccess } from '../utils';
+import {
+  AttachmentUnavailableError,
+  getAttachmentUnavailableMessage,
+  notify,
+  notifyError,
+  notifySuccess,
+} from '../utils';
 import { saveFile } from '../utils/fileSystemAccess';
 
 const base64ToUint8Array = (base64) => Buffer.from(base64, 'base64');
@@ -45,16 +51,16 @@ export const useDocumentActions = () => {
           { replacement: { type: 'info' } },
         );
 
-        const response = await api.get(`attachment/${document.attachmentId}`, { base64: true });
-        const unavailableMessage = getAttachmentUnavailableMessage(response);
-        if (unavailableMessage) {
-          notifyError(unavailableMessage);
-          return;
-        }
-
         const saved = await saveFile({
           defaultFileName: document.name,
-          getData: async () => base64ToUint8Array(response.data),
+          getData: async () => {
+            const response = await api.get(`attachment/${document.attachmentId}`, { base64: true });
+            const unavailableMessage = getAttachmentUnavailableMessage(response);
+            if (unavailableMessage) {
+              throw new AttachmentUnavailableError(unavailableMessage);
+            }
+            return base64ToUint8Array(response.data);
+          },
           extension: extension(document.type),
           mimetype: document.type,
         });
@@ -68,7 +74,9 @@ export const useDocumentActions = () => {
           );
         }
       } catch (error) {
-        notifyError(error.message);
+        notifyError(
+          error instanceof AttachmentUnavailableError ? error.userMessage : error.message,
+        );
       }
     },
     [api],

--- a/packages/web/app/hooks/useDocumentActions.jsx
+++ b/packages/web/app/hooks/useDocumentActions.jsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { TranslatedText } from '@tamanu/ui-components';
 import { useApi } from '../api';
-import { notify, notifyError, notifySuccess } from '../utils';
+import { getAttachmentUnavailableMessage, notify, notifyError, notifySuccess } from '../utils';
 import { saveFile } from '../utils/fileSystemAccess';
 
 const base64ToUint8Array = (base64) => Buffer.from(base64, 'base64');
@@ -45,13 +45,16 @@ export const useDocumentActions = () => {
           { replacement: { type: 'info' } },
         );
 
+        const response = await api.get(`attachment/${document.attachmentId}`, { base64: true });
+        const unavailableMessage = getAttachmentUnavailableMessage(response);
+        if (unavailableMessage) {
+          notifyError(unavailableMessage);
+          return;
+        }
+
         const saved = await saveFile({
           defaultFileName: document.name,
-          getData: async () => {
-            // Download attachment (*currently the API only supports base64 responses)
-            const { data } = await api.get(`attachment/${document.attachmentId}`, { base64: true });
-            return base64ToUint8Array(data);
-          },
+          getData: async () => base64ToUint8Array(response.data),
           extension: extension(document.type),
           mimetype: document.type,
         });
@@ -74,11 +77,16 @@ export const useDocumentActions = () => {
   const onPrintPDF = useCallback(
     async (attachmentId) => {
       try {
-        const { data } = await api.get(`attachment/${attachmentId}`, {
+        const response = await api.get(`attachment/${attachmentId}`, {
           base64: true,
         });
+        const unavailableMessage = getAttachmentUnavailableMessage(response);
+        if (unavailableMessage) {
+          notifyError(unavailableMessage);
+          return;
+        }
         const url = URL.createObjectURL(
-          new Blob([Buffer.from(data, 'base64').buffer], { type: 'application/pdf' }),
+          new Blob([Buffer.from(response.data, 'base64').buffer], { type: 'application/pdf' }),
         );
 
         // Triggers the useEffect that handles printing logic

--- a/packages/web/app/utils/attachments.jsx
+++ b/packages/web/app/utils/attachments.jsx
@@ -3,6 +3,15 @@ import React from 'react';
 import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
 import { TranslatedText } from '@tamanu/ui-components';
 
+// Carries the message for a caller that can only signal by throwing, such as a
+// `saveFile` data callback, which runs after the save picker has been accepted.
+export class AttachmentUnavailableError extends Error {
+  constructor(message) {
+    super('Attachment content is unavailable');
+    this.userMessage = message;
+  }
+}
+
 // spec: ATCH, AV
 // The attachment routes answer 202 with an availability state in place of the
 // bytes, so a response carrying no data is a file that exists and is not being

--- a/packages/web/app/utils/attachments.jsx
+++ b/packages/web/app/utils/attachments.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
+import { TranslatedText } from '@tamanu/ui-components';
+
+// spec: ATCH, AV
+// The attachment routes answer 202 with an availability state in place of the
+// bytes, so a response carrying no data is a file that exists and is not being
+// served. Pending takes one message whichever way it is pending; infected takes
+// its own, so a reader is told the content is not coming rather than left
+// waiting on it.
+export const getAttachmentUnavailableMessage = ({ data, availability }) => {
+  if (data) return null;
+
+  if (availability === BLOB_AVAILABILITY_STATES.WITHHELD_INFECTED) {
+    return (
+      <TranslatedText
+        stringId="attachment.unavailable.withheld"
+        fallback="This file has been withheld as unsafe by a virus scan and cannot be viewed. Contact your system administrator."
+      />
+    );
+  }
+
+  return (
+    <TranslatedText
+      stringId="attachment.unavailable.pending"
+      fallback="This file is not available yet. Please try again shortly."
+    />
+  );
+};

--- a/packages/web/app/utils/attachments.jsx
+++ b/packages/web/app/utils/attachments.jsx
@@ -19,7 +19,9 @@ export class AttachmentUnavailableError extends Error {
 // its own, so a reader is told the content is not coming rather than left
 // waiting on it.
 export const getAttachmentUnavailableMessage = ({ data, availability }) => {
-  if (data) return null;
+  // Absence, not falsiness: zero-byte content has a defined hash and is stored
+  // like any other blob, so it comes back as an empty string and is served.
+  if (data != null) return null;
 
   if (availability === BLOB_AVAILABILITY_STATES.WITHHELD_INFECTED) {
     return (

--- a/packages/web/app/utils/index.js
+++ b/packages/web/app/utils/index.js
@@ -1,4 +1,4 @@
-export { getAttachmentUnavailableMessage } from './attachments';
+export { AttachmentUnavailableError, getAttachmentUnavailableMessage } from './attachments';
 export { getImageSourceFromData, getFileInDocumentsPath, imageDataIsFileName } from './image';
 export * from './utils';
 export * from './getConfigObject';

--- a/packages/web/app/utils/index.js
+++ b/packages/web/app/utils/index.js
@@ -1,3 +1,4 @@
+export { getAttachmentUnavailableMessage } from './attachments';
 export { getImageSourceFromData, getFileInDocumentsPath, imageDataIsFileName } from './image';
 export * from './utils';
 export * from './getConfigObject';


### PR DESCRIPTION
### Changes

Two gaps found checking the epic for completeness.

**Web never learned to read content-pending.** The blob store answers `202 { availability }` for a reference whose bytes have not arrived, but every web attachment read did `const { data } = await api.get(...)`, and 202 is `response.ok`, so `data` came back `undefined`: a broken image with no message in the previews and the photo-answer modal, and a `Buffer.from(undefined, 'base64')` TypeError in the download and print toasts. Mobile and the asset path already handle this. Awaiting-upload is reachable in ordinary use, whenever another facility or a device originated the attachment and has not pushed yet. `getAttachmentUnavailableMessage(response)` now returns a message when a response carries no data, one for pending whichever way it is pending and a distinct one for withheld-infected, and the five call sites render or toast it. The fetch stays inside `saveFile`'s `getData` callback, since the picker must open on the click's transient activation, so the download path signals with a thrown `AttachmentUnavailableError` instead.

The facility profile picture route was never rewired either: it fetched from central by id, ignored the local store, and sent `data: undefined` on a 202. It now resolves through the cache like any other attachment. The resolution the attachment route already did moved to `resolveBlobForRead` for the two callers; that route's behaviour is unchanged and its 12 tests still cover it.

**A dropped facility cache blob left nothing to count.** `#healCache` deletes the row, which is what makes the repair self-correcting and also what makes it indistinguishable from an eviction, which deletes the row the same way. So the runbook's "only a concern if it persists" had no data behind it, and `blob_integrity` was grading a column that cannot populate for that tier. The drop now increments a `local_system_facts` counter with a timestamp. No schema change: leaving an `absent` row instead would have pulled in the eviction budget, reconciliation and the scrub's pass, which is not a change worth making days before QA. bestool#820 reads it.

Two things a reviewer might read as mistakes. The ID card print falls back to its blank pixel for a pending picture rather than surfacing a message, because an ID card prints without a photo the same way for a patient who has none. And `PatientProfilePicture.test.js`'s disabled case is now enabled: it was skipped because the endpoint needed a real central server, which locally-held content no longer does.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
