### PR TITLE
fix(web): TAM-7037: leave no writable behind when a download has no content

### DIFF
--- a/packages/web/__tests__/utils/fileSystemAccess.test.js
+++ b/packages/web/__tests__/utils/fileSystemAccess.test.js
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { saveFile } from '../../app/utils/fileSystemAccess';
+
+// A save that cannot produce its content has to leave nothing behind. Content is
+// resolved through a callback, and an attachment whose bytes have not arrived
+// rejects there routinely rather than exceptionally, so the failure path is the
+// common one rather than the edge.
+describe('saveFile', () => {
+  let writable;
+  let fileHandle;
+
+  beforeEach(() => {
+    writable = { write: vi.fn(), close: vi.fn(), abort: vi.fn() };
+    fileHandle = { createWritable: vi.fn(async () => writable) };
+    window.showSaveFilePicker = vi.fn(async () => fileHandle);
+  });
+
+  const save = getData =>
+    saveFile({ defaultFileName: 'discharge summary', getData, mimetype: 'application/pdf' });
+
+  it('writes the content the caller produced', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+
+    await expect(save(async () => data)).resolves.toBe(true);
+
+    expect(writable.write).toHaveBeenCalledWith(data);
+    expect(writable.close).toHaveBeenCalled();
+    expect(writable.abort).not.toHaveBeenCalled();
+  });
+
+  it('opens no writable at all when the content cannot be produced', async () => {
+    const failure = new Error('content is not available yet');
+
+    await expect(save(async () => Promise.reject(failure))).rejects.toBe(failure);
+
+    // Nothing to abort, because nothing was opened: a writable created alongside
+    // the content would be unreachable once the pair rejected.
+    expect(fileHandle.createWritable).not.toHaveBeenCalled();
+  });
+
+  it('aborts the writable when writing fails', async () => {
+    const failure = new Error('disk went away');
+    writable.write.mockRejectedValueOnce(failure);
+
+    await expect(save(async () => new Uint8Array([1]))).rejects.toBe(failure);
+
+    expect(writable.abort).toHaveBeenCalled();
+    expect(writable.close).not.toHaveBeenCalled();
+  });
+
+  it('reports a cancelled picker as not saved rather than as a failure', async () => {
+    const aborted = new Error('user cancelled');
+    aborted.name = 'AbortError';
+    window.showSaveFilePicker.mockRejectedValueOnce(aborted);
+
+    await expect(save(async () => new Uint8Array([1]))).resolves.toBe(false);
+  });
+});

--- a/packages/web/app/utils/fileSystemAccess.js
+++ b/packages/web/app/utils/fileSystemAccess.js
@@ -73,7 +73,12 @@ export const saveFile = async ({
     /** @type {FileSystemWritableFileStream} */
     let writable;
     try {
-      const [writable, data] = await Promise.all([fileHandle.createWritable(), getData()]);
+      // The data comes first so a failure to produce it leaves no writable behind:
+      // one created alongside it would be unreachable once the pair rejected, and
+      // so could never be aborted. The picker has already run by here, so nothing
+      // in this order depends on user activation.
+      const data = await getData();
+      writable = await fileHandle.createWritable();
       await writable.write(data);
       await writable.close();
     } catch (error) {


### PR DESCRIPTION
### Changes

`saveFile` raced `createWritable()` against `getData()` in a `Promise.all`. If `getData()` rejected, the writable the other half had already opened was unreachable: nothing held a reference to it, so the catch could not abort it. A shadowed binding hid the same problem on the other path, where `const [writable, data] = ...` inside the `try` shadowed the outer `let writable`, so the catch's `writable?.abort()` always saw `undefined` and a failed `write()` never aborted either.

Both predate the epic, and the epic is what makes them matter. `getData()` used to reject only on a network failure. Since #10752 it rejects routinely, throwing `AttachmentUnavailableError` whenever an attachment's bytes have not reached the serving server, which is ordinary during the backfill window and whenever another facility has not pushed yet. So a rare path became a common one, and it leaves a swap file where the user chose to save.

Resolving the content before opening the writable fixes both: an unavailable attachment now opens no writable at all, so there is nothing to abort, and a failed write aborts the one that does exist. The save picker has already run by this point, so nothing here depends on transient user activation. The ordering that does (`showSaveFilePicker` before any fetch) is untouched, and `test/b2-web-coverage` adds a test that fails if anyone hoists the fetch above the picker.

Four tests, mutation-checked: restoring the original shape fails exactly the two cases describing these defects and leaves the happy path and the cancelled-picker path green. Full web suite 356 pass.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
