### PR TITLE
db(blobs): TAM-7037: halt a downgrade before it drops a hash column, and document the rollback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,7 @@ treated as a hard pre-filter on any suggested action.
 | [blob-integrity](runbooks/blob-integrity.md) | Attachment or asset bytes corrupt or missing (`blob_integrity` check) | Complete |
 | [blob-correction-rate](runbooks/blob-correction-rate.md) | Blobs being repaired from parity often enough to signal failing media (`blob_correction_rate` check) | Complete |
 | [blob-antivirus](runbooks/blob-antivirus.md) | Content quarantined as malware, or scanning stalled (`blob_antivirus` check) | Complete |
+| [blob-backfill-rollback](runbooks/blob-backfill-rollback.md) | Putting attachment and asset bytes back in the database, before a version downgrade | Complete |
 
 ## SOPs
 

--- a/docs/reference/query-cookbook.md
+++ b/docs/reference/query-cookbook.md
@@ -679,6 +679,113 @@ GROUP BY tier
 ORDER BY tier;
 ```
 
+### Backfill progress
+
+After the upgrade to the version that carries blob storage, a background job moves
+the attachment and asset bytes that were held in database columns out to the
+store. It starts on its own, works in small batches every few minutes, and stops
+when nothing is left. No operator action starts or finishes it.
+
+Central and a facility do different work here, which changes how the figures read:
+
+- **Central** moves both `attachments` and `assets` rows: each row gains a hash
+  and gives up its bytes. It rewrites its changelog entries for both tables.
+- **A facility** copies its asset bytes into its own store and leaves the rows
+  alone. Those rows change only when central's updated rows arrive over sync. It
+  rewrites asset changelog entries, and deliberately leaves attachment rows and
+  attachment changelog entries as they are, so a count against attachments on a
+  facility is expected and will not fall.
+
+Progress shows in the counts below. The database's on-disk size stays where it is
+while the job runs: clearing a byte column makes the space reusable inside the
+database without handing it back to the filesystem, which takes a `VACUUM FULL` or
+`pg_repack` and is a separate operator decision.
+
+**What is left to move.** The rows still holding bytes and the changelog entries
+still holding a copy of them. `stored_bytes` is the size as stored (compressed),
+so treat it as an order of magnitude rather than an exact volume. **[diagnose]**
+
+```sql
+SELECT 'rows: attachments' AS unit,
+       count(*) AS remaining,
+       pg_size_pretty(sum(pg_column_size(data))) AS stored_bytes
+FROM attachments
+WHERE data IS NOT NULL AND hash IS NULL
+UNION ALL
+SELECT 'rows: assets', count(*), pg_size_pretty(sum(pg_column_size(data)))
+FROM assets
+WHERE data IS NOT NULL AND hash IS NULL
+UNION ALL
+SELECT 'changelog: ' || table_name, count(*), NULL
+FROM logs.changes
+WHERE table_schema = 'public'
+  AND table_name IN ('attachments', 'assets')
+  AND record_data->>'data' IS NOT NULL
+GROUP BY table_name;
+```
+
+A changelog line missing from the output means there is nothing left for that
+table. On a facility the changelog count has no index to work with and scans the
+changelog, so it can take a while on a large one. It is still read-only.
+
+**What is already on the store.** Rows and entries that carry a hash and no bytes.
+Content created since the upgrade was never in the database and is counted here
+too, so read this as the size of the store-backed set rather than as a tally of
+what the job has moved. **[diagnose]**
+
+```sql
+SELECT 'rows: attachments' AS unit, count(*) AS on_store
+FROM attachments
+WHERE hash IS NOT NULL
+UNION ALL
+SELECT 'rows: assets', count(*)
+FROM assets
+WHERE hash IS NOT NULL
+UNION ALL
+SELECT 'changelog: ' || table_name, count(*)
+FROM logs.changes
+WHERE table_schema = 'public'
+  AND table_name IN ('attachments', 'assets')
+  AND record_data->>'hash' IS NOT NULL
+  AND record_data->>'data' IS NULL
+GROUP BY table_name;
+```
+
+**Is it moving.** Run this twice, several minutes apart, and compare. It is the
+same total the server itself uses to decide the job is done: at zero the backfill
+is complete and stops looking. On a facility, drop the `attachments` line and
+narrow the changelog filter to `table_name = 'assets'`, since neither is that
+server's work. **[diagnose]**
+
+```sql
+SELECT now() AS at,
+       (SELECT count(*) FROM attachments WHERE data IS NOT NULL AND hash IS NULL)
+     + (SELECT count(*) FROM assets WHERE data IS NOT NULL AND hash IS NULL)
+     + (SELECT count(*) FROM logs.changes
+        WHERE table_schema = 'public'
+          AND table_name IN ('attachments', 'assets')
+          AND record_data->>'data' IS NOT NULL) AS remaining;
+```
+
+The job runs every few minutes, so if the figure has not moved after fifteen
+minutes or so, read the server log for `BlobBackfillTask`
+(`../sops/read-logs.md`):
+
+| Log line | What it means |
+| --- | --- |
+| `moved content into the blob store` | A batch finished, with the unit and how many |
+| `paused, not enough free disk to admit more content` | The store has reached its free-disk reserve and stopped rather than crossing it. It resumes on its own once there is room; the fix is space on the volume holding `blobStorage.root` |
+| `content still to move` | A pass ended with work outstanding, which is normal mid-run |
+| `complete, no in-database blob content remains` | Finished, and every hash confirmed backed by content the server holds |
+| `complete except for content this server does not hold` | Nothing is left holding bytes, but a hash has no content behind it locally. See `../runbooks/blob-integrity.md` |
+
+No `BlobBackfillTask` lines at all means the job is not running: check that the
+server's task process is up and that `schedules.blobBackfill.enabled` has not been
+turned off in settings.
+
+To put content back in the database (a version downgrade, or an abandoned
+backfill), see `../runbooks/blob-backfill-rollback.md`.
+
 ## Blob antivirus
 
 Only where the deployment has turned scanning on. See

--- a/docs/runbooks/blob-backfill-rollback.md
+++ b/docs/runbooks/blob-backfill-rollback.md
@@ -76,12 +76,15 @@ rows back out to the store while the command is moving them in.
 
 **The rollback runs first, the downgrade second.**
 
-Reversing the attachment hash migration restores the `NOT NULL` constraint on
-`attachments.data`, which fails while any attachment row carries a hash instead of
-bytes. Migrations reverse newest first, so by the time it fails the assets hash
-column has already been dropped and committed: those rows are left with no bytes
-and no hash naming their content, and the rollback can no longer put anything
-back. Recovering from that is a database restore from backup.
+Reversing either hash migration restores the `NOT NULL` constraint on that table's
+`data` column, which fails while any row still carries a hash instead of bytes.
+Each migration runs in its own transaction, so a failure rolls that migration back
+whole, hash column included: the downgrade stops, and nothing is lost. That is the
+guard, and it is why the order matters rather than being a preference.
+
+A downgrade attempted without the rollback therefore halts part way, with the
+migrations newer than these already reversed. Run the rollback, confirm it
+finished, then run the downgrade again.
 
 So the order is: stop the services, run the rollback, confirm it finished, then
 run the downgrade.

--- a/docs/runbooks/blob-backfill-rollback.md
+++ b/docs/runbooks/blob-backfill-rollback.md
@@ -1,0 +1,159 @@
+# Runbook: blob backfill rollback (putting content back in the database)
+
+The backfill has moved attachment and asset bytes out of the database and onto the
+blob store, and they need to go back: almost always because the deployment is
+being taken back to a version from before blob storage, which means reversing the
+database migrations as well.
+
+Every action is tagged with its class from the ladder in `../README.md`. Check
+`../ruled-out-actions.md` before running anything mutating.
+
+**Restoring from backup is the real path if a backfill has gone wrong.** A backup
+cycle holds the database and the store together
+(`facility-restored-from-backup.md` §5), and it recovers content that has been
+lost. The rollback is a convenience: it only changes where intact bytes live, and
+only while the store still holds all of them. Reach for it when the store is
+healthy and the database has to look the way it did before the upgrade.
+
+## 1. When this applies
+
+- A central server is going back to a version from before blob storage, so its
+  migrations have to reverse.
+- A backfill is being abandoned part way and the deployment wants its content back
+  in database columns. The rollback works at any stage, complete or not.
+
+It does not apply when:
+
+- **Content is missing or corrupt.** The rollback reads every byte back out of the
+  store, so it cannot re-inflate a database from a store with holes in it, and it
+  stops dead at the first blob it cannot read. That is `blob-integrity.md`.
+- **The store is gone** (volume lost, root deleted). There is nothing to restore
+  from, so this is a backup restore.
+- **One file is the problem.** Nothing here is per-file. See `blob-integrity.md`.
+- **The server is a facility.** The command runs on central only, and there is no
+  facility equivalent (§7).
+
+## 2. What the rollback does
+
+It walks every attachment and asset row carrying a hash, streams that content out
+of the store, writes it back into the row's byte column and clears the hash. Then
+it does the same for changelog entries, restoring the byte snapshot each one used
+to carry.
+
+Four things worth knowing before you start:
+
+- **It covers everything carrying a hash.** Content uploaded since the upgrade was
+  never in the database, and the rollback puts it there too. Expect the database to
+  grow by roughly the size of the content the store holds for attachments and
+  assets.
+- **It leaves the store alone.** Blobs and their registry rows stay exactly as they
+  are, so nothing is destroyed and the backfill can simply run again afterwards.
+- **Restored asset rows re-sync.** Assets are pulled from central, so facilities
+  receive those bytes over ordinary sync again once the rows change.
+- **It resumes.** A row that has its bytes back is not picked up again, so a run
+  that is interrupted continues from where it stopped when re-run.
+
+## 3. Before running it
+
+**[diagnose]** On central, run the "Backfill progress" and "Integrity state
+summary" queries in `../reference/query-cookbook.md`.
+
+- Any `corrupt` or `absent` blob will stop the run when it reaches that content.
+  Resolve it through `blob-integrity.md` first, or accept that the rollback will
+  not get past it.
+- Check free space on the database volume against the store's size. The bytes are
+  going back into the database, and clearing them originally did not shrink the
+  database files, so the space they used may still be held by the tables.
+- Confirm the server's backup cycle is current. It is what covers this going
+  wrong.
+
+**[dev-OTS]** Stop the backfill before starting, by stopping the central server's
+task process (`../sops/restart-services.md`) or setting
+`schedules.blobBackfill.enabled` to false in settings. Left running, the job moves
+rows back out to the store while the command is moving them in.
+
+## 4. Order against the migrations
+
+**The rollback runs first, the downgrade second.**
+
+Reversing the attachment hash migration restores the `NOT NULL` constraint on
+`attachments.data`, which fails while any attachment row carries a hash instead of
+bytes. Migrations reverse newest first, so by the time it fails the assets hash
+column has already been dropped and committed: those rows are left with no bytes
+and no hash naming their content, and the rollback can no longer put anything
+back. Recovering from that is a database restore from backup.
+
+So the order is: stop the services, run the rollback, confirm it finished, then
+run the downgrade.
+
+## 5. Run it
+
+**[dev-OTS]** Mutating, against a live production database, rewriting every
+attachment and asset row and their changelog entries. It is reversible (the
+backfill moves the content out again on the next upgrade), which is what keeps it
+off the ruled-out list. A developer runs it, with the reason for the downgrade
+established and a current backup confirmed. It is never a support first-line
+action.
+
+Central only. From the current release's central-server directory, the same place
+report generation runs from (`../sops/run-db-report.md`):
+
+```bash
+node dist rollbackBlobBackfill
+```
+
+Where the release runs from source rather than a build, the invocation is
+`node --import tsx app rollbackBlobBackfill` (see `../sops/run-db-report.md` for
+the same distinction).
+
+- `--batchSize` is rows restored per batch, default 50.
+- `--delay` is the pause in milliseconds between batches, default 1000. Raise it
+  to tread more lightly on a busy server, or pass `0` to run without pausing on a
+  server that is already stopped.
+
+It runs in the foreground and logs a line per batch (`Restored to the database`,
+with the unit and a running total), ending with `Completed blob backfill
+rollback`. It can run for hours on a large deployment, so start it somewhere a
+dropped connection will not kill it. Interrupting it is safe.
+
+## 6. Confirm it worked
+
+**[diagnose]** Re-run the "Backfill progress" queries
+(`../reference/query-cookbook.md`). Finished means the store-backed counts are
+zero across the board: no attachment or asset row carries a hash, and no changelog
+entry carries a hash with its bytes cleared. The remaining-to-move counts will
+have risen to match, because every row is back to holding its bytes.
+
+Do not start the downgrade on a partial result. A single row left carrying a hash
+is enough to fail it, with the consequences in §4.
+
+## 7. Escalate
+
+- **The run stops with `Blob not found` or `Blob is corrupt`.** A hash the database
+  references has no usable content in the store. The command has no way past it
+  and will stop at the same row on every re-run, so the content has to be restored
+  or the reference dealt with first. Take the hash to `blob-integrity.md`.
+- **A downgrade was started before the rollback and failed.** Do not retry it. Asset
+  hashes are already gone (§4), and what to do next is a restore decision.
+- **A facility needs the same thing.** There is no facility rollback command, and a
+  facility holds hash-carrying attachment rows of its own (uploads since the
+  upgrade, and attachments pulled from central), so its downgrade meets the same
+  failure. Taking a facility back a version is a restore from its backup cycle:
+  `facility-restored-from-backup.md`.
+- **The database volume fills part way through.** Restored rows keep their bytes, so
+  free space and re-run rather than improvising around it.
+
+Include the server, how far the rollback got (the counts from §6), the failing
+hash if there is one, and whether the downgrade has been attempted.
+
+## 8. Do not
+
+- Do **not** delete store files or `blobs` rows to tidy up after a rollback. Until
+  the downgrade is done and the deployment has settled, they are what the rollback
+  reads from, and a second pass over a partly restored database still needs them.
+- Do **not** run it with the backfill still scheduled. The two work against each
+  other, one moving content out as the other moves it in.
+- Do **not** run it to free space on the store volume. It grows the database by
+  more than the store gives back, and it removes nothing from the filesystem.
+- Do **not** treat it as a recovery for lost or corrupt content. It can only
+  produce content the store still holds.

--- a/packages/database/src/migrations/1785830000000-addAttachmentHash.ts
+++ b/packages/database/src/migrations/1785830000000-addAttachmentHash.ts
@@ -19,9 +19,11 @@ export async function up(query: QueryInterface): Promise<void> {
 
 export async function down(query: QueryInterface): Promise<void> {
   await query.removeColumn(TABLE, 'hash');
-  // DESTRUCTIVE: hash-backed rows have no in-database bytes, so restoring the NOT
-  // NULL constraint fails while any such row exists; those rows must be backfilled
-  // or removed before rolling back.
+  // A hash-backed row has no in-database bytes, so this fails while any such row
+  // exists and the whole migration rolls back, `hash` included. That is
+  // deliberate: dropping `hash` while `data` is null would leave the row naming
+  // nothing, with its content stranded in the store. The backfill rollback has to
+  // run first, and this is what stops a downgrade that skipped it.
   await query.changeColumn(TABLE, 'data', {
     type: DataTypes.BLOB,
     allowNull: false,

--- a/packages/database/src/migrations/1785860000000-addAssetHashColumn.ts
+++ b/packages/database/src/migrations/1785860000000-addAssetHashColumn.ts
@@ -21,6 +21,13 @@ export async function up(query: QueryInterface): Promise<void> {
 
 export async function down(query: QueryInterface): Promise<void> {
   await query.removeColumn(TABLE, 'hash');
-  // DESTRUCTIVE: rows whose bytes moved to the blob store have a null `data`;
-  // restoring NOT NULL would fail against them, so `data` is left nullable.
+  // A row whose bytes moved to the store has a null `data`, so this fails while
+  // any such row exists and the whole migration rolls back, `hash` included. That
+  // is deliberate: dropping `hash` while `data` is null would leave the row naming
+  // nothing, with its content stranded in the store. The backfill rollback has to
+  // run first, and this is what stops a downgrade that skipped it.
+  await query.changeColumn(TABLE, 'data', {
+    type: DataTypes.BLOB,
+    allowNull: false,
+  });
 }


### PR DESCRIPTION
### Changes

Two operator-facing gaps around the backfill, which is the one job in this epic that runs once, unattended, against real data, at up to hundreds of gigabytes.

**No way to see progress.** BKFL says progress and completion are visible to operators as the amount moved and the amount remaining. They existed only as log lines: nothing in the query cookbook, the healthchecks map, or any runbook, so an operator mid-upgrade could not answer "how far along is it, and is it stuck". The cookbook's "Blob store" section gains a **Backfill progress** subsection with three diagnose-class queries, derived from `BlobBackfill.countRemaining()`, its changelog arm, and the sum `BlobBackfillTask.countQueue()` uses to latch completion, rather than invented. Nothing was added to `healthchecks.md`, which maps failing checks to runbooks and has no backfill check to map.

**No runbook for a rollback**, and a guard that only half worked. `1785830000000-addAttachmentHash.down` restores `NOT NULL` on `attachments.data`, which fails while any hash-carrying row remains. Each migration runs in its own transaction (`migrations.js:202`), so that failure rolls the whole migration back, `hash` column included: the downgrade halts and nothing is lost. That is a good guard.

Its sibling `1785860000000-addAssetHashColumn.down` did the opposite, leaving `data` nullable on the grounds that restoring `NOT NULL` would fail. It would, and that was the point. As written it succeeded and committed, dropping `assets.hash` while `data` was null, so those rows named nothing and their content was stranded in the store with no way back. Assets carries the newer timestamp and migrations reverse newest first, so a downgrade run without the rollback lost the asset mapping silently and only then halted on attachments.

The asset migration now restores `NOT NULL` as attachments does, so both halt atomically and the downgrade stops before anything is dropped. `docs/runbooks/blob-backfill-rollback.md` documents the ordering, what the rollback does, the precondition that the store must be intact, and how to tell it finished.

The runbook leads with restoring from backup being the real path if a backfill has gone wrong, which is the epic's own position: the rollback only changes where intact bytes live. The command is classified dev-OTS and explicitly not a support first-line action.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
