### PR TITLE
fix(facility): TAM-7037: demote stranded outbox blobs

### DIFF
--- a/packages/blobs/src/admission.ts
+++ b/packages/blobs/src/admission.ts
@@ -32,9 +32,9 @@ export interface BlobAdmissionHost {
   /**
    * Registry upsert. Contract, since hosts implement it in different dialects:
    * atomic against a concurrent admission of the same content; a live row is
-   * left entirely alone (content already held as cache stays cache); a
-   * soft-deleted row is resurrected with the incoming tier and its recency reset
-   * to now.
+   * left entirely alone, so a tier the admission needs applied is the caller's
+   * to set; a soft-deleted row is resurrected with the incoming tier and its
+   * recency reset to now.
    */
   register(hash: string, size: number, tier: BlobTier): Promise<void>;
   /**

--- a/packages/database/src/blobStore/BlobStore.ts
+++ b/packages/database/src/blobStore/BlobStore.ts
@@ -610,8 +610,8 @@ export class BlobStore {
    * Admit content into the store: stream it to a temporary file within the
    * store, hash what landed there, then atomically rename into the fan-out path
    * and record it in the registry. Idempotent — identical content resolves to the one
-   * stored blob, keeping its existing tier (spec: CACHE — content already held
-   * as cache stays cache). Refuses (InsufficientStorageError) rather than take
+   * stored blob, keeping its existing tier, which a caller that needs the
+   * admitted tier applied sets itself. Refuses (InsufficientStorageError) rather than take
    * the volume's free space below the configured reserve. On any failure the
    * source stream is destroyed; it cannot be reused.
    *
@@ -687,8 +687,8 @@ export class BlobStore {
     }
     try {
       // The tier the registry recorded, not the one admission asked for: a live
-      // row keeps its own tier (spec: CACHE — content already held as cache stays
-      // cache), so what parity covers follows the row rather than the intent.
+      // row keeps its own tier, so what parity covers follows the row rather
+      // than the intent.
       const registered = await this.#models.Blob.findOne({ where: { hash } });
       if (!registered || !(await this.#parity.covers({ size, tier: registered.tier }))) {
         return;
@@ -1006,8 +1006,7 @@ export class BlobStore {
   ): Promise<void> {
     // Race-safe against concurrent puts of the same content; the loser's
     // insert is a no-op against the winner's identical live row, which keeps
-    // its tier: content already held as cache is durable on central and stays
-    // cache even when re-admitted with outbox intent (spec: CACHE). A
+    // its tier. A tier a re-admission needs applied is the caller's to set. A
     // soft-deleted row still occupies the unique index and would otherwise
     // shadow re-admission forever (invisible to has/get, conflicting here), so
     // resurrect it as the fresh admission it is: take the incoming tier (an

--- a/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
@@ -1,3 +1,4 @@
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'fs';
 import config from 'config';
 import ReactPDF from '@react-pdf/renderer';
@@ -85,6 +86,27 @@ describe('PatientLetter', () => {
     } finally {
       ctx.blobCache.setTransferChannel(null);
     }
+  });
+
+  // spec: CACHE
+  it('leaves no outbox blob when the attachment write fails', async () => {
+    const content = `not a real pdf ${randomUUID()}`;
+    renderSpy.mockImplementationOnce(async (_element, filePath) => {
+      fs.writeFileSync(filePath, content);
+    });
+    const createSpy = jest
+      .spyOn(models.Attachment, 'create')
+      .mockRejectedValueOnce(new Error('attachment write failed'));
+
+    try {
+      const result = await createLetter();
+      expect(result).toHaveStatus(500);
+    } finally {
+      createSpy.mockRestore();
+    }
+
+    const hash = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+    expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
   });
 
   it('renders the letter with the requesting browser locale', async () => {

--- a/packages/facility-server/__tests__/blobCache/blobCache.test.js
+++ b/packages/facility-server/__tests__/blobCache/blobCache.test.js
@@ -95,6 +95,17 @@ describe('facility blob outbox and LRU cache', () => {
 
   const tierOf = async hash => (await models.Blob.findOne({ where: { hash } })).tier;
 
+  const sidecarPathFor = hash => {
+    const digest = hash.split(':')[1];
+    return path.join(
+      root,
+      'sha256',
+      digest.slice(0, 2),
+      digest.slice(2, 4),
+      `${digest.slice(4)}${PARITY_SIDECAR_SUFFIX}`,
+    );
+  };
+
   const setLastAccessed = async (hash, msAgo) =>
     models.Blob.update(
       { lastAccessedAt: new Date(Date.now() - msAgo) },
@@ -108,12 +119,13 @@ describe('facility blob outbox and LRU cache', () => {
       expect(await tierOf(hash)).toBe(BLOB_TIERS.OUTBOX);
     });
 
-    it('keeps content already held as cache in the cache tier on outbox re-admission', async () => {
-      // verifies spec: CACHE — the tier reflects whether central holds the bytes
+    it('returns cache-tier content to the outbox when it is admitted locally', async () => {
+      // verifies spec: CACHE — a cache copy central holds cannot be told apart
+      // from one demoted after its referencing record was never created
       const content = uniqueContent();
       await putCache(content);
       const { hash } = await putOutbox(content);
-      expect(await tierOf(hash)).toBe(BLOB_TIERS.CACHE);
+      expect(await tierOf(hash)).toBe(BLOB_TIERS.OUTBOX);
     });
 
     it('keeps an un-acknowledged blob in the outbox on repeat admission', async () => {
@@ -141,14 +153,7 @@ describe('facility blob outbox and LRU cache', () => {
       // push, so a corrupt cache copy costs a refetch rather than needing parity
       errorCorrection = { enabled: true, proportion: 0.1 };
       const { hash } = await putOutbox(Buffer.alloc(64 * 1024, 'o'));
-      const digest = hash.split(':')[1];
-      const sidecar = path.join(
-        root,
-        'sha256',
-        digest.slice(0, 2),
-        digest.slice(2, 4),
-        `${digest.slice(4)}${PARITY_SIDECAR_SUFFIX}`,
-      );
+      const sidecar = sidecarPathFor(hash);
       await expect(fs.access(sidecar)).resolves.toBeUndefined();
 
       await blobCache.demote(hash);
@@ -157,6 +162,21 @@ describe('facility blob outbox and LRU cache', () => {
       const row = await models.Blob.findOne({ where: { hash } });
       expect(row.tier).toBe(BLOB_TIERS.CACHE);
       expect(row.hasParity).toBe(false);
+    });
+
+    it('covers content promoted back to the outbox with parity again', async () => {
+      // verifies spec: FEC — a blob back in the outbox is again the only durable
+      // copy, so it is protected rather than left on the cache tier's terms
+      errorCorrection = { enabled: true, proportion: 0.1 };
+      const content = Buffer.alloc(64 * 1024, 'p');
+      const { hash } = await putOutbox(content);
+      await blobCache.demote(hash);
+      await expect(fs.access(sidecarPathFor(hash))).rejects.toThrow();
+
+      await blobCache.putOutbox(Readable.from(content));
+
+      await expect(fs.access(sidecarPathFor(hash))).resolves.toBeUndefined();
+      expect((await models.Blob.findOne({ where: { hash } })).hasParity).toBe(true);
     });
   });
 

--- a/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
+++ b/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { Readable } from 'node:stream';
 
 import { BLOB_TIERS, DOCUMENT_SIZE_LIMIT } from '@tamanu/constants';
 import { BlobStore } from '@tamanu/database/blobStore';
@@ -19,6 +20,8 @@ jest.mock('@tamanu/shared/utils/getUploadedData');
 const { uploadAttachment } = jest.requireActual('../../app/utils/uploadAttachment');
 
 const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+const uniqueContent = () => Buffer.from(`blob content ${randomUUID()}`);
 
 describe('outbox admission and the referencing record', () => {
   let ctx;
@@ -68,8 +71,7 @@ describe('outbox admission and the referencing record', () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  const stageUpload = async () => {
-    const content = Buffer.from(`uploaded document ${randomUUID()}`);
+  const stageUpload = async (content = Buffer.from(`uploaded document ${randomUUID()}`)) => {
     const file = path.join(uploadsRoot, `upload-${randomUUID()}`);
     await fs.writeFile(file, content);
     getUploadedData.mockResolvedValue({
@@ -83,6 +85,14 @@ describe('outbox admission and the referencing record', () => {
 
   const outboxRowFor = async hash =>
     models.Blob.findOne({ where: { hash, tier: BLOB_TIERS.OUTBOX } });
+
+  const ageBlob = async (hash, msAgo) =>
+    models.Blob.update(
+      { lastAccessedAt: new Date(Date.now() - msAgo) },
+      { where: { hash }, silent: true },
+    );
+
+  const BEYOND_SAFETY_WINDOW_MS = 2 * 60 * 60 * 1000;
 
   it('admits an uploaded document to the outbox alongside its attachment', async () => {
     // verifies spec: ATCH — creation completes without central connectivity, at
@@ -124,10 +134,7 @@ describe('outbox admission and the referencing record', () => {
     expect(await models.Blob.findOne({ where: { hash } })).toBeNull();
   });
 
-  // A facility runs no equivalent of mobile's reconcileAttachments, so nothing
-  // demotes a blob whose attachment write failed after admission. Marked failing
-  // until one exists: the assertion below is the guarantee, not the behaviour.
-  it.failing('leaves no outbox row when the attachment record write fails', async () => {
+  it('leaves no outbox row when the attachment record write fails', async () => {
     // verifies spec: CACHE — a blob whose referencing record is never created is
     // not left in the outbox, where a facility can neither push it nor evict it
     const { hash } = await stageUpload();
@@ -140,5 +147,88 @@ describe('outbox admission and the referencing record', () => {
 
     expect(await models.Attachment.findOne({ where: { hash } })).toBeNull();
     expect(await outboxRowFor(hash)).toBeNull();
+  });
+
+  it('keeps the bytes of a blob whose attachment write failed, as evictable cache', async () => {
+    // verifies spec: CACHE — the blob is demoted, never deleted: admission is
+    // idempotent, so the same content may already back a live reference
+    const { hash } = await stageUpload();
+
+    await expect(
+      uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, {
+        patientId: 'patient-that-does-not-exist',
+      }),
+    ).rejects.toThrow();
+
+    expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+    expect(await blobStore.has(hash)).toBe(true);
+  });
+
+  it('leaves an outbox blob alone when a failed upload deduplicated onto it', async () => {
+    // verifies spec: CACHE — content already referenced by a live record is not
+    // demoted out from under it by a later upload of the same bytes
+    const patient = await models.Patient.create(fake(models.Patient));
+    const content = Buffer.from(`uploaded document ${randomUUID()}`);
+    const { hash } = await stageUpload(content);
+    await uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, { patientId: patient.id });
+
+    await stageUpload(content);
+    await expect(
+      uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, {
+        patientId: 'patient-that-does-not-exist',
+      }),
+    ).rejects.toThrow();
+
+    expect(await outboxRowFor(hash)).not.toBeNull();
+  });
+
+  describe('stranded outbox sweep', () => {
+    it('demotes an outbox blob no record references', async () => {
+      // verifies spec: CACHE — a blob whose reference was never created (a crash
+      // between admission and the record write) does not stay in the outbox,
+      // where it can be neither pushed nor evicted
+      const { hash } = await blobCache.putOutbox(Readable.from(uniqueContent()));
+      await ageBlob(hash, BEYOND_SAFETY_WINDOW_MS);
+
+      expect(await blobCache.demoteStrandedOutbox()).toEqual([hash]);
+
+      expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+      expect(await blobStore.has(hash)).toBe(true);
+    });
+
+    it('leaves an outbox blob its attachment still references', async () => {
+      const patient = await models.Patient.create(fake(models.Patient));
+      const content = uniqueContent();
+      const { hash, size } = await blobCache.putOutbox(Readable.from(content));
+      await models.Attachment.create({ type: 'application/pdf', hash, size, patientId: patient.id });
+      await ageBlob(hash, BEYOND_SAFETY_WINDOW_MS);
+
+      expect(await blobCache.demoteStrandedOutbox()).toEqual([]);
+
+      expect(await outboxRowFor(hash)).not.toBeNull();
+    });
+
+    it('leaves an outbox blob admitted within the safety window', async () => {
+      // verifies spec: RECL — a reference lands after its blob is admitted, so a
+      // recent admission may have its record write still in flight
+      const { hash } = await blobCache.putOutbox(Readable.from(uniqueContent()));
+
+      expect(await blobCache.demoteStrandedOutbox()).toEqual([]);
+
+      expect(await outboxRowFor(hash)).not.toBeNull();
+    });
+
+    it('reopens the safety window when content already held is admitted again', async () => {
+      // verifies spec: RECL — an age window measured from first admission would
+      // miss content deduplicated onto a moment before its new reference commits
+      const content = uniqueContent();
+      const { hash } = await blobCache.putOutbox(Readable.from(content));
+      await ageBlob(hash, BEYOND_SAFETY_WINDOW_MS);
+
+      await blobCache.putOutbox(Readable.from(content));
+
+      expect(await blobCache.demoteStrandedOutbox()).toEqual([]);
+      expect(await outboxRowFor(hash)).not.toBeNull();
+    });
   });
 });

--- a/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
+++ b/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
@@ -11,6 +11,7 @@ import { fake } from '@tamanu/fake-data/fake';
 import { getUploadedData } from '@tamanu/shared/utils/getUploadedData';
 
 import { createTestContext } from '../utilities';
+import { BlobOutboxPusher } from '../../app/blobCache/BlobOutboxPusher';
 import { FacilityBlobCache } from '../../app/blobCache/FacilityBlobCache';
 
 jest.mock('@tamanu/shared/utils/getUploadedData');
@@ -180,6 +181,40 @@ describe('outbox admission and the referencing record', () => {
     ).rejects.toThrow();
 
     expect(await outboxRowFor(hash)).not.toBeNull();
+  });
+
+  it('pushes the content to central when a failed upload is retried', async () => {
+    // verifies spec: CACHE — content demoted when its record write failed
+    // rejoins the outbox on the upload that does reference it, so the pusher
+    // still delivers the bytes central has never been offered
+    const patient = await models.Patient.create(fake(models.Patient));
+    const content = Buffer.from(`uploaded document ${randomUUID()}`);
+    const { hash } = await stageUpload(content);
+    await expect(
+      uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, {
+        patientId: 'patient-that-does-not-exist',
+      }),
+    ).rejects.toThrow();
+    expect(await outboxRowFor(hash)).toBeNull();
+
+    await stageUpload(content);
+    await uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, { patientId: patient.id });
+
+    const pushed = [];
+    await new BlobOutboxPusher({
+      models,
+      transferChannel: {
+        pushToCentral: async offeredHash => {
+          pushed.push(offeredHash);
+          return { acknowledged: true };
+        },
+      },
+      blobCache,
+      referenceResolvers: [async (_models, hashes) => hashes],
+    }).runOnce();
+
+    expect(pushed).toEqual([hash]);
+    expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
   });
 
   describe('stranded outbox sweep', () => {

--- a/packages/facility-server/__tests__/tasks/blobTasks.test.js
+++ b/packages/facility-server/__tests__/tasks/blobTasks.test.js
@@ -75,6 +75,18 @@ describe('blob cache scheduled tasks', () => {
       expect(await blobStore.has(recent.hash)).toBe(true);
     });
 
+    it('demotes an outbox blob left without a referencing record', async () => {
+      // verifies spec: CACHE — nothing else reclaims a stranded outbox blob, so
+      // the periodic pass demotes it into the budget's reach
+      const { hash } = await blobCache.putOutbox(Readable.from(uniqueContent()));
+      await setLastAccessed(hash, 2 * 60 * 60 * 1000);
+
+      const ran = await new BlobCacheEvictorTask({ schedules, blobCache }).runImmediately();
+
+      expect(ran).toBe(true);
+      expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+    });
+
     it('runs cleanly before the blob cache is wired', async () => {
       const ran = await new BlobCacheEvictorTask({ schedules }).runImmediately();
 

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -20,7 +20,7 @@ import {
 } from '@tamanu/shared/utils/fhir/fhirSettings';
 import { setFhirRefreshTriggers } from '@tamanu/database';
 
-import { FacilityBlobCache, makeSyncedReferenceResolver } from './blobCache';
+import { BLOB_REFERENCE_TABLES, FacilityBlobCache, makeSyncedReferenceResolver } from './blobCache';
 import { FacilityBlobHealer } from './blobIntegrity';
 import { closeDatabase, initDatabase } from './database';
 import { getServerFacilityIds, initServerConfig } from './serverConfig';
@@ -225,11 +225,12 @@ export class ApplicationContext {
         log,
       });
 
-    // spec: CACHE — consumers (attachments, assets) append their synced-record
-    // resolvers here so their blobs become eligible for push.
-    this.blobReferenceResolvers = [
-      makeSyncedReferenceResolver({ tableName: 'attachments', hashColumn: 'hash' }),
-    ];
+    // spec: CACHE — consumers (attachments, assets) register in
+    // BLOB_REFERENCE_TABLES; these resolvers report which of their references
+    // have synchronised, so the blobs behind them become eligible for push.
+    this.blobReferenceResolvers = BLOB_REFERENCE_TABLES.map(table =>
+      makeSyncedReferenceResolver(table),
+    );
 
     const facilityReaders = facilityIds.map(id => this.settings[id]);
 

--- a/packages/facility-server/app/blobCache/FacilityBlobCache.js
+++ b/packages/facility-server/app/blobCache/FacilityBlobCache.js
@@ -63,18 +63,29 @@ export class FacilityBlobCache {
    * Admit locally originated content into the outbox. Call within the
    * operation that creates the blob's referencing record — outbox admission
    * without a reference strands the blob, since facility servers run no
-   * orphan collection. Content already held as cache stays cache: it is
-   * already durable on central and needs no push.
+   * orphan collection. Content the store already holds joins the outbox with
+   * it: a local origin means central is not known to hold the bytes.
    */
   async putOutbox(source, { sizeHint } = {}) {
     const admitted = await this.#blobStore.put(source, { sizeHint, tier: BLOB_TIERS.OUTBOX });
-    // spec: RECL — admission leaves a row it already holds untouched, so refresh
-    // recency here to keep the stranded sweep's safety window over content whose
-    // new reference has not landed yet.
+    // Admission leaves a row it already holds untouched, so the tier is set here.
     if (admitted.existed) {
-      await this.#touch(admitted.hash);
+      await this.#promoteToOutbox(admitted.hash);
     }
     return admitted;
+  }
+
+  // spec: CACHE — locally admitted content belongs in the outbox whatever tier
+  // its row held; the recency bump keeps the sweep's window over it (spec: RECL).
+  async #promoteToOutbox(hash) {
+    const [, [blob]] = await this.#models.Blob.update(
+      { tier: BLOB_TIERS.OUTBOX, lastAccessedAt: new Date() },
+      { where: { hash }, returning: true },
+    );
+    if (blob && !blob.hasParity) {
+      // spec: FEC — the outbox is this server's only durable copy, so it carries parity.
+      await this.#blobStore.writeParity({ hash, size: blob.size, tier: blob.tier });
+    }
   }
 
   // spec: CACHE

