### PR TITLE
fix(medications): no-issue: hide modal close icon and pin page size for printed medication labels

### DIFF
--- a/packages/ui-components/src/components/BaseModal.jsx
+++ b/packages/ui-components/src/components/BaseModal.jsx
@@ -49,7 +49,6 @@ const Dialog = styled(MuiDialog)`
       print-color-adjust: exact;
     }
 
-    .MuiDialogTitle-root,
     .MuiDialogActions-root {
       display: none;
     }
@@ -87,6 +86,13 @@ const Header = styled.header`
   flex-wrap: wrap;
   padding-block: 14px;
   padding-inline: 32px 14px;
+
+  // Holds the title and the close/print icon buttons (Actions), neither of which
+  // has a MuiDialogTitle-root/MuiDialogActions-root class, so the print rule on
+  // Dialog above can't reach them — hide the whole header directly instead.
+  @media print {
+    display: none;
+  }
 `;
 
 const ModalTitle = styled(DialogTitle).attrs({ 'data-testid': 'modaltitle-ojhf' })`

--- a/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
@@ -136,6 +136,13 @@ const LabelFooterText = styled.div`
   overflow-wrap: break-word;
 `;
 
+export const useLabelDimensions = () => {
+  const { getSetting } = useSettings();
+  const width = getSetting('medications.dispensing.prescriptionLabelSize.width') ?? 80;
+  const height = getSetting('medications.dispensing.prescriptionLabelSize.height') ?? 40;
+  return { width, height };
+};
+
 export const getMedicationLabel = (quantity, units, getEnumTranslation) => {
   if (!quantity) return '';
   if (!units) return `${quantity}`;
@@ -200,9 +207,7 @@ const calculateDynamicFontSizes = (data, labelWidth, labelHeight) => {
 export const MedicationLabel = React.memo(({ data }) => {
   const { formatShortest } = useDateTime();
   const { getEnumTranslation } = useTranslation();
-  const { getSetting } = useSettings();
-  const labelWidth = getSetting('medications.dispensing.prescriptionLabelSize.width') ?? 80;
-  const labelHeight = getSetting('medications.dispensing.prescriptionLabelSize.height') ?? 40;
+  const { width: labelWidth, height: labelHeight } = useLabelDimensions();
 
   const {
     medicationName,

--- a/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
@@ -24,6 +24,15 @@ const Label = styled.div`
   @media print {
     width: ${props => props.$width}mm;
     height: ${props => props.$height}mm;
+
+    // @page is sized to exactly one label, so without an explicit break the
+    // browser decides for itself where to split the flex column of labels —
+    // unreliably, since the flex gap below still eats into that exact-sized
+    // page. Force one label per page/physical label instead.
+    &:not(:last-child) {
+      break-after: page;
+      page-break-after: always;
+    }
   }
 `;
 

--- a/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
@@ -24,15 +24,7 @@ const Label = styled.div`
   @media print {
     width: ${props => props.$width}mm;
     height: ${props => props.$height}mm;
-
-    // @page is sized to exactly one label, so without an explicit break the
-    // browser decides for itself where to split the flex column of labels —
-    // unreliably, since the flex gap below still eats into that exact-sized
-    // page. Force one label per page/physical label instead.
-    &:not(:last-child) {
-      break-after: page;
-      page-break-after: always;
-    }
+    flex-shrink: 0;
   }
 `;
 

--- a/packages/web/app/components/PatientPrinting/printouts/MedicationLabelPrintPreview.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/MedicationLabelPrintPreview.jsx
@@ -10,6 +10,12 @@ const PrintContainer = styled.div`
   flex-direction: column;
   gap: 14px;
   align-items: center;
+
+  @media print {
+    // Each label forces a page break after itself (see MedicationLabel), so this
+    // gap would otherwise eat into the next exact-sized page and misalign it.
+    gap: 0;
+  }
 `;
 
 const PrintDescription = styled(Box)`

--- a/packages/web/app/components/PatientPrinting/printouts/MedicationLabelPrintPreview.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/MedicationLabelPrintPreview.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled, { createGlobalStyle } from 'styled-components';
 import { Box } from '@material-ui/core';
 import { TranslatedText } from '../../Translation';
-import { MedicationLabel } from './MedicationLabel';
+import { MedicationLabel, useLabelDimensions } from './MedicationLabel';
 
 const PrintContainer = styled.div`
   display: flex;
@@ -25,7 +25,7 @@ export const PrintStyles = createGlobalStyle`
   @media print {
     @page {
       margin: 0;
-      size: auto;
+      size: ${props => props.$width}mm ${props => props.$height}mm;
     }
 
     html, body {
@@ -33,7 +33,6 @@ export const PrintStyles = createGlobalStyle`
       padding: 0;
     }
 
-    .MuiDialogTitle-root,
     .MuiDialogActions-root {
       display: none;
     }
@@ -56,9 +55,11 @@ export const PrintStyles = createGlobalStyle`
 `;
 
 export const MedicationLabelPrintPreview = ({ labels, showDescription = true }) => {
+  const { width, height } = useLabelDimensions();
+
   return (
     <>
-      <PrintStyles />
+      <PrintStyles $width={width} $height={height} />
       {showDescription && (
         <PrintDescription>
           <TranslatedText

--- a/packages/web/app/components/PatientPrinting/printouts/MedicationLabelPrintPreview.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/MedicationLabelPrintPreview.jsx
@@ -12,9 +12,28 @@ const PrintContainer = styled.div`
   align-items: center;
 
   @media print {
-    // Each label forces a page break after itself (see MedicationLabel), so this
-    // gap would otherwise eat into the next exact-sized page and misalign it.
+    // Each LabelPrintPage fills and forces a break onto its own page, so this
+    // gap would otherwise add extra height on top of that and misalign it.
     gap: 0;
+  }
+`;
+
+const LabelPrintPage = styled.div`
+  @media print {
+    // The printer/OS paper size doesn't always end up matching the label's own
+    // exact mm dimensions (e.g. the driver falls back to a larger default
+    // media size), so centre the label within whichever page size is actually
+    // used rather than assuming it fills the page.
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100vh;
+
+    &:not(:last-child) {
+      break-after: page;
+      page-break-after: always;
+    }
   }
 `;
 
@@ -76,7 +95,9 @@ export const MedicationLabelPrintPreview = ({ labels, showDescription = true }) 
       )}
       <PrintContainer>
         {labels.map((label, index) => (
-          <MedicationLabel key={label.id || index} data={label} />
+          <LabelPrintPage key={label.id || index}>
+            <MedicationLabel data={label} />
+          </LabelPrintPage>
         ))}
       </PrintContainer>
     </>


### PR DESCRIPTION
### Changes

Printed medication labels showed a stray "x" over the label content and had page-size/alignment issues on the Zebra ZD621 label printer.

- The modal's close/print icon buttons lived in a plain `Actions` div with no `MuiDialogActions-root` class, so the print stylesheet's hide rule never matched them and the close icon printed on top of the label. Fixed by hiding the whole modal `Header` (title + icon buttons) under `@media print` in `BaseModal`.
- The label print stylesheet used `@page { size: auto; }`, leaving the printed page geometry up to the browser/driver default rather than the configured label stock. Now pins `@page` size to the `medications.dispensing.prescriptionLabelSize` setting (same dimensions the label itself renders at), extracted into a shared `useLabelDimensions` hook to avoid duplicating the setting keys/defaults.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [x] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->