### PR TITLE
test(blobs): TAM-7037: close the automatable coverage gaps

### DIFF
--- a/packages/blobs/src/admission.ts
+++ b/packages/blobs/src/admission.ts
@@ -32,9 +32,9 @@ export interface BlobAdmissionHost {
   /**
    * Registry upsert. Contract, since hosts implement it in different dialects:
    * atomic against a concurrent admission of the same content; a live row is
-   * left entirely alone (content already held as cache stays cache); a
-   * soft-deleted row is resurrected with the incoming tier and its recency reset
-   * to now.
+   * left entirely alone, so a tier the admission needs applied is the caller's
+   * to set; a soft-deleted row is resurrected with the incoming tier and its
+   * recency reset to now.
    */
   register(hash: string, size: number, tier: BlobTier): Promise<void>;
   /**

--- a/packages/central-server/__tests__/attachment.test.js
+++ b/packages/central-server/__tests__/attachment.test.js
@@ -370,6 +370,35 @@ describe('Attachment (central-server)', () => {
       expect(result).toBeForbidden();
     });
 
+    // spec: BLAC, ATCH
+    // The permission check governs the referencing record and runs ahead of the
+    // hash branch, so a blob-backed attachment is refused exactly as a row
+    // holding its own bytes is.
+    describe('on a hash-backed attachment', () => {
+      let blobBacked;
+
+      beforeEach(async () => {
+        const { hash, size } = await ctx.blobStore.put(
+          Readable.from([Buffer.from('content the permission check governs', 'utf8')]),
+        );
+        blobBacked = await models.Attachment.create({ type: 'text/plain', hash, size });
+      });
+
+      it('rejects reading it without read Attachment permission', async () => {
+        app = await baseApp.asNewRole([['create', 'Attachment']], { id: 'practitioner' });
+
+        const result = await app.get(`/v1/attachment/${blobBacked.id}`);
+        expect(result).toBeForbidden();
+      });
+
+      it('serves it with read Attachment permission', async () => {
+        app = await baseApp.asNewRole([['read', 'Attachment']], { id: 'practitioner' });
+
+        const result = await app.get(`/v1/attachment/${blobBacked.id}`);
+        expect(result).toHaveSucceeded();
+      });
+    });
+
     it('rejects getting an attachment if there is no create Attachment permission', async () => {
       app = await baseApp.asNewRole([['read', 'Attachment']], { id: 'practitioner' });
 

--- a/packages/central-server/__tests__/blobBackfillTask.test.js
+++ b/packages/central-server/__tests__/blobBackfillTask.test.js
@@ -5,9 +5,16 @@ import path from 'node:path';
 import { QueryTypes } from 'sequelize';
 
 import { BlobStore } from '@tamanu/database/blobStore';
+import { log } from '@tamanu/shared/services/logging';
 import { BlobBackfillTask } from '@tamanu/shared/tasks';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { createTestContext } from './utilities';
+
+// The pause between batches is observed rather than waited out.
+jest.mock('@tamanu/utils/sleepAsync', () => ({
+  sleepAsync: jest.fn().mockResolvedValue(undefined),
+}));
 
 const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
 
@@ -60,6 +67,7 @@ describe('BlobBackfillTask', () => {
 
   beforeEach(async () => {
     root = ctx.blobStore.root;
+    sleepAsync.mockClear();
 
     await sequelize.query('DELETE FROM attachments');
     await sequelize.query('DELETE FROM assets');
@@ -188,5 +196,91 @@ describe('BlobBackfillTask', () => {
     expect(row.hash).toBeNull();
     expect(row.data).not.toBeNull();
     await fs.rm(starvedStore.root, { recursive: true, force: true });
+  });
+
+  // spec: BKFL
+  // The pause between batches is what keeps a long run off the back of a live
+  // deployment, so it has to be taken and be the configured length.
+  describe('batch pacing', () => {
+    it('pauses for the configured length between batches', async () => {
+      for (let i = 0; i < 3; i++) await insertAttachment(Buffer.from(`document ${i}`));
+
+      await makeTask({ batchSize: 1, batchSleepAsyncDurationInMilliseconds: 250 }).run();
+
+      expect(sleepAsync).toHaveBeenCalledWith(250);
+      expect(sleepAsync.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('does not pause when the configured length is zero', async () => {
+      for (let i = 0; i < 3; i++) await insertAttachment(Buffer.from(`document ${i}`));
+
+      await makeTask({ batchSize: 1, batchSleepAsyncDurationInMilliseconds: 0 }).run();
+
+      expect(sleepAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  // spec: BKFL
+  // The report a run ends on is the only operator-visible completion signal, and
+  // no bytes left in the database is only half of done.
+  describe('completion reporting', () => {
+    let info;
+    let warn;
+
+    const messagesOf = spy => spy.mock.calls.map(([message]) => message);
+
+    beforeEach(() => {
+      info = jest.spyOn(log, 'info');
+      warn = jest.spyOn(log, 'warn');
+    });
+
+    afterEach(() => {
+      info.mockRestore();
+      warn.mockRestore();
+    });
+
+    it('reports completion once nothing holds bytes and every hash resolves', async () => {
+      await insertAttachment(Buffer.from('the last of the legacy content'));
+
+      await makeTask({ batchSize: 10, batchSleepAsyncDurationInMilliseconds: 0 }).run();
+
+      expect(messagesOf(info)).toContain(
+        'BlobBackfillTask: complete, no in-database blob content remains',
+      );
+    });
+
+    it('reports content still to move when a pass leaves rows behind', async () => {
+      await insertAsset(Buffer.from('a letterhead a facility only seeds'));
+
+      const previous = global.serverInfo;
+      global.serverInfo = { serverType: 'facility' };
+      try {
+        await makeTask({ batchSize: 10, batchSleepAsyncDurationInMilliseconds: 0 }).run();
+      } finally {
+        // eslint-disable-next-line require-atomic-updates -- single-threaded save/restore
+        global.serverInfo = previous;
+      }
+
+      expect(messagesOf(info)).toContain('BlobBackfillTask: content still to move');
+      expect(messagesOf(info)).not.toContain(
+        'BlobBackfillTask: complete, no in-database blob content remains',
+      );
+    });
+
+    it('reports a referenced hash the server holds no content for rather than completion', async () => {
+      await sequelize.query(
+        `INSERT INTO attachments (id, type, size, hash) VALUES ($id, 'image/png', 4, $hash)`,
+        { bind: { id: randomUUID(), hash: `sha256:${'d'.repeat(64)}` } },
+      );
+
+      await makeTask({ batchSize: 10, batchSleepAsyncDurationInMilliseconds: 0 }).run();
+
+      expect(messagesOf(warn)).toContain(
+        'BlobBackfillTask: complete except for content this server does not hold',
+      );
+      expect(messagesOf(info)).not.toContain(
+        'BlobBackfillTask: complete, no in-database blob content remains',
+      );
+    });
   });
 });

--- a/packages/central-server/__tests__/blobTransfer.test.js
+++ b/packages/central-server/__tests__/blobTransfer.test.js
@@ -13,6 +13,7 @@ import {
 } from '@tamanu/constants';
 
 import { registerBlobReferenceSource } from '../app/blobReferences';
+import { CentralSyncManager } from '../app/sync/CentralSyncManager';
 import { createTestContext } from './utilities';
 
 const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
@@ -684,6 +685,26 @@ describe('Blob transfer channel', () => {
       expect(response.status).toBe(403);
     });
 
+    // spec: BLAC
+    // One inaccessible facility refuses the whole list, whichever position it
+    // holds: a check that accepted the request because some declared facility
+    // was accessible would then scope the operation to the inaccessible one too.
+    it('refuses a facility list mixing one the user can access with one it cannot', async () => {
+      const content = Buffer.from('referenced at the sensitive facility alone');
+      const hash = await seedHeldBlob(content);
+      await reference(hash, { facilityId: sensitiveFacility.id });
+
+      for (const facilityIds of [
+        [facilityA.id, sensitiveFacility.id],
+        [sensitiveFacility.id, facilityA.id],
+      ]) {
+        const scope = { token: tokenA, facilityIds };
+        expect(await availability(hash, scope)).toBeForbidden();
+        expect(await getBlob(hash, scope)).toBeForbidden();
+        expect(await offer(hash, content.length, scope)).toBeForbidden();
+      }
+    });
+
     describe('fetch', () => {
       it('serves a blob referenced by a record in the declared facility scope', async () => {
         const content = Buffer.from('scoped fetch in scope');
@@ -912,5 +933,75 @@ describe('Blob transfer channel', () => {
       });
     });
 
+    // spec: BLAC, ATCH
+    // Everything above scopes through the scratch reference table, so this runs
+    // the same gate over the `attachments` registration that ships: real rows,
+    // entering sync_lookup through the same build a pull reads from.
+    describe('attachment references', () => {
+      let inScopeHash;
+      let sensitiveHash;
+
+      const attachmentCarrying = async (hash, content, overrides) =>
+        await models.Attachment.create(
+          fake(models.Attachment, {
+            ...overrides,
+            type: 'text/plain',
+            size: content.length,
+            hash,
+            data: null,
+          }),
+        );
+
+      beforeAll(async () => {
+        const inScopeContent = Buffer.from('bytes an attachment row references');
+        inScopeHash = await seedHeldBlob(inScopeContent);
+        await attachmentCarrying(inScopeHash, inScopeContent, { patientId: patientAtA.id });
+
+        await models.PatientFacility.create({
+          id: models.PatientFacility.generateId(),
+          patientId: patientAtA.id,
+          facilityId: sensitiveFacility.id,
+        });
+        const department = await models.Department.create(
+          fake(models.Department, { facilityId: sensitiveFacility.id }),
+        );
+        const location = await models.Location.create(
+          fake(models.Location, { facilityId: sensitiveFacility.id }),
+        );
+        const examiner = await models.User.create(fake(models.User));
+        const encounter = await models.Encounter.create(
+          fake(models.Encounter, {
+            patientId: patientAtA.id,
+            departmentId: department.id,
+            locationId: location.id,
+            examinerId: examiner.id,
+            endDate: null,
+          }),
+        );
+        const sensitiveContent = Buffer.from('bytes attached at the sensitive facility');
+        sensitiveHash = await seedHeldBlob(sensitiveContent);
+        await attachmentCarrying(sensitiveHash, sensitiveContent, { encounterId: encounter.id });
+
+        await new CentralSyncManager(ctx).updateLookupTable();
+      });
+
+      it('serves a blob an attachment row references within the declared scope', async () => {
+        const served = await getBlob(inScopeHash, scopeA).buffer(true);
+        expect(served).toHaveSucceeded();
+        expect(Buffer.from(served.body).toString()).toBe('bytes an attachment row references');
+
+        const elsewhere = await availability(inScopeHash, scopeB);
+        expect(elsewhere.body).toEqual({
+          availability: BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD,
+        });
+      });
+
+      it('applies the sensitive-facility restriction to an attachment', async () => {
+        const outside = await availability(sensitiveHash, scopeA);
+        expect(outside.body).toEqual({ availability: BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD });
+
+        expect(await getBlob(sensitiveHash, scopeSensitive)).toHaveSucceeded();
+      });
+    });
   });
 });

--- a/packages/central-server/__tests__/subCommands/rollbackBlobBackfill.test.js
+++ b/packages/central-server/__tests__/subCommands/rollbackBlobBackfill.test.js
@@ -1,0 +1,153 @@
+import { randomUUID } from 'node:crypto';
+import { QueryTypes } from 'sequelize';
+
+import { BlobBackfill } from '@tamanu/database/blobStore';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
+
+import { createTestContext } from '../utilities';
+import { rollbackBlobBackfill } from '../../app/subCommands/rollbackBlobBackfill';
+
+// The pause between batches is the whole of the command's pacing, so it is
+// observed rather than waited out.
+jest.mock('@tamanu/utils/sleepAsync', () => ({
+  sleepAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+// spec: BKFL
+// Reverses the backfill by re-inflating the database from the blob store, ahead
+// of a version downgrade. It restores from the store rather than a backup, and
+// paces itself so a live deployment is not starved while it runs.
+describe('rollbackBlobBackfill', () => {
+  let ctx;
+  let models;
+  let sequelize;
+  let backfill;
+
+  const insertAttachment = async content => {
+    const id = randomUUID();
+    await sequelize.query(
+      `INSERT INTO attachments (id, type, size, data) VALUES ($id, 'image/png', $size, $data)`,
+      { bind: { id, size: content.length, data: content } },
+    );
+    return id;
+  };
+
+  const insertAsset = async content => {
+    const id = randomUUID();
+    await sequelize.query(
+      `INSERT INTO assets (id, name, type, data) VALUES ($id, $name, 'image/png', $data)`,
+      { bind: { id, name: `asset-${id}`, data: content } },
+    );
+    return id;
+  };
+
+  const rowOf = async (table, id) =>
+    await sequelize.query(`SELECT hash, data FROM ${table} WHERE id = $id`, {
+      bind: { id },
+      type: QueryTypes.SELECT,
+      plain: true,
+    });
+
+  const changelogEntriesHoldingBytes = async () => {
+    const row = await sequelize.query(
+      `
+        SELECT count(*) AS count FROM logs.changes
+        WHERE table_schema = 'public'
+          AND table_name IN ('attachments', 'assets')
+          AND record_data->>'data' IS NOT NULL
+      `,
+      { type: QueryTypes.SELECT, plain: true },
+    );
+    return Number(row.count);
+  };
+
+  const backfillEverything = async () => {
+    for (const tableName of ['attachments', 'assets']) {
+      await backfill.moveReferenceRows(tableName, 100);
+    }
+    await backfill.rewriteChangelogEntries(100);
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+    sequelize = ctx.store.sequelize;
+    backfill = new BlobBackfill({ sequelize, blobStore: ctx.blobStore });
+    // The command builds its own store from settings, having no server context.
+    await models.Setting.set('blobStorage.root', ctx.blobStore.root);
+  });
+
+  afterAll(async () => {
+    await ctx.close();
+  });
+
+  beforeEach(async () => {
+    sleepAsync.mockClear();
+    await sequelize.query('DELETE FROM attachments');
+    await sequelize.query('DELETE FROM assets');
+    await sequelize.query(
+      `DELETE FROM logs.changes WHERE table_name IN ('attachments', 'assets')`,
+    );
+    await models.Blob.destroy({ where: {}, force: true });
+  });
+
+  it('restores both reference tables and the changelog', async () => {
+    const attachmentContent = Buffer.from('an attachment on its way back');
+    const assetContent = Buffer.from('an asset on its way back');
+    const attachmentId = await insertAttachment(attachmentContent);
+    const assetId = await insertAsset(assetContent);
+    await backfillEverything();
+    expect(await changelogEntriesHoldingBytes()).toBe(0);
+
+    await rollbackBlobBackfill({ delay: 0 });
+
+    const attachment = await rowOf('attachments', attachmentId);
+    expect(attachment.hash).toBeNull();
+    expect(Buffer.from(attachment.data)).toEqual(attachmentContent);
+    const asset = await rowOf('assets', assetId);
+    expect(asset.hash).toBeNull();
+    expect(Buffer.from(asset.data)).toEqual(assetContent);
+    expect(await changelogEntriesHoldingBytes()).toBe(2);
+  });
+
+  it('restores fifty rows a batch when no batch size is given', async () => {
+    const rollbackRows = jest.spyOn(BlobBackfill.prototype, 'rollbackReferenceRows');
+    const rollbackChangelog = jest.spyOn(BlobBackfill.prototype, 'rollbackChangelogEntries');
+    await insertAttachment(Buffer.from('one row is enough to size a batch'));
+    await backfillEverything();
+
+    await rollbackBlobBackfill({ delay: 0 });
+
+    expect(rollbackRows).toHaveBeenCalled();
+    expect(rollbackChangelog).toHaveBeenCalled();
+    for (const call of [...rollbackRows.mock.calls, ...rollbackChangelog.mock.calls]) {
+      expect(call.at(-1)).toBe(50);
+    }
+    rollbackRows.mockRestore();
+    rollbackChangelog.mockRestore();
+  });
+
+  it('pauses for the configured delay between batches', async () => {
+    for (let i = 0; i < 3; i++) await insertAttachment(Buffer.from(`document ${i}`));
+    await backfillEverything();
+
+    await rollbackBlobBackfill({ batchSize: 1, delay: 250 });
+
+    expect(sleepAsync).toHaveBeenCalledWith(250);
+    expect(sleepAsync.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('runs without pausing when the delay is explicitly zero', async () => {
+    for (let i = 0; i < 3; i++) await insertAttachment(Buffer.from(`unpaced document ${i}`));
+    await backfillEverything();
+
+    await rollbackBlobBackfill({ batchSize: 1, delay: 0 });
+
+    expect(sleepAsync).not.toHaveBeenCalled();
+    const pending = await sequelize.query(
+      `SELECT count(*) AS count FROM attachments WHERE hash IS NOT NULL`,
+      { type: QueryTypes.SELECT, plain: true },
+    );
+    expect(Number(pending.count)).toBe(0);
+  });
+});

--- a/packages/central-server/__tests__/sync/blobQuarantineSync.test.js
+++ b/packages/central-server/__tests__/sync/blobQuarantineSync.test.js
@@ -1,0 +1,138 @@
+import { FACT_CURRENT_SYNC_TICK, FACT_LOOKUP_UP_TO_TICK } from '@tamanu/constants/facts';
+import { SYSTEM_USER_UUID } from '@tamanu/constants';
+import { fake } from '@tamanu/fake-data/fake';
+
+import {
+  createTestContext,
+  initializeCentralSyncManagerWithContext,
+  waitForSession,
+} from '../utilities';
+
+// spec: AV
+// Central scans and its verdict is authoritative, so a quarantine is written on
+// central and pulled everywhere: a facility or device that runs no scanner of
+// its own still knows not to serve, fetch or heal the content. The record
+// carries no scope, so it reaches a server whether or not that server holds the
+// bytes or shares a patient with whoever uploaded them.
+describe('Blob quarantine propagation', () => {
+  let ctx;
+  let models;
+
+  const INFECTED_HASH = `sha256:${'ab'.repeat(32)}`;
+
+  const lookupEnabledConfig = {
+    sync: {
+      lookupTable: { enabled: true },
+      maxRecordsPerSnapshotChunk: 100000000,
+    },
+  };
+
+  const quarantinesPulledBy = async (centralSyncManager, { facilityIds, isMobile = false }) => {
+    const { sessionId } = await centralSyncManager.startSession({ facilityIds, isMobile });
+    await waitForSession(centralSyncManager, sessionId);
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      { since: 1, facilityIds },
+      () => true,
+    );
+    const changes = await centralSyncManager.getOutgoingChanges(sessionId, {});
+    return changes.filter(change => change.recordType === 'blob_quarantines');
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    ({ models } = ctx.store);
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    jest.resetModules();
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 2);
+    await models.SyncLookupTick.truncate({ force: true });
+    await models.SyncDeviceTick.truncate({ force: true });
+    await models.BlobQuarantine.truncate({ force: true });
+    await models.Facility.truncate({ cascade: true, force: true });
+    await models.User.truncate({ cascade: true, force: true });
+    await models.User.create({
+      id: SYSTEM_USER_UUID,
+      email: 'system',
+      displayName: 'System',
+      role: 'system',
+    });
+    await models.LocalSystemFact.set(FACT_LOOKUP_UP_TO_TICK, null);
+    await models.SyncLookup.truncate({ force: true });
+    await models.DebugLog.truncate({ force: true });
+
+    await models.BlobQuarantine.create({
+      hash: INFECTED_HASH,
+      scannerVersion: 'ClamAV 1.0.5',
+      signatureVersion: '27100',
+    });
+  });
+
+  it('sends a quarantine to a facility with the versions behind the verdict', async () => {
+    const facility = await models.Facility.create(fake(models.Facility));
+    const centralSyncManager = initializeCentralSyncManagerWithContext(ctx);
+
+    const [quarantine, ...rest] = await quarantinesPulledBy(centralSyncManager, {
+      facilityIds: [facility.id],
+    });
+
+    expect(rest).toHaveLength(0);
+    expect(quarantine.data).toMatchObject({
+      hash: INFECTED_HASH,
+      scannerVersion: 'ClamAV 1.0.5',
+      signatureVersion: '27100',
+    });
+  });
+
+  it('sends it to a facility sharing neither content nor patients with the upload', async () => {
+    const unrelatedFacility = await models.Facility.create(fake(models.Facility));
+    const centralSyncManager = initializeCentralSyncManagerWithContext(ctx);
+
+    const quarantines = await quarantinesPulledBy(centralSyncManager, {
+      facilityIds: [unrelatedFacility.id],
+    });
+
+    expect(quarantines.map(({ data }) => data.hash)).toEqual([INFECTED_HASH]);
+  });
+
+  it('sends it to a device session', async () => {
+    const facility = await models.Facility.create(fake(models.Facility));
+    const centralSyncManager = initializeCentralSyncManagerWithContext(ctx);
+
+    const quarantines = await quarantinesPulledBy(centralSyncManager, {
+      facilityIds: [facility.id],
+      isMobile: true,
+    });
+
+    expect(quarantines.map(({ data }) => data.hash)).toEqual([INFECTED_HASH]);
+  });
+
+  it('sends it through the sync lookup table', async () => {
+    // The deployed configuration snapshots from sync_lookup rather than the
+    // source tables, so an unscoped record has to reach the lookup to propagate.
+    jest.doMock('@tamanu/shared/utils/withConfig', () => ({
+      withConfig: fn => {
+        const inner = (...args) => fn(...args, lookupEnabledConfig);
+        inner.overrideConfig = fn;
+        return inner;
+      },
+    }));
+    const facility = await models.Facility.create(fake(models.Facility));
+    const centralSyncManager = initializeCentralSyncManagerWithContext(ctx, lookupEnabledConfig);
+    await centralSyncManager.updateLookupTable();
+
+    const lookup = await models.SyncLookup.findOne({
+      where: { recordType: 'blob_quarantines' },
+    });
+    expect(lookup.patientId).toBeNull();
+    expect(lookup.facilityId).toBeNull();
+
+    const quarantines = await quarantinesPulledBy(centralSyncManager, {
+      facilityIds: [facility.id],
+    });
+    expect(quarantines.map(({ data }) => data.hash)).toEqual([INFECTED_HASH]);
+  });
+});

--- a/packages/central-server/__tests__/sync/blobScopeAgreesWithPullFilter.test.js
+++ b/packages/central-server/__tests__/sync/blobScopeAgreesWithPullFilter.test.js
@@ -1,0 +1,222 @@
+import { FACT_CURRENT_SYNC_TICK } from '@tamanu/constants/facts';
+import {
+  createSnapshotTable,
+  dropSnapshotTable,
+  findSyncSnapshotRecords,
+  getModelsForPull,
+  SYNC_SESSION_DIRECTION,
+} from '@tamanu/database/sync';
+import { fake } from '@tamanu/fake-data/fake';
+import { fakeUUID } from '@tamanu/utils/generateId';
+
+import { CentralSyncManager } from '../../app/sync/CentralSyncManager';
+import { isHashReferencedInScope } from '../../app/blobReferences';
+import { createMarkedForSyncPatientsTable } from '../../app/sync/createMarkedForSyncPatientsTable';
+import { snapshotOutgoingChanges } from '../../app/sync/snapshotOutgoingChanges';
+import { createTestContext } from '../utilities';
+
+// spec: BLAC
+// Blob access is authorised at the reference layer against the same data scoping
+// record synchronisation applies, and `isHashReferencedInScope` reproduces the
+// pull filter's scope predicate by hand. The two are covered separately
+// elsewhere; what this asserts is that they agree, over a fixture spanning every
+// dimension the predicate turns on. Drift between them widens blob access past
+// what record sync grants, which is a facility fetching bytes for a record it is
+// not entitled to hold.
+describe('Blob scope agrees with the record sync pull filter', () => {
+  let ctx;
+  let models;
+  let sequelize;
+  let outgoingModels;
+  let facilityA;
+  let facilityB;
+  let sensitiveFacility;
+  let attachments;
+
+  const lookupEnabledConfig = {
+    sync: {
+      lookupTable: {
+        enabled: true,
+      },
+      maxRecordsPerSnapshotChunk: 10000000,
+    },
+  };
+
+  const sessionConfig = { syncAllLabRequests: false, isMobile: false };
+
+  const markedForSyncPatient = async (facility, patient) =>
+    await models.PatientFacility.create({
+      id: models.PatientFacility.generateId(),
+      patientId: patient.id,
+      facilityId: facility.id,
+    });
+
+  const encounterAt = async (facility, patient) => {
+    const department = await models.Department.create(
+      fake(models.Department, { facilityId: facility.id }),
+    );
+    const location = await models.Location.create(
+      fake(models.Location, { facilityId: facility.id }),
+    );
+    const examiner = await models.User.create(fake(models.User));
+    return await models.Encounter.create(
+      fake(models.Encounter, {
+        patientId: patient.id,
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: examiner.id,
+        endDate: null,
+      }),
+    );
+  };
+
+  // Each attachment gets its own hash, so a set of admitted hashes names a set of
+  // records and the two scopings are comparable record for record.
+  let hashSeq = 0;
+  const attachmentCarryingHash = async (label, overrides) => {
+    const hash = `sha256:${String(hashSeq++).padStart(2, '0').repeat(32)}`;
+    await models.Attachment.create(
+      fake(models.Attachment, { ...overrides, type: 'text/plain', size: 1, hash, data: null }),
+    );
+    return { label, hash };
+  };
+
+  // The set of hashes a pull for these facilities admits, taken from the records
+  // the snapshot actually holds rather than from a re-derived predicate.
+  const syncPullAdmits = async facilityIds => {
+    const sessionId = fakeUUID();
+    const startTime = new Date();
+    await models.SyncSession.create({
+      id: sessionId,
+      startTime,
+      lastConnectionTime: startTime,
+      debugInfo: {},
+    });
+    await createSnapshotTable(sequelize, sessionId);
+    try {
+      const markedForSyncPatients = await createMarkedForSyncPatientsTable(
+        sequelize,
+        sessionId,
+        true,
+        facilityIds,
+        -1,
+      );
+      const patientCount = await models.PatientFacility.count({
+        where: { facilityId: facilityIds },
+      });
+      await snapshotOutgoingChanges(
+        ctx.store,
+        outgoingModels,
+        -1,
+        patientCount,
+        markedForSyncPatients,
+        sessionId,
+        facilityIds,
+        null,
+        sessionConfig,
+        lookupEnabledConfig,
+      );
+      const snapshotted = await findSyncSnapshotRecords(
+        ctx.store,
+        sessionId,
+        SYNC_SESSION_DIRECTION.OUTGOING,
+        0,
+        Number.MAX_SAFE_INTEGER,
+        'attachments',
+      );
+      const admittedIds = new Set(snapshotted.map(record => record.recordId));
+      const rows = await models.Attachment.findAll({
+        where: { id: [...admittedIds] },
+      });
+      return rows.map(row => row.hash).sort();
+    } finally {
+      await dropSnapshotTable(sequelize, sessionId);
+    }
+  };
+
+  const blobScopeAdmits = async facilityIds => {
+    const admitted = [];
+    for (const { hash } of attachments) {
+      if (await isHashReferencedInScope(sequelize, { hash, facilityIds })) {
+        admitted.push(hash);
+      }
+    }
+    return admitted.sort();
+  };
+
+  // Named rather than compared as bare digests, so a failure says which record
+  // the two scopings disagree about.
+  const labelsOf = hashes =>
+    hashes.map(hash => attachments.find(a => a.hash === hash)?.label ?? hash).sort();
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    ({ models, sequelize } = ctx.store);
+    outgoingModels = getModelsForPull(models);
+
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 2);
+
+    facilityA = await models.Facility.create(fake(models.Facility));
+    facilityB = await models.Facility.create(fake(models.Facility));
+    sensitiveFacility = await models.Facility.create(fake(models.Facility, { isSensitive: true }));
+
+    const patientAtA = await models.Patient.create(fake(models.Patient));
+    const patientAtB = await models.Patient.create(fake(models.Patient));
+    const patientAtBoth = await models.Patient.create(fake(models.Patient));
+    const patientMarkedNowhere = await models.Patient.create(fake(models.Patient));
+    await markedForSyncPatient(facilityA, patientAtA);
+    await markedForSyncPatient(facilityB, patientAtB);
+    await markedForSyncPatient(facilityA, patientAtBoth);
+    await markedForSyncPatient(facilityB, patientAtBoth);
+    await markedForSyncPatient(sensitiveFacility, patientAtA);
+
+    const sensitiveEncounter = await encounterAt(sensitiveFacility, patientAtA);
+    const ordinaryEncounter = await encounterAt(facilityA, patientAtA);
+
+    attachments = [
+      await attachmentCarryingHash('patient at A', { patientId: patientAtA.id }),
+      await attachmentCarryingHash('patient at B', { patientId: patientAtB.id }),
+      await attachmentCarryingHash('patient at both', { patientId: patientAtBoth.id }),
+      await attachmentCarryingHash('patient marked nowhere', {
+        patientId: patientMarkedNowhere.id,
+      }),
+      await attachmentCarryingHash('sensitive encounter', {
+        encounterId: sensitiveEncounter.id,
+      }),
+      await attachmentCarryingHash('ordinary encounter', { encounterId: ordinaryEncounter.id }),
+      await attachmentCarryingHash('no patient or encounter', {}),
+    ];
+
+    await new CentralSyncManager(ctx).updateLookupTable();
+  });
+
+  afterAll(() => ctx.close());
+
+  it.each([
+    ['a single facility', () => [facilityA.id]],
+    ['a facility sharing only some of its patients', () => [facilityB.id]],
+    ['a sensitive facility', () => [sensitiveFacility.id]],
+    ['a server running several facilities', () => [facilityA.id, facilityB.id]],
+    ['a scope including a sensitive facility', () => [facilityA.id, sensitiveFacility.id]],
+  ])('admits the same records as a pull for %s', async (_name, facilityIds) => {
+    const scope = facilityIds();
+    expect(labelsOf(await blobScopeAdmits(scope))).toEqual(labelsOf(await syncPullAdmits(scope)));
+  });
+
+  // The agreement above is only worth asserting if the fixture actually
+  // discriminates: were every record in scope everywhere, the two predicates
+  // could differ arbitrarily and still agree here.
+  it('spans records the scope both admits and refuses', async () => {
+    for (const admitted of [
+      await blobScopeAdmits([facilityA.id]),
+      await syncPullAdmits([facilityA.id]),
+    ]) {
+      expect(admitted.length).toBeGreaterThan(0);
+      expect(admitted.length).toBeLessThan(attachments.length);
+      expect(labelsOf(admitted)).not.toContain('sensitive encounter');
+    }
+    expect(labelsOf(await blobScopeAdmits([sensitiveFacility.id]))).toContain(
+      'sensitive encounter',
+    );
+  });
+});

--- a/packages/central-server/__tests__/tasks/blobBackfillScheduling.test.js
+++ b/packages/central-server/__tests__/tasks/blobBackfillScheduling.test.js
@@ -1,0 +1,39 @@
+import { ScheduledTask } from '@tamanu/shared/tasks/ScheduledTask';
+
+import { createTestContext } from '../utilities';
+import { startScheduledTasks } from '../../app/tasks';
+
+// spec: BKFL
+// The backfill runs from server start with no operator action, which means it
+// is among the tasks the server schedules on boot rather than something an
+// operator has to kick off.
+describe('BlobBackfillTask scheduling', () => {
+  let ctx;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+
+  afterAll(() => ctx.close());
+
+  it('is scheduled, enabled, when the server starts its tasks', async () => {
+    const polled = [];
+    // Recorded rather than called through, so no cron jobs outlive the test.
+    const beginPolling = jest
+      .spyOn(ScheduledTask.prototype, 'beginPolling')
+      .mockImplementation(function record() {
+        polled.push({ name: this.getName(), enabled: this.isEnabled, schedule: this.schedule });
+      });
+
+    const stopTasks = await startScheduledTasks(ctx);
+    try {
+      expect(polled).toContainEqual(
+        expect.objectContaining({ name: 'BlobBackfillTask', enabled: true }),
+      );
+      expect(polled.find(({ name }) => name === 'BlobBackfillTask').schedule).toBeTruthy();
+    } finally {
+      stopTasks();
+      beginPolling.mockRestore();
+    }
+  });
+});

--- a/packages/database/__tests__/blobStore/BlobParity.test.ts
+++ b/packages/database/__tests__/blobStore/BlobParity.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { Readable } from 'node:stream';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   CENTRAL_PARITY_TIERS,
@@ -175,6 +175,7 @@ describe('blob parity', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(root, { recursive: true, force: true });
   });
 
@@ -376,6 +377,30 @@ describe('blob parity', () => {
       );
       expect(await fs.readFile(storedPath(hash))).toEqual(damaged);
       expect(fakeBlob.rows.get(hash)!.correctionCount).toBe(0);
+    });
+
+    // spec: FEC, CAS
+    // A repair lands over bytes that are already there. POSIX renames over them;
+    // Windows/NTFS refuses, so the occupant has to go before the rename can win,
+    // and only a faked rename reaches that on a POSIX test host.
+    it('replaces damaged bytes where they cannot be renamed over', async () => {
+      const blob = content();
+      const store = makeStore();
+      const { hash } = await admit(blob, BLOB_TIERS.CACHE, store);
+      await damageShards(hash, [7]);
+
+      const occupied = Object.assign(new Error('rename failed with EEXIST'), { code: 'EEXIST' });
+      const realRename = fs.rename;
+      const rename = vi
+        .spyOn(fs, 'rename')
+        .mockRejectedValueOnce(occupied)
+        .mockImplementation(realRename);
+
+      expect(await store.repairFromParity(hash)).toBe(true);
+
+      expect(rename).toHaveBeenCalledTimes(2);
+      expect(await fs.readFile(storedPath(hash))).toEqual(blob);
+      expect(await fs.readdir(path.join(root, 'tmp'))).toHaveLength(0);
     });
 
     // spec: FEC

--- a/packages/database/__tests__/blobStore/BlobStore.test.ts
+++ b/packages/database/__tests__/blobStore/BlobStore.test.ts
@@ -112,15 +112,21 @@ describe('BlobStore', () => {
       statfs: async () => ({ bavail: volumeFreeBytes, bsize: 1 }),
     });
 
+  const storedPath = (hash: string) => {
+    const digest = hash.split(':')[1];
+    return path.join(root, 'sha256', digest.slice(0, 2), digest.slice(2, 4), digest.slice(4));
+  };
+
   // Rewrite a stored blob's bytes in place, leaving its registry row and its
   // path untouched: bit rot as the store would meet it.
   const corruptStoredBytes = async (hash: string, replacement: string) => {
-    const digest = hash.split(':')[1];
-    await fs.writeFile(
-      path.join(root, 'sha256', digest.slice(0, 2), digest.slice(2, 4), digest.slice(4)),
-      replacement,
-    );
+    await fs.writeFile(storedPath(hash), replacement);
   };
+
+  const renameFailure = (code: string) =>
+    Object.assign(new Error(`rename failed with ${code}`), { code });
+
+  const tempFiles = async () => await fs.readdir(path.join(root, 'tmp'));
 
   beforeEach(async () => {
     root = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-store-test-'));
@@ -203,6 +209,71 @@ describe('BlobStore', () => {
       expect(again.existed).toBe(true);
       expect(fakeBlob.rows.get(hash)).toMatchObject({ hash, size: 11 });
       expect(await store.has(hash)).toBe(true);
+    });
+  });
+
+  // spec: CAS
+  // Renaming over an occupied destination, and transient sharing violations from
+  // an antivirus or indexer handle, only happen on Windows/NTFS: POSIX never
+  // raises them here, so a faked rename is the only exercise this branch gets.
+  describe('atomic placement', () => {
+    const realRename = fs.rename;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('places the content whole once a transient rename failure clears', async () => {
+      const rename = vi
+        .spyOn(fs, 'rename')
+        .mockRejectedValueOnce(renameFailure('EPERM'))
+        .mockRejectedValueOnce(renameFailure('EBUSY'))
+        .mockImplementation(realRename);
+      const store = makeStore();
+
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+
+      expect(rename).toHaveBeenCalledTimes(3);
+      expect((await readAll(await store.get(hash))).toString()).toBe('hello world');
+      expect(await tempFiles()).toHaveLength(0);
+    });
+
+    it('keeps the bytes a concurrent put placed and drops its own', async () => {
+      vi.spyOn(fs, 'rename').mockImplementationOnce(async (_from, to) => {
+        // The other put won between this one's presence check and its rename.
+        await fs.writeFile(to as string, 'placed by the concurrent put');
+        throw renameFailure('EEXIST');
+      });
+      const store = makeStore();
+
+      const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+
+      expect(hash).toBe(HELLO_HASH);
+      expect((await fs.readFile(storedPath(hash))).toString()).toBe('placed by the concurrent put');
+      expect(await tempFiles()).toHaveLength(0);
+    });
+
+    it('gives up once the attempts are exhausted, storing nothing', async () => {
+      const rename = vi.spyOn(fs, 'rename').mockRejectedValue(renameFailure('EBUSY'));
+      const store = makeStore();
+
+      await expect(store.put(Readable.from(Buffer.from('hello world')))).rejects.toMatchObject({
+        code: 'EBUSY',
+      });
+      expect(rename.mock.calls.length).toBeGreaterThan(1);
+      expect(await store.has(HELLO_HASH)).toBe(false);
+      expect(await tempFiles()).toHaveLength(0);
+    });
+
+    it('does not retry a failure that waiting cannot clear', async () => {
+      const rename = vi.spyOn(fs, 'rename').mockRejectedValue(renameFailure('EXDEV'));
+      const store = makeStore();
+
+      await expect(store.put(Readable.from(Buffer.from('hello world')))).rejects.toMatchObject({
+        code: 'EXDEV',
+      });
+      expect(rename).toHaveBeenCalledTimes(1);
+      expect(await tempFiles()).toHaveLength(0);
     });
   });
 
@@ -417,6 +488,25 @@ describe('BlobStore', () => {
       await store.stage(HELLO_HASH, Readable.from(Buffer.from('hello')), { offset: 0 });
       await fs.mkdir(path.join(root, 'tmp'), { recursive: true });
       await fs.writeFile(path.join(root, 'tmp', 'leftover'), 'x');
+
+      expect(await collect(store)).toEqual([]);
+    });
+
+    it('skips a file misplaced under the fan-out directories of another blob', async () => {
+      const store = makeStore();
+      const digest = HELLO_HASH.split(':')[1];
+      // The same characters as a stored blob's path, split a byte along: joined
+      // up they name a real blob, so only the location the fan-out actually
+      // encodes tells this apart from content.
+      const misplaced = path.join(
+        root,
+        'sha256',
+        digest.slice(0, 2),
+        digest.slice(2, 5),
+        digest.slice(5),
+      );
+      await fs.mkdir(path.dirname(misplaced), { recursive: true });
+      await fs.writeFile(misplaced, 'hello world');
 
       expect(await collect(store)).toEqual([]);
     });

--- a/packages/database/__tests__/blobStore/blobRegistry.test.ts
+++ b/packages/database/__tests__/blobStore/blobRegistry.test.ts
@@ -1,0 +1,157 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { QueryTypes } from 'sequelize';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { BLOB_INTEGRITY_STATES, BLOB_SCAN_VERDICTS, type BlobScanVerdict } from '@tamanu/constants';
+import { fake } from '@tamanu/fake-data/fake';
+
+import { BlobStore } from '../../src/blobStore/BlobStore';
+import { getModelsForPull, getModelsForPush } from '../../src/sync/getModelsForDirection';
+import { closeDatabase, createTestDatabase } from '../utilities';
+
+const SCANNER_VERSION = 'ClamAV 1.0.5';
+const SIGNATURE_VERSION = '27100';
+
+describe('blob registry', () => {
+  let models: any;
+  let sequelize: any;
+  let store: BlobStore;
+  let root: string;
+
+  beforeAll(async () => {
+    ({ models, sequelize } = await createTestDatabase());
+  });
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-registry-'));
+    store = new BlobStore({
+      root,
+      models,
+      getFreeDiskReserveBytes: async () => 0,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  // Content no other case shares, so every admission is a fresh row rather than
+  // an upsert onto one an earlier case or an earlier run left behind.
+  const admit = async () => {
+    const { hash } = await store.put(Readable.from(Buffer.from(`blob ${randomUUID()}`)));
+    return hash;
+  };
+
+  // spec: CAS
+  describe('locality', () => {
+    it('is neither pulled nor pushed by a sync session', () => {
+      expect(Object.keys(getModelsForPull(models))).not.toContain('Blob');
+      expect(Object.keys(getModelsForPush(models))).not.toContain('Blob');
+    });
+
+    it('carries no sync tick column, so no write to it is ever marked for sync', async () => {
+      const columns = await sequelize.query(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = 'blobs'`,
+        { type: QueryTypes.SELECT },
+      );
+
+      expect(columns.map((column: any) => column.column_name)).not.toContain(
+        'updated_at_sync_tick',
+      );
+    });
+
+    it('carries no changelog trigger', async () => {
+      const triggers = await sequelize.query(
+        `SELECT trigger.tgname FROM pg_trigger trigger
+         JOIN pg_proc proc ON proc.oid = trigger.tgfoid
+         JOIN pg_namespace namespace ON namespace.oid = proc.pronamespace
+         WHERE trigger.tgrelid = 'public.blobs'::regclass
+           AND NOT trigger.tgisinternal
+           AND namespace.nspname = 'logs'
+           AND proc.proname = 'record_change'`,
+        { type: QueryTypes.SELECT },
+      );
+
+      expect(triggers).toEqual([]);
+    });
+
+    it('records nothing to the change log when a blob is admitted', async () => {
+      // A logged write alongside it, so the case fails rather than passes
+      // vacuously if change logging is off in this session.
+      const referenceData = await models.ReferenceData.create(fake(models.ReferenceData));
+      const hash = await admit();
+      const blob = await models.Blob.findOne({ where: { hash } });
+
+      const logged = await sequelize.query(
+        `SELECT table_name FROM logs.changes WHERE record_id IN ($blobId, $referenceDataId)`,
+        {
+          bind: { blobId: blob.id, referenceDataId: referenceData.id },
+          type: QueryTypes.SELECT,
+        },
+      );
+
+      expect(logged.map((entry: any) => entry.table_name)).toEqual(['reference_data']);
+    });
+  });
+
+  // spec: AV
+  describe('scan verdict and integrity state', () => {
+    const recordVerdict = async (hash: string, verdict: BlobScanVerdict) =>
+      await store.recordScanVerdict(hash, {
+        verdict,
+        scannerVersion: SCANNER_VERSION,
+        signatureVersion: SIGNATURE_VERSION,
+      });
+
+    it('records a verdict over content already standing as corrupt, leaving that state', async () => {
+      const hash = await admit();
+      await store.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.CORRUPT);
+
+      await recordVerdict(hash, BLOB_SCAN_VERDICTS.CLEAN);
+
+      expect(await store.stat(hash)).toMatchObject({
+        integrityState: BLOB_INTEGRITY_STATES.CORRUPT,
+        scanVerdict: BLOB_SCAN_VERDICTS.CLEAN,
+      });
+    });
+
+    it('records an integrity state without disturbing the verdict', async () => {
+      const hash = await admit();
+      await recordVerdict(hash, BLOB_SCAN_VERDICTS.INFECTED);
+
+      await store.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.CORRUPT);
+      expect(await store.stat(hash)).toMatchObject({
+        integrityState: BLOB_INTEGRITY_STATES.CORRUPT,
+        scanVerdict: BLOB_SCAN_VERDICTS.INFECTED,
+      });
+
+      // Bytes that verify again say nothing about what they contain: the blob is
+      // still the malware it was found to be.
+      await store.recordIntegrityState(hash, BLOB_INTEGRITY_STATES.VERIFIED);
+      expect(await store.stat(hash)).toMatchObject({
+        integrityState: BLOB_INTEGRITY_STATES.VERIFIED,
+        scanVerdict: BLOB_SCAN_VERDICTS.INFECTED,
+      });
+    });
+
+    it('records the scanner and signatures behind a verdict, so it can be aged', async () => {
+      const hash = await admit();
+
+      await recordVerdict(hash, BLOB_SCAN_VERDICTS.CLEAN);
+
+      const blob = await models.Blob.findOne({ where: { hash } });
+      expect(blob.scannerVersion).toBe(SCANNER_VERSION);
+      expect(blob.signatureVersion).toBe(SIGNATURE_VERSION);
+      expect(blob.scannedAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/packages/database/__tests__/blobStore/createScannerDriver.test.ts
+++ b/packages/database/__tests__/blobStore/createScannerDriver.test.ts
@@ -1,0 +1,103 @@
+import net from 'node:net';
+import { Readable } from 'node:stream';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { BLOB_SCAN_VERDICTS, BLOB_SCANNERS } from '@tamanu/constants';
+
+import { createScannerDriver } from '../../src/blobStore/scanning/createScannerDriver';
+
+// clamd answers zVERSION as soon as the command arrives, and zINSTREAM only once
+// the zero-length frame has ended the content, so a fake has to read the framing
+// to know when a request is complete.
+function completedCommand(request: Buffer): string | null {
+  const terminator = request.indexOf(0);
+  if (terminator === -1) {
+    return null;
+  }
+  const command = request.subarray(0, terminator).toString();
+  if (command !== 'zINSTREAM') {
+    return command;
+  }
+  let position = terminator + 1;
+  while (position + 4 <= request.length) {
+    const length = request.readUInt32BE(position);
+    if (length === 0) {
+      return command;
+    }
+    position += 4 + length;
+  }
+  return null;
+}
+
+// spec: AV
+describe('createScannerDriver', () => {
+  let server: net.Server | null = null;
+
+  afterEach(async () => {
+    const running = server;
+    server = null;
+    if (running) {
+      await new Promise(closed => {
+        running.close(closed);
+      });
+    }
+  });
+
+  const fakeClamd = async (replies: Record<string, string>) => {
+    const connections: string[] = [];
+    server = net.createServer(socket => {
+      const received: Buffer[] = [];
+      let answered = false;
+      socket.on('data', chunk => {
+        received.push(chunk);
+        const command = answered ? null : completedCommand(Buffer.concat(received));
+        if (command) {
+          answered = true;
+          connections.push(command);
+          socket.end(replies[command]);
+        }
+      });
+    });
+    await new Promise<void>(listening => {
+      server!.listen(0, '127.0.0.1', listening);
+    });
+    const { port } = server!.address() as net.AddressInfo;
+    return { address: `127.0.0.1:${port}`, connections };
+  };
+
+  it('starts no scanner when the server names none', () => {
+    const driver = createScannerDriver({
+      scanner: BLOB_SCANNERS.NONE,
+      address: '127.0.0.1:3310',
+      timeoutMs: 1000,
+    });
+
+    expect(driver).toBeNull();
+  });
+
+  it('drives clamd at the named address when the server names clamd', async () => {
+    const { address, connections } = await fakeClamd({
+      zVERSION: 'ClamAV 1.0.5/27100/Thu Aug  7 08:22:03 2026\0',
+      zINSTREAM: 'stream: OK\0',
+    });
+
+    const driver = createScannerDriver({
+      scanner: BLOB_SCANNERS.CLAMD,
+      address,
+      timeoutMs: 5000,
+    });
+
+    expect(await driver!.versions()).toEqual({
+      scannerVersion: 'ClamAV 1.0.5',
+      signatureVersion: '27100',
+    });
+    expect(
+      await driver!.scan({
+        hash: 'sha256:whatever',
+        size: 3,
+        open: async () => Readable.from([Buffer.from('abc')]),
+      }),
+    ).toBe(BLOB_SCAN_VERDICTS.CLEAN);
+    expect(connections).toEqual(['zVERSION', 'zINSTREAM']);
+  });
+});

--- a/packages/database/src/blobStore/BlobStore.ts
+++ b/packages/database/src/blobStore/BlobStore.ts
@@ -610,8 +610,8 @@ export class BlobStore {
    * Admit content into the store: stream it to a temporary file within the
    * store, hash what landed there, then atomically rename into the fan-out path
    * and record it in the registry. Idempotent — identical content resolves to the one
-   * stored blob, keeping its existing tier (spec: CACHE — content already held
-   * as cache stays cache). Refuses (InsufficientStorageError) rather than take
+   * stored blob, keeping its existing tier, which a caller that needs the
+   * admitted tier applied sets itself. Refuses (InsufficientStorageError) rather than take
    * the volume's free space below the configured reserve. On any failure the
    * source stream is destroyed; it cannot be reused.
    *
@@ -687,8 +687,8 @@ export class BlobStore {
     }
     try {
       // The tier the registry recorded, not the one admission asked for: a live
-      // row keeps its own tier (spec: CACHE — content already held as cache stays
-      // cache), so what parity covers follows the row rather than the intent.
+      // row keeps its own tier, so what parity covers follows the row rather
+      // than the intent.
       const registered = await this.#models.Blob.findOne({ where: { hash } });
       if (!registered || !(await this.#parity.covers({ size, tier: registered.tier }))) {
         return;
@@ -1006,8 +1006,7 @@ export class BlobStore {
   ): Promise<void> {
     // Race-safe against concurrent puts of the same content; the loser's
     // insert is a no-op against the winner's identical live row, which keeps
-    // its tier: content already held as cache is durable on central and stays
-    // cache even when re-admitted with outbox intent (spec: CACHE). A
+    // its tier. A tier a re-admission needs applied is the caller's to set. A
     // soft-deleted row still occupies the unique index and would otherwise
     // shadow re-admission forever (invisible to has/get, conflicting here), so
     // resurrect it as the fresh admission it is: take the incoming tier (an

--- a/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import config from 'config';
 import ReactPDF from '@react-pdf/renderer';
 
+import { BLOB_TIERS } from '@tamanu/constants';
 import { fake, fakeUser } from '@tamanu/fake-data/fake';
 import { createDummyPatient } from '@tamanu/database/demoData/patients';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
@@ -62,6 +63,28 @@ describe('PatientLetter', () => {
     expect(attachment.data).toBeFalsy();
     expect(attachment.patientId).toBe(patient.id);
     expect(await ctx.blobStore.has(attachment.hash)).toBe(true);
+  });
+
+  // spec: ATCH
+  it('admits the letter at the outbox tier with central unreachable', async () => {
+    ctx.blobCache.setTransferChannel({
+      fetchFromCentral: async () => {
+        throw new Error('central is unreachable');
+      },
+      pushToCentral: async () => {
+        throw new Error('central is unreachable');
+      },
+    });
+    try {
+      const result = await createLetter();
+      expect(result).toHaveSucceeded();
+
+      const attachment = await models.Attachment.findByPk(result.body.attachmentId);
+      const blob = await models.Blob.findOne({ where: { hash: attachment.hash } });
+      expect(blob.tier).toBe(BLOB_TIERS.OUTBOX);
+    } finally {
+      ctx.blobCache.setTransferChannel(null);
+    }
   });
 
   it('renders the letter with the requesting browser locale', async () => {

--- a/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
@@ -1,3 +1,4 @@
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'fs';
 import config from 'config';
 import ReactPDF from '@react-pdf/renderer';
@@ -85,6 +86,27 @@ describe('PatientLetter', () => {
     } finally {
       ctx.blobCache.setTransferChannel(null);
     }
+  });
+
+  // spec: CACHE
+  it('leaves no outbox blob when the attachment write fails', async () => {
+    const content = `not a real pdf ${randomUUID()}`;
+    renderSpy.mockImplementationOnce(async (_element, filePath) => {
+      fs.writeFileSync(filePath, content);
+    });
+    const createSpy = jest
+      .spyOn(models.Attachment, 'create')
+      .mockRejectedValueOnce(new Error('attachment write failed'));
+
+    try {
+      const result = await createLetter();
+      expect(result).toHaveStatus(500);
+    } finally {
+      createSpy.mockRestore();
+    }
+
+    const hash = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+    expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
   });
 
   it('renders the letter with the requesting browser locale', async () => {

--- a/packages/facility-server/__tests__/apiv1/asset.test.js
+++ b/packages/facility-server/__tests__/apiv1/asset.test.js
@@ -11,6 +11,7 @@ const NAME = ASSET_NAMES.LETTERHEAD_LOGO;
 const LEGACY_NAME = ASSET_NAMES.CERTIFICATE_BOTTOM_HALF_IMG;
 const PENDING_NAME = ASSET_NAMES.DEATH_CERTIFICATE_BOTTOM_HALF_IMG;
 const UNUPLOADED_NAME = ASSET_NAMES.VACCINE_CERTIFICATE_WATERMARK;
+const SCOPED_NAME = ASSET_NAMES.INVOICE_FOOTER;
 const IMAGE = Buffer.from('facility-asset-image-bytes');
 
 describe('Asset GET endpoint', () => {
@@ -61,6 +62,36 @@ describe('Asset GET endpoint', () => {
     expect(response).toHaveSucceeded();
     expect(response.body.data).toBeNull();
     expect(response.body.availability).toBe(BLOB_AVAILABILITY_STATES.AWAITING_FETCH);
+  });
+
+  it('prefers a facility-specific asset over the deployment-wide one', async () => {
+    // verifies spec: ASSET
+    const deploymentWide = Buffer.from('deployment-wide-invoice-footer');
+    const facilitySpecific = Buffer.from('this-facility-invoice-footer');
+    const wide = await ctx.blobStore.put(Readable.from([deploymentWide]), {
+      sizeHint: deploymentWide.length,
+    });
+    const specific = await ctx.blobStore.put(Readable.from([facilitySpecific]), {
+      sizeHint: facilitySpecific.length,
+    });
+    await models.Asset.create({
+      name: SCOPED_NAME,
+      type: 'image/png',
+      hash: wide.hash,
+      data: null,
+      facilityId: null,
+    });
+    await models.Asset.create({
+      name: SCOPED_NAME,
+      type: 'image/png',
+      hash: specific.hash,
+      data: null,
+      facilityId,
+    });
+
+    const response = await app.get(`/api/asset/${SCOPED_NAME}`).query({ facilityId });
+    expect(response).toHaveSucceeded();
+    expect(Buffer.from(response.body.data)).toEqual(facilitySpecific);
   });
 
   it('returns an empty object when no asset row exists', async () => {

--- a/packages/facility-server/__tests__/blobCache/blobCache.test.js
+++ b/packages/facility-server/__tests__/blobCache/blobCache.test.js
@@ -8,6 +8,7 @@ import { FACILITY_PARITY_TIERS, PARITY_SIDECAR_SUFFIX } from '@tamanu/blobs';
 import { BLOB_INTEGRITY_STATES, BLOB_TIERS } from '@tamanu/constants';
 import { FACT_LAST_SUCCESSFUL_SYNC_PUSH } from '@tamanu/constants/facts';
 import { BlobStore } from '@tamanu/database/blobStore';
+import { log } from '@tamanu/shared/services/logging';
 
 import { createTestContext } from '../utilities';
 import { FacilityBlobCache } from '../../app/blobCache/FacilityBlobCache';
@@ -222,6 +223,29 @@ describe('facility blob outbox and LRU cache', () => {
       const served = await readAll(await blobCache.open(hash));
       expect(served.equals(content)).toBe(true);
       expect(fetched).toBe(1);
+    });
+
+    it('evicts least-recently-used content when a fetch takes the cache over budget', async () => {
+      // verifies spec: CACHE — the budget is enforced when a blob is admitted,
+      // and never at the expense of the arrival that triggered the admission
+      const stale = await putCache();
+      const recent = await putCache();
+      await setLastAccessed(stale.hash, 3 * 60 * 60 * 1000);
+      await setLastAccessed(recent.hash, 60 * 60 * 1000);
+
+      const content = uniqueContent();
+      const hash = hashOf(content);
+      cacheBudgetBytes = recent.content.length + content.length;
+      blobCache.setTransferChannel({
+        fetchFromCentral: async () => await blobStore.put(Readable.from(content)),
+      });
+
+      const served = await readAll(await blobCache.open(hash));
+
+      expect(served.equals(content)).toBe(true);
+      expect(await blobStore.has(hash)).toBe(true);
+      expect(await blobStore.has(stale.hash)).toBe(false);
+      expect(await blobStore.has(recent.hash)).toBe(true);
     });
   });
 
@@ -539,6 +563,90 @@ describe('facility blob outbox and LRU cache', () => {
       expect(status.count).toBe(2);
       expect(status.totalBytes).toBeGreaterThan(0);
       expect(status.oldestEligibleTick).toBe(42);
+    });
+
+    describe('escalation', () => {
+      let errorLog;
+
+      beforeEach(() => {
+        errorLog = jest.spyOn(log, 'error').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        errorLog.mockRestore();
+      });
+
+      const dysfunctionCalls = () =>
+        errorLog.mock.calls.filter(([message]) => /outbox dysfunction/i.test(message));
+
+      // A blob eligible at the given cursor, with the cursor left where the
+      // caller wants it for the cycle under test.
+      const eligibleSince = async (pusher, tick) => {
+        await models.LocalSystemFact.set(FACT_LAST_SUCCESSFUL_SYNC_PUSH, String(tick));
+        await pusher.recordSyncCycle();
+        errorLog.mockClear();
+      };
+
+      it('escalates a blob left unpushed across several successful syncs', async () => {
+        // verifies spec: CAP — the connection is working but the push path is not
+        const { hash } = await putOutbox();
+        const pusher = makeCyclePusher(hash);
+        await eligibleSince(pusher, 10);
+
+        await models.LocalSystemFact.set(FACT_LAST_SUCCESSFUL_SYNC_PUSH, '100');
+        await pusher.recordSyncCycle();
+
+        expect(dysfunctionCalls()).toHaveLength(1);
+        expect(dysfunctionCalls()[0][1]).toMatchObject({
+          ticksSinceEligible: 90,
+          outboxCount: 1,
+        });
+      });
+
+      it('stays quiet while a blob has only just become eligible', async () => {
+        // verifies spec: CAP — accumulation is measured against sync progress,
+        // so a blob that has not yet outlived several cycles is not dysfunction
+        const { hash } = await putOutbox();
+        const pusher = makeCyclePusher(hash);
+        await eligibleSince(pusher, 10);
+
+        await models.LocalSystemFact.set(FACT_LAST_SUCCESSFUL_SYNC_PUSH, '12');
+        await pusher.recordSyncCycle();
+
+        expect(dysfunctionCalls()).toHaveLength(0);
+      });
+
+      it('treats a blob whose transfer is in flight as healthy accumulation', async () => {
+        // verifies spec: CAP — escalation applies to eligible blobs that are not
+        // being attempted, so a slow but progressing transfer is not dysfunction
+        const { hash } = await putOutbox();
+        let resolvePush;
+        let attempts = 0;
+        const pusher = new BlobOutboxPusher({
+          models,
+          transferChannel: {
+            pushToCentral: () => {
+              attempts += 1;
+              return new Promise(resolve => {
+                resolvePush = () => resolve({ acknowledged: true });
+              });
+            },
+          },
+          blobCache,
+          referenceResolvers: [async (_models, hashes) => hashes.filter(h => h === hash)],
+        });
+        await eligibleSince(pusher, 10);
+
+        const push = pusher.runOnce();
+        await waitFor(() => attempts === 1);
+        await models.LocalSystemFact.set(FACT_LAST_SUCCESSFUL_SYNC_PUSH, '100');
+        await pusher.recordSyncCycle();
+
+        expect(dysfunctionCalls()).toHaveLength(0);
+
+        resolvePush();
+        await push;
+      });
     });
   });
 

--- a/packages/facility-server/__tests__/blobCache/blobCache.test.js
+++ b/packages/facility-server/__tests__/blobCache/blobCache.test.js
@@ -95,6 +95,17 @@ describe('facility blob outbox and LRU cache', () => {
 
   const tierOf = async hash => (await models.Blob.findOne({ where: { hash } })).tier;
 
+  const sidecarPathFor = hash => {
+    const digest = hash.split(':')[1];
+    return path.join(
+      root,
+      'sha256',
+      digest.slice(0, 2),
+      digest.slice(2, 4),
+      `${digest.slice(4)}${PARITY_SIDECAR_SUFFIX}`,
+    );
+  };
+
   const setLastAccessed = async (hash, msAgo) =>
     models.Blob.update(
       { lastAccessedAt: new Date(Date.now() - msAgo) },
@@ -108,12 +119,13 @@ describe('facility blob outbox and LRU cache', () => {
       expect(await tierOf(hash)).toBe(BLOB_TIERS.OUTBOX);
     });
 
-    it('keeps content already held as cache in the cache tier on outbox re-admission', async () => {
-      // verifies spec: CACHE — the tier reflects whether central holds the bytes
+    it('returns cache-tier content to the outbox when it is admitted locally', async () => {
+      // verifies spec: CACHE — a cache copy central holds cannot be told apart
+      // from one demoted after its referencing record was never created
       const content = uniqueContent();
       await putCache(content);
       const { hash } = await putOutbox(content);
-      expect(await tierOf(hash)).toBe(BLOB_TIERS.CACHE);
+      expect(await tierOf(hash)).toBe(BLOB_TIERS.OUTBOX);
     });
 
     it('keeps an un-acknowledged blob in the outbox on repeat admission', async () => {
@@ -141,14 +153,7 @@ describe('facility blob outbox and LRU cache', () => {
       // push, so a corrupt cache copy costs a refetch rather than needing parity
       errorCorrection = { enabled: true, proportion: 0.1 };
       const { hash } = await putOutbox(Buffer.alloc(64 * 1024, 'o'));
-      const digest = hash.split(':')[1];
-      const sidecar = path.join(
-        root,
-        'sha256',
-        digest.slice(0, 2),
-        digest.slice(2, 4),
-        `${digest.slice(4)}${PARITY_SIDECAR_SUFFIX}`,
-      );
+      const sidecar = sidecarPathFor(hash);
       await expect(fs.access(sidecar)).resolves.toBeUndefined();
 
       await blobCache.demote(hash);
@@ -157,6 +162,21 @@ describe('facility blob outbox and LRU cache', () => {
       const row = await models.Blob.findOne({ where: { hash } });
       expect(row.tier).toBe(BLOB_TIERS.CACHE);
       expect(row.hasParity).toBe(false);
+    });
+
+    it('covers content promoted back to the outbox with parity again', async () => {
+      // verifies spec: FEC — a blob back in the outbox is again the only durable
+      // copy, so it is protected rather than left on the cache tier's terms
+      errorCorrection = { enabled: true, proportion: 0.1 };
+      const content = Buffer.alloc(64 * 1024, 'p');
+      const { hash } = await putOutbox(content);
+      await blobCache.demote(hash);
+      await expect(fs.access(sidecarPathFor(hash))).rejects.toThrow();
+
+      await blobCache.putOutbox(Readable.from(content));
+
+      await expect(fs.access(sidecarPathFor(hash))).resolves.toBeUndefined();
+      expect((await models.Blob.findOne({ where: { hash } })).hasParity).toBe(true);
     });
   });
 

--- a/packages/facility-server/__tests__/blobCache/cacheBudgetSettings.test.js
+++ b/packages/facility-server/__tests__/blobCache/cacheBudgetSettings.test.js
@@ -1,0 +1,101 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import config from 'config';
+
+import { SETTINGS_SCOPES } from '@tamanu/constants';
+import { settingsCache } from '@tamanu/settings';
+import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
+
+import { createTestContext } from '../utilities';
+import { ApplicationContext } from '../../app/ApplicationContext';
+
+const uniqueContent = () => Buffer.from(`blob content ${randomUUID()}`);
+
+// The cache budget is only ever read through the application context, so this
+// suite boots one rather than injecting a budget the way the rest do.
+describe('cache size budget from facility settings', () => {
+  let ctx;
+  let models;
+  let appContext;
+  let root;
+  let facilityId;
+
+  const setBudgetGB = async budgetGB => {
+    await models.Setting.set(
+      'blobStorage.cacheSizeBudgetGB',
+      budgetGB,
+      SETTINGS_SCOPES.FACILITY,
+      facilityId,
+    );
+    settingsCache.reset();
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    [facilityId] = selectFacilityIds(config);
+
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'cache-budget-settings-'));
+    await models.Setting.set('blobStorage.root', root, SETTINGS_SCOPES.FACILITY, facilityId);
+    settingsCache.reset();
+
+    appContext = await new ApplicationContext().init();
+  });
+
+  afterAll(async () => {
+    await models.Setting.destroy({ where: { key: 'blobStorage.root' }, force: true });
+    await models.Setting.destroy({ where: { key: 'blobStorage.cacheSizeBudgetGB' }, force: true });
+    settingsCache.reset();
+    await fs.rm(root, { recursive: true, force: true });
+    await ctx.close();
+  });
+
+  beforeEach(async () => {
+    await models.Blob.destroy({ where: {}, force: true });
+  });
+
+  const putCache = async () => {
+    const content = uniqueContent();
+    const { hash } = await appContext.blobStore.put(Readable.from(content));
+    return { hash, content };
+  };
+
+  const setLastAccessed = async (hash, msAgo) =>
+    models.Blob.update(
+      { lastAccessedAt: new Date(Date.now() - msAgo) },
+      { where: { hash }, silent: true },
+    );
+
+  it('evicts once the cache exceeds the configured budget', async () => {
+    // verifies spec: CACHE — the budget is an administrator setting scoped to
+    // the facility
+    const stale = await putCache();
+    const recent = await putCache();
+    await setLastAccessed(stale.hash, 2 * 60 * 60 * 1000);
+    // a budget in bytes just under what the two blobs occupy, expressed in GB
+    await setBudgetGB((stale.content.length + recent.content.length - 1) / 1024 ** 3);
+
+    await appContext.blobCache.enforceBudget();
+
+    expect(await appContext.blobStore.has(stale.hash)).toBe(false);
+    expect(await appContext.blobStore.has(recent.hash)).toBe(true);
+  });
+
+  it('reads the setting as gigabytes rather than bytes', async () => {
+    // verifies spec: CACHE — a budget of a fraction of a gigabyte still leaves
+    // room for content a byte-denominated reading of the same number would evict
+    const stale = await putCache();
+    const recent = await putCache();
+    await setLastAccessed(stale.hash, 2 * 60 * 60 * 1000);
+    await setBudgetGB((stale.content.length + recent.content.length) / 1024 ** 3);
+
+    await appContext.blobCache.enforceBudget();
+
+    expect(await appContext.blobStore.has(stale.hash)).toBe(true);
+    expect(await appContext.blobStore.has(recent.hash)).toBe(true);
+  });
+});

--- a/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
+++ b/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
@@ -1,0 +1,144 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { BLOB_TIERS, DOCUMENT_SIZE_LIMIT } from '@tamanu/constants';
+import { BlobStore } from '@tamanu/database/blobStore';
+import { InsufficientStorageError } from '@tamanu/errors';
+import { fake } from '@tamanu/fake-data/fake';
+import { getUploadedData } from '@tamanu/shared/utils/getUploadedData';
+
+import { createTestContext } from '../utilities';
+import { FacilityBlobCache } from '../../app/blobCache/FacilityBlobCache';
+
+jest.mock('@tamanu/shared/utils/getUploadedData');
+
+// The route suites run against a mocked uploadAttachment; this one is about the
+// real thing, so it reaches past that mock.
+const { uploadAttachment } = jest.requireActual('../../app/utils/uploadAttachment');
+
+const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+describe('outbox admission and the referencing record', () => {
+  let ctx;
+  let models;
+  let root;
+  let uploadsRoot;
+  let blobStore;
+  let blobCache;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    uploadsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'outbox-admission-uploads-'));
+  });
+
+  afterAll(async () => {
+    await fs.rm(uploadsRoot, { recursive: true, force: true });
+    await ctx.close();
+  });
+
+  beforeEach(async () => {
+    await models.Attachment.destroy({ where: {}, force: true });
+    await models.Blob.destroy({ where: {}, force: true });
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'outbox-admission-store-'));
+    blobStore = new BlobStore({
+      root,
+      models,
+      getFreeDiskReserveBytes: async () => 0,
+    });
+    blobCache = new FacilityBlobCache({
+      blobStore,
+      models,
+      getCacheBudgetBytes: async () => 10 * 1024 ** 3,
+    });
+    // Central is unreachable throughout: creating an attachment must not need it.
+    blobCache.setTransferChannel({
+      fetchFromCentral: async () => {
+        throw new Error('central is unreachable');
+      },
+      pushToCentral: async () => {
+        throw new Error('central is unreachable');
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const stageUpload = async () => {
+    const content = Buffer.from(`uploaded document ${randomUUID()}`);
+    const file = path.join(uploadsRoot, `upload-${randomUUID()}`);
+    await fs.writeFile(file, content);
+    getUploadedData.mockResolvedValue({
+      file,
+      deleteFileAfterImport: false,
+      type: 'application/pdf',
+      name: 'a scanned referral',
+    });
+    return { content, hash: hashOf(content) };
+  };
+
+  const outboxRowFor = async hash =>
+    models.Blob.findOne({ where: { hash, tier: BLOB_TIERS.OUTBOX } });
+
+  it('admits an uploaded document to the outbox alongside its attachment', async () => {
+    // verifies spec: ATCH — creation completes without central connectivity, at
+    // the outbox tier, and the background pusher delivers the bytes afterwards
+    const patient = await models.Patient.create(fake(models.Patient));
+    const { hash, content } = await stageUpload();
+
+    await uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, { patientId: patient.id });
+
+    const attachment = await models.Attachment.findOne({ where: { hash } });
+    expect(attachment).not.toBeNull();
+    expect(attachment.size).toBe(content.length);
+    expect(attachment.data).toBeNull();
+    expect(await outboxRowFor(hash)).not.toBeNull();
+  });
+
+  it('rejects an upload the store cannot admit without crossing the free-disk reserve', async () => {
+    // verifies spec: ATCH, CAP — the refusal fails the upload at the time it is
+    // attempted, leaving neither an attachment nor a blob behind
+    const patient = await models.Patient.create(fake(models.Patient));
+    const { hash } = await stageUpload();
+    const starvedCache = new FacilityBlobCache({
+      blobStore: new BlobStore({
+        root,
+        models,
+        getFreeDiskReserveBytes: async () => Number.MAX_SAFE_INTEGER,
+      }),
+      models,
+      getCacheBudgetBytes: async () => 10 * 1024 ** 3,
+    });
+
+    await expect(
+      uploadAttachment({ models, blobCache: starvedCache }, DOCUMENT_SIZE_LIMIT, {
+        patientId: patient.id,
+      }),
+    ).rejects.toThrow(InsufficientStorageError);
+
+    expect(await models.Attachment.findOne({ where: { hash } })).toBeNull();
+    expect(await models.Blob.findOne({ where: { hash } })).toBeNull();
+  });
+
+  // A facility runs no equivalent of mobile's reconcileAttachments, so nothing
+  // demotes a blob whose attachment write failed after admission. Marked failing
+  // until one exists: the assertion below is the guarantee, not the behaviour.
+  it.failing('leaves no outbox row when the attachment record write fails', async () => {
+    // verifies spec: CACHE — a blob whose referencing record is never created is
+    // not left in the outbox, where a facility can neither push it nor evict it
+    const { hash } = await stageUpload();
+
+    await expect(
+      uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, {
+        patientId: 'patient-that-does-not-exist',
+      }),
+    ).rejects.toThrow();
+
+    expect(await models.Attachment.findOne({ where: { hash } })).toBeNull();
+    expect(await outboxRowFor(hash)).toBeNull();
+  });
+});

--- a/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
+++ b/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { Readable } from 'node:stream';
 
 import { BLOB_TIERS, DOCUMENT_SIZE_LIMIT } from '@tamanu/constants';
 import { BlobStore } from '@tamanu/database/blobStore';
@@ -10,6 +11,7 @@ import { fake } from '@tamanu/fake-data/fake';
 import { getUploadedData } from '@tamanu/shared/utils/getUploadedData';
 
 import { createTestContext } from '../utilities';
+import { BlobOutboxPusher } from '../../app/blobCache/BlobOutboxPusher';
 import { FacilityBlobCache } from '../../app/blobCache/FacilityBlobCache';
 
 jest.mock('@tamanu/shared/utils/getUploadedData');
@@ -19,6 +21,8 @@ jest.mock('@tamanu/shared/utils/getUploadedData');
 const { uploadAttachment } = jest.requireActual('../../app/utils/uploadAttachment');
 
 const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+const uniqueContent = () => Buffer.from(`blob content ${randomUUID()}`);
 
 describe('outbox admission and the referencing record', () => {
   let ctx;
@@ -68,8 +72,7 @@ describe('outbox admission and the referencing record', () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  const stageUpload = async () => {
-    const content = Buffer.from(`uploaded document ${randomUUID()}`);
+  const stageUpload = async (content = Buffer.from(`uploaded document ${randomUUID()}`)) => {
     const file = path.join(uploadsRoot, `upload-${randomUUID()}`);
     await fs.writeFile(file, content);
     getUploadedData.mockResolvedValue({
@@ -83,6 +86,14 @@ describe('outbox admission and the referencing record', () => {
 
   const outboxRowFor = async hash =>
     models.Blob.findOne({ where: { hash, tier: BLOB_TIERS.OUTBOX } });
+
+  const ageBlob = async (hash, msAgo) =>
+    models.Blob.update(
+      { lastAccessedAt: new Date(Date.now() - msAgo) },
+      { where: { hash }, silent: true },
+    );
+
+  const BEYOND_SAFETY_WINDOW_MS = 2 * 60 * 60 * 1000;
 
   it('admits an uploaded document to the outbox alongside its attachment', async () => {
     // verifies spec: ATCH — creation completes without central connectivity, at
@@ -124,10 +135,7 @@ describe('outbox admission and the referencing record', () => {
     expect(await models.Blob.findOne({ where: { hash } })).toBeNull();
   });
 
-  // A facility runs no equivalent of mobile's reconcileAttachments, so nothing
-  // demotes a blob whose attachment write failed after admission. Marked failing
-  // until one exists: the assertion below is the guarantee, not the behaviour.
-  it.failing('leaves no outbox row when the attachment record write fails', async () => {
+  it('leaves no outbox row when the attachment record write fails', async () => {
     // verifies spec: CACHE — a blob whose referencing record is never created is
     // not left in the outbox, where a facility can neither push it nor evict it
     const { hash } = await stageUpload();
@@ -140,5 +148,122 @@ describe('outbox admission and the referencing record', () => {
 
     expect(await models.Attachment.findOne({ where: { hash } })).toBeNull();
     expect(await outboxRowFor(hash)).toBeNull();
+  });
+
+  it('keeps the bytes of a blob whose attachment write failed, as evictable cache', async () => {
+    // verifies spec: CACHE — the blob is demoted, never deleted: admission is
+    // idempotent, so the same content may already back a live reference
+    const { hash } = await stageUpload();
+
+    await expect(
+      uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, {
+        patientId: 'patient-that-does-not-exist',
+      }),
+    ).rejects.toThrow();
+
+    expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+    expect(await blobStore.has(hash)).toBe(true);
+  });
+
+  it('leaves an outbox blob alone when a failed upload deduplicated onto it', async () => {
+    // verifies spec: CACHE — content already referenced by a live record is not
+    // demoted out from under it by a later upload of the same bytes
+    const patient = await models.Patient.create(fake(models.Patient));
+    const content = Buffer.from(`uploaded document ${randomUUID()}`);
+    const { hash } = await stageUpload(content);
+    await uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, { patientId: patient.id });
+
+    await stageUpload(content);
+    await expect(
+      uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, {
+        patientId: 'patient-that-does-not-exist',
+      }),
+    ).rejects.toThrow();
+
+    expect(await outboxRowFor(hash)).not.toBeNull();
+  });
+
+  it('pushes the content to central when a failed upload is retried', async () => {
+    // verifies spec: CACHE — content demoted when its record write failed
+    // rejoins the outbox on the upload that does reference it, so the pusher
+    // still delivers the bytes central has never been offered
+    const patient = await models.Patient.create(fake(models.Patient));
+    const content = Buffer.from(`uploaded document ${randomUUID()}`);
+    const { hash } = await stageUpload(content);
+    await expect(
+      uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, {
+        patientId: 'patient-that-does-not-exist',
+      }),
+    ).rejects.toThrow();
+    expect(await outboxRowFor(hash)).toBeNull();
+
+    await stageUpload(content);
+    await uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, { patientId: patient.id });
+
+    const pushed = [];
+    await new BlobOutboxPusher({
+      models,
+      transferChannel: {
+        pushToCentral: async offeredHash => {
+          pushed.push(offeredHash);
+          return { acknowledged: true };
+        },
+      },
+      blobCache,
+      referenceResolvers: [async (_models, hashes) => hashes],
+    }).runOnce();
+
+    expect(pushed).toEqual([hash]);
+    expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+  });
+
+  describe('stranded outbox sweep', () => {
+    it('demotes an outbox blob no record references', async () => {
+      // verifies spec: CACHE — a blob whose reference was never created (a crash
+      // between admission and the record write) does not stay in the outbox,
+      // where it can be neither pushed nor evicted
+      const { hash } = await blobCache.putOutbox(Readable.from(uniqueContent()));
+      await ageBlob(hash, BEYOND_SAFETY_WINDOW_MS);
+
+      expect(await blobCache.demoteStrandedOutbox()).toEqual([hash]);
+
+      expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+      expect(await blobStore.has(hash)).toBe(true);
+    });
+
+    it('leaves an outbox blob its attachment still references', async () => {
+      const patient = await models.Patient.create(fake(models.Patient));
+      const content = uniqueContent();
+      const { hash, size } = await blobCache.putOutbox(Readable.from(content));
+      await models.Attachment.create({ type: 'application/pdf', hash, size, patientId: patient.id });
+      await ageBlob(hash, BEYOND_SAFETY_WINDOW_MS);
+
+      expect(await blobCache.demoteStrandedOutbox()).toEqual([]);
+
+      expect(await outboxRowFor(hash)).not.toBeNull();
+    });
+
+    it('leaves an outbox blob admitted within the safety window', async () => {
+      // verifies spec: RECL — a reference lands after its blob is admitted, so a
+      // recent admission may have its record write still in flight
+      const { hash } = await blobCache.putOutbox(Readable.from(uniqueContent()));
+
+      expect(await blobCache.demoteStrandedOutbox()).toEqual([]);
+
+      expect(await outboxRowFor(hash)).not.toBeNull();
+    });
+
+    it('reopens the safety window when content already held is admitted again', async () => {
+      // verifies spec: RECL — an age window measured from first admission would
+      // miss content deduplicated onto a moment before its new reference commits
+      const content = uniqueContent();
+      const { hash } = await blobCache.putOutbox(Readable.from(content));
+      await ageBlob(hash, BEYOND_SAFETY_WINDOW_MS);
+
+      await blobCache.putOutbox(Readable.from(content));
+
+      expect(await blobCache.demoteStrandedOutbox()).toEqual([]);
+      expect(await outboxRowFor(hash)).not.toBeNull();
+    });
   });
 });

--- a/packages/facility-server/__tests__/tasks/blobTasks.test.js
+++ b/packages/facility-server/__tests__/tasks/blobTasks.test.js
@@ -1,0 +1,110 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import { BLOB_TIERS } from '@tamanu/constants';
+import { BlobStore } from '@tamanu/database/blobStore';
+
+import { createTestContext } from '../utilities';
+import { BlobOutboxPusher, FacilityBlobCache } from '../../app/blobCache';
+import { BlobCacheEvictorTask } from '../../app/tasks/BlobCacheEvictorTask';
+import { BlobOutboxPusherTask } from '../../app/tasks/BlobOutboxPusherTask';
+
+const uniqueContent = () => Buffer.from(`blob content ${randomUUID()}`);
+
+describe('blob cache scheduled tasks', () => {
+  let ctx;
+  let models;
+  let schedules;
+  let root;
+  let blobStore;
+  let blobCache;
+  let cacheBudgetBytes;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    schedules = ctx.schedules;
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await models.Blob.destroy({ where: {}, force: true });
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-tasks-test-'));
+    cacheBudgetBytes = 10 * 1024 ** 3;
+    blobStore = new BlobStore({ root, models, getFreeDiskReserveBytes: async () => 0 });
+    blobCache = new FacilityBlobCache({
+      blobStore,
+      models,
+      getCacheBudgetBytes: async () => cacheBudgetBytes,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const putCache = async () => {
+    const content = uniqueContent();
+    const { hash } = await blobStore.put(Readable.from(content));
+    return { hash, content };
+  };
+
+  const setLastAccessed = async (hash, msAgo) =>
+    models.Blob.update(
+      { lastAccessedAt: new Date(Date.now() - msAgo) },
+      { where: { hash }, silent: true },
+    );
+
+  describe('BlobCacheEvictorTask', () => {
+    it('brings the cache back within its budget', async () => {
+      // verifies spec: CACHE — the budget is enforced by a periodic check as
+      // well as at admission
+      const stale = await putCache();
+      const recent = await putCache();
+      await setLastAccessed(stale.hash, 2 * 60 * 60 * 1000);
+      cacheBudgetBytes = recent.content.length;
+
+      const ran = await new BlobCacheEvictorTask({ schedules, blobCache }).runImmediately();
+
+      expect(ran).toBe(true);
+      expect(await blobStore.has(stale.hash)).toBe(false);
+      expect(await blobStore.has(recent.hash)).toBe(true);
+    });
+
+    it('runs cleanly before the blob cache is wired', async () => {
+      const ran = await new BlobCacheEvictorTask({ schedules }).runImmediately();
+
+      expect(ran).toBe(true);
+    });
+  });
+
+  describe('BlobOutboxPusherTask', () => {
+    it('drains the outbox', async () => {
+      // verifies spec: CACHE — the pusher runs on its own schedule, independent
+      // of sync sessions
+      const content = uniqueContent();
+      const { hash } = await blobCache.putOutbox(Readable.from(content));
+      const blobOutboxPusher = new BlobOutboxPusher({
+        models,
+        transferChannel: { pushToCentral: async () => ({ acknowledged: true }) },
+        blobCache,
+        referenceResolvers: [async (_models, hashes) => hashes],
+      });
+
+      const ran = await new BlobOutboxPusherTask({ schedules, blobOutboxPusher }).runImmediately();
+
+      expect(ran).toBe(true);
+      expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+    });
+
+    it('runs cleanly before the pusher is wired', async () => {
+      const ran = await new BlobOutboxPusherTask({ schedules }).runImmediately();
+
+      expect(ran).toBe(true);
+    });
+  });
+});

--- a/packages/facility-server/__tests__/tasks/blobTasks.test.js
+++ b/packages/facility-server/__tests__/tasks/blobTasks.test.js
@@ -75,6 +75,18 @@ describe('blob cache scheduled tasks', () => {
       expect(await blobStore.has(recent.hash)).toBe(true);
     });
 
+    it('demotes an outbox blob left without a referencing record', async () => {
+      // verifies spec: CACHE — nothing else reclaims a stranded outbox blob, so
+      // the periodic pass demotes it into the budget's reach
+      const { hash } = await blobCache.putOutbox(Readable.from(uniqueContent()));
+      await setLastAccessed(hash, 2 * 60 * 60 * 1000);
+
+      const ran = await new BlobCacheEvictorTask({ schedules, blobCache }).runImmediately();
+
+      expect(ran).toBe(true);
+      expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+    });
+
     it('runs cleanly before the blob cache is wired', async () => {
       const ran = await new BlobCacheEvictorTask({ schedules }).runImmediately();
 

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -20,7 +20,7 @@ import {
 } from '@tamanu/shared/utils/fhir/fhirSettings';
 import { setFhirRefreshTriggers } from '@tamanu/database';
 
-import { FacilityBlobCache, makeSyncedReferenceResolver } from './blobCache';
+import { BLOB_REFERENCE_TABLES, FacilityBlobCache, makeSyncedReferenceResolver } from './blobCache';
 import { FacilityBlobHealer } from './blobIntegrity';
 import { closeDatabase, initDatabase } from './database';
 import { getServerFacilityIds, initServerConfig } from './serverConfig';
@@ -225,11 +225,12 @@ export class ApplicationContext {
         log,
       });
 
-    // spec: CACHE — consumers (attachments, assets) append their synced-record
-    // resolvers here so their blobs become eligible for push.
-    this.blobReferenceResolvers = [
-      makeSyncedReferenceResolver({ tableName: 'attachments', hashColumn: 'hash' }),
-    ];
+    // spec: CACHE — consumers (attachments, assets) register in
+    // BLOB_REFERENCE_TABLES; these resolvers report which of their references
+    // have synchronised, so the blobs behind them become eligible for push.
+    this.blobReferenceResolvers = BLOB_REFERENCE_TABLES.map(table =>
+      makeSyncedReferenceResolver(table),
+    );
 
     const facilityReaders = facilityIds.map(id => this.settings[id]);
 

--- a/packages/facility-server/app/blobCache/FacilityBlobCache.js
+++ b/packages/facility-server/app/blobCache/FacilityBlobCache.js
@@ -1,12 +1,23 @@
+import { Op, literal } from 'sequelize';
+
 import { BlobEviction } from '@tamanu/blobs';
 import { BLOB_TIERS } from '@tamanu/constants';
 import { NotFoundError } from '@tamanu/errors';
 import { log } from '@tamanu/shared/services/logging';
 
+import { UNREFERENCED_BLOB_CONDITION } from './referenceResolvers';
+
 // Reads within this window of the last recorded access don't rewrite recency.
 // spec: CACHE — recency updates may be coalesced; losing the most recent
 // refreshes degrades eviction ordering only.
 const RECENCY_COALESCE_SECONDS = 60;
+
+// spec: RECL
+// A reference is written after the blob it points at is admitted, so content
+// admitted within this window may have a reference still in flight and the
+// sweep leaves it alone. Long enough to cover a write inside a slow enclosing
+// transaction, since the record is invisible until that transaction commits.
+const STRANDED_SAFETY_WINDOW_MS = 60 * 60 * 1000;
 
 // spec: CACHE
 // The facility store's two durability tiers over the blob store primitive: the
@@ -52,11 +63,87 @@ export class FacilityBlobCache {
    * Admit locally originated content into the outbox. Call within the
    * operation that creates the blob's referencing record — outbox admission
    * without a reference strands the blob, since facility servers run no
-   * orphan collection. Content already held as cache stays cache: it is
-   * already durable on central and needs no push.
+   * orphan collection. Content the store already holds joins the outbox with
+   * it: a local origin means central is not known to hold the bytes.
    */
   async putOutbox(source, { sizeHint } = {}) {
-    return await this.#blobStore.put(source, { sizeHint, tier: BLOB_TIERS.OUTBOX });
+    const admitted = await this.#blobStore.put(source, { sizeHint, tier: BLOB_TIERS.OUTBOX });
+    // Admission leaves a row it already holds untouched, so the tier is set here.
+    if (admitted.existed) {
+      await this.#promoteToOutbox(admitted.hash);
+    }
+    return admitted;
+  }
+
+  // spec: CACHE — locally admitted content belongs in the outbox whatever tier
+  // its row held; the recency bump keeps the sweep's window over it (spec: RECL).
+  async #promoteToOutbox(hash) {
+    const [, [blob]] = await this.#models.Blob.update(
+      { tier: BLOB_TIERS.OUTBOX, lastAccessedAt: new Date() },
+      { where: { hash }, returning: true },
+    );
+    if (blob && !blob.hasParity) {
+      // spec: FEC — the outbox is this server's only durable copy, so it carries parity.
+      await this.#blobStore.writeParity({ hash, size: blob.size, tier: blob.tier });
+    }
+  }
+
+  // spec: CACHE
+  /**
+   * Demote a blob whose referencing record failed to write, so it does not sit
+   * in the outbox where this server can neither push nor evict it. Best effort:
+   * the caller is already failing with its own error, and the periodic sweep
+   * covers whatever this misses.
+   */
+  async demoteIfStranded(hash) {
+    try {
+      return await this.#demoteStranded({ hash });
+    } catch (error) {
+      log.warn('FacilityBlobCache: could not demote a stranded outbox blob', {
+        hash,
+        error: error.message,
+      });
+      return [];
+    }
+  }
+
+  // spec: CACHE
+  /**
+   * Demote every outbox blob no live record references. Covers what a write
+   * path cannot: a crash between admission and the record write leaves no
+   * catch to run, and the blob would otherwise persist forever.
+   */
+  async demoteStrandedOutbox() {
+    const demoted = await this.#demoteStranded({ minimumAgeMs: STRANDED_SAFETY_WINDOW_MS });
+    if (demoted.length > 0) {
+      log.info('FacilityBlobCache: demoted stranded outbox blobs', { hashes: demoted });
+    }
+    return demoted;
+  }
+
+  // Demotes rather than deletes, and tests the reference in the same statement
+  // as the update: admission is content-addressed and idempotent, so these bytes
+  // may be the only copy backing a reference this pass cannot see.
+  async #demoteStranded({ hash, minimumAgeMs = 0 }) {
+    const [, demoted] = await this.#models.Blob.update(
+      { tier: BLOB_TIERS.CACHE, eligibleSinceTick: null },
+      {
+        where: {
+          tier: BLOB_TIERS.OUTBOX,
+          ...(hash ? { hash } : {}),
+          ...(minimumAgeMs
+            ? { lastAccessedAt: { [Op.lt]: new Date(Date.now() - minimumAgeMs) } }
+            : {}),
+          [Op.and]: [literal(UNREFERENCED_BLOB_CONDITION)],
+        },
+        returning: ['hash'],
+      },
+    );
+    for (const blob of demoted) {
+      // spec: FEC — a facility covers only its outbox with parity.
+      await this.#blobStore.discardParity(blob.hash);
+    }
+    return demoted.map(blob => blob.hash);
   }
 
   // spec: CACHE