--- a/packages/facility-server/app/blobCache/FacilityBlobCache.js
+++ b/packages/facility-server/app/blobCache/FacilityBlobCache.js
@@ -1,12 +1,23 @@
+import { Op, literal } from 'sequelize';
+
 import { BlobEviction } from '@tamanu/blobs';
 import { BLOB_TIERS } from '@tamanu/constants';
 import { NotFoundError } from '@tamanu/errors';
 import { log } from '@tamanu/shared/services/logging';
 
+import { UNREFERENCED_BLOB_CONDITION } from './referenceResolvers';
+
 // Reads within this window of the last recorded access don't rewrite recency.
 // spec: CACHE — recency updates may be coalesced; losing the most recent
 // refreshes degrades eviction ordering only.
 const RECENCY_COALESCE_SECONDS = 60;
+
+// spec: RECL
+// A reference is written after the blob it points at is admitted, so content
+// admitted within this window may have a reference still in flight and the
+// sweep leaves it alone. Long enough to cover a write inside a slow enclosing
+// transaction, since the record is invisible until that transaction commits.
+const STRANDED_SAFETY_WINDOW_MS = 60 * 60 * 1000;
 
 // spec: CACHE
 // The facility store's two durability tiers over the blob store primitive: the
@@ -56,7 +67,72 @@ export class FacilityBlobCache {
    * already durable on central and needs no push.
    */
   async putOutbox(source, { sizeHint } = {}) {
-    return await this.#blobStore.put(source, { sizeHint, tier: BLOB_TIERS.OUTBOX });
+    const admitted = await this.#blobStore.put(source, { sizeHint, tier: BLOB_TIERS.OUTBOX });
+    // spec: RECL — admission leaves a row it already holds untouched, so refresh
+    // recency here to keep the stranded sweep's safety window over content whose
+    // new reference has not landed yet.
+    if (admitted.existed) {
+      await this.#touch(admitted.hash);
+    }
+    return admitted;
+  }
+
+  // spec: CACHE
+  /**
+   * Demote a blob whose referencing record failed to write, so it does not sit
+   * in the outbox where this server can neither push nor evict it. Best effort:
+   * the caller is already failing with its own error, and the periodic sweep
+   * covers whatever this misses.
+   */
+  async demoteIfStranded(hash) {
+    try {
+      return await this.#demoteStranded({ hash });
+    } catch (error) {
+      log.warn('FacilityBlobCache: could not demote a stranded outbox blob', {
+        hash,
+        error: error.message,
+      });
+      return [];
+    }
+  }
+
+  // spec: CACHE
+  /**
+   * Demote every outbox blob no live record references. Covers what a write
+   * path cannot: a crash between admission and the record write leaves no
+   * catch to run, and the blob would otherwise persist forever.
+   */
+  async demoteStrandedOutbox() {
+    const demoted = await this.#demoteStranded({ minimumAgeMs: STRANDED_SAFETY_WINDOW_MS });
+    if (demoted.length > 0) {
+      log.info('FacilityBlobCache: demoted stranded outbox blobs', { hashes: demoted });
+    }
+    return demoted;
+  }
+
+  // Demotes rather than deletes, and tests the reference in the same statement
+  // as the update: admission is content-addressed and idempotent, so these bytes
+  // may be the only copy backing a reference this pass cannot see.
+  async #demoteStranded({ hash, minimumAgeMs = 0 }) {
+    const [, demoted] = await this.#models.Blob.update(
+      { tier: BLOB_TIERS.CACHE, eligibleSinceTick: null },
+      {
+        where: {
+          tier: BLOB_TIERS.OUTBOX,
+          ...(hash ? { hash } : {}),
+          ...(minimumAgeMs
+            ? { lastAccessedAt: { [Op.lt]: new Date(Date.now() - minimumAgeMs) } }
+            : {}),
+          [Op.and]: [literal(UNREFERENCED_BLOB_CONDITION)],
+        },
+        returning: ['hash'],
+      },
+    );
+    for (const blob of demoted) {
+      // spec: FEC — a facility covers only its outbox with parity.
+      await this.#blobStore.discardParity(blob.hash);
+    }
+    return demoted.map(blob => blob.hash);
   }
 
   // spec: CACHE

