### PR TITLE
fix(mobile): TAM-7037: show an existing photo

### DIFF
--- a/packages/mobile/App/ui/components/UploadPhoto/index.spec.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.spec.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { Popup } from 'popup-ui';
+import { useNetInfo } from '@react-native-community/netinfo';
 
 import { BLOB_TIERS } from '@tamanu/constants';
 
 import { Database } from '~/infra/db';
 import { useBackend } from '~/ui/hooks';
 import { Attachment } from '~/models/Attachment';
+import { BlobAwaitingUploadError } from '~/services/blobs/BlobTransferChannel';
 import { MobileBlobCache } from '~/services/blobs/MobileBlobCache';
 import { MobileBlobStore } from '~/services/blobs/MobileBlobStore';
 import { deriveFreeDiskReserveBytes } from '~/services/blobs/deviceStorage';
@@ -21,6 +23,8 @@ jest.mock('react-native-fs', () => ({
 
 jest.mock('popup-ui', () => ({ Popup: { show: jest.fn(), hide: jest.fn() } }));
 
+jest.mock('@react-native-community/netinfo', () => ({ useNetInfo: jest.fn() }));
+
 jest.mock('/helpers/file', () => ({ deleteFileInDocuments: jest.fn(async () => {}) }));
 
 jest.mock('/helpers/image', () => ({
@@ -34,9 +38,15 @@ jest.mock('~/ui/hooks', () => ({ useBackend: jest.fn() }));
 
 const ROOT = '/blobs';
 const RESIZED_PATH = '/documents/resized.jpg';
+const HELD_PATH = '/documents/held.jpg';
+const FETCHED_PATH = '/documents/fetched.jpg';
 const PHOTO_BYTES = 'the captured photograph';
 const PHOTO_HASH = sha256Hash(PHOTO_BYTES);
+const PHOTO_URI = `data:image/jpeg;base64, ${Buffer.from(PHOTO_BYTES).toString('base64')}`;
 const CAPTURED_IMAGE = { base64: 'Y2FwdHVyZWQ=', uri: 'file:///documents/original.jpg' };
+
+const displayedImageUri = (container): string | undefined =>
+  container.queryAll(node => node.type === 'Image')[0]?.props?.source?.uri;
 
 describe('<UploadPhoto />', () => {
   let fs: FakeBlobFileSystem;
@@ -65,13 +75,15 @@ describe('<UploadPhoto />', () => {
 
     onChange = jest.fn();
     (useBackend as jest.Mock).mockReturnValue({ models: Database.models, blobCache: cache });
+    (useNetInfo as jest.Mock).mockReturnValue({ isInternetReachable: true });
     (getImageFromCamera as jest.Mock).mockResolvedValue(CAPTURED_IMAGE);
     (resizeImage as jest.Mock).mockResolvedValue({ path: RESIZED_PATH });
     fs.seed(RESIZED_PATH, PHOTO_BYTES);
   });
 
   // verifies spec: MOB, CACHE — capture admits to the outbox tier and the
-  // record carries the hash and the admitted size, never the bytes
+  // record carries the hash and the admitted size, never the bytes or a
+  // pointer to a file outside the store
   it('stores a captured photo in the outbox and records only its hash and size', async () => {
     const { getByText } = await render(<UploadPhoto onChange={onChange} value={null} />);
 
@@ -82,19 +94,12 @@ describe('<UploadPhoto />', () => {
     const attachment = await Database.models.Attachment.findOne({ where: { id: attachmentId } });
     expect(attachment.hash).toBe(PHOTO_HASH);
     expect(Number(attachment.size)).toBe(PHOTO_BYTES.length);
+    expect(attachment.filePath).toBeNull();
 
     const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
     expect(blob.tier).toBe(BLOB_TIERS.OUTBOX);
     expect(fs.contentsOf(store.pathFor(PHOTO_HASH)).toString()).toBe(PHOTO_BYTES);
-
-    const [row] = await Database.models.Attachment.getRepository().query(
-      'SELECT * FROM attachments WHERE id = ?',
-      [attachmentId],
-    );
-    const carriesBytes = Object.values(row).some(
-      column => typeof column === 'string' && column.includes(CAPTURED_IMAGE.base64),
-    );
-    expect(carriesBytes).toBe(false);
+    expect(fs.contentsOf(RESIZED_PATH)).toBeUndefined();
   });
 
   // verifies spec: MOB, CAP — a capture the store cannot admit names the
@@ -118,22 +123,89 @@ describe('<UploadPhoto />', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  // verifies spec: MOB — a read resolves the record's hash against the device's
+  // store, so an answer that already holds a photo shows it and can drop it
+  it('shows a photo the answer already holds and offers to remove it', async () => {
+    const attachment = await holdPhotoOnDevice();
+
+    const { container, getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+
+    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    expect(getByText('Remove photo')).toBeTruthy();
+    expect(getByText('Change photo')).toBeTruthy();
+    expect(queryByText('Upload photo')).toBeNull();
+  });
+
+  // verifies spec: MOB — content the device does not hold is fetched by hash
+  // and admitted to the cache tier
+  it('fetches a photo the device does not hold', async () => {
+    const attachment = await seedAttachment();
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        fs.seed(FETCHED_PATH, PHOTO_BYTES);
+        return await store.putFile(FETCHED_PATH);
+      }),
+    } as any);
+
+    const { container } = await render(<UploadPhoto onChange={onChange} value={attachment.id} />);
+
+    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
+    expect(blob.tier).toBe(BLOB_TIERS.CACHE);
+  });
+
+  // verifies spec: MOB, XFER — content pending at its origin presents as a
+  // photo awaiting its content, never as an answer with no photo
+  it('reports a photo still awaiting upload from the device that captured it', async () => {
+    const attachment = await seedAttachment();
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        throw new BlobAwaitingUploadError(PHOTO_HASH);
+      }),
+    } as any);
+
+    const { getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+
+    await waitFor(() =>
+      expect(getByText(/has not finished uploading from the device that captured it/)).toBeTruthy(),
+    );
+    expect(getByText('Remove photo')).toBeTruthy();
+    expect(queryByText('Upload photo')).toBeNull();
+  });
+
+  // verifies spec: MOB — content this device has not fetched is distinct from
+  // content pending at its origin, and neither reads as a missing photo
+  it('reports a photo not on this device when there is no connectivity', async () => {
+    (useNetInfo as jest.Mock).mockReturnValue({ isInternetReachable: false });
+    const attachment = await seedAttachment();
+
+    const { getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+
+    await waitFor(() => expect(getByText(/is not on this device yet/)).toBeTruthy());
+    expect(getByText(/Connect to the internet to fetch it/)).toBeTruthy();
+    expect(getByText('Remove photo')).toBeTruthy();
+    expect(queryByText('Upload photo')).toBeNull();
+  });
+
   // verifies spec: MOB, CACHE — a removed photo's blob has no referencing
   // record left, so it can never become eligible for push
-  it('demotes the removed photo\'s blob to reclaimable cache', async () => {
-    const { getByText, rerender } = await render(<UploadPhoto onChange={onChange} value={null} />);
-    await takePhoto(getByText);
-    await waitFor(() => getByText('Remove photo'));
+  it("demotes the removed photo's blob to reclaimable cache", async () => {
+    const attachment = await holdPhotoOnDevice();
 
-    const [attachmentId] = onChange.mock.calls[0];
-    await rerender(<UploadPhoto onChange={onChange} value={attachmentId} />);
-    await act(async () => {
-      await fireEvent.press(getByText('Remove photo'));
-    });
+    const { container, getByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    await removePhoto(getByText);
 
-    await waitFor(async () => {
-      expect(await Database.models.Attachment.findOne({ where: { id: attachmentId } })).toBeNull();
-    });
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(await Database.models.Attachment.findOne({ where: { id: attachment.id } })).toBeNull();
     const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
     expect(blob.tier).toBe(BLOB_TIERS.CACHE);
   });
@@ -142,33 +214,75 @@ describe('<UploadPhoto />', () => {
   // one blob, so demoting on the first removal would make content another
   // record still references evictable before it has been pushed
   it('leaves the blob in the outbox while another attachment references its hash', async () => {
-    const { getByText, rerender } = await render(<UploadPhoto onChange={onChange} value={null} />);
-    await takePhoto(getByText);
-    await waitFor(() => getByText('Remove photo'));
+    const attachment = await holdPhotoOnDevice();
+    const sharer = await seedAttachment();
 
-    const sharer = await Database.models.Attachment.createAndSaveOne<Attachment>({
-      hash: PHOTO_HASH,
-      size: PHOTO_BYTES.length,
-      type: 'image/jpeg',
-    });
+    const { container, getByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    await removePhoto(getByText);
 
-    const [attachmentId] = onChange.mock.calls[0];
-    await rerender(<UploadPhoto onChange={onChange} value={attachmentId} />);
-    await act(async () => {
-      await fireEvent.press(getByText('Remove photo'));
-    });
-
-    await waitFor(async () => {
-      expect(await Database.models.Attachment.findOne({ where: { id: attachmentId } })).toBeNull();
-    });
+    expect(await Database.models.Attachment.findOne({ where: { id: attachment.id } })).toBeNull();
     expect(await Database.models.Attachment.findOne({ where: { id: sharer.id } })).not.toBeNull();
     const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
     expect(blob.tier).toBe(BLOB_TIERS.OUTBOX);
   });
 
+  // A fetch that lands after the photo is removed must not put it back on
+  // screen, since the record it belonged to is gone.
+  it('discards content that arrives after the photo is removed', async () => {
+    let releaseFetch: () => void;
+    const fetchReleased = new Promise<void>(resolve => {
+      releaseFetch = resolve;
+    });
+    const attachment = await seedAttachment();
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        await fetchReleased;
+        fs.seed(FETCHED_PATH, PHOTO_BYTES);
+        return await store.putFile(FETCHED_PATH);
+      }),
+    } as any);
+
+    const read = jest.spyOn(cache, 'readBase64');
+
+    const { container, getByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await removePhoto(getByText);
+    await act(async () => {
+      releaseFetch();
+      await read.mock.results[0].value;
+    });
+
+    expect(displayedImageUri(container)).toBeUndefined();
+    expect(getByText('Upload photo')).toBeTruthy();
+  });
+
+  async function seedAttachment(): Promise<Attachment> {
+    return await Database.models.Attachment.createAndSaveOne<Attachment>({
+      hash: PHOTO_HASH,
+      size: PHOTO_BYTES.length,
+      type: 'image/jpeg',
+    });
+  }
+
+  async function holdPhotoOnDevice(): Promise<Attachment> {
+    fs.seed(HELD_PATH, PHOTO_BYTES);
+    await cache.putOutbox(HELD_PATH);
+    return await seedAttachment();
+  }
+
   async function takePhoto(getByText): Promise<void> {
     await act(async () => {
       await fireEvent.press(getByText('Take photo with camera'));
+    });
+  }
+
+  async function removePhoto(getByText): Promise<void> {
+    await act(async () => {
+      await fireEvent.press(getByText('Remove photo'));
     });
   }
 });

--- a/packages/mobile/App/ui/components/UploadPhoto/index.spec.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import { Popup } from 'popup-ui';
 import { useNetInfo } from '@react-native-community/netinfo';
 
@@ -44,21 +44,58 @@ const PHOTO_BYTES = 'the captured photograph';
 const PHOTO_HASH = sha256Hash(PHOTO_BYTES);
 const PHOTO_URI = `data:image/jpeg;base64, ${Buffer.from(PHOTO_BYTES).toString('base64')}`;
 const CAPTURED_IMAGE = { base64: 'Y2FwdHVyZWQ=', uri: 'file:///documents/original.jpg' };
+const CAPTURED_URI = `data:image/jpeg;base64, ${CAPTURED_IMAGE.base64}`;
 
 const displayedImageUri = (container): string | undefined =>
   container.queryAll(node => node.type === 'Image')[0]?.props?.source?.uri;
+
+// The device reports connectivity through the hook's own state, which is what
+// re-renders a mounted component when it changes.
+const connectivity = {
+  current: { isInternetReachable: true } as { isInternetReachable: boolean | null },
+  subscribers: new Set<(value: { isInternetReachable: boolean | null }) => void>(),
+};
+
+const useConnectivity = (): { isInternetReachable: boolean | null } => {
+  const [reported, setReported] = React.useState(connectivity.current);
+  React.useEffect(() => {
+    connectivity.subscribers.add(setReported);
+    return (): void => {
+      connectivity.subscribers.delete(setReported);
+    };
+  }, []);
+  return reported;
+};
+
+const deviceIsOffline = (): void => {
+  connectivity.current = { isInternetReachable: false };
+};
+
+const connectivityIsUnknown = (): void => {
+  connectivity.current = { isInternetReachable: null };
+};
+
+const connectivityReturns = async (): Promise<void> => {
+  connectivity.current = { isInternetReachable: true };
+  await act(async () => {
+    connectivity.subscribers.forEach(notify => notify(connectivity.current));
+  });
+};
 
 describe('<UploadPhoto />', () => {
   let fs: FakeBlobFileSystem;
   let store: MobileBlobStore;
   let cache: MobileBlobCache;
   let onChange: jest.Mock;
+  let backendCalls: Promise<void>[];
+  let contentReads: number;
 
   beforeAll(async () => {
     await Database.connect();
   });
 
   beforeEach(async () => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
     await Database.models.Attachment.getRepository().clear();
     await Database.models.Blob.getRepository().clear();
@@ -72,10 +109,12 @@ describe('<UploadPhoto />', () => {
       fs,
     });
     cache = new MobileBlobCache({ blobStore: store, models: Database.models, fs });
+    trackBackendCalls();
 
     onChange = jest.fn();
     (useBackend as jest.Mock).mockReturnValue({ models: Database.models, blobCache: cache });
-    (useNetInfo as jest.Mock).mockReturnValue({ isInternetReachable: true });
+    connectivity.current = { isInternetReachable: true };
+    (useNetInfo as jest.Mock).mockImplementation(useConnectivity);
     (getImageFromCamera as jest.Mock).mockResolvedValue(CAPTURED_IMAGE);
     (resizeImage as jest.Mock).mockResolvedValue({ path: RESIZED_PATH });
     fs.seed(RESIZED_PATH, PHOTO_BYTES);
@@ -88,7 +127,6 @@ describe('<UploadPhoto />', () => {
     const { getByText } = await render(<UploadPhoto onChange={onChange} value={null} />);
 
     await takePhoto(getByText);
-    await waitFor(() => expect(onChange).toHaveBeenCalled());
 
     const [attachmentId] = onChange.mock.calls[0];
     const attachment = await Database.models.Attachment.findOne({ where: { id: attachmentId } });
@@ -112,7 +150,6 @@ describe('<UploadPhoto />', () => {
     );
 
     await takePhoto(getByText);
-    await waitFor(() => expect(Popup.show).toHaveBeenCalled());
 
     const [popup] = (Popup.show as jest.Mock).mock.calls[0];
     expect(popup.title).toMatch(/storage space on this device/i);
@@ -131,8 +168,9 @@ describe('<UploadPhoto />', () => {
     const { container, getByText, queryByText } = await render(
       <UploadPhoto onChange={onChange} value={attachment.id} />,
     );
+    await settleRead();
 
-    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
     expect(getByText('Remove photo')).toBeTruthy();
     expect(getByText('Change photo')).toBeTruthy();
     expect(queryByText('Upload photo')).toBeNull();
@@ -142,16 +180,12 @@ describe('<UploadPhoto />', () => {
   // and admitted to the cache tier
   it('fetches a photo the device does not hold', async () => {
     const attachment = await seedAttachment();
-    cache.setTransferChannel({
-      fetchFromCentral: jest.fn(async () => {
-        fs.seed(FETCHED_PATH, PHOTO_BYTES);
-        return await store.putFile(FETCHED_PATH);
-      }),
-    } as any);
+    fetchesPhoto();
 
     const { container } = await render(<UploadPhoto onChange={onChange} value={attachment.id} />);
+    await settleRead();
 
-    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
     const blob = await Database.models.Blob.findOne({ where: { hash: PHOTO_HASH } });
     expect(blob.tier).toBe(BLOB_TIERS.CACHE);
   });
@@ -169,28 +203,105 @@ describe('<UploadPhoto />', () => {
     const { getByText, queryByText } = await render(
       <UploadPhoto onChange={onChange} value={attachment.id} />,
     );
+    await settleRead();
 
-    await waitFor(() =>
-      expect(getByText(/has not finished uploading from the device that captured it/)).toBeTruthy(),
-    );
+    expect(getByText(/has not finished uploading from the device that captured it/)).toBeTruthy();
     expect(getByText('Remove photo')).toBeTruthy();
     expect(queryByText('Upload photo')).toBeNull();
   });
 
-  // verifies spec: MOB — content this device has not fetched is distinct from
+  // verifies spec: MOB — content this device could not fetch is distinct from
   // content pending at its origin, and neither reads as a missing photo
-  it('reports a photo not on this device when there is no connectivity', async () => {
-    (useNetInfo as jest.Mock).mockReturnValue({ isInternetReachable: false });
+  it('reports a photo not on this device when the fetch cannot reach the network', async () => {
+    deviceIsOffline();
     const attachment = await seedAttachment();
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        throw new Error('network request failed');
+      }),
+    } as any);
 
     const { getByText, queryByText } = await render(
       <UploadPhoto onChange={onChange} value={attachment.id} />,
     );
+    await settleRead();
 
-    await waitFor(() => expect(getByText(/is not on this device yet/)).toBeTruthy());
+    expect(getByText(/is not on this device yet/)).toBeTruthy();
     expect(getByText(/Connect to the internet to fetch it/)).toBeTruthy();
     expect(getByText('Remove photo')).toBeTruthy();
     expect(queryByText('Upload photo')).toBeNull();
+  });
+
+  // verifies spec: MOB — a record whose content this device cannot resolve is
+  // a photo awaiting its content, not an answer with no photo
+  it('reports a photo whose record has not reached this device', async () => {
+    const { getByText, queryByText } = await render(
+      <UploadPhoto onChange={onChange} value="an-answer-from-another-device" />,
+    );
+    await settleRead();
+
+    expect(getByText(/is not on this device yet/)).toBeTruthy();
+    expect(getByText('Remove photo')).toBeTruthy();
+    expect(queryByText('Upload photo')).toBeNull();
+  });
+
+  // The connectivity the device reports arrives after the first render, so a
+  // photo already being read must not be stranded by it.
+  it('shows the photo when connectivity is reported while the read is in flight', async () => {
+    connectivityIsUnknown();
+    const attachment = await seedAttachment();
+    const releaseFetch = deferPhotoFetch();
+
+    const { container } = await render(<UploadPhoto onChange={onChange} value={attachment.id} />);
+    await connectivityReturns();
+    releaseFetch();
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
+    expect(contentReads).toBe(1);
+  });
+
+  // verifies spec: MOB — content the device could not fetch is fetched again
+  // once it has connectivity, so the advice to connect can be acted on
+  it('fetches the photo again once connectivity returns', async () => {
+    deviceIsOffline();
+    const attachment = await seedAttachment();
+    let reachable = false;
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        if (!reachable) {
+          throw new Error('network request failed');
+        }
+        fs.seed(FETCHED_PATH, PHOTO_BYTES);
+        return await store.putFile(FETCHED_PATH);
+      }),
+    } as any);
+
+    const { container } = await render(<UploadPhoto onChange={onChange} value={attachment.id} />);
+    await settleRead();
+    expect(displayedImageUri(container)).toBeUndefined();
+
+    reachable = true;
+    await connectivityReturns();
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
+  });
+
+  // A photo captured here is already on screen, so the value the form hands
+  // back is not read from the store again.
+  it('does not read back a photo it just captured', async () => {
+    const { container, getByText, rerender } = await render(
+      <UploadPhoto onChange={onChange} value={null} />,
+    );
+    await takePhoto(getByText);
+
+    const [attachmentId] = onChange.mock.calls[0];
+    await rerender(<UploadPhoto onChange={onChange} value={attachmentId} />);
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(CAPTURED_URI);
+    expect(contentReads).toBe(0);
   });
 
   // verifies spec: MOB, CACHE — a removed photo's blob has no referencing
@@ -201,7 +312,8 @@ describe('<UploadPhoto />', () => {
     const { container, getByText } = await render(
       <UploadPhoto onChange={onChange} value={attachment.id} />,
     );
-    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    await settleRead();
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
     await removePhoto(getByText);
 
     expect(onChange).toHaveBeenCalledWith(null);
@@ -220,7 +332,8 @@ describe('<UploadPhoto />', () => {
     const { container, getByText } = await render(
       <UploadPhoto onChange={onChange} value={attachment.id} />,
     );
-    await waitFor(() => expect(displayedImageUri(container)).toBe(PHOTO_URI));
+    await settleRead();
+    expect(displayedImageUri(container)).toBe(PHOTO_URI);
     await removePhoto(getByText);
 
     expect(await Database.models.Attachment.findOne({ where: { id: attachment.id } })).toBeNull();
@@ -229,35 +342,38 @@ describe('<UploadPhoto />', () => {
     expect(blob.tier).toBe(BLOB_TIERS.OUTBOX);
   });
 
-  // A fetch that lands after the photo is removed must not put it back on
+  // A read that lands after the photo is removed must not put it back on
   // screen, since the record it belonged to is gone.
   it('discards content that arrives after the photo is removed', async () => {
-    let releaseFetch: () => void;
-    const fetchReleased = new Promise<void>(resolve => {
-      releaseFetch = resolve;
-    });
     const attachment = await seedAttachment();
-    cache.setTransferChannel({
-      fetchFromCentral: jest.fn(async () => {
-        await fetchReleased;
-        fs.seed(FETCHED_PATH, PHOTO_BYTES);
-        return await store.putFile(FETCHED_PATH);
-      }),
-    } as any);
-
-    const read = jest.spyOn(cache, 'readBase64');
+    const releaseFetch = deferPhotoFetch();
 
     const { container, getByText } = await render(
       <UploadPhoto onChange={onChange} value={attachment.id} />,
     );
     await removePhoto(getByText);
-    await act(async () => {
-      releaseFetch();
-      await read.mock.results[0].value;
-    });
+    releaseFetch();
+    await settleRead();
 
     expect(displayedImageUri(container)).toBeUndefined();
     expect(getByText('Upload photo')).toBeTruthy();
+  });
+
+  // A capture owns the field from the moment it completes, so a read of the
+  // photo it replaced must not put the old one back on screen.
+  it('keeps the captured photo when the read it replaced lands afterwards', async () => {
+    const attachment = await seedAttachment();
+    const releaseFetch = deferPhotoFetch();
+
+    const { container, getByText } = await render(
+      <UploadPhoto onChange={onChange} value={attachment.id} />,
+    );
+    await takePhoto(getByText);
+    releaseFetch();
+    await settleRead();
+
+    expect(displayedImageUri(container)).toBe(CAPTURED_URI);
+    expect(getByText('Remove photo')).toBeTruthy();
   });
 
   async function seedAttachment(): Promise<Attachment> {
@@ -273,6 +389,64 @@ describe('<UploadPhoto />', () => {
     await cache.putOutbox(HELD_PATH);
     return await seedAttachment();
   }
+
+  function fetchesPhoto(): void {
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        fs.seed(FETCHED_PATH, PHOTO_BYTES);
+        return await store.putFile(FETCHED_PATH);
+      }),
+    } as any);
+  }
+
+  function deferPhotoFetch(): () => void {
+    let release: () => void;
+    const released = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    cache.setTransferChannel({
+      fetchFromCentral: jest.fn(async () => {
+        await released;
+        fs.seed(FETCHED_PATH, PHOTO_BYTES);
+        return await store.putFile(FETCHED_PATH);
+      }),
+    } as any);
+    return () => release();
+  }
+
+  // A photo resolves behind six or more database round trips. Draining the
+  // calls the component makes, rather than polling what it has rendered,
+  // keeps these assertions off a wall-clock budget.
+  function trackBackendCalls(): void {
+    backendCalls = [];
+    contentReads = 0;
+    const track = <T,>(call: Promise<T>): Promise<T> => {
+      backendCalls.push(call.then(ignoreOutcome, ignoreOutcome));
+      return call;
+    };
+
+    const { Attachment: attachmentModel } = Database.models;
+    const findOne = attachmentModel.findOne.bind(attachmentModel);
+    jest.spyOn(attachmentModel, 'findOne').mockImplementation(options => track(findOne(options)));
+
+    const readBase64 = cache.readBase64.bind(cache);
+    jest.spyOn(cache, 'readBase64').mockImplementation(hash => {
+      contentReads += 1;
+      return track(readBase64(hash));
+    });
+  }
+
+  async function settleRead(): Promise<void> {
+    await act(async () => {
+      for (let drained = 0; drained < backendCalls.length; ) {
+        const pending = backendCalls.slice(drained);
+        drained = backendCalls.length;
+        await Promise.all(pending);
+      }
+    });
+  }
+
+  function ignoreOutcome(): void {}
 
   async function takePhoto(getByText): Promise<void> {
     await act(async () => {

--- a/packages/mobile/App/ui/components/UploadPhoto/index.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
 import RNFS from 'react-native-fs';
 import { Popup } from 'popup-ui';
+import { useNetInfo } from '@react-native-community/netinfo';
 import { ERROR_TYPE } from '@tamanu/errors';
 import { useBackend } from '~/ui/hooks';
 import { StyledImage, StyledView, StyledText } from '/styled/common';
@@ -12,6 +13,8 @@ import {
   resizeImage,
 } from '/helpers/image';
 import { deleteFileInDocuments } from '/helpers/file';
+import { BlobAwaitingUploadError } from '~/services/blobs';
+import type { BackendManager } from '~/services/BackendManager';
 import { BaseInputProps } from '../../interfaces/BaseInputProps';
 import { Button } from '~/ui/components/Button';
 import { theme } from '~/ui/styled/theme';
@@ -27,6 +30,12 @@ const IMAGE_SOURCE_TYPES = {
   LIBRARY: 'library',
 };
 
+const AWAITING_UPLOAD_MESSAGE =
+  'This image has not finished uploading from the device that captured it.\nTry again later.';
+
+const NOT_ON_DEVICE_MESSAGE =
+  'This image is not on this device yet.\nConnect to the internet to fetch it.';
+
 export interface PhotoProps extends BaseInputProps {
   onChange: Function;
   value: string;
@@ -40,12 +49,37 @@ interface UploadPhotoComponentProps {
   onPressChoosePhoto: Function;
   onPressTakePhoto: Function;
   onPressRemovePhoto: Function;
+  hasPhoto: boolean;
   imageData: string;
   errorMessage?: string;
   loading: boolean;
 }
 
 const IMAGE_WIDTH = Dimensions.get('window').width * 0.6;
+
+const resolvePhoto = async (
+  attachmentId: string,
+  { models, blobCache }: Pick<BackendManager, 'models' | 'blobCache'>,
+  isInternetReachable: boolean,
+): Promise<{ imageData?: string; errorMessage?: string }> => {
+  try {
+    const attachment = await models.Attachment.findOne({ where: { id: attachmentId } });
+    if (!attachment?.hash) {
+      return { errorMessage: NOT_ON_DEVICE_MESSAGE };
+    }
+    return { imageData: await blobCache.readBase64(attachment.hash) };
+  } catch (error) {
+    // spec: MOB, XFER — an existing file awaiting its content, with the
+    // awaiting-upload and awaiting-fetch cases distinguished
+    if (error instanceof BlobAwaitingUploadError) {
+      return { errorMessage: AWAITING_UPLOAD_MESSAGE };
+    }
+    if (!isInternetReachable) {
+      return { errorMessage: NOT_ON_DEVICE_MESSAGE };
+    }
+    return { errorMessage: `Error loading image: ${error.message}` };
+  }
+};
 
 const ImageActionButton = ({ onPress, label, marginTop = 5, border = true }) => (
   <Button
@@ -82,6 +116,7 @@ const UploadPhotoComponent = ({
   onPressChoosePhoto,
   onPressTakePhoto,
   onPressRemovePhoto,
+  hasPhoto,
   imageData,
   errorMessage,
   loading,
@@ -89,14 +124,14 @@ const UploadPhotoComponent = ({
   <StyledView marginTop={5}>
     {loading && <LoadingPlaceholder />}
     {imageData && <UploadedImage imageData={imageData} />}
-    {!imageData && errorMessage && <Text>{`Error loading image: ${errorMessage}`}</Text>}
+    {!imageData && errorMessage && <Text>{errorMessage}</Text>}
     <StyledText fontWeight="500" color={theme.colors.TEXT_SUPER_DARK} marginTop={10}>
-      {imageData ? 'Change photo' : 'Upload photo'}
+      {hasPhoto ? 'Change photo' : 'Upload photo'}
     </StyledText>
     <StyledView justifyContent="space-between" marginLeft={-10}>
       <ImageActionButton onPress={onPressChoosePhoto} label="Choose photo from library" />
       <ImageActionButton onPress={onPressTakePhoto} label="Take photo with camera" />
-      {imageData && (
+      {hasPhoto && (
         <ImageActionButton
           onPress={onPressRemovePhoto}
           label="Remove photo"
@@ -109,10 +144,15 @@ const UploadPhotoComponent = ({
 );
 
 export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(Boolean(value));
   const [errorMessage, setErrorMessage] = useState(null);
   const [imageData, setImageData] = useState(null);
+  const [hasPhoto, setHasPhoto] = useState(Boolean(value));
+  // The value already taken up, so a photo captured here is not read back from
+  // the store, and a read still in flight when it is removed is discarded.
+  const shownValue = useRef(null);
   const { models, blobCache } = useBackend();
+  const { isInternetReachable } = useNetInfo();
 
   const removeAttachment = useCallback(async value => {
     if (!value) {
@@ -137,9 +177,43 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
 
   const removePhotoCallback = useCallback(async () => {
     onChange(null);
+    shownValue.current = null;
+    setHasPhoto(false);
     setImageData(null);
+    setErrorMessage(null);
     await removeAttachment(value);
   }, [value]);
+
+  // spec: MOB
+  // A photo the answer already holds resolves through its record's hash:
+  // content the device holds reads without connectivity, content it does not
+  // hold is fetched by hash.
+  useEffect(() => {
+    if (!value || value === shownValue.current) {
+      return;
+    }
+    shownValue.current = value;
+    let cancelled = false;
+
+    setHasPhoto(true);
+    setImageData(null);
+    setErrorMessage(null);
+    setLoading(true);
+
+    (async (): Promise<void> => {
+      const resolved = await resolvePhoto(value, { models, blobCache }, isInternetReachable);
+      if (cancelled || shownValue.current !== value) {
+        return;
+      }
+      setImageData(resolved.imageData ?? null);
+      setErrorMessage(resolved.errorMessage ?? null);
+      setLoading(false);
+    })();
+
+    return (): void => {
+      cancelled = true;
+    };
+  }, [value, models, blobCache, isInternetReachable]);
 
   const addPhotoCallback = useCallback(
     async imageType => {
@@ -153,10 +227,11 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
         }
       } catch (error) {
         await removePhotoCallback();
-        setErrorMessage(error.message);
+        setErrorMessage(`Error loading image: ${error.message}`);
         return;
       }
 
+      setHasPhoto(false);
       setImageData(null);
       setLoading(true);
 
@@ -195,7 +270,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
           });
           return;
         }
-        setErrorMessage(error.message);
+        setErrorMessage(`Error loading image: ${error.message}`);
         return;
       }
 
@@ -206,6 +281,8 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
       });
 
       onChange(id);
+      shownValue.current = id;
+      setHasPhoto(true);
       setImageData(image.base64);
       setLoading(false);
     },
@@ -214,6 +291,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
 
   return (
     <UploadPhotoComponent
+      hasPhoto={hasPhoto}
       imageData={imageData}
       errorMessage={errorMessage}
       onPressTakePhoto={() => addPhotoCallback(IMAGE_SOURCE_TYPES.CAMERA)}

--- a/packages/mobile/App/ui/components/UploadPhoto/index.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
 import RNFS from 'react-native-fs';
 import { Popup } from 'popup-ui';
 import { useNetInfo } from '@react-native-community/netinfo';
-import { ERROR_TYPE } from '@tamanu/errors';
+import { ERROR_TYPE, NotFoundError } from '@tamanu/errors';
 import { useBackend } from '~/ui/hooks';
 import { StyledImage, StyledView, StyledText } from '/styled/common';
 import {
@@ -57,28 +57,56 @@ interface UploadPhotoComponentProps {
 
 const IMAGE_WIDTH = Dimensions.get('window').width * 0.6;
 
-const resolvePhoto = async (
+// One fact, so a read that lands late can be told from the photo the field
+// holds now.
+interface Photo {
+  attachmentId: string | null;
+  status: 'empty' | 'loading' | 'ready' | 'unavailable';
+  imageData?: string;
+  error?: Error;
+}
+
+const NO_PHOTO: Photo = { attachmentId: null, status: 'empty' };
+
+const readPhoto = async (
   attachmentId: string,
   { models, blobCache }: Pick<BackendManager, 'models' | 'blobCache'>,
-  isInternetReachable: boolean,
-): Promise<{ imageData?: string; errorMessage?: string }> => {
+): Promise<Photo> => {
   try {
     const attachment = await models.Attachment.findOne({ where: { id: attachmentId } });
     if (!attachment?.hash) {
-      return { errorMessage: NOT_ON_DEVICE_MESSAGE };
+      throw new NotFoundError(`This device holds no record for attachment ${attachmentId}`);
     }
-    return { imageData: await blobCache.readBase64(attachment.hash) };
+    return {
+      attachmentId,
+      status: 'ready',
+      imageData: await blobCache.readBase64(attachment.hash),
+    };
   } catch (error) {
-    // spec: MOB, XFER — an existing file awaiting its content, with the
-    // awaiting-upload and awaiting-fetch cases distinguished
-    if (error instanceof BlobAwaitingUploadError) {
-      return { errorMessage: AWAITING_UPLOAD_MESSAGE };
-    }
-    if (!isInternetReachable) {
-      return { errorMessage: NOT_ON_DEVICE_MESSAGE };
-    }
-    return { errorMessage: `Error loading image: ${error.message}` };
+    return { attachmentId, status: 'unavailable', error };
   }
+};
+
+const photoMessage = (
+  { attachmentId, error }: Photo,
+  isInternetReachable: boolean,
+): string | null => {
+  if (!error) {
+    return null;
+  }
+  if (!attachmentId) {
+    // Nothing attached, so the failure came from a capture rather than a read.
+    return `Error loading image: ${error.message}`;
+  }
+  // spec: MOB, XFER — an existing file awaiting its content, with the
+  // awaiting-upload and awaiting-fetch cases distinguished
+  if (error instanceof BlobAwaitingUploadError) {
+    return AWAITING_UPLOAD_MESSAGE;
+  }
+  if (error instanceof NotFoundError || !isInternetReachable) {
+    return NOT_ON_DEVICE_MESSAGE;
+  }
+  return `Error loading image: ${error.message}`;
 };
 
 const ImageActionButton = ({ onPress, label, marginTop = 5, border = true }) => (
@@ -144,13 +172,9 @@ const UploadPhotoComponent = ({
 );
 
 export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
-  const [loading, setLoading] = useState(Boolean(value));
-  const [errorMessage, setErrorMessage] = useState(null);
-  const [imageData, setImageData] = useState(null);
-  const [hasPhoto, setHasPhoto] = useState(Boolean(value));
-  // The value already taken up, so a photo captured here is not read back from
-  // the store, and a read still in flight when it is removed is discarded.
-  const shownValue = useRef(null);
+  const [photo, setPhoto] = useState<Photo>(() =>
+    value ? { attachmentId: value, status: 'loading' } : NO_PHOTO,
+  );
   const { models, blobCache } = useBackend();
   const { isInternetReachable } = useNetInfo();
 
@@ -177,11 +201,17 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
 
   const removePhotoCallback = useCallback(async () => {
     onChange(null);
-    shownValue.current = null;
-    setHasPhoto(false);
-    setImageData(null);
-    setErrorMessage(null);
+    setPhoto(NO_PHOTO);
     await removeAttachment(value);
+  }, [value]);
+
+  useEffect(() => {
+    setPhoto(current => {
+      if (current.attachmentId === value) {
+        return current;
+      }
+      return value ? { attachmentId: value, status: 'loading' } : NO_PHOTO;
+    });
   }, [value]);
 
   // spec: MOB
@@ -189,31 +219,31 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
   // content the device holds reads without connectivity, content it does not
   // hold is fetched by hash.
   useEffect(() => {
-    if (!value || value === shownValue.current) {
+    const { attachmentId, status } = photo;
+    if (status !== 'loading' || !attachmentId) {
       return;
     }
-    shownValue.current = value;
-    let cancelled = false;
-
-    setHasPhoto(true);
-    setImageData(null);
-    setErrorMessage(null);
-    setLoading(true);
-
     (async (): Promise<void> => {
-      const resolved = await resolvePhoto(value, { models, blobCache }, isInternetReachable);
-      if (cancelled || shownValue.current !== value) {
-        return;
-      }
-      setImageData(resolved.imageData ?? null);
-      setErrorMessage(resolved.errorMessage ?? null);
-      setLoading(false);
+      const read = await readPhoto(attachmentId, { models, blobCache });
+      // A capture or removal that lands first owns the field; this read is stale.
+      setPhoto(current =>
+        current.attachmentId === attachmentId && current.status === 'loading' ? read : current,
+      );
     })();
+  }, [photo, models, blobCache]);
 
-    return (): void => {
-      cancelled = true;
-    };
-  }, [value, models, blobCache, isInternetReachable]);
+  // spec: MOB — content the device could not fetch is retried once it has
+  // connectivity, so the advice to connect is one the component can act on.
+  useEffect(() => {
+    if (!isInternetReachable) {
+      return;
+    }
+    setPhoto(current =>
+      current.status === 'unavailable'
+        ? { attachmentId: current.attachmentId, status: 'loading' }
+        : current,
+    );
+  }, [isInternetReachable]);
 
   const addPhotoCallback = useCallback(
     async imageType => {
@@ -227,13 +257,11 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
         }
       } catch (error) {
         await removePhotoCallback();
-        setErrorMessage(`Error loading image: ${error.message}`);
+        setPhoto({ ...NO_PHOTO, error });
         return;
       }
 
-      setHasPhoto(false);
-      setImageData(null);
-      setLoading(true);
+      setPhoto({ attachmentId: null, status: 'loading' });
 
       // image-picker produces quite expensive files so
       // always delete them straight away to save storage
@@ -257,7 +285,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
       try {
         putResult = await blobCache.putOutbox(path);
       } catch (error) {
-        setLoading(false);
+        setPhoto(NO_PHOTO);
         await deleteFileInDocuments(path);
         if (error?.type === ERROR_TYPE.STORAGE_INSUFFICIENT) {
           // spec: CAP — the refusal names the device's storage as the cause
@@ -270,7 +298,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
           });
           return;
         }
-        setErrorMessage(`Error loading image: ${error.message}`);
+        setPhoto({ ...NO_PHOTO, error });
         return;
       }
 
@@ -281,23 +309,20 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
       });
 
       onChange(id);
-      shownValue.current = id;
-      setHasPhoto(true);
-      setImageData(image.base64);
-      setLoading(false);
+      setPhoto({ attachmentId: id, status: 'ready', imageData: image.base64 });
     },
     [value],
   );
 
   return (
     <UploadPhotoComponent
-      hasPhoto={hasPhoto}
-      imageData={imageData}
-      errorMessage={errorMessage}
+      hasPhoto={Boolean(photo.attachmentId)}
+      imageData={photo.imageData}
+      errorMessage={photoMessage(photo, isInternetReachable)}
       onPressTakePhoto={() => addPhotoCallback(IMAGE_SOURCE_TYPES.CAMERA)}
       onPressChoosePhoto={() => addPhotoCallback(IMAGE_SOURCE_TYPES.LIBRARY)}
       onPressRemovePhoto={removePhotoCallback}
-      loading={loading}
+      loading={photo.status === 'loading'}
     />
   );
 });


### PR DESCRIPTION
### Changes

`UploadPhoto` never resolved the value it was given, so it only ever showed a photo captured in that same mount. A survey answer that already held one rendered empty, and because "Change photo" and "Remove photo" were gated on the resolved image rather than on the answer, an existing photo read as no photo and invited a second upload. This is reachable inside a single session: `FormFields` renders `<FullView key={currentScreenIndex}>`, so paging forward and back remounts the question with the value set and the photo disappears mid-survey.

The component now resolves the attachment's hash through `blobCache.readBase64` on mount and whenever the value changes, the same read-through `ViewPhotoLink` uses, so content the device holds reads offline and content it does not hold is fetched by hash. The controls key off a `hasPhoto` state seeded from the value, so an unresolvable photo still reads as holding one.

Content that cannot be shown gets its own message rather than a generic error: awaiting upload from the capturing device, or not held with no connectivity. The `Error loading image:` wrapper came off the render site so a pending state is no longer labelled an error.

Two things a reviewer would otherwise flag. The resolution logic and its two strings are duplicated with `ViewPhotoLink` rather than shared, because that component also carries a central-by-id fallback for legacy hashless attachments that this one has no use for; a shared hook is the right move if a third reader appears. And capture still deletes the old attachment before admitting the new one, so a failed `putOutbox` leaves the answer pointing at a deleted record. That ordering bug predates this change and is left alone, but it now surfaces as "not on this device yet" rather than silently showing nothing.

**This also fixes the mobile CI failure on the base branch.** The shared-hash removal test was polling `waitFor` against a 1000 ms real-timer budget for a single sqlite read; it now awaits the press handler's promise directly and does not poll.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