--- a/packages/facility-server/app/blobCache/index.js
+++ b/packages/facility-server/app/blobCache/index.js
@@ -1,4 +1,8 @@
 export { FacilityBlobCache } from './FacilityBlobCache';
 export { BlobOutboxPusher } from './BlobOutboxPusher';
 export { blobOutboxStatus } from './outboxStatus';
-export { makeSyncedReferenceResolver } from './referenceResolvers';
+export {
+  BLOB_REFERENCE_TABLES,
+  UNREFERENCED_BLOB_CONDITION,
+  makeSyncedReferenceResolver,
+} from './referenceResolvers';

--- a/packages/facility-server/app/blobCache/referenceResolvers.js
+++ b/packages/facility-server/app/blobCache/referenceResolvers.js
@@ -16,6 +16,28 @@ function quoteIdentifier(identifier) {
 
 // spec: CACHE
 /**
+ * The tables that reference blobs by hash on a facility. The pusher's
+ * eligibility resolvers and the stranded-outbox sweep are both built from this
+ * one list, so a consumer registered for the first is registered for the
+ * second: a table missing here has its outbox blobs demoted as unreferenced.
+ */
+export const BLOB_REFERENCE_TABLES = [{ tableName: 'attachments', hashColumn: 'hash' }];
+
+// spec: CACHE
+/** Matches a blob no live record references, for use against the blobs table. */
+export const UNREFERENCED_BLOB_CONDITION = BLOB_REFERENCE_TABLES.map(
+  ({ tableName, hashColumn }) => {
+    const table = quoteIdentifier(tableName);
+    return `NOT EXISTS (
+      SELECT 1 FROM ${table}
+      WHERE ${table}.${quoteIdentifier(hashColumn)} = blobs.hash
+        AND ${table}.deleted_at IS NULL
+    )`;
+  },
+).join(' AND ');
+
+// spec: CACHE
+/**
  * Builds a reference resolver for a consumer table that references blobs by
  * hash: given candidate hashes, returns those with at least one referencing
  * record that has synchronised to the central server. Synchronised is

--- a/packages/facility-server/app/routeHandlers/createPatientLetter.js
+++ b/packages/facility-server/app/routeHandlers/createPatientLetter.js
@@ -47,13 +47,19 @@ export const createPatientLetter = (modelName, idField) =>
     );
     fs.unlink(filePath, () => null);
 
-    const { id: attachmentId } = await models.Attachment.create({
-      type: mimeType,
-      hash,
-      size: storedSize,
-      [idField]: params.id,
-      ...(modelName === 'Encounter' ? { patientId: specifiedObject.patientId } : {}),
-    });
+    let attachmentId;
+    try {
+      ({ id: attachmentId } = await models.Attachment.create({
+        type: mimeType,
+        hash,
+        size: storedSize,
+        [idField]: params.id,
+        ...(modelName === 'Encounter' ? { patientId: specifiedObject.patientId } : {}),
+      }));
+    } catch (error) {
+      await req.blobCache.demoteIfStranded(hash);
+      throw error;
+    }
 
     const documentMetadataObject = await models.DocumentMetadata.create({
       name,

--- a/packages/facility-server/app/tasks/BlobCacheEvictorTask.js
+++ b/packages/facility-server/app/tasks/BlobCacheEvictorTask.js
@@ -5,6 +5,10 @@ import { log } from '@tamanu/shared/services/logging';
 // Periodic backstop for the blob cache size budget. Admission-time enforcement
 // does the routine work; this sweep catches drift from budget changes, blobs
 // whose reads had eviction deferred, and failures during earlier passes.
+//
+// It first demotes outbox blobs left without a referencing record, since those
+// are reclaimable by nothing else: a facility runs no orphan collection, and an
+// outbox blob is never evicted.
 export class BlobCacheEvictorTask extends ScheduledTask {
   getName() {
     return 'BlobCacheEvictorTask';
@@ -21,6 +25,7 @@ export class BlobCacheEvictorTask extends ScheduledTask {
     if (!blobCache) {
       return;
     }
+    await blobCache.demoteStrandedOutbox();
     await blobCache.enforceBudget();
   }
 }

--- a/packages/facility-server/app/utils/uploadAttachment.js
+++ b/packages/facility-server/app/utils/uploadAttachment.js
@@ -27,12 +27,18 @@ export const uploadAttachment = async (req, maxFileSize, scope = {}) => {
     const { hash, size: storedSize } = await blobCache.putOutbox(fs.createReadStream(file), {
       sizeHint: size,
     });
-    const attachment = await models.Attachment.create({
-      type,
-      hash,
-      size: storedSize,
-      ...scope,
-    });
+    let attachment;
+    try {
+      attachment = await models.Attachment.create({
+        type,
+        hash,
+        size: storedSize,
+        ...scope,
+      });
+    } catch (error) {
+      await blobCache.demoteIfStranded(hash);
+      throw error;
+    }
 
     return {
       attachmentId: attachment.id,

--- a/packages/mobile/App/services/blobs/MobileBlobCache.spec.ts
+++ b/packages/mobile/App/services/blobs/MobileBlobCache.spec.ts
@@ -38,6 +38,19 @@ describe('MobileBlobCache', () => {
       const row = await Database.models.Blob.findOne({ where: { hash } });
       expect(row.tier).toBe(BLOB_TIERS.OUTBOX);
     });
+
+    // verifies spec: MOB, CACHE — a cache copy central holds cannot be told
+    // apart from one demoted after its referencing record was never created
+    it('returns cache-tier content to the outbox when the device captures it', async () => {
+      fs.seed('/tmp/held.jpg', 'same photo');
+      const { hash } = await store.putFile('/tmp/held.jpg', { tier: BLOB_TIERS.CACHE });
+
+      fs.seed('/tmp/captured.jpg', 'same photo');
+      await cache.putOutbox('/tmp/captured.jpg');
+
+      const row = await Database.models.Blob.findOne({ where: { hash } });
+      expect(row.tier).toBe(BLOB_TIERS.OUTBOX);
+    });
   });
 
   describe('open', () => {

--- a/packages/mobile/App/services/blobs/MobileBlobCache.ts
+++ b/packages/mobile/App/services/blobs/MobileBlobCache.ts
@@ -73,11 +73,20 @@ export class MobileBlobCache {
    * Admit device-captured content into the outbox, consuming the source file
    * so no second copy remains outside the store. Call within the operation
    * that creates the blob's referencing record; a blob stranded by a crash in
-   * between is demoted to cache by the startup reconciliation. Content already
-   * held as cache stays cache: it is already durable on central.
+   * between is demoted to cache by the startup reconciliation. Content the
+   * store already holds joins the outbox with it: a device capture means
+   * central is not known to hold the bytes.
    */
   async putOutbox(sourcePath: string): Promise<PutResult> {
-    return await this.#blobStore.putFile(sourcePath, { tier: BLOB_TIERS.OUTBOX });
+    const admitted = await this.#blobStore.putFile(sourcePath, { tier: BLOB_TIERS.OUTBOX });
+    // Admission leaves a row it already holds untouched, so the tier is set here.
+    if (admitted.existed) {
+      await this.#models.Blob.getRepository().update(
+        { hash: admitted.hash },
+        { tier: BLOB_TIERS.OUTBOX },
+      );
+    }
+    return admitted;
   }
 
   // spec: MOB, SCRUB