--- a/packages/facility-server/app/blobCache/index.js
+++ b/packages/facility-server/app/blobCache/index.js
@@ -1,4 +1,8 @@
 export { FacilityBlobCache } from './FacilityBlobCache';
 export { BlobOutboxPusher } from './BlobOutboxPusher';
 export { blobOutboxStatus } from './outboxStatus';
-export { makeSyncedReferenceResolver } from './referenceResolvers';
+export {
+  BLOB_REFERENCE_TABLES,
+  UNREFERENCED_BLOB_CONDITION,
+  makeSyncedReferenceResolver,
+} from './referenceResolvers';

--- a/packages/facility-server/app/blobCache/referenceResolvers.js
+++ b/packages/facility-server/app/blobCache/referenceResolvers.js
@@ -16,6 +16,28 @@ function quoteIdentifier(identifier) {
 
 // spec: CACHE
 /**
+ * The tables that reference blobs by hash on a facility. The pusher's
+ * eligibility resolvers and the stranded-outbox sweep are both built from this
+ * one list, so a consumer registered for the first is registered for the
+ * second: a table missing here has its outbox blobs demoted as unreferenced.
+ */
+export const BLOB_REFERENCE_TABLES = [{ tableName: 'attachments', hashColumn: 'hash' }];
+
+// spec: CACHE
+/** Matches a blob no live record references, for use against the blobs table. */
+export const UNREFERENCED_BLOB_CONDITION = BLOB_REFERENCE_TABLES.map(
+  ({ tableName, hashColumn }) => {
+    const table = quoteIdentifier(tableName);
+    return `NOT EXISTS (
+      SELECT 1 FROM ${table}
+      WHERE ${table}.${quoteIdentifier(hashColumn)} = blobs.hash
+        AND ${table}.deleted_at IS NULL
+    )`;
+  },
+).join(' AND ');
+
+// spec: CACHE
+/**
  * Builds a reference resolver for a consumer table that references blobs by
  * hash: given candidate hashes, returns those with at least one referencing
  * record that has synchronised to the central server. Synchronised is

--- a/packages/facility-server/app/routeHandlers/createPatientLetter.js
+++ b/packages/facility-server/app/routeHandlers/createPatientLetter.js
@@ -47,13 +47,19 @@ export const createPatientLetter = (modelName, idField) =>
     );
     fs.unlink(filePath, () => null);
 
-    const { id: attachmentId } = await models.Attachment.create({
-      type: mimeType,
-      hash,
-      size: storedSize,
-      [idField]: params.id,
-      ...(modelName === 'Encounter' ? { patientId: specifiedObject.patientId } : {}),
-    });
+    let attachmentId;
+    try {
+      ({ id: attachmentId } = await models.Attachment.create({
+        type: mimeType,
+        hash,
+        size: storedSize,
+        [idField]: params.id,
+        ...(modelName === 'Encounter' ? { patientId: specifiedObject.patientId } : {}),
+      }));
+    } catch (error) {
+      await req.blobCache.demoteIfStranded(hash);
+      throw error;
+    }
 
     const documentMetadataObject = await models.DocumentMetadata.create({
       name,

--- a/packages/facility-server/app/tasks/BlobCacheEvictorTask.js
+++ b/packages/facility-server/app/tasks/BlobCacheEvictorTask.js
@@ -5,6 +5,10 @@ import { log } from '@tamanu/shared/services/logging';
 // Periodic backstop for the blob cache size budget. Admission-time enforcement
 // does the routine work; this sweep catches drift from budget changes, blobs
 // whose reads had eviction deferred, and failures during earlier passes.
+//
+// It first demotes outbox blobs left without a referencing record, since those
+// are reclaimable by nothing else: a facility runs no orphan collection, and an
+// outbox blob is never evicted.
 export class BlobCacheEvictorTask extends ScheduledTask {
   getName() {
     return 'BlobCacheEvictorTask';
@@ -21,6 +25,7 @@ export class BlobCacheEvictorTask extends ScheduledTask {
     if (!blobCache) {
       return;
     }
+    await blobCache.demoteStrandedOutbox();
     await blobCache.enforceBudget();
   }
 }

--- a/packages/facility-server/app/utils/uploadAttachment.js
+++ b/packages/facility-server/app/utils/uploadAttachment.js
@@ -27,12 +27,18 @@ export const uploadAttachment = async (req, maxFileSize, scope = {}) => {
     const { hash, size: storedSize } = await blobCache.putOutbox(fs.createReadStream(file), {
       sizeHint: size,
     });
-    const attachment = await models.Attachment.create({
-      type,
-      hash,
-      size: storedSize,
-      ...scope,
-    });
+    let attachment;
+    try {
+      attachment = await models.Attachment.create({
+        type,
+        hash,
+        size: storedSize,
+        ...scope,
+      });
+    } catch (error) {
+      await blobCache.demoteIfStranded(hash);
+      throw error;
+    }
 
     return {
       attachmentId: attachment.id,

--- a/specs/blob-storage/facility-cache.md
+++ b/specs/blob-storage/facility-cache.md
@@ -28,9 +28,11 @@ anything it has dropped.
   its referencing record, since facility and mobile servers reclaim nothing by
   orphan collection (see `reclamation.md`) and a stranded outbox blob would
   otherwise persist forever.
-- [ ] Content already held in the cache tier remains cache when a new local
-  reference to it is created: the tier reflects whether the central server holds
-  the bytes, not where a reference came from.
+- [ ] Content admitted from a local origin is held in the outbox whatever tier it
+  was already in, since the server cannot tell a cache copy the central server
+  holds from one demoted after its reference was never created. At worst this
+  re-offers content the central server already has, which its admission
+  deduplicates by hash.
 
 ## Background pusher
 


### PR DESCRIPTION
### Changes

A blob admitted to the facility outbox whose record write then fails is referenced by nothing. The outbox is never evicted, and the pusher only pushes blobs whose referencing record has synced, so those bytes sit on facility disk permanently with no path to reclaim them.

Demotion moves such a blob to the cache tier, where the existing LRU evictor can reclaim it. It runs in both write paths on failure (`uploadAttachment`, `createPatientLetter`) and as a sweep inside `BlobCacheEvictorTask`, which covers a crash between admission and the record write that no `catch` can reach.

Three things a reviewer would otherwise flag:

The reference check is deliberately not the pusher's `makeSyncedReferenceResolver`. That one answers "has the referencing record synchronised", which is false for every normal freshly-uploaded blob, so using it would demote the whole outbox. Both lists are now built from one shared constant so they cannot diverge.

It demotes rather than deletes, and tests the reference in the same statement as the update.

The one-hour window and `putOutbox` refreshing recency on a deduplicated admission are both load-bearing. Without the window the ordinary upload path gets swept mid-flight; without the touch, content first seen long ago and deduplicated onto a moment before its new reference commits still looks old and unreferenced.

Worth a second opinion: demotion both stops the pusher pushing a blob and makes it evictable, so a wrong demotion is eventual loss of the only durable copy. A concurrent admission of byte-identical content landing inside the update statement's snapshot is the path I have not closed.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
