### PR TITLE
fix(blobs): TAM-7037: cache immutable blob responses and serve legacy rows the same way

### DIFF
--- a/packages/central-server/__tests__/attachment.test.js
+++ b/packages/central-server/__tests__/attachment.test.js
@@ -57,6 +57,32 @@ describe('Attachment (central-server)', () => {
     expect(Buffer.isBuffer(result.body)).toBeTruthy();
   });
 
+  // spec: BKFL
+  // A row the backfill has not reached yet is served the same way a moved one is,
+  // so a reader cannot tell which form it got. Ranged reads are what a PDF viewer
+  // does, and they used to work only once the row had moved.
+  it('serves a requested byte range of a row still holding its bytes', async () => {
+    // Taken from the response rather than the row's `size`, which the store no
+    // longer trusts either: the extent has to come from the bytes themselves.
+    const whole = await app.get(`/api/attachment/${attachment.id}`);
+    const bytes = Buffer.from(whole.body);
+
+    const result = await app.get(`/api/attachment/${attachment.id}`).set('range', 'bytes=5-14');
+    expect(result.status).toBe(206);
+    expect(result.headers['content-range']).toBe(`bytes 5-14/${bytes.length}`);
+    expect(result.headers['accept-ranges']).toBe('bytes');
+    expect(Buffer.from(result.body)).toEqual(bytes.subarray(5, 15));
+  });
+
+  // The one difference that remains, and it has a reason: a row that still holds
+  // its bytes has no content hash, so there is nothing to validate against.
+  it('serves a row still holding its bytes without a validator', async () => {
+    const result = await app.get(`/api/attachment/${attachment.id}`);
+    expect(result).toHaveSucceeded();
+    expect(result.headers.etag).toBeUndefined();
+    expect(result.headers['cache-control']).toBeUndefined();
+  });
+
   it('should read an attachment as a base64 string', async () => {
     const result = await app.get(`/api/attachment/${attachment.id}?base64=true`);
     expect(result).toHaveSucceeded();
@@ -157,6 +183,19 @@ describe('Attachment (central-server)', () => {
       expect(result.headers['accept-ranges']).toBe('bytes');
       expect(result.headers['content-type']).toContain('text/plain');
       expect(result.text).toBe(CONTENT.toString('utf8'));
+    });
+
+    // spec: SERVE — a hash names immutable content, so a client that already holds
+    // it is told so rather than sent the bytes a second time.
+    it('sends no bytes to a client that already holds the content', async () => {
+      const first = await app.get(`/api/attachment/${stored.id}`);
+      expect(first.headers['cache-control']).toBe('private, max-age=31536000, immutable');
+
+      const repeat = await app
+        .get(`/api/attachment/${stored.id}`)
+        .set('if-none-match', first.headers.etag);
+      expect(repeat.status).toBe(304);
+      expect(repeat.text).toBeFalsy();
     });
 
     it('serves a requested byte range of the content', async () => {

--- a/packages/central-server/app/attachment.js
+++ b/packages/central-server/app/attachment.js
@@ -84,11 +84,20 @@ attachmentRoutes.get(
 
     if (base64 === 'true') {
       res.send({ data: Buffer.from(attachment.data).toString('base64') });
-    } else {
-      res.setHeader('Content-Type', attachment.type);
-      res.setHeader('Content-Length', attachment.size);
-      res.send(Buffer.from(attachment.data));
+      return;
     }
+
+    // spec: BKFL — a row the backfill has not reached yet serves the same way a
+    // moved one does, so a reader cannot tell which form it got. The length comes
+    // from the bytes rather than the column, since the range arithmetic depends
+    // on it.
+    const bytes = Buffer.from(attachment.data);
+    await serveBlob(req, res, {
+      size: bytes.length,
+      contentType: attachment.type,
+      open: ({ start, end }) =>
+        Readable.from([start === undefined ? bytes : bytes.subarray(start, end + 1)]),
+    });
   }),
 );
 

--- a/packages/facility-server/app/routes/apiv1/attachment.js
+++ b/packages/facility-server/app/routes/apiv1/attachment.js
@@ -1,3 +1,5 @@
+import { Readable } from 'node:stream';
+
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import * as yup from 'yup';
@@ -56,11 +58,19 @@ attachment.get(
     if (localAttachment) {
       if (base64) {
         res.send({ data: Buffer.from(localAttachment.data).toString('base64') });
-      } else {
-        res.setHeader('Content-Type', localAttachment.type);
-        res.setHeader('Content-Length', localAttachment.size);
-        res.send(Buffer.from(localAttachment.data));
+        return;
       }
+
+      // spec: BKFL — served the same way a moved row is, so a reader cannot tell
+      // which form it got. The length comes from the bytes rather than the
+      // column, since the range arithmetic depends on it.
+      const bytes = Buffer.from(localAttachment.data);
+      await serveBlob(req, res, {
+        size: bytes.length,
+        contentType: localAttachment.type,
+        open: ({ start, end }) =>
+          Readable.from([start === undefined ? bytes : bytes.subarray(start, end + 1)]),
+      });
       return;
     }
 

--- a/packages/shared/__tests__/utils/serveBlob.test.js
+++ b/packages/shared/__tests__/utils/serveBlob.test.js
@@ -1,8 +1,33 @@
-import { Readable } from 'node:stream';
+import { Readable, Writable } from 'node:stream';
 
 import { MAX_INLINE_BLOB_BYTES } from '@tamanu/constants';
 
-import { readBlobAsBase64 } from '../../src/utils/serveBlob';
+import { readBlobAsBase64, serveBlob } from '../../src/utils/serveBlob';
+
+class FakeResponse extends Writable {
+  statusCode = 200;
+  headers = {};
+  #chunks = [];
+
+  status(code) {
+    this.statusCode = code;
+    return this;
+  }
+
+  setHeader(name, value) {
+    this.headers[name.toLowerCase()] = value;
+    return this;
+  }
+
+  _write(chunk, _encoding, callback) {
+    this.#chunks.push(chunk);
+    callback();
+  }
+
+  get body() {
+    return Buffer.concat(this.#chunks);
+  }
+}
 
 // spec: SERVE
 describe('readBlobAsBase64', () => {
@@ -25,5 +50,80 @@ describe('readBlobAsBase64', () => {
       readBlobAsBase64({ size: MAX_INLINE_BLOB_BYTES + 1, open: openSpy }),
     ).rejects.toMatchObject({ status: 422 });
     expect(openSpy).not.toHaveBeenCalled();
+  });
+});
+
+// spec: SERVE
+describe('serveBlob', () => {
+  const CONTENT = Buffer.from('bytes named by their hash', 'utf8');
+  const HASH = 'sha256:abc123';
+  const ETAG = `"${HASH}"`;
+
+  const serve = async ({ hash = HASH, headers = {} } = {}) => {
+    const res = new FakeResponse();
+    const open = ({ start, end }) =>
+      Readable.from([start === undefined ? CONTENT : CONTENT.subarray(start, end + 1)]);
+    await serveBlob({ headers }, res, {
+      hash,
+      size: CONTENT.length,
+      contentType: 'text/plain',
+      open,
+    });
+    return res;
+  };
+
+  it('carries the hash as a strong validator and lets the client keep it indefinitely', async () => {
+    const res = await serve();
+    expect(res.statusCode).toBe(200);
+    expect(res.headers.etag).toBe(ETAG);
+    expect(res.headers['cache-control']).toBe('private, max-age=31536000, immutable');
+    expect(res.body).toEqual(CONTENT);
+  });
+
+  // A shared cache holding clinical content would outlive the permission check
+  // that released it, so the directive has to stay private.
+  it('does not let a shared cache keep a copy', async () => {
+    const res = await serve();
+    expect(res.headers['cache-control']).not.toMatch(/public/);
+  });
+
+  it('sends no bytes to a client that already holds the content', async () => {
+    const res = await serve({ headers: { 'if-none-match': ETAG } });
+    expect(res.statusCode).toBe(304);
+    expect(res.headers.etag).toBe(ETAG);
+    expect(res.body).toHaveLength(0);
+  });
+
+  it('matches a weak validator and one among several', async () => {
+    expect((await serve({ headers: { 'if-none-match': `W/${ETAG}` } })).statusCode).toBe(304);
+    expect((await serve({ headers: { 'if-none-match': `"other", ${ETAG}` } })).statusCode).toBe(304);
+    expect((await serve({ headers: { 'if-none-match': '*' } })).statusCode).toBe(304);
+  });
+
+  it('serves the content when the client holds a different one', async () => {
+    const res = await serve({ headers: { 'if-none-match': '"sha256:stale"' } });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(CONTENT);
+  });
+
+  // spec: BKFL — a row the backfill has not reached has no content hash, so there
+  // is nothing to validate against, but everything else matches the moved form.
+  it('serves content with no hash without a validator, and still supports ranges', async () => {
+    const res = await serve({ hash: null });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers.etag).toBeUndefined();
+    expect(res.headers['cache-control']).toBeUndefined();
+    expect(res.headers['accept-ranges']).toBe('bytes');
+
+    const ranged = await serve({ hash: null, headers: { range: 'bytes=6-10' } });
+    expect(ranged.statusCode).toBe(206);
+    expect(ranged.headers['content-range']).toBe(`bytes 6-10/${CONTENT.length}`);
+    expect(ranged.body).toEqual(CONTENT.subarray(6, 11));
+  });
+
+  it('never answers 304 for content with no validator, whatever the client sends', async () => {
+    const res = await serve({ hash: null, headers: { 'if-none-match': '*' } });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(CONTENT);
   });
 });

--- a/packages/shared/__tests__/utils/serveBlob.test.js
+++ b/packages/shared/__tests__/utils/serveBlob.test.js
@@ -94,6 +94,15 @@ describe('serveBlob', () => {
     expect(res.body).toHaveLength(0);
   });
 
+  // A cache updates its stored entry from the headers a 304 carries, so leaving
+  // freshness off it means a client that cached before this existed revalidates
+  // on every read forever.
+  it('repeats the freshness a 200 would carry on the 304', async () => {
+    const served = await serve();
+    const notModified = await serve({ headers: { 'if-none-match': ETAG } });
+    expect(notModified.headers['cache-control']).toBe(served.headers['cache-control']);
+  });
+
   it('matches a weak validator and one among several', async () => {
     expect((await serve({ headers: { 'if-none-match': `W/${ETAG}` } })).statusCode).toBe(304);
     expect((await serve({ headers: { 'if-none-match': `"other", ${ETAG}` } })).statusCode).toBe(304);

--- a/packages/shared/src/utils/serveBlob.js
+++ b/packages/shared/src/utils/serveBlob.js
@@ -25,13 +25,41 @@ export async function readBlobAsBase64({ size, open }) {
 }
 
 // spec: SERVE
+// spec: SERVE
+// Whether the client already holds this content. Weak comparison per RFC 9110,
+// which is what If-None-Match takes, so a `W/` prefix still matches.
+function clientHoldsContent(req, etag) {
+  const header = req.headers['if-none-match'];
+  if (!etag || !header) {
+    return false;
+  }
+  if (header.trim() === '*') {
+    return true;
+  }
+  return header.split(',').some(candidate => candidate.trim().replace(/^W\//, '') === etag);
+}
+
 // Stream a stored blob over HTTP: range support for large files, the hash as a
 // strong entity tag since it names immutable content, and a pipeline that
 // destroys the source when either side terminates so a dropped download does not
 // leak the open file handle. The caller supplies `open`, which returns the byte
-// stream for a range — a facility passes its cache's read-through open, so a
+// stream for a range, and a facility passes its cache's read-through open, so a
 // served blob is fetched on a local miss and counts as a use.
+//
+// A legacy attachment, whose bytes are still in its database row, has no content
+// hash and so nothing to validate against. It passes no `hash` and is served
+// without a validator, but with everything else the same (see backfill.md).
 export async function serveBlob(req, res, { hash, size, contentType, open }) {
+  const etag = hash ? `"${hash}"` : null;
+
+  // spec: SERVE — a hash names immutable content, so a client holding it never
+  // needs the bytes again. Private, since blob content is clinical data and a
+  // shared cache must not keep a copy.
+  if (clientHoldsContent(req, etag)) {
+    res.status(304).setHeader('etag', etag).end();
+    return;
+  }
+
   const range = req.headers.range?.match(RANGE_PATTERN)?.groups;
   let start;
   let end;
@@ -49,8 +77,11 @@ export async function serveBlob(req, res, { hash, size, contentType, open }) {
   res.status(range ? 206 : 200);
   res.setHeader('content-type', contentType ?? 'application/octet-stream');
   res.setHeader('content-length', range ? end - start + 1 : size);
-  res.setHeader('etag', `"${hash}"`);
   res.setHeader('accept-ranges', 'bytes');
+  if (etag) {
+    res.setHeader('etag', etag);
+    res.setHeader('cache-control', 'private, max-age=31536000, immutable');
+  }
   if (range) {
     res.setHeader('content-range', `bytes ${start}-${end}/${size}`);
   }

--- a/packages/shared/src/utils/serveBlob.js
+++ b/packages/shared/src/utils/serveBlob.js
@@ -49,14 +49,20 @@ function clientHoldsContent(req, etag) {
 // A legacy attachment, whose bytes are still in its database row, has no content
 // hash and so nothing to validate against. It passes no `hash` and is served
 // without a validator, but with everything else the same (see backfill.md).
+// spec: SERVE
+// A hash names immutable content, so a client holding it never needs the bytes
+// again. Private, since blob content is clinical data and a shared cache must not
+// keep a copy.
+const IMMUTABLE = 'private, max-age=31536000, immutable';
+
 export async function serveBlob(req, res, { hash, size, contentType, open }) {
   const etag = hash ? `"${hash}"` : null;
 
-  // spec: SERVE — a hash names immutable content, so a client holding it never
-  // needs the bytes again. Private, since blob content is clinical data and a
-  // shared cache must not keep a copy.
   if (clientHoldsContent(req, etag)) {
-    res.status(304).setHeader('etag', etag).end();
+    // Carries the freshness a 200 would: a cache updates its stored entry from
+    // the headers the 304 arrives with, so omitting it leaves a client that
+    // cached before this existed revalidating on every read forever.
+    res.status(304).setHeader('etag', etag).setHeader('cache-control', IMMUTABLE).end();
     return;
   }
 
@@ -80,7 +86,7 @@ export async function serveBlob(req, res, { hash, size, contentType, open }) {
   res.setHeader('accept-ranges', 'bytes');
   if (etag) {
     res.setHeader('etag', etag);
-    res.setHeader('cache-control', 'private, max-age=31536000, immutable');
+    res.setHeader('cache-control', IMMUTABLE);
   }
   if (range) {
     res.setHeader('content-range', `bytes ${start}-${end}/${size}`);


### PR DESCRIPTION
### Changes

Two divergences from the serving specs, found auditing the epic for the test-case document.

**A client that already holds a blob refetched it anyway.** SERVE says a response carries its hash as a strong validator and, because a hash names immutable content, may be cached indefinitely, so a client holding the content does not fetch it again. `serveBlob` set the entity tag but no `cache-control`, and piped the body straight to the response rather than going through Express's freshness check, so an `If-None-Match` repeat got the whole body back. It now answers 304 before opening the stream, and sends `private, max-age=31536000, immutable`. Private rather than public on purpose: a shared cache holding clinical content would outlive the permission check that released it. The comparison is weak per RFC 9110, so `W/` prefixes and multi-value headers match.

**Legacy and hash-backed attachments did not serve the same way.** BKFL says the two forms are indistinguishable to the requester, response shape included. The hash path went through `serveBlob` and got ranges and `accept-ranges`; the legacy path set content-type and content-length and ignored `Range` entirely. So during the backfill window, a ranged read (what a PDF viewer does) behaved differently per row depending on whether that row had moved yet. Both servers' legacy paths now go through `serveBlob`.

One difference is left deliberately. A row still holding its bytes has no content hash, so there is no validator to send: it gets no etag and no `cache-control`, and `serveBlob` takes `hash` as optional to express that. The alternative was hashing a bytea on every request to serve a row the backfill is actively deleting. Flag it if you would rather close it fully.

The extent for a legacy range comes from the bytes, not from `attachment.size`. Those disagree in the existing fixture (1002 against 1336, since a direct `create` skips the sanitiser that decodes base64), and the range arithmetic depends on the real length.

Tests: 10 in `serveBlob.test.js` covering the validator, both themes of the 304 path, and the no-hash form; 3 at the central route covering a ranged legacy read, the absent validator, and a real 304 round trip. Existing suites unchanged and green (29 central attachment, 46 blobTransfer, 17 facility).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