--- a/packages/mobile/App/services/blobs/outboxDurability.spec.ts
+++ b/packages/mobile/App/services/blobs/outboxDurability.spec.ts
@@ -1,0 +1,87 @@
+import { BLOB_TIERS } from '@tamanu/constants';
+
+import { Database } from '~/infra/db';
+import { LAST_SUCCESSFUL_PUSH } from '~/services/sync/constants';
+import { FakeBlobFileSystem } from '/root/tests/helpers/fakeBlobFileSystem';
+import { BlobOutboxPusher } from './BlobOutboxPusher';
+import { MobileBlobCache } from './MobileBlobCache';
+import { MobileBlobStore } from './MobileBlobStore';
+import { reconcileAttachments } from './reconcileAttachments';
+import { deriveFreeDiskReserveBytes } from './deviceStorage';
+
+const PUSH_TICK = 10;
+
+describe('capture stranded before its record, then captured again', () => {
+  let fs: FakeBlobFileSystem;
+  let store: MobileBlobStore;
+  let cache: MobileBlobCache;
+  let pushed: string[];
+  let pusher: BlobOutboxPusher;
+
+  beforeAll(async () => {
+    await Database.connect();
+  });
+
+  beforeEach(async () => {
+    await Database.models.Blob.getRepository().clear();
+    await Database.models.Attachment.getRepository().clear();
+    await Database.models.LocalSystemFact.getRepository().clear();
+    await Database.models.LocalSystemFact.getRepository().query(
+      `INSERT INTO local_system_facts (id, key, value) VALUES (?, ?, ?)`,
+      [`fact-${LAST_SUCCESSFUL_PUSH}`, LAST_SUCCESSFUL_PUSH, String(PUSH_TICK)],
+    );
+    fs = new FakeBlobFileSystem();
+    store = new MobileBlobStore({
+      root: '/blobs',
+      models: Database.models,
+      getFreeDiskReserveBytes: deriveFreeDiskReserveBytes,
+      fs,
+    });
+    cache = new MobileBlobCache({ blobStore: store, models: Database.models, fs });
+    pushed = [];
+    pusher = new BlobOutboxPusher({
+      models: Database.models,
+      transferChannel: {
+        pushToCentral: async (hash: string) => {
+          pushed.push(hash);
+          return { acknowledged: true };
+        },
+      } as any,
+      blobCache: cache,
+    });
+  });
+
+  // verifies spec: MOB, CACHE — content demoted after its record was never
+  // created rejoins the outbox on the capture that does reference it, so the
+  // pusher still delivers bytes central has never been offered
+  it('pushes the content once a later capture gives it a record', async () => {
+    fs.seed('/tmp/photo.jpg', 'photo bytes');
+    const { hash } = await cache.putOutbox('/tmp/photo.jpg');
+
+    await reconcileAttachments({ models: Database.models, blobStore: store, fs });
+    expect(await tierOf(hash)).toBe(BLOB_TIERS.CACHE);
+
+    fs.seed('/tmp/photo-again.jpg', 'photo bytes');
+    await cache.putOutbox('/tmp/photo-again.jpg');
+    await seedSyncedAttachment(hash);
+
+    await pusher.runOnce();
+
+    expect(pushed).toEqual([hash]);
+    // acknowledged, so it is cache the central server holds rather than lost
+    expect(await tierOf(hash)).toBe(BLOB_TIERS.CACHE);
+  });
+
+  async function tierOf(hash: string): Promise<string> {
+    const row = await Database.models.Blob.findOne({ where: { hash } });
+    return row.tier;
+  }
+
+  async function seedSyncedAttachment(hash: string): Promise<void> {
+    await Database.models.Attachment.getRepository().query(
+      `INSERT INTO attachments (id, type, hash, size, updatedAtSyncTick)
+       VALUES (?, 'image/jpeg', ?, 100, ?)`,
+      ['att-recaptured', hash, PUSH_TICK - 5],
+    );
+  }
+});

