### PR TITLE
fix(mobile): TAM-7037: return re-admitted content to the outbox

### DIFF
--- a/packages/mobile/App/services/blobs/MobileBlobCache.spec.ts
+++ b/packages/mobile/App/services/blobs/MobileBlobCache.spec.ts
@@ -38,6 +38,19 @@ describe('MobileBlobCache', () => {
       const row = await Database.models.Blob.findOne({ where: { hash } });
       expect(row.tier).toBe(BLOB_TIERS.OUTBOX);
     });
+
+    // verifies spec: MOB, CACHE — a cache copy central holds cannot be told
+    // apart from one demoted after its referencing record was never created
+    it('returns cache-tier content to the outbox when the device captures it', async () => {
+      fs.seed('/tmp/held.jpg', 'same photo');
+      const { hash } = await store.putFile('/tmp/held.jpg', { tier: BLOB_TIERS.CACHE });
+
+      fs.seed('/tmp/captured.jpg', 'same photo');
+      await cache.putOutbox('/tmp/captured.jpg');
+
+      const row = await Database.models.Blob.findOne({ where: { hash } });
+      expect(row.tier).toBe(BLOB_TIERS.OUTBOX);
+    });
   });
 
   describe('open', () => {

--- a/packages/mobile/App/services/blobs/MobileBlobCache.ts
+++ b/packages/mobile/App/services/blobs/MobileBlobCache.ts
@@ -73,11 +73,20 @@ export class MobileBlobCache {
    * Admit device-captured content into the outbox, consuming the source file
    * so no second copy remains outside the store. Call within the operation
    * that creates the blob's referencing record; a blob stranded by a crash in
-   * between is demoted to cache by the startup reconciliation. Content already
-   * held as cache stays cache: it is already durable on central.
+   * between is demoted to cache by the startup reconciliation. Content the
+   * store already holds joins the outbox with it: a device capture means
+   * central is not known to hold the bytes.
    */
   async putOutbox(sourcePath: string): Promise<PutResult> {
-    return await this.#blobStore.putFile(sourcePath, { tier: BLOB_TIERS.OUTBOX });
+    const admitted = await this.#blobStore.putFile(sourcePath, { tier: BLOB_TIERS.OUTBOX });
+    // Admission leaves a row it already holds untouched, so the tier is set here.
+    if (admitted.existed) {
+      await this.#models.Blob.getRepository().update(
+        { hash: admitted.hash },
+        { tier: BLOB_TIERS.OUTBOX },
+      );
+    }
+    return admitted;
   }
 
   // spec: MOB, SCRUB

--- a/packages/mobile/App/services/blobs/outboxDurability.spec.ts
+++ b/packages/mobile/App/services/blobs/outboxDurability.spec.ts
@@ -1,0 +1,87 @@
+import { BLOB_TIERS } from '@tamanu/constants';
+
+import { Database } from '~/infra/db';
+import { LAST_SUCCESSFUL_PUSH } from '~/services/sync/constants';
+import { FakeBlobFileSystem } from '/root/tests/helpers/fakeBlobFileSystem';
+import { BlobOutboxPusher } from './BlobOutboxPusher';
+import { MobileBlobCache } from './MobileBlobCache';
+import { MobileBlobStore } from './MobileBlobStore';
+import { reconcileAttachments } from './reconcileAttachments';
+import { deriveFreeDiskReserveBytes } from './deviceStorage';
+
+const PUSH_TICK = 10;
+
+describe('capture stranded before its record, then captured again', () => {
+  let fs: FakeBlobFileSystem;
+  let store: MobileBlobStore;
+  let cache: MobileBlobCache;
+  let pushed: string[];
+  let pusher: BlobOutboxPusher;
+
+  beforeAll(async () => {
+    await Database.connect();
+  });
+
+  beforeEach(async () => {
+    await Database.models.Blob.getRepository().clear();
+    await Database.models.Attachment.getRepository().clear();
+    await Database.models.LocalSystemFact.getRepository().clear();
+    await Database.models.LocalSystemFact.getRepository().query(
+      `INSERT INTO local_system_facts (id, key, value) VALUES (?, ?, ?)`,
+      [`fact-${LAST_SUCCESSFUL_PUSH}`, LAST_SUCCESSFUL_PUSH, String(PUSH_TICK)],
+    );
+    fs = new FakeBlobFileSystem();
+    store = new MobileBlobStore({
+      root: '/blobs',
+      models: Database.models,
+      getFreeDiskReserveBytes: deriveFreeDiskReserveBytes,
+      fs,
+    });
+    cache = new MobileBlobCache({ blobStore: store, models: Database.models, fs });
+    pushed = [];
+    pusher = new BlobOutboxPusher({
+      models: Database.models,
+      transferChannel: {
+        pushToCentral: async (hash: string) => {
+          pushed.push(hash);
+          return { acknowledged: true };
+        },
+      } as any,
+      blobCache: cache,
+    });
+  });
+
+  // verifies spec: MOB, CACHE — content demoted after its record was never
+  // created rejoins the outbox on the capture that does reference it, so the
+  // pusher still delivers bytes central has never been offered
+  it('pushes the content once a later capture gives it a record', async () => {
+    fs.seed('/tmp/photo.jpg', 'photo bytes');
+    const { hash } = await cache.putOutbox('/tmp/photo.jpg');
+
+    await reconcileAttachments({ models: Database.models, blobStore: store, fs });
+    expect(await tierOf(hash)).toBe(BLOB_TIERS.CACHE);
+
+    fs.seed('/tmp/photo-again.jpg', 'photo bytes');
+    await cache.putOutbox('/tmp/photo-again.jpg');
+    await seedSyncedAttachment(hash);
+
+    await pusher.runOnce();
+
+    expect(pushed).toEqual([hash]);
+    // acknowledged, so it is cache the central server holds rather than lost
+    expect(await tierOf(hash)).toBe(BLOB_TIERS.CACHE);
+  });
+
+  async function tierOf(hash: string): Promise<string> {
+    const row = await Database.models.Blob.findOne({ where: { hash } });
+    return row.tier;
+  }
+
+  async function seedSyncedAttachment(hash: string): Promise<void> {
+    await Database.models.Attachment.getRepository().query(
+      `INSERT INTO attachments (id, type, hash, size, updatedAtSyncTick)
+       VALUES (?, 'image/jpeg', ?, 100, ?)`,
+      ['att-recaptured', hash, PUSH_TICK - 5],
+    );
+  }
+});


### PR DESCRIPTION
### Changes

`MobileBlobCache.putOutbox`'s docblock states both halves of a content-loss bug in consecutive sentences: "a blob stranded by a crash in between is demoted to cache by the startup reconciliation. Content already held as cache stays cache: it is already durable on central." A blob demoted as stranded is not durable on central, so those cannot both hold.

The sequence: a photo is captured, `Attachment.createAndSaveOne` does not follow (crash, or a failed write), and `demoteStrandedOutboxBlobs` moves the blob to cache at next startup. The user captures the same photo again. `MobileBlobStore.#register` gates its `DO UPDATE` on `WHERE blobs.deletedAt IS NOT NULL`, so a live row keeps its cache tier whatever tier admission asked for. `BlobOutboxPusher` only lists outbox rows, so central is never offered the content, while eviction can delete it. The later read falls through to a fetch central cannot satisfy.

This predates the epic. It is the same defect fixed for the facility server in the outbox stranding PR, and the fix has the same shape: `putOutbox` promotes a re-admitted existing row back to the outbox rather than leaving admission's no-op in place. The registry upsert is untouched, since a live row keeping its tier is what that primitive guarantees and `contract.ts` conformance-tests it against both stores; the tier rule is the cache layer's.

Two deliberate differences from the facility fix, both checked rather than assumed. There is no parity counterpart, because mobile has no parity at all. And promotion does not refresh recency: the facility bumps it because its sweep is age-windowed, whereas mobile's demotion runs only at startup, before the UI or sync can admit anything, so a bump would protect nothing.

The full-sequence test is a new file, since it spans the reconciliation, the cache and the pusher, and every existing blobs spec covers a single module.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