--- a/packages/mobile/App/ui/components/UploadPhoto/index.spec.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.spec.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Popup } from 'popup-ui';
+
+import { BLOB_TIERS } from '@tamanu/constants';
+
+import { Database } from '~/infra/db';
+import { useBackend } from '~/ui/hooks';
+import { Attachment } from '~/models/Attachment';
+import { MobileBlobCache } from '~/services/blobs/MobileBlobCache';
+import { MobileBlobStore } from '~/services/blobs/MobileBlobStore';
+import { deriveFreeDiskReserveBytes } from '~/services/blobs/deviceStorage';
+import { FakeBlobFileSystem, sha256Hash } from '/root/tests/helpers/fakeBlobFileSystem';
+import { getImageFromCamera, resizeImage } from '/helpers/image';
+import { UploadPhoto } from './index';
+
+jest.mock('react-native-fs', () => ({
+  __esModule: true,
+  default: { DocumentDirectoryPath: '/documents' },
+}));
+
+jest.mock('popup-ui', () => ({ Popup: { show: jest.fn(), hide: jest.fn() } }));
+
+jest.mock('/helpers/file', () => ({ deleteFileInDocuments: jest.fn(async () => {}) }));
+
+jest.mock('/helpers/image', () => ({
+  getImageFromCamera: jest.fn(),
+  getImageFromPhotoLibrary: jest.fn(),
+  imageToBase64URI: (image: string): string => `data:image/jpeg;base64, ${image}`,
+  resizeImage: jest.fn(),
+}));
+
+jest.mock('~/ui/hooks', () => ({ useBackend: jest.fn() }));
+
+const ROOT = '/blobs';
+const RESIZED_PATH = '/documents/resized.jpg';
+const PHOTO_BYTES = 'the captured photograph';
+const PHOTO_HASH = sha256Hash(PHOTO_BYTES);
+const CAPTURED_IMAGE = { base64: 'Y2FwdHVyZWQ=', uri: 'file:///documents/original.jpg' };
+
+describe('<UploadPhoto />', () => {
+  let fs: FakeBlobFileSystem;
+  let store: MobileBlobStore;
+  let cache: MobileBlobCache;
+  let onChange: jest.Mock;
+
+  beforeAll(async () => {
+    await Database.connect();
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await Database.models.Attachment.getRepository().clear();
+    await Database.models.Blob.getRepository().clear();
+
+    fs = new FakeBlobFileSystem();
+    store = new MobileBlobStore({
+      root: ROOT,
+      models: Database.models,
+      getFreeDiskReserveBytes: deriveFreeDiskReserveBytes,
+      evictCache: bytesNeeded => cache.evictBytes(bytesNeeded),
+      fs,
+    });
+    cache = new MobileBlobCache({ blobStore: store, models: Database.models, fs });
+
+    onChange = jest.fn();
+    (useBackend as jest.Mock).mockReturnValue({ models: Database.models, blobCache: cache });
+    (getImageFromCamera as jest.Mock).mockResolvedValue(CAPTURED_IMAGE);
+    (resizeImage as jest.Mock).mockResolvedValue({ path: RESIZED_PATH });
+    fs.seed(RESIZED_PATH, PHOTO_BYTES);
+  });
+
+  // verifies spec: MOB, CACHE — capture admits to the outbox tier and the
+  // record carries the hash and the admitted size, never the bytes
+  it('stores a captured photo in the outbox and records only its hash and size', async () => {
+    const { getByText } = await render(<UploadPhoto onChange={onChange} value={null} />);
+
+    await takePhoto(getByText);
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+
+    const [attachmentId] = onChange.mock.calls[0];
+    const attachment = await Database.models.Attachment.findOne({ where: { id: attachmentId } });
+    expect(attachment.hash).toBe(PHOTO_HASH);
+    expect(Number(attachment.size)).toBe(PHOTO_BYTES.length);
+
+    const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
+    expect(blob.tier).toBe(BLOB_TIERS.OUTBOX);
+    expect(fs.contentsOf(store.pathFor(PHOTO_HASH)).toString()).toBe(PHOTO_BYTES);
+
+    const [row] = await Database.models.Attachment.getRepository().query(
+      'SELECT * FROM attachments WHERE id = ?',
+      [attachmentId],
+    );
+    const carriesBytes = Object.values(row).some(
+      column => typeof column === 'string' && column.includes(CAPTURED_IMAGE.base64),
+    );
+    expect(carriesBytes).toBe(false);
+  });
+
+  // verifies spec: MOB, CAP — a capture the store cannot admit names the
+  // device's storage as the cause and leaves nothing behind
+  it('shows the device-storage message and creates no attachment when the store is full', async () => {
+    fs.freeSpace = 1024 ** 2;
+
+    const { getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value={null} />,
+    );
+
+    await takePhoto(getByText);
+    await waitFor(() => expect(Popup.show).toHaveBeenCalled());
+
+    const [popup] = (Popup.show as jest.Mock).mock.calls[0];
+    expect(popup.title).toMatch(/storage space on this device/i);
+    expect(popup.textBody).toMatch(/free up space on the device/i);
+    expect(queryByText(/Error loading image/)).toBeNull();
+
+    expect(await Database.models.Attachment.getRepository().count()).toBe(0);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // verifies spec: MOB, CACHE — a removed photo's blob has no referencing
+  // record left, so it can never become eligible for push
+  it('demotes the removed photo\'s blob to reclaimable cache', async () => {
+    const { getByText, rerender } = await render(<UploadPhoto onChange={onChange} value={null} />);
+    await takePhoto(getByText);
+    await waitFor(() => getByText('Remove photo'));
+
+    const [attachmentId] = onChange.mock.calls[0];
+    await rerender(<UploadPhoto onChange={onChange} value={attachmentId} />);
+    await act(async () => {
+      await fireEvent.press(getByText('Remove photo'));
+    });
+
+    await waitFor(async () => {
+      expect(await Database.models.Attachment.findOne({ where: { id: attachmentId } })).toBeNull();
+    });
+    const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
+    expect(blob.tier).toBe(BLOB_TIERS.CACHE);
+  });
+
+  // verifies spec: MOB, CACHE — content addressing lets two attachments share
+  // one blob, so demoting on the first removal would make content another
+  // record still references evictable before it has been pushed
+  it('leaves the blob in the outbox while another attachment references its hash', async () => {
+    const { getByText, rerender } = await render(<UploadPhoto onChange={onChange} value={null} />);
+    await takePhoto(getByText);
+    await waitFor(() => getByText('Remove photo'));
+
+    const sharer = await Database.models.Attachment.createAndSaveOne<Attachment>({
+      hash: PHOTO_HASH,
+      size: PHOTO_BYTES.length,
+      type: 'image/jpeg',
+    });
+
+    const [attachmentId] = onChange.mock.calls[0];
+    await rerender(<UploadPhoto onChange={onChange} value={attachmentId} />);
+    await act(async () => {
+      await fireEvent.press(getByText('Remove photo'));
+    });
+
+    await waitFor(async () => {
+      expect(await Database.models.Attachment.findOne({ where: { id: attachmentId } })).toBeNull();
+    });
+    expect(await Database.models.Attachment.findOne({ where: { id: sharer.id } })).not.toBeNull();
+    const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
+    expect(blob.tier).toBe(BLOB_TIERS.OUTBOX);
+  });
+
+  async function takePhoto(getByText): Promise<void> {
+    await act(async () => {
+      await fireEvent.press(getByText('Take photo with camera'));
+    });
+  }
+});

--- a/packages/mobile/App/ui/components/UploadPhoto/index.spec.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.spec.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import { Popup } from 'popup-ui';
+import { useNetInfo } from '@react-native-community/netinfo';
 
 import { BLOB_TIERS } from '@tamanu/constants';
 
 import { Database } from '~/infra/db';
 import { useBackend } from '~/ui/hooks';
 import { Attachment } from '~/models/Attachment';
+import { BlobAwaitingUploadError } from '~/services/blobs/BlobTransferChannel';
 import { MobileBlobCache } from '~/services/blobs/MobileBlobCache';
 import { MobileBlobStore } from '~/services/blobs/MobileBlobStore';
 import { deriveFreeDiskReserveBytes } from '~/services/blobs/deviceStorage';
@@ -21,6 +23,8 @@ jest.mock('react-native-fs', () => ({
 
 jest.mock('popup-ui', () => ({ Popup: { show: jest.fn(), hide: jest.fn() } }));
 
+jest.mock('@react-native-community/netinfo', () => ({ useNetInfo: jest.fn() }));
+
 jest.mock('/helpers/file', () => ({ deleteFileInDocuments: jest.fn(async () => {}) }));
 
 jest.mock('/helpers/image', () => ({
@@ -34,21 +38,64 @@ jest.mock('~/ui/hooks', () => ({ useBackend: jest.fn() }));
 
 const ROOT = '/blobs';
 const RESIZED_PATH = '/documents/resized.jpg';
+const HELD_PATH = '/documents/held.jpg';
+const FETCHED_PATH = '/documents/fetched.jpg';
 const PHOTO_BYTES = 'the captured photograph';
 const PHOTO_HASH = sha256Hash(PHOTO_BYTES);
+const PHOTO_URI = `data:image/jpeg;base64, ${Buffer.from(PHOTO_BYTES).toString('base64')}`;
 const CAPTURED_IMAGE = { base64: 'Y2FwdHVyZWQ=', uri: 'file:///documents/original.jpg' };
+const CAPTURED_URI = `data:image/jpeg;base64, ${CAPTURED_IMAGE.base64}`;
+
+const displayedImageUri = (container): string | undefined =>
+  container.queryAll(node => node.type === 'Image')[0]?.props?.source?.uri;
+
+// The device reports connectivity through the hook's own state, which is what
+// re-renders a mounted component when it changes.
+const connectivity = {
+  current: { isInternetReachable: true } as { isInternetReachable: boolean | null },
+  subscribers: new Set<(value: { isInternetReachable: boolean | null }) => void>(),
+};
+
+const useConnectivity = (): { isInternetReachable: boolean | null } => {
+  const [reported, setReported] = React.useState(connectivity.current);
+  React.useEffect(() => {
+    connectivity.subscribers.add(setReported);
+    return (): void => {
+      connectivity.subscribers.delete(setReported);
+    };
+  }, []);
+  return reported;
+};
+
+const deviceIsOffline = (): void => {
+  connectivity.current = { isInternetReachable: false };
+};
+
+const connectivityIsUnknown = (): void => {
+  connectivity.current = { isInternetReachable: null };
+};
+
+const connectivityReturns = async (): Promise<void> => {
+  connectivity.current = { isInternetReachable: true };
+  await act(async () => {
+    connectivity.subscribers.forEach(notify => notify(connectivity.current));
+  });
+};
 
 describe('<UploadPhoto />', () => {
   let fs: FakeBlobFileSystem;
   let store: MobileBlobStore;
   let cache: MobileBlobCache;
   let onChange: jest.Mock;
+  let backendCalls: Promise<void>[];
+  let contentReads: number;
 
   beforeAll(async () => {
     await Database.connect();
   });
 
   beforeEach(async () => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
     await Database.models.Attachment.getRepository().clear();
     await Database.models.Blob.getRepository().clear();
@@ -62,39 +109,35 @@ describe('<UploadPhoto />', () => {
       fs,
     });
     cache = new MobileBlobCache({ blobStore: store, models: Database.models, fs });
+    trackBackendCalls();
 
     onChange = jest.fn();
     (useBackend as jest.Mock).mockReturnValue({ models: Database.models, blobCache: cache });
+    connectivity.current = { isInternetReachable: true };
+    (useNetInfo as jest.Mock).mockImplementation(useConnectivity);
     (getImageFromCamera as jest.Mock).mockResolvedValue(CAPTURED_IMAGE);
     (resizeImage as jest.Mock).mockResolvedValue({ path: RESIZED_PATH });
     fs.seed(RESIZED_PATH, PHOTO_BYTES);
   });
 
   // verifies spec: MOB, CACHE — capture admits to the outbox tier and the
-  // record carries the hash and the admitted size, never the bytes
+  // record carries the hash and the admitted size, never the bytes or a
+  // pointer to a file outside the store
   it('stores a captured photo in the outbox and records only its hash and size', async () => {
     const { getByText } = await render(<UploadPhoto onChange={onChange} value={null} />);
 
     await takePhoto(getByText);
-    await waitFor(() => expect(onChange).toHaveBeenCalled());
 
     const [attachmentId] = onChange.mock.calls[0];
     const attachment = await Database.models.Attachment.findOne({ where: { id: attachmentId } });
     expect(attachment.hash).toBe(PHOTO_HASH);
     expect(Number(attachment.size)).toBe(PHOTO_BYTES.length);
+    expect(attachment.filePath).toBeNull();
 
     const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
     expect(blob.tier).toBe(BLOB_TIERS.OUTBOX);
     expect(fs.contentsOf(store.pathFor(PHOTO_HASH)).toString()).toBe(PHOTO_BYTES);
-
-    const [row] = await Database.models.Attachment.getRepository().query(
-      'SELECT * FROM attachments WHERE id = ?',
-      [attachmentId],
-    );
-    const carriesBytes = Object.values(row).some(
-      column => typeof column === 'string' && column.includes(CAPTURED_IMAGE.base64),
-    );
-    expect(carriesBytes).toBe(false);
+    expect(fs.contentsOf(RESIZED_PATH)).toBeUndefined();
   });
 
   // verifies spec: MOB, CAP — a capture the store cannot admit names the
@@ -107,7 +150,6 @@ describe('<UploadPhoto />', () => {
     );
 
     await takePhoto(getByText);
-    await waitFor(() => expect(Popup.show).toHaveBeenCalled());
 
     const [popup] = (Popup.show as jest.Mock).mock.calls[0];
     expect(popup.title).toMatch(/storage space on this device/i);
@@ -118,22 +160,164 @@ describe('<UploadPhoto />', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  // verifies spec: MOB, CACHE — a removed photo's blob has no referencing
-  // record left, so it can never become eligible for push
-  it('demotes the removed photo\'s blob to reclaimable cache', async () => {
-    const { getByText, rerender } = await render(<UploadPhoto onChange={onChange} value={null} />);
+  // verifies spec: MOB — a read resolves the record's hash against the device's
+  // store, so an answer that already holds a photo shows it and can drop it
+  it('shows a photo the answer already holds and offers to remove it', async () => {
+    const attachment = await holdPhotoOnDevice();
+
+    const { container, getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
+    expect(getByText('Remove photo')).toBeTruthy();
+    expect(getByText('Change photo')).toBeTruthy();
+    expect(queryByText('Upload photo')).toBeNull();
+  });
+
+  // verifies spec: MOB — content the device does not hold is fetched by hash
+  // and admitted to the cache tier
+  it('fetches a photo the device does not hold', async () => {
+    const attachment = await seedAttachment();
+    fetchesPhoto();
+
+    const { container } = await render(<UploadPhoto onChange={onChange} value={attachment.id} />);
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
+    const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
+    expect(blob.tier).toBe(BLOB_TIERS.CACHE);
+  });
+
+  // verifies spec: MOB, XFER — content pending at its origin presents as a
+  // photo awaiting its content, never as an answer with no photo
+  it('reports a photo still awaiting upload from the device that captured it', async () => {
+    const attachment = await seedAttachment();
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        throw new BlobAwaitingUploadError(PHOTO_HASH);
+      }),
+    } as any);
+
+    const { getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await settleRead();
+
+    expect(getByText(/has not finished uploading from the device that captured it/)).toBeTruthy();
+    expect(getByText('Remove photo')).toBeTruthy();
+    expect(queryByText('Upload photo')).toBeNull();
+  });
+
+  // verifies spec: MOB — content this device could not fetch is distinct from
+  // content pending at its origin, and neither reads as a missing photo
+  it('reports a photo not on this device when the fetch cannot reach the network', async () => {
+    deviceIsOffline();
+    const attachment = await seedAttachment();
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        throw new Error('network request failed');
+      }),
+    } as any);
+
+    const { getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await settleRead();
+
+    expect(getByText(/is not on this device yet/)).toBeTruthy();
+    expect(getByText(/Connect to the internet to fetch it/)).toBeTruthy();
+    expect(getByText('Remove photo')).toBeTruthy();
+    expect(queryByText('Upload photo')).toBeNull();
+  });
+
+  // verifies spec: MOB — a record whose content this device cannot resolve is
+  // a photo awaiting its content, not an answer with no photo
+  it('reports a photo whose record has not reached this device', async () => {
+    const { getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value="an-answer-from-another-device" />,
+    );
+    await settleRead();
+
+    expect(getByText(/is not on this device yet/)).toBeTruthy();
+    expect(getByText('Remove photo')).toBeTruthy();
+    expect(queryByText('Upload photo')).toBeNull();
+  });
+
+  // The connectivity the device reports arrives after the first render, so a
+  // photo already being read must not be stranded by it.
+  it('shows the photo when connectivity is reported while the read is in flight', async () => {
+    connectivityIsUnknown();
+    const attachment = await seedAttachment();
+    const releaseFetch = deferPhotoFetch();
+
+    const { container } = await render(<UploadPhoto onChange={onChange} value={attachment.id} />);
+    await connectivityReturns();
+    releaseFetch();
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
+    expect(contentReads).toBe(1);
+  });
+
+  // verifies spec: MOB — content the device could not fetch is fetched again
+  // once it has connectivity, so the advice to connect can be acted on
+  it('fetches the photo again once connectivity returns', async () => {
+    deviceIsOffline();
+    const attachment = await seedAttachment();
+    let reachable = false;
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        if (!reachable) {
+          throw new Error('network request failed');
+        }
+        fs.seed(FETCHED_PATH, PHOTO_BYTES);
+        return await store.putFile(FETCHED_PATH);
+      }),
+    } as any);
+
+    const { container } = await render(<UploadPhoto onChange={onChange} value={attachment.id} />);
+    await settleRead();
+    expect(displayedImageUri(container)).toBeUndefined();
+
+    reachable = true;
+    await connectivityReturns();
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
+  });
+
+  // A photo captured here is already on screen, so the value the form hands
+  // back is not read from the store again.
+  it('does not read back a photo it just captured', async () => {
+    const { container, getByText, rerender } = await render(
+      <UploadPhoto onChange={onChange} value={null} />,
+    );
     await takePhoto(getByText);
-    await waitFor(() => getByText('Remove photo'));
 
     const [attachmentId] = onChange.mock.calls[0];
     await rerender(<UploadPhoto onChange={onChange} value={attachmentId} />);
-    await act(async () => {
-      await fireEvent.press(getByText('Remove photo'));
-    });
+    await settleRead();
 
-    await waitFor(async () => {
-      expect(await Database.models.Attachment.findOne({ where: { id: attachmentId } })).toBeNull();
-    });
+    expect(displayedImageUri(container)).toBe(CAPTURED_URI);
+    expect(contentReads).toBe(0);
+  });
+
+  // verifies spec: MOB, CACHE — a removed photo's blob has no referencing
+  // record left, so it can never become eligible for push
+  it("demotes the removed photo's blob to reclaimable cache", async () => {
+    const attachment = await holdPhotoOnDevice();
+
+    const { container, getByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await settleRead();
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
+    await removePhoto(getByText);
+
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(await Database.models.Attachment.findOne({ where: { id: attachment.id } })).toBeNull();
     const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
     expect(blob.tier).toBe(BLOB_TIERS.CACHE);
   });
@@ -142,33 +326,137 @@ describe('<UploadPhoto />', () => {
   // one blob, so demoting on the first removal would make content another
   // record still references evictable before it has been pushed
   it('leaves the blob in the outbox while another attachment references its hash', async () => {
-    const { getByText, rerender } = await render(<UploadPhoto onChange={onChange} value={null} />);
-    await takePhoto(getByText);
-    await waitFor(() => getByText('Remove photo'));
+    const attachment = await holdPhotoOnDevice();
+    const sharer = await seedAttachment();
 
-    const sharer = await Database.models.Attachment.createAndSaveOne<Attachment>({
-      hash: PHOTO_HASH,
-      size: PHOTO_BYTES.length,
-      type: 'image/jpeg',
-    });
+    const { container, getByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await settleRead();
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
+    await removePhoto(getByText);
 
-    const [attachmentId] = onChange.mock.calls[0];
-    await rerender(<UploadPhoto onChange={onChange} value={attachmentId} />);
-    await act(async () => {
-      await fireEvent.press(getByText('Remove photo'));
-    });
-
-    await waitFor(async () => {
-      expect(await Database.models.Attachment.findOne({ where: { id: attachmentId } })).toBeNull();
-    });
+    expect(await Database.models.Attachment.findOne({ where: { id: attachment.id } })).toBeNull();
     expect(await Database.models.Attachment.findOne({ where: { id: sharer.id } })).not.toBeNull();
     const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
     expect(blob.tier).toBe(BLOB_TIERS.OUTBOX);
   });
 
+  // A read that lands after the photo is removed must not put it back on
+  // screen, since the record it belonged to is gone.
+  it('discards content that arrives after the photo is removed', async () => {
+    const attachment = await seedAttachment();
+    const releaseFetch = deferPhotoFetch();
+
+    const { container, getByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await removePhoto(getByText);
+    releaseFetch();
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBeUndefined();
+    expect(getByText('Upload photo')).toBeTruthy();
+  });
+
+  // A capture owns the field from the moment it completes, so a read of the
+  // photo it replaced must not put the old one back on screen.
+  it('keeps the captured photo when the read it replaced lands afterwards', async () => {
+    const attachment = await seedAttachment();
+    const releaseFetch = deferPhotoFetch();
+
+    const { container, getByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await takePhoto(getByText);
+    releaseFetch();
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(CAPTURED_URI);
+    expect(getByText('Remove photo')).toBeTruthy();
+  });
+
+  async function seedAttachment(): Promise<Attachment> {
+    return await Database.models.Attachment.createAndSaveOne<Attachment>({
+      hash: PHOTO_HASH,
+      size: PHOTO_BYTES.length,
+      type: 'image/jpeg',
+    });
+  }
+
+  async function holdPhotoOnDevice(): Promise<Attachment> {
+    fs.seed(HELD_PATH, PHOTO_BYTES);
+    await cache.putOutbox(HELD_PATH);
+    return await seedAttachment();
+  }
+
+  function fetchesPhoto(): void {
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        fs.seed(FETCHED_PATH, PHOTO_BYTES);
+        return await store.putFile(FETCHED_PATH);
+      }),
+    } as any);
+  }
+
+  function deferPhotoFetch(): () => void {
+    let release: () => void;
+    const released = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        await released;
+        fs.seed(FETCHED_PATH, PHOTO_BYTES);
+        return await store.putFile(FETCHED_PATH);
+      }),
+    } as any);
+    return () => release();
+  }
+
+  // A photo resolves behind six or more database round trips. Draining the
+  // calls the component makes, rather than polling what it has rendered,
+  // keeps these assertions off a wall-clock budget.
+  function trackBackendCalls(): void {
+    backendCalls = [];
+    contentReads = 0;
+    const track = <T,>(call: Promise<T>): Promise<T> => {
+      backendCalls.push(call.then(ignoreOutcome, ignoreOutcome));
+      return call;
+    };
+
+    const { Attachment: attachmentModel } = Database.models;
+    const findOne = attachmentModel.findOne.bind(attachmentModel);
+    jest.spyOn(attachmentModel, 'findOne').mockImplementation(options => track(findOne(options)));
+
+    const readBase64 = cache.readBase64.bind(cache);
+    jest.spyOn(cache, 'readBase64').mockImplementation(hash => {
+      contentReads += 1;
+      return track(readBase64(hash));
+    });
+  }
+
+  async function settleRead(): Promise<void> {
+    await act(async () => {
+      for (let drained = 0; drained < backendCalls.length; ) {
+        const pending = backendCalls.slice(drained);
+        drained = backendCalls.length;
+        await Promise.all(pending);
+      }
+    });
+  }
+
+  function ignoreOutcome(): void {}
+
   async function takePhoto(getByText): Promise<void> {
     await act(async () => {
       await fireEvent.press(getByText('Take photo with camera'));
+    });
+  }
+
+  async function removePhoto(getByText): Promise<void> {
+    await act(async () => {
+      await fireEvent.press(getByText('Remove photo'));
     });
   }
 });

--- a/packages/mobile/App/ui/components/UploadPhoto/index.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
 import RNFS from 'react-native-fs';
 import { Popup } from 'popup-ui';
-import { ERROR_TYPE } from '@tamanu/errors';
+import { useNetInfo } from '@react-native-community/netinfo';
+import { ERROR_TYPE, NotFoundError } from '@tamanu/errors';
 import { useBackend } from '~/ui/hooks';
 import { StyledImage, StyledView, StyledText } from '/styled/common';
 import {
@@ -12,6 +13,8 @@ import {
   resizeImage,
 } from '/helpers/image';
 import { deleteFileInDocuments } from '/helpers/file';
+import { BlobAwaitingUploadError } from '~/services/blobs';
+import type { BackendManager } from '~/services/BackendManager';
 import { BaseInputProps } from '../../interfaces/BaseInputProps';
 import { Button } from '~/ui/components/Button';
 import { theme } from '~/ui/styled/theme';
@@ -27,6 +30,12 @@ const IMAGE_SOURCE_TYPES = {
   LIBRARY: 'library',
 };
 
+const AWAITING_UPLOAD_MESSAGE =
+  'This image has not finished uploading from the device that captured it.\nTry again later.';
+
+const NOT_ON_DEVICE_MESSAGE =
+  'This image is not on this device yet.\nConnect to the internet to fetch it.';
+
 export interface PhotoProps extends BaseInputProps {
   onChange: Function;
   value: string;
@@ -40,12 +49,65 @@ interface UploadPhotoComponentProps {
   onPressChoosePhoto: Function;
   onPressTakePhoto: Function;
   onPressRemovePhoto: Function;
+  hasPhoto: boolean;
   imageData: string;
   errorMessage?: string;
   loading: boolean;
 }
 
 const IMAGE_WIDTH = Dimensions.get('window').width * 0.6;
+
+// One fact, so a read that lands late can be told from the photo the field
+// holds now.
+interface Photo {
+  attachmentId: string | null;
+  status: 'empty' | 'loading' | 'ready' | 'unavailable';
+  imageData?: string;
+  error?: Error;
+}
+
+const NO_PHOTO: Photo = { attachmentId: null, status: 'empty' };
+
+const readPhoto = async (
+  attachmentId: string,
+  { models, blobCache }: Pick<BackendManager, 'models' | 'blobCache'>,
+): Promise<Photo> => {
+  try {
+    const attachment = await models.Attachment.findOne({ where: { id: attachmentId } });
+    if (!attachment?.hash) {
+      throw new NotFoundError(`This device holds no record for attachment ${attachmentId}`);
+    }
+    return {
+      attachmentId,
+      status: 'ready',
+      imageData: await blobCache.readBase64(attachment.hash),
+    };
+  } catch (error) {
+    return { attachmentId, status: 'unavailable', error };
+  }
+};
+
+const photoMessage = (
+  { attachmentId, error }: Photo,
+  isInternetReachable: boolean,
+): string | null => {
+  if (!error) {
+    return null;
+  }
+  if (!attachmentId) {
+    // Nothing attached, so the failure came from a capture rather than a read.
+    return `Error loading image: ${error.message}`;
+  }
+  // spec: MOB, XFER — an existing file awaiting its content, with the
+  // awaiting-upload and awaiting-fetch cases distinguished
+  if (error instanceof BlobAwaitingUploadError) {
+    return AWAITING_UPLOAD_MESSAGE;
+  }
+  if (error instanceof NotFoundError || !isInternetReachable) {
+    return NOT_ON_DEVICE_MESSAGE;
+  }
+  return `Error loading image: ${error.message}`;
+};
 
 const ImageActionButton = ({ onPress, label, marginTop = 5, border = true }) => (
   <Button
@@ -82,6 +144,7 @@ const UploadPhotoComponent = ({
   onPressChoosePhoto,
   onPressTakePhoto,
   onPressRemovePhoto,
+  hasPhoto,
   imageData,
   errorMessage,
   loading,
@@ -89,14 +152,14 @@ const UploadPhotoComponent = ({
   <StyledView marginTop={5}>
     {loading && <LoadingPlaceholder />}
     {imageData && <UploadedImage imageData={imageData} />}
-    {!imageData && errorMessage && <Text>{`Error loading image: ${errorMessage}`}</Text>}
+    {!imageData && errorMessage && <Text>{errorMessage}</Text>}
     <StyledText fontWeight="500" color={theme.colors.TEXT_SUPER_DARK} marginTop={10}>
-      {imageData ? 'Change photo' : 'Upload photo'}
+      {hasPhoto ? 'Change photo' : 'Upload photo'}
     </StyledText>
     <StyledView justifyContent="space-between" marginLeft={-10}>
       <ImageActionButton onPress={onPressChoosePhoto} label="Choose photo from library" />
       <ImageActionButton onPress={onPressTakePhoto} label="Take photo with camera" />
-      {imageData && (
+      {hasPhoto && (
         <ImageActionButton
           onPress={onPressRemovePhoto}
           label="Remove photo"
@@ -109,10 +172,11 @@ const UploadPhotoComponent = ({
 );
 
 export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
-  const [loading, setLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState(null);
-  const [imageData, setImageData] = useState(null);
+  const [photo, setPhoto] = useState<Photo>(() =>
+    value ? { attachmentId: value, status: 'loading' } : NO_PHOTO,
+  );
   const { models, blobCache } = useBackend();
+  const { isInternetReachable } = useNetInfo();
 
   const removeAttachment = useCallback(async value => {
     if (!value) {
@@ -137,9 +201,49 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
 
   const removePhotoCallback = useCallback(async () => {
     onChange(null);
-    setImageData(null);
+    setPhoto(NO_PHOTO);
     await removeAttachment(value);
   }, [value]);
+
+  useEffect(() => {
+    setPhoto(current => {
+      if (current.attachmentId === value) {
+        return current;
+      }
+      return value ? { attachmentId: value, status: 'loading' } : NO_PHOTO;
+    });
+  }, [value]);
+
+  // spec: MOB
+  // A photo the answer already holds resolves through its record's hash:
+  // content the device holds reads without connectivity, content it does not
+  // hold is fetched by hash.
+  useEffect(() => {
+    const { attachmentId, status } = photo;
+    if (status !== 'loading' || !attachmentId) {
+      return;
+    }
+    (async (): Promise<void> => {
+      const read = await readPhoto(attachmentId, { models, blobCache });
+      // A capture or removal that lands first owns the field; this read is stale.
+      setPhoto(current =>
+        current.attachmentId === attachmentId && current.status === 'loading' ? read : current,
+      );
+    })();
+  }, [photo, models, blobCache]);
+
+  // spec: MOB — content the device could not fetch is retried once it has
+  // connectivity, so the advice to connect is one the component can act on.
+  useEffect(() => {
+    if (!isInternetReachable) {
+      return;
+    }
+    setPhoto(current =>
+      current.status === 'unavailable'
+        ? { attachmentId: current.attachmentId, status: 'loading' }
+        : current,
+    );
+  }, [isInternetReachable]);
 
   const addPhotoCallback = useCallback(
     async imageType => {
@@ -153,12 +257,11 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
         }
       } catch (error) {
         await removePhotoCallback();
-        setErrorMessage(error.message);
+        setPhoto({ ...NO_PHOTO, error });
         return;
       }
 
-      setImageData(null);
-      setLoading(true);
+      setPhoto({ attachmentId: null, status: 'loading' });
 
       // image-picker produces quite expensive files so
       // always delete them straight away to save storage
@@ -182,7 +285,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
       try {
         putResult = await blobCache.putOutbox(path);
       } catch (error) {
-        setLoading(false);
+        setPhoto(NO_PHOTO);
         await deleteFileInDocuments(path);
         if (error?.type === ERROR_TYPE.STORAGE_INSUFFICIENT) {
           // spec: CAP — the refusal names the device's storage as the cause
@@ -195,7 +298,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
           });
           return;
         }
-        setErrorMessage(error.message);
+        setPhoto({ ...NO_PHOTO, error });
         return;
       }
 
@@ -206,20 +309,20 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
       });
 
       onChange(id);
-      setImageData(image.base64);
-      setLoading(false);
+      setPhoto({ attachmentId: id, status: 'ready', imageData: image.base64 });
     },
     [value],
   );
 
   return (
     <UploadPhotoComponent
-      imageData={imageData}
-      errorMessage={errorMessage}
+      hasPhoto={Boolean(photo.attachmentId)}
+      imageData={photo.imageData}
+      errorMessage={photoMessage(photo, isInternetReachable)}
       onPressTakePhoto={() => addPhotoCallback(IMAGE_SOURCE_TYPES.CAMERA)}
       onPressChoosePhoto={() => addPhotoCallback(IMAGE_SOURCE_TYPES.LIBRARY)}
       onPressRemovePhoto={removePhotoCallback}
-      loading={loading}
+      loading={photo.status === 'loading'}
     />
   );
 });

--- a/packages/mobile/App/ui/components/ViewPhotoLink.spec.tsx
+++ b/packages/mobile/App/ui/components/ViewPhotoLink.spec.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { useNetInfo } from '@react-native-community/netinfo';
+
+import { Database } from '~/infra/db';
+import { useBackend } from '~/ui/hooks';
+import { Attachment } from '~/models/Attachment';
+import { BlobAwaitingUploadError } from '~/services/blobs/BlobTransferChannel';
+import { MobileBlobCache } from '~/services/blobs/MobileBlobCache';
+import { MobileBlobStore } from '~/services/blobs/MobileBlobStore';
+import { deriveFreeDiskReserveBytes } from '~/services/blobs/deviceStorage';
+import { FakeBlobFileSystem, sha256Hash } from '/root/tests/helpers/fakeBlobFileSystem';
+import { ViewPhotoLink } from './ViewPhotoLink';
+
+jest.mock('react-native-fs', () => ({
+  __esModule: true,
+  default: { DocumentDirectoryPath: '/documents' },
+}));
+
+jest.mock('@react-native-community/netinfo', () => ({ useNetInfo: jest.fn() }));
+
+jest.mock('@react-native-camera-roll/camera-roll', () => ({
+  __esModule: true,
+  default: { save: jest.fn() },
+}));
+
+jest.mock('/helpers/file', () => ({
+  deleteFileInDocuments: jest.fn(async () => {}),
+  saveFileInDocuments: jest.fn(async () => '/documents/saved.jpg'),
+}));
+
+jest.mock('~/ui/hooks', () => ({ useBackend: jest.fn() }));
+
+const ROOT = '/blobs';
+const PHOTO_BYTES = 'the photograph on the device';
+const PHOTO_HASH = sha256Hash(PHOTO_BYTES);
+const PHOTO_BASE64 = Buffer.from(PHOTO_BYTES).toString('base64');
+const PHOTO_URI = `data:image/jpeg;base64, ${PHOTO_BASE64}`;
+
+const displayedImageUri = (container): string | undefined =>
+  container.queryAll(node => node.type === 'Image')[0]?.props?.source?.uri;
+
+describe('<ViewPhotoLink />', () => {
+  let fs: FakeBlobFileSystem;
+  let store: MobileBlobStore;
+  let cache: MobileBlobCache;
+  let centralServer: { get: jest.Mock };
+
+  beforeAll(async () => {
+    await Database.connect();
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await Database.models.Attachment.getRepository().clear();
+    await Database.models.Blob.getRepository().clear();
+
+    fs = new FakeBlobFileSystem();
+    store = new MobileBlobStore({
+      root: ROOT,
+      models: Database.models,
+      getFreeDiskReserveBytes: deriveFreeDiskReserveBytes,
+      evictCache: bytesNeeded => cache.evictBytes(bytesNeeded),
+      fs,
+    });
+    cache = new MobileBlobCache({ blobStore: store, models: Database.models, fs });
+
+    centralServer = { get: jest.fn() };
+    (useBackend as jest.Mock).mockReturnValue({
+      models: Database.models,
+      blobCache: cache,
+      centralServer,
+    });
+    (useNetInfo as jest.Mock).mockReturnValue({ isInternetReachable: true });
+  });
+
+  // verifies spec: MOB — a read resolves the hash against the device's store,
+  // and content the device holds is read without connectivity
+  it('displays content the device holds without asking the central server', async () => {
+    fs.seed('/documents/captured.jpg', PHOTO_BYTES);
+    await cache.putOutbox('/documents/captured.jpg');
+    const attachment = await seedAttachment(PHOTO_HASH);
+
+    const { container, getByText } = await render(<ViewPhotoLink imageId={attachment.id} />);
+    await act(async () => {
+      await fireEvent.press(getByText('View Image'));
+    });
+
+    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    expect(centralServer.get).not.toHaveBeenCalled();
+  });
+
+  // verifies spec: MOB, XFER — content pending at its origin is distinct from
+  // content this device simply has not fetched
+  it('reports content still awaiting upload from the device that captured it', async () => {
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        throw new BlobAwaitingUploadError(PHOTO_HASH);
+      }),
+    } as any);
+    const attachment = await seedAttachment(PHOTO_HASH);
+
+    const { getByText } = await render(<ViewPhotoLink imageId={attachment.id} />);
+    await act(async () => {
+      await fireEvent.press(getByText('View Image'));
+    });
+
+    await waitFor(() =>
+      expect(getByText(/has not finished uploading from the device that captured it/)).toBeTruthy(),
+    );
+    expect(centralServer.get).not.toHaveBeenCalled();
+  });
+
+  // verifies spec: MOB — content the device does not hold and cannot fetch
+  // presents as a file awaiting its content, not as a missing record
+  it('reports content not yet on this device when there is no connectivity', async () => {
+    (useNetInfo as jest.Mock).mockReturnValue({ isInternetReachable: false });
+    const attachment = await seedAttachment(PHOTO_HASH);
+
+    const { getByText } = await render(<ViewPhotoLink imageId={attachment.id} />);
+    await act(async () => {
+      await fireEvent.press(getByText('View Image'));
+    });
+
+    await waitFor(() => expect(getByText(/is not on this device yet/)).toBeTruthy());
+    expect(getByText(/Connect to the internet to fetch it/)).toBeTruthy();
+    expect(centralServer.get).not.toHaveBeenCalled();
+  });
+
+  // A record with no hash is only reachable over the central attachment route,
+  // so an offline device can say nothing better than that it needs a connection.
+  it('reports that a hashless record needs a live connection when offline', async () => {
+    (useNetInfo as jest.Mock).mockReturnValue({ isInternetReachable: false });
+    const attachment = await seedAttachment(null);
+
+    const { getByText } = await render(<ViewPhotoLink imageId={attachment.id} />);
+    await act(async () => {
+      await fireEvent.press(getByText('View Image'));
+    });
+
+    await waitFor(() =>
+      expect(getByText(/do not currently have an internet connection/)).toBeTruthy(),
+    );
+    expect(centralServer.get).not.toHaveBeenCalled();
+  });
+
+  // verifies spec: MOB, ATCH — a record carrying no hash falls back to the
+  // central attachment route, which serves it by id
+  it('serves a hashless record from the central attachment route', async () => {
+    const attachment = await seedAttachment(null);
+    centralServer.get.mockResolvedValue({ data: PHOTO_BASE64 });
+
+    const { container, getByText } = await render(<ViewPhotoLink imageId={attachment.id} />);
+    await act(async () => {
+      await fireEvent.press(getByText('View Image'));
+    });
+
+    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    expect(centralServer.get).toHaveBeenCalledWith(`attachment/${attachment.id}`, {
+      base64: true,
+    });
+  });
+
+  async function seedAttachment(hash: string | null): Promise<Attachment> {
+    return await Database.models.Attachment.createAndSaveOne<Attachment>({
+      hash,
+      size: PHOTO_BYTES.length,
+      type: 'image/jpeg',
+    });
+  }
+});

--- a/packages/mobile/App/ui/components/ViewPhotoLink.spec.tsx
+++ b/packages/mobile/App/ui/components/ViewPhotoLink.spec.tsx
@@ -127,8 +127,7 @@ describe('<ViewPhotoLink />', () => {
     expect(centralServer.get).not.toHaveBeenCalled();
   });
 
-  // A record with no hash is only reachable over the central attachment route,
-  // so an offline device can say nothing better than that it needs a connection.
+  // A record with no hash is reachable only over the central attachment route.
   it('reports that a hashless record needs a live connection when offline', async () => {
     (useNetInfo as jest.Mock).mockReturnValue({ isInternetReachable: false });
     const attachment = await seedAttachment(null);

--- a/packages/shared/__tests__/utils/serveBlob.test.js
+++ b/packages/shared/__tests__/utils/serveBlob.test.js
@@ -1,3 +1,7 @@
+import { createReadStream } from 'node:fs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { Readable, Writable } from 'node:stream';
 
 import { MAX_INLINE_BLOB_BYTES } from '@tamanu/constants';
@@ -7,6 +11,7 @@ import { readBlobAsBase64, serveBlob } from '../../src/utils/serveBlob';
 class FakeResponse extends Writable {
   statusCode = 200;
   headers = {};
+  onWrite = () => {};
   #chunks = [];
 
   status(code) {
@@ -22,6 +27,7 @@ class FakeResponse extends Writable {
   _write(chunk, _encoding, callback) {
     this.#chunks.push(chunk);
     callback();
+    this.onWrite();
   }
 
   get body() {
@@ -134,5 +140,84 @@ describe('serveBlob', () => {
     const res = await serve({ hash: null, headers: { 'if-none-match': '*' } });
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(CONTENT);
+  });
+
+  it('writes the first bytes out before the source has produced its last', async () => {
+    const res = new FakeResponse();
+    let sourceFinished = false;
+    let finishedAtFirstWrite = null;
+    let release;
+    const released = new Promise(resolve => {
+      release = resolve;
+    });
+    // Released on the first write, or shortly after regardless, so a serve that
+    // reads the whole blob before writing any of it fails the assertion below
+    // rather than waiting on a write that is never coming.
+    const fallback = setTimeout(() => release(), 100);
+    res.onWrite = () => {
+      finishedAtFirstWrite ??= sourceFinished;
+      release();
+    };
+
+    async function* slowly() {
+      yield CONTENT.subarray(0, 5);
+      await released;
+      sourceFinished = true;
+      yield CONTENT.subarray(5);
+    }
+
+    try {
+      await serveBlob({ headers: {} }, res, {
+        hash: HASH,
+        size: CONTENT.length,
+        contentType: 'text/plain',
+        open: () => Readable.from(slowly()),
+      });
+    } finally {
+      clearTimeout(fallback);
+    }
+
+    expect(finishedAtFirstWrite).toBe(false);
+    expect(res.body).toEqual(CONTENT);
+  });
+
+  describe('a client that goes away mid-download', () => {
+    let root;
+    let filePath;
+
+    beforeAll(async () => {
+      root = await fs.mkdtemp(path.join(os.tmpdir(), 'serve-blob-'));
+      filePath = path.join(root, 'content');
+      // Past the read stream's buffer, so the download is still in flight when
+      // the client disconnects.
+      await fs.writeFile(filePath, Buffer.alloc(256 * 1024, 'a'));
+    });
+
+    afterAll(async () => {
+      await fs.rm(root, { recursive: true, force: true });
+    });
+
+    // How an interrupted fetch pauses before resuming with a range request, so
+    // it must not surface as a failure, and it must not leave the file open.
+    it('is not an error, and leaves no open file handle', async () => {
+      const res = new FakeResponse();
+      res.onWrite = () => res.destroy();
+      const source = createReadStream(filePath);
+      const closed = new Promise(resolve => {
+        source.once('close', resolve);
+      });
+
+      await expect(
+        serveBlob({ headers: {} }, res, {
+          hash: HASH,
+          size: 256 * 1024,
+          contentType: 'text/plain',
+          open: () => source,
+        }),
+      ).resolves.toBeUndefined();
+
+      await closed;
+      expect(source.closed).toBe(true);
+    });
   });
 });

--- a/packages/web/__tests__/api/queries/useAssetQuery.test.jsx
+++ b/packages/web/__tests__/api/queries/useAssetQuery.test.jsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ASSET_NAMES, BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
+
+import { createQueryClient } from '../../helpers';
+
+const { apiGet } = vi.hoisted(() => ({ apiGet: vi.fn() }));
+
+vi.mock('../../../app/api/useApi', () => ({ useApi: () => ({ get: apiGet }) }));
+vi.mock('../../../app/contexts/Auth', () => ({ useAuth: () => ({ facilityId: 'facility-1' }) }));
+
+import { useAssetQuery } from '../../../app/api/queries/useAssetQuery';
+
+const ASSET_NAME = ASSET_NAMES.VACCINATION_CERTIFICATE_FOOTER;
+const FALLBACK_NAME = ASSET_NAMES.CERTIFICATE_BOTTOM_HALF_IMG;
+
+// Express serialises the row's image buffer this way, so it is what the browser
+// actually receives.
+const uploaded = (...bytes) => ({ type: 'image/png', data: { type: 'Buffer', data: bytes } });
+const neverUploaded = () => ({});
+const contentPending = () => ({
+  type: 'image/png',
+  data: null,
+  availability: BLOB_AVAILABILITY_STATES.AWAITING_FETCH,
+});
+
+const respondWith = (byName) =>
+  apiGet.mockImplementation(async (endpoint) => byName[endpoint.replace('asset/', '')]);
+
+const requestedAssets = () => apiGet.mock.calls.map(([endpoint]) => endpoint);
+
+const renderAssetQuery = () => {
+  const queryClient = createQueryClient();
+  return renderHook(() => useAssetQuery(ASSET_NAME), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+};
+
+const settled = async (result) => {
+  await waitFor(() => expect(result.current.isFetching).toBe(false));
+};
+
+describe('useAssetQuery', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+  });
+
+  // spec: ASSET
+  // A fallback stands in only for an asset that was never uploaded, so a
+  // pending asset must never be substituted with a different image.
+  it('never asks for the fallback of a content-pending asset', async () => {
+    respondWith({ [ASSET_NAME]: contentPending(), [FALLBACK_NAME]: uploaded(9, 9, 9) });
+
+    const { result } = renderAssetQuery();
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+    await settled(result);
+
+    expect(requestedAssets()).toEqual([`asset/${ASSET_NAME}`]);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('substitutes the fallback for an asset that was never uploaded', async () => {
+    respondWith({ [ASSET_NAME]: neverUploaded(), [FALLBACK_NAME]: uploaded(1, 2, 3) });
+
+    const { result } = renderAssetQuery();
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+
+    expect(requestedAssets()).toContain(`asset/${FALLBACK_NAME}`);
+    expect(result.current.data).toBe('data:image/png;base64,AQID');
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('shows the asset itself without reaching for the fallback', async () => {
+    respondWith({ [ASSET_NAME]: uploaded(4, 5, 6), [FALLBACK_NAME]: uploaded(9, 9, 9) });
+
+    const { result } = renderAssetQuery();
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    await settled(result);
+
+    expect(requestedAssets()).toEqual([`asset/${ASSET_NAME}`]);
+    expect(result.current.data).toBe('data:image/png;base64,BAUG');
+  });
+});

--- a/packages/web/__tests__/components/DocumentPreview/PDFPreview.test.jsx
+++ b/packages/web/__tests__/components/DocumentPreview/PDFPreview.test.jsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+
+const { apiGet, getDocument } = vi.hoisted(() => ({ apiGet: vi.fn(), getDocument: vi.fn() }));
+
+vi.mock('../../../app/api', () => ({ useApi: () => ({ get: apiGet }) }));
+vi.mock('pdfjs-dist', () => ({ GlobalWorkerOptions: {}, getDocument }));
+
+// Rendering a page needs a real canvas, which jsdom does not provide; stand in
+// with the page number so the assertions read as what is on screen.
+vi.mock('../../../app/components/DocumentPreview/PDFPage', () => ({
+  PDFPage: ({ page }) => <div>{`Page ${page.pageNumber}`}</div>,
+}));
+
+import PDFPreview from '../../../app/components/DocumentPreview/PDFPreview';
+
+const PDF = 'JVBERi0xLjQ=';
+const PENDING_MESSAGE = 'This file is not available yet. Please try again shortly.';
+
+const loadedDocument = (numPages) => ({
+  promise: Promise.resolve({
+    numPages,
+    getPage: async (pageNumber) => ({ pageNumber }),
+  }),
+});
+
+const renderPreview = () =>
+  renderElementWithTranslatedText(
+    <PDFPreview
+      attachmentId="attachment-1"
+      pageCount={0}
+      setPageCount={vi.fn()}
+      scrollPage={1}
+      setScrollPage={vi.fn()}
+    />,
+  );
+
+describe('PDFPreview', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    getDocument.mockReset();
+  });
+
+  // spec: ATCH
+  // A 202 carries no bytes, so the base64 decode would be handed `undefined`
+  // and the document would fail to open with no explanation.
+  it('tells the clinician the document is not available yet', async () => {
+    apiGet.mockResolvedValue({ availability: BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD });
+
+    renderPreview();
+
+    expect(await screen.findByText(PENDING_MESSAGE)).toBeTruthy();
+    expect(getDocument).not.toHaveBeenCalled();
+  });
+
+  it('renders the pages when the content is served', async () => {
+    apiGet.mockResolvedValue({ data: PDF });
+    getDocument.mockReturnValue(loadedDocument(2));
+
+    renderPreview();
+
+    expect(await screen.findByText('Page 1')).toBeTruthy();
+    expect(screen.getByText('Page 2')).toBeTruthy();
+    expect(screen.queryByText(PENDING_MESSAGE)).toBeNull();
+  });
+});

--- a/packages/web/__tests__/components/DocumentPreview/PhotoPreview.test.jsx
+++ b/packages/web/__tests__/components/DocumentPreview/PhotoPreview.test.jsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+
+const { apiGet } = vi.hoisted(() => ({ apiGet: vi.fn() }));
+
+vi.mock('../../../app/api', () => ({ useApi: () => ({ get: apiGet }) }));
+
+import PhotoPreview from '../../../app/components/DocumentPreview/PhotoPreview';
+
+const IMAGE = 'aGVsbG8=';
+const PENDING_MESSAGE = 'This file is not available yet. Please try again shortly.';
+const WITHHELD_MESSAGE =
+  'This file has been withheld as unsafe by a virus scan and cannot be viewed. Contact your system administrator.';
+
+describe('PhotoPreview', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+  });
+
+  // spec: ATCH
+  // A 202 carries no bytes, so without this the src is
+  // `data:image/jpeg;base64,undefined` and the clinician sees a broken image.
+  it('tells the clinician the photo is not available yet instead of showing a broken image', async () => {
+    apiGet.mockResolvedValue({ availability: BLOB_AVAILABILITY_STATES.AWAITING_FETCH });
+
+    renderElementWithTranslatedText(<PhotoPreview attachmentId="attachment-1" />);
+
+    expect(await screen.findByText(PENDING_MESSAGE)).toBeTruthy();
+    expect(screen.queryByTestId('image-znla')).toBeNull();
+  });
+
+  it('says content withheld as unsafe is not coming', async () => {
+    apiGet.mockResolvedValue({ availability: BLOB_AVAILABILITY_STATES.WITHHELD_INFECTED });
+
+    renderElementWithTranslatedText(<PhotoPreview attachmentId="attachment-1" />);
+
+    expect(await screen.findByText(WITHHELD_MESSAGE)).toBeTruthy();
+    expect(screen.queryByTestId('image-znla')).toBeNull();
+  });
+
+  it('renders the photo when its content is served', async () => {
+    apiGet.mockResolvedValue({ data: IMAGE });
+
+    renderElementWithTranslatedText(<PhotoPreview attachmentId="attachment-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('image-znla').getAttribute('src')).toBe(
+        `data:image/jpeg;base64,${IMAGE}`,
+      ),
+    );
+    expect(screen.queryByText(PENDING_MESSAGE)).toBeNull();
+  });
+});

--- a/packages/web/__tests__/components/ViewPhotoLink.test.jsx
+++ b/packages/web/__tests__/components/ViewPhotoLink.test.jsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
+
+import { renderElementWithTranslatedText } from '../helpers';
+
+const { apiGet } = vi.hoisted(() => ({ apiGet: vi.fn() }));
+
+vi.mock('../../app/api', () => ({ useApi: () => ({ get: apiGet }) }));
+vi.mock('../../app/contexts/ExportContext', () => ({ useExport: () => ({ isExporting: false }) }));
+vi.mock('../../app/contexts/Auth', () => ({ useAuth: () => ({ ability: { can: () => false } }) }));
+vi.mock('../../app/views/patients/components/DeletePhotoLinkModal', () => ({
+  DeletePhotoLinkModal: () => null,
+}));
+
+import { ViewPhotoLink } from '../../app/components/ViewPhotoLink';
+
+const IMAGE = 'aGVsbG8=';
+const PENDING_MESSAGE = 'This file is not available yet. Please try again shortly.';
+const WITHHELD_MESSAGE =
+  'This file has been withheld as unsafe by a virus scan and cannot be viewed. Contact your system administrator.';
+
+const openPhoto = async () => {
+  renderElementWithTranslatedText(<ViewPhotoLink answerId="answer-1" imageId="attachment-1" />);
+  await userEvent.click(screen.getByRole('button', { name: 'View image' }));
+};
+
+describe('ViewPhotoLink', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+  });
+
+  // spec: ATCH
+  // A 202 is an ok response carrying no bytes, so the modal would otherwise sit
+  // on its loading indicator forever.
+  it('tells the clinician the photo is not available yet', async () => {
+    apiGet.mockResolvedValue({ availability: BLOB_AVAILABILITY_STATES.AWAITING_FETCH });
+
+    await openPhoto();
+
+    expect(await screen.findByText(PENDING_MESSAGE)).toBeTruthy();
+    expect(screen.queryByTestId('image-7oxc')).toBeNull();
+  });
+
+  it('says content withheld as unsafe is not coming', async () => {
+    apiGet.mockResolvedValue({ availability: BLOB_AVAILABILITY_STATES.WITHHELD_INFECTED });
+
+    await openPhoto();
+
+    expect(await screen.findByText(WITHHELD_MESSAGE)).toBeTruthy();
+    expect(screen.queryByTestId('image-7oxc')).toBeNull();
+  });
+
+  it('shows the photo when its content is served', async () => {
+    apiGet.mockResolvedValue({ data: IMAGE });
+
+    await openPhoto();
+
+    const image = await screen.findByTestId('image-7oxc');
+    expect(image.getAttribute('src')).toBe(`data:image/jpeg;base64,${IMAGE}`);
+    expect(screen.queryByText(PENDING_MESSAGE)).toBeNull();
+  });
+});

--- a/packages/web/__tests__/hooks/useDocumentActions.test.jsx
+++ b/packages/web/__tests__/hooks/useDocumentActions.test.jsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ToastContainer, toast } from 'react-toastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
+
+import { renderElementWithTranslatedText } from '../helpers';
+
+const { apiGet } = vi.hoisted(() => ({ apiGet: vi.fn() }));
+
+vi.mock('../../app/api', () => ({ useApi: () => ({ get: apiGet }) }));
+
+import { useDocumentActions } from '../../app/hooks/useDocumentActions';
+
+const DOCUMENT = {
+  name: 'discharge-summary',
+  type: 'application/pdf',
+  attachmentId: 'attachment-1',
+};
+const PDF = 'JVBERi0xLjQ=';
+const PENDING_MESSAGE = 'This file is not available yet. Please try again shortly.';
+
+let fetchesBeforePicker;
+let writtenBytes;
+
+const stubSavePicker = () => {
+  fetchesBeforePicker = null;
+  writtenBytes = null;
+  window.showSaveFilePicker = vi.fn(async () => {
+    fetchesBeforePicker = apiGet.mock.calls.length;
+    return {
+      createWritable: async () => ({
+        write: async (data) => {
+          writtenBytes = data;
+        },
+        close: async () => {},
+      }),
+    };
+  });
+};
+
+const printIframes = () => document.querySelectorAll('iframe');
+
+const Harness = () => {
+  const { onDownload, onPrintPDF } = useDocumentActions();
+  return (
+    <>
+      <button type="button" onClick={() => onDownload(DOCUMENT)}>
+        Download
+      </button>
+      <button type="button" onClick={() => onPrintPDF(DOCUMENT.attachmentId)}>
+        Print
+      </button>
+    </>
+  );
+};
+
+const clickAction = async (name) => {
+  renderElementWithTranslatedText(
+    <>
+      <ToastContainer />
+      <Harness />
+    </>,
+  );
+  await userEvent.click(screen.getByRole('button', { name }));
+};
+
+describe('useDocumentActions', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    stubSavePicker();
+    URL.createObjectURL = vi.fn(() => 'blob:document');
+  });
+
+  afterEach(() => {
+    toast.dismiss();
+    delete window.showSaveFilePicker;
+  });
+
+  describe('download', () => {
+    it('reports the file is not available yet rather than a raw error', async () => {
+      apiGet.mockResolvedValue({ availability: BLOB_AVAILABILITY_STATES.AWAITING_UPLOAD });
+
+      await clickAction('Download');
+
+      expect(await screen.findByText(PENDING_MESSAGE)).toBeTruthy();
+      expect(writtenBytes).toBeNull();
+    });
+
+    it('writes the served content to the file the user picked', async () => {
+      apiGet.mockResolvedValue({ data: PDF });
+
+      await clickAction('Download');
+
+      expect(await screen.findByText('Successfully downloaded file')).toBeTruthy();
+      expect(Buffer.from(writtenBytes).toString('base64')).toBe(PDF);
+    });
+
+    // The save picker needs the click's transient user activation, which an
+    // awaited network call can outlive, so the fetch belongs inside saveFile's
+    // data callback and must not be hoisted above it.
+    it('opens the save picker before fetching anything', async () => {
+      apiGet.mockResolvedValue({ data: PDF });
+
+      await clickAction('Download');
+
+      expect(await screen.findByText('Successfully downloaded file')).toBeTruthy();
+      expect(fetchesBeforePicker).toBe(0);
+    });
+  });
+
+  describe('print', () => {
+    it('reports the file is not available yet and sends nothing to the printer', async () => {
+      apiGet.mockResolvedValue({ availability: BLOB_AVAILABILITY_STATES.AWAITING_FETCH });
+
+      await clickAction('Print');
+
+      expect(await screen.findByText(PENDING_MESSAGE)).toBeTruthy();
+      expect(URL.createObjectURL).not.toHaveBeenCalled();
+      expect(printIframes()).toHaveLength(0);
+    });
+
+    it('sends the served content to the printer', async () => {
+      apiGet.mockResolvedValue({ data: PDF });
+
+      await clickAction('Print');
+
+      await vi.waitFor(() => expect(printIframes()).toHaveLength(1));
+      expect(printIframes()[0].src).toBe('blob:document');
+      expect(screen.queryByText(PENDING_MESSAGE)).toBeNull();
+    });
+  });
+});

--- a/packages/web/__tests__/utils/useCertificate.test.jsx
+++ b/packages/web/__tests__/utils/useCertificate.test.jsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ASSET_NAMES, BLOB_AVAILABILITY_STATES } from '@tamanu/constants';
+
+import { createQueryClient } from '../helpers';
+
+const { apiGet } = vi.hoisted(() => ({ apiGet: vi.fn() }));
+
+vi.mock('../../app/api/useApi', () => ({ useApi: () => ({ get: apiGet }) }));
+vi.mock('../../app/contexts/Auth', () => ({ useAuth: () => ({ facilityId: 'facility-1' }) }));
+vi.mock('../../app/contexts/Settings', () => ({
+  useSettings: () => ({ getSetting: () => ({ title: 'Ministry of Health', subTitle: 'Tamanu' }) }),
+}));
+vi.mock('react-redux', () => ({ useSelector: () => ({ displayName: 'Test Clinician' }) }));
+
+import { useCertificate } from '../../app/utils/useCertificate';
+
+// Express serialises the row's image buffer this way, so it is what the browser
+// actually receives.
+const uploaded = (...bytes) => ({ type: 'image/png', data: { type: 'Buffer', data: bytes } });
+const neverUploaded = () => ({});
+const contentPending = () => ({
+  type: 'image/png',
+  data: null,
+  availability: BLOB_AVAILABILITY_STATES.AWAITING_FETCH,
+});
+
+const respondWith = (byName, fallback) =>
+  apiGet.mockImplementation(async (endpoint) => byName[endpoint.replace('asset/', '')] ?? fallback);
+
+const renderCertificate = () => {
+  const queryClient = createQueryClient();
+  return renderHook(() => useCertificate(), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+};
+
+describe('useCertificate', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+  });
+
+  // spec: ASSET
+  // The document must not print without artwork it is meant to carry, so
+  // consumers gating on isFetching hold it until the bytes arrive.
+  it('stays not-ready while an asset is awaiting its content', async () => {
+    respondWith({ [ASSET_NAMES.LETTERHEAD_LOGO]: contentPending() }, uploaded(1, 2, 3));
+
+    const { result } = renderCertificate();
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+    await waitFor(() => expect(result.current.data.watermark).not.toBeNull());
+
+    expect(result.current.isFetching).toBe(true);
+    expect(result.current.data.logo).toBeNull();
+  });
+
+  it('becomes ready once every asset has resolved', async () => {
+    respondWith({}, uploaded(1, 2, 3));
+
+    const { result } = renderCertificate();
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.data.logo).toBe('data:image/png;base64,AQID');
+  });
+
+  // spec: ASSET
+  // Artwork is an optional element, so a deployment that uploaded none still
+  // prints; only a pending asset holds the document back.
+  it('becomes ready when no asset was ever uploaded', async () => {
+    respondWith({}, neverUploaded());
+
+    const { result } = renderCertificate();
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.data.logo).toBeNull();
+  });
+});

--- a/specs/blob-storage/facility-cache.md
+++ b/specs/blob-storage/facility-cache.md
@@ -28,9 +28,11 @@ anything it has dropped.
   its referencing record, since facility and mobile servers reclaim nothing by
   orphan collection (see `reclamation.md`) and a stranded outbox blob would
   otherwise persist forever.
-- [ ] Content already held in the cache tier remains cache when a new local
-  reference to it is created: the tier reflects whether the central server holds
-  the bytes, not where a reference came from.
+- [ ] Content admitted from a local origin is held in the outbox whatever tier it
+  was already in, since the server cannot tell a cache copy the central server
+  holds from one demoted after its reference was never created. At worst this
+  re-offers content the central server already has, which its admission
+  deduplicates by hash.
 
 ## Background pusher
 


### PR DESCRIPTION
### Changes

Tests only, no production code. Closes most of the automatable gaps the coverage audit recorded in `.workhorse/test-cases/b2/overview.md`, which until now existed as a list nobody had worked.

Five packages, kept apart so each area is reviewable on its own:

- **central-server** (7 files). Chief among them, blob scoping is now pinned to the record sync pull filter. `isHashReferencedInScope` reproduces that predicate by hand, both sides were covered individually, and nothing asserted they agree, so drift would have silently widened blob access past what record synchronisation grants. The test drives both sides for real over a fixture spanning patients marked at one facility, both, neither, and a sensitive-facility encounter, and compares them as labels so a failure names the record they disagree about. A sixth case asserts the fixture discriminates, so agreement cannot be vacuous. Also: partly-entitled facility lists, permission refusal on a hash-backed attachment, real `attachments` rows through the channel, quarantine propagation by sync, and the rollback subcommand, which had no test at all.
- **facility-server** (6 files). Budget enforcement at admission, the budget resolving from settings rather than an injected value, both scheduled tasks, outbox dysfunction escalation including the in-flight exclusion, and creation succeeding with central unreachable.
- **database** (4 files). `createScannerDriver`, which is the whole of "a server opts in by naming a scanner" and had nothing; registry locality; the atomic placement retry path that only ever runs on Windows in production; verdict and integrity state independence.
- **web** (6 files). The asset fallback rule, which matters because a fallback standing in for a content-pending asset prints a different image on a clinical document. Plus the four attachment consumers rendering the unavailable message.
- **mobile** (2 files). Both UI components, which had no tests while the services beneath them had 53 cases.

**Every test was mutation-checked**: the behaviour it covers was broken, the test confirmed to fail, and the code restored. Where a mutation could not be constructed, that is stated rather than glossed. This mattered: the audit that produced the gap list had already found a test that could not fail for the reason its name claimed.

One test is committed as `it.failing` on purpose. Facility outbox admission is not coupled to creating its referencing record, which `facility-cache.md:27` requires, so a failed write strands a blob that is un-pushable and un-evictable permanently. That is a real hole, not a missing test, and it wants its own change: deleting the blob would be wrong, since dedupe means the hash may back another attachment. The marker keeps the branch green and flips to a failure the moment the guarantee starts holding.

Ticking the closed items in the coverage document is deliberately not done here. Each tick should be verified against the merged tests rather than transcribed from a summary, which is the standard that document sets for itself.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
