### PR TITLE
fix(scheduling): L3: show which day each end of an overnight booking falls on

### DIFF
--- a/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
+++ b/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
@@ -223,11 +223,21 @@
         display: block;
       }
 
-      /* F and F2: 130px so the icon can never be pushed onto a line of its own */
+      /* F and F2: sized to its content with 122px as a floor, so the cards still
+         line up on the common case but no locale can be clipped */
       .time-text.day-month-stacked {
-        width: 130px;
+        width: max-content;
+        min-width: 122px;
         text-transform: none;
         display: block;
+      }
+
+      /* Current behaviour under a wider locale: fixed 122px, no clipping rule,
+         so the range runs over the card */
+      .time-text.overflowing {
+        display: block;
+        white-space: nowrap;
+        overflow: visible;
       }
 
       .nowrap {
@@ -286,8 +296,10 @@
       last days.
     </p>
     <p class="intro-note">
-      Dates render dd/MM/yyyy here (en-AU); the reported deployment renders MM/DD/YYYY. The time
-      column is 122px today, and the pane budgets 60px of height per row.
+      Widths quoted are en-AU; the reported deployment renders MM/DD/YYYY. Date and time formatting
+      follows a deployment setting that falls back to each user's browser locale, so the same range
+      runs up to 25% wider elsewhere. The last two sections carry that through. The time column is
+      122px today, and the pane budgets 60px of height per row.
     </p>
 
     <div id="options"></div>
@@ -413,7 +425,7 @@
         {
           title: 'F. The same, wrapped to two lines',
           caption:
-            'Option E over two lines, with the icon pinned to the end of the second line so it can never be pushed onto a line of its own. Needs 130px rather than 122px, and the card keeps almost all of its width. Row height still has to grow.',
+            'Option E over two lines, with the icon pinned to the end of the second line so it can never be pushed onto a line of its own. The column is sized to its content with 122px as a floor, so it holds in any locale. Row height still has to grow.',
           timeClass: 'day-month-stacked',
           rows: dayIndex => {
             const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
@@ -428,7 +440,7 @@
         {
           title: 'F2. The same, with the icon in place of the dash',
           caption:
-            'The icon does the work of the range dash. Two lines and 130px again, one glyph shorter, and it reads as running through the night. No explicit separator, so the two times rely on the icon and the line order.',
+            'The icon does the work of the range dash: one glyph shorter, and it reads as running through the night. No explicit separator, so the two times rely on the icon and the line order.',
           timeClass: 'day-month-stacked',
           rows: dayIndex => {
             const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
@@ -449,6 +461,56 @@
             const slice = ['10:00am - 11:59pm', '12:00am - 11:59pm', '12:00am - 11:30am'][dayIndex];
             return order(dayIndex, overnight(`${slice} ${MOON}`), sameDay('8:30am - 9:00am'));
           },
+        },
+      ];
+
+      // Middle day of the stay, where neither end is today, so both dates show.
+      // Times and dates come from Intl in each locale, with the same format
+      // options the app passes (hour12 is forced on, so 24-hour locales still
+      // carry a localised am/pm marker).
+      const LOCALES = [
+        { label: 'en-AU', start: '12 Aug 10:00am', end: '14 Aug 11:30am' },
+        { label: 'es-ES', start: '12 ago 10:00a. m.', end: '14 ago 11:30a. m.' },
+        { label: 'pt-BR', start: '12 de ago. 10:00am', end: '14 de ago. 11:30am' },
+        { label: 'ja-JP', start: '8月12日 午前10:00', end: '8月14日 午前11:30' },
+        { label: 'hu-HU', start: 'aug. 12. de.10:00', end: 'aug. 14. de.11:30' },
+      ];
+
+      const LOCALE_SECTIONS = [
+        {
+          title: 'Option F across locales',
+          caption:
+            'The middle day in five locales, with the column sized to its content. Nothing clips, and the card gives up width only where the locale needs it.',
+          panes: LOCALES.map(locale => ({
+            label: locale.label,
+            timeClass: 'day-month-stacked',
+            rows: [
+              overnight(
+                `${locale.start} –<br /><span class="nowrap">${locale.end} ${SMALL_MOON}</span>`,
+              ),
+              sameDay('8:30am – 9:00am'),
+            ],
+          })),
+        },
+        {
+          title: 'Why a pixel budget cannot hold',
+          caption:
+            'Current behaviour, unchanged, in two wider locales. The range already needs 148px in es-ES and 139px in ja-JP against a 122px column, and the column has no clipping rule, so it runs over the card today. Any fixed width is a guess at a locale.',
+          panes: [
+            {
+              label: 'es-ES · 148px in a 122px column',
+              timeClass: 'overflowing',
+              rows: [
+                overnight('10:00a. m. - 11:30a. m.'),
+                sameDay('8:30a. m. - 9:00a. m.'),
+              ],
+            },
+            {
+              label: 'ja-JP · 139px in a 122px column',
+              timeClass: 'overflowing',
+              rows: [overnight('午前10:00 - 午前11:30'), sameDay('午前8:30 - 午前9:00')],
+            },
+          ],
         },
       ];
 
@@ -490,16 +552,44 @@
           </div>
         </div>`;
 
-      document.getElementById('options').innerHTML = OPTIONS.map(
-        option => `
-          <section class="option">
-            <h2 class="option-title">${option.title}</h2>
-            <p class="option-caption">${option.caption}</p>
-            <div class="panes">
-              ${DAYS.map((_, dayIndex) => renderPane(option, dayIndex)).join('')}
+      const renderLabelledPane = pane => `
+        <div class="pane-with-label">
+          <div class="day-label">${pane.label}</div>
+          <div class="container">
+            <div class="title-container">
+              <h4 class="heading4">Today's bookings</h4>
+              <span class="action-link">View all…</span>
             </div>
-          </section>`,
-      ).join('');
+            <div class="timeline">
+              ${pane.rows.map(row => renderRow(row, pane.timeClass)).join('')}
+            </div>
+            <div class="footer"></div>
+          </div>
+        </div>`;
+
+      const section = (title, caption, panes) => `
+        <section class="option">
+          <h2 class="option-title">${title}</h2>
+          <p class="option-caption">${caption}</p>
+          <div class="panes">${panes}</div>
+        </section>`;
+
+      document.getElementById('options').innerHTML = [
+        ...OPTIONS.map(option =>
+          section(
+            option.title,
+            option.caption,
+            DAYS.map((_, dayIndex) => renderPane(option, dayIndex)).join(''),
+          ),
+        ),
+        ...LOCALE_SECTIONS.map(localeSection =>
+          section(
+            localeSection.title,
+            localeSection.caption,
+            localeSection.panes.map(renderLabelledPane).join(''),
+          ),
+        ),
+      ].join('');
     </script>
   </body>
 </html>

--- a/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
+++ b/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
@@ -1,0 +1,481 @@
+<!-- spec: scheduling/overview.md -->
+<!DOCTYPE html>
+<html lang="en-AU">
+  <head>
+    <meta charset="utf-8" />
+    <title>Today's bookings overnight time options</title>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
+
+      :root {
+        --primary: #326699;
+        --darkest-text: #444444;
+        --dark-text: #666666;
+        --mid-text: #888888;
+        --outline: #dedede;
+        --white: #ffffff;
+        --background: #f3f5f7;
+        --purple: #4101c9;
+        --green: #19934e;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 32px 40px 64px;
+        background-color: var(--background);
+        font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+        color: var(--darkest-text);
+        font-size: 14px;
+        line-height: 18px;
+      }
+
+      h1 {
+        font-weight: 500;
+        font-size: 24px;
+        line-height: 32px;
+        margin: 0 0 8px;
+      }
+
+      .intro {
+        max-width: 780px;
+        margin: 0 0 8px;
+        color: var(--dark-text);
+      }
+
+      .intro-note {
+        max-width: 780px;
+        margin: 0 0 40px;
+        color: var(--mid-text);
+        font-size: 11px;
+        line-height: 15px;
+      }
+
+      .option {
+        margin-bottom: 44px;
+      }
+
+      .option-title {
+        font-weight: 500;
+        font-size: 18px;
+        line-height: 24px;
+        margin: 0 0 4px;
+      }
+
+      .option-caption {
+        max-width: 780px;
+        margin: 0 0 16px;
+        color: var(--dark-text);
+      }
+
+      .option-caption code {
+        font-size: 13px;
+        color: var(--darkest-text);
+      }
+
+      .panes {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 24px;
+      }
+
+      .pane-with-label {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .day-label {
+        font-size: 11px;
+        line-height: 15px;
+        color: var(--mid-text);
+      }
+
+      /* Faithful to TodayBookingsPane */
+
+      .container {
+        min-width: 366px;
+        width: 366px;
+        border: 1px solid var(--outline);
+        border-radius: 3px;
+        padding-top: 15px;
+        background-color: var(--white);
+        display: flex;
+        flex-direction: column;
+      }
+
+      .container.wide {
+        min-width: 530px;
+        width: 530px;
+      }
+
+      .title-container {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border-bottom: 1px solid var(--outline);
+        padding-bottom: 6px;
+        margin: 0 20px 11px;
+      }
+
+      .heading4 {
+        font-weight: 500;
+        font-size: 16px;
+        line-height: 21px;
+        margin: 0;
+      }
+
+      .action-link {
+        text-decoration: underline;
+        cursor: pointer;
+        font-size: 14px;
+      }
+
+      .timeline {
+        padding: 0 20px 0 12px;
+        margin: 0 0 -16px;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .timeline-item {
+        display: flex;
+        min-height: 60px;
+      }
+
+      .timeline-separator {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        flex: 0 0 auto;
+        position: relative;
+        top: 21px;
+      }
+
+      .timeline-dot {
+        display: flex;
+        padding: 0;
+        margin: 0;
+        background: transparent;
+        box-shadow: none;
+      }
+
+      .timeline-connector {
+        flex-grow: 1;
+        width: 1px;
+        background-color: var(--outline);
+      }
+
+      .timeline-item:last-child .timeline-connector {
+        display: none;
+      }
+
+      .timeline-content {
+        font-size: 14px;
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        padding: 0 0 0 6px;
+        flex: 1;
+        min-width: 0;
+      }
+
+      .time-text {
+        flex-grow: 0;
+        flex-shrink: 0;
+        width: 122px;
+        text-transform: lowercase;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      /* B: the range is wider than the column and the column has no clipping
+         rule, so in the real DOM it spills over the card. Clipped here so the
+         comparison stays readable. */
+      .time-text.clipped {
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      /* C: sized to content so it cannot overlap the card */
+      .time-text.fit {
+        width: max-content;
+        white-space: nowrap;
+      }
+
+      /* D */
+      .time-text.shortest {
+        width: 136px;
+        display: block;
+      }
+
+      /* E: day-month dates are words, so the column's lowercasing is scoped
+         back to the times */
+      .time-text.day-month {
+        width: 200px;
+        text-transform: none;
+        display: block;
+      }
+
+      /* F */
+      .time-text.day-month-stacked {
+        width: 122px;
+        text-transform: none;
+        display: block;
+      }
+
+      .card-slot {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .card {
+        height: 54px;
+        border-radius: 3px;
+        padding: 8px 16px;
+      }
+
+      .card-heading {
+        font-size: 14px;
+        font-weight: 500;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .card-body {
+        font-size: 14px;
+        font-weight: 400;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .footer {
+        margin: 4px 20px 0;
+        flex-grow: 1;
+        min-height: 20px;
+        border-top: 1px solid var(--outline);
+        background-color: var(--white);
+      }
+
+      .moon {
+        flex: 0 0 auto;
+        color: var(--primary);
+        display: inline-flex;
+        vertical-align: -2px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Today's bookings overnight time options</h1>
+    <p class="intro">
+      One booking runs 12 Aug 10:00am to 14 Aug 11:30am. Each option is shown on all three days of
+      the stay, alongside a same-day booking so the effect on the common case is visible. Rows are
+      ordered by start time, which is why the overnight booking sorts to the top on the middle and
+      last days.
+    </p>
+    <p class="intro-note">
+      Dates render dd/MM/yyyy here (en-AU); the reported deployment renders MM/DD/YYYY. The time
+      column is 122px today, and the pane budgets 60px of height per row.
+    </p>
+
+    <div id="options"></div>
+
+    <script>
+      const MOON = `<span class="moon" aria-label="Overnight booking"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M10 2c-1.82 0-3.53.5-5 1.35C7.99 5.08 10 8.3 10 12s-2.01 6.92-5 8.65C6.47 21.5 8.18 22 10 22c5.52 0 10-4.48 10-10S15.52 2 10 2z"/></svg></span>`;
+
+      const STATUS = {
+        arrived: {
+          colour: '#4101c9',
+          icon: colour =>
+            `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-label="Arrived"><circle cx="12" cy="12" r="9" stroke="${colour}"/></svg>`,
+        },
+        seen: {
+          colour: '#19934e',
+          icon: colour =>
+            `<svg width="13" height="13" viewBox="0 0 24 24" aria-label="Seen"><path d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" fill="white"/><path d="M12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2ZM17.5833 9.25L10.9167 15.9167C10.75 16.0833 10.5833 16.1667 10.3333 16.1667C10.0833 16.1667 9.91667 16.0833 9.75 15.9167L6.41667 12.5833C6.08333 12.25 6.08333 11.75 6.41667 11.4167C6.75 11.0833 7.25 11.0833 7.58333 11.4167L10.3333 14.1667L16.4167 8.08333C16.75 7.75 17.25 7.75 17.5833 8.08333C17.9167 8.41667 17.9167 8.91667 17.5833 9.25Z" fill="${colour}"/></svg>`,
+        },
+      };
+
+      const DAYS = [
+        { label: 'Wed 12 Aug · first day', short: '12/08/2026', shortest: '12/08/26' },
+        { label: 'Thu 13 Aug · middle day', short: '13/08/2026', shortest: '13/08/26' },
+        { label: 'Fri 14 Aug · last day', short: '14/08/2026', shortest: '14/08/26' },
+      ];
+
+      const START = { short: '12/08/2026', shortest: '12/08/26', dayMonth: '12 Aug', time: '10:00am' };
+      const END = { short: '14/08/2026', shortest: '14/08/26', dayMonth: '14 Aug', time: '11:30am' };
+
+      const overnight = time => ({
+        time,
+        heading: 'Outpatient Outpatient',
+        body: 'Barton Aufderhar',
+        status: 'arrived',
+      });
+
+      const sameDay = time => ({
+        time,
+        heading: 'Ward 1 Bed 2',
+        body: 'Marisol Frami',
+        status: 'seen',
+      });
+
+      // Day 0: the overnight booking starts at 10:00am, so it sorts after the
+      // 8:30am booking. Days 1 and 2: it started on 12 Aug, so it sorts first.
+      const order = (dayIndex, overnightRow, sameDayRow) =>
+        dayIndex === 0 ? [sameDayRow, overnightRow] : [overnightRow, sameDayRow];
+
+      const OPTIONS = [
+        {
+          title: 'Current behaviour',
+          caption: 'Two bare times of day. Reads as a 90-minute booking on every day of the stay.',
+          timeClass: '',
+          rows: dayIndex =>
+            order(dayIndex, overnight('10:00am - 11:30am'), sameDay('8:30am - 9:00am')),
+        },
+        {
+          title: 'A. Start time and overnight icon',
+          caption:
+            'Matches the location bookings calendar tiles, and there is nothing new to build. No end time anywhere on the dashboard, and the last day leads with a time that is not today.',
+          timeClass: '',
+          rows: dayIndex =>
+            order(dayIndex, overnight(`10:00am ${MOON}`), sameDay('8:30am - 9:00am')),
+        },
+        {
+          title: 'B. DateTimeRangeDisplay as it stands',
+          caption:
+            'The direct swap, no layout change. The range needs about 280px against a 122px column, so it does not fit. The component always renders the start date, so same-day rows pick one up too.',
+          timeClass: 'clipped',
+          rows: dayIndex =>
+            order(
+              dayIndex,
+              overnight(`${START.short} ${START.time} – ${END.short} ${END.time}`),
+              sameDay(`${DAYS[dayIndex].short} 8:30am – 9:00am`),
+            ),
+        },
+        {
+          title: 'C. DateTimeRangeDisplay as it stands, column widened',
+          caption:
+            'Same swap, with the time column sized to content and the pane grown to 530px to keep the card readable. Truthful on every day. The pane is 45% wider, and same-day rows carry a date they do not need.',
+          timeClass: 'fit',
+          wide: true,
+          rows: dayIndex =>
+            order(
+              dayIndex,
+              overnight(`${START.short} ${START.time} – ${END.short} ${END.time}`),
+              sameDay(`${DAYS[dayIndex].short} 8:30am – 9:00am`),
+            ),
+        },
+        {
+          title: 'D. Squeezed with shortest dates over two lines',
+          caption:
+            'Passes <code>dateFormat="shortest"</code> and wraps. Both dates are visible so the icon is redundant. Needs 136px and two lines, so the pane\'s per-row height budget has to grow. Same-day rows still carry a date.',
+          timeClass: 'shortest',
+          rows: dayIndex =>
+            order(
+              dayIndex,
+              overnight(`${START.shortest} ${START.time} –<br />${END.shortest} ${END.time}`),
+              sameDay(`${DAYS[dayIndex].shortest} 8:30am –<br />9:00am`),
+            ),
+        },
+        {
+          title: "E. Squeezed by dropping today's date",
+          caption:
+            'New behaviour in the shared component: suppress a date that falls on today, and render the rest as day-month. Same-day rows are untouched. Only the middle day, where neither end is today, needs two lines. At 200px the card truncates the location.',
+          timeClass: 'day-month',
+          rows: dayIndex => {
+            const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
+            const end = dayIndex === 2 ? END.time : `${END.dayMonth} ${END.time}`;
+            const separator = dayIndex === 1 ? `– ${MOON}<br />` : `– `;
+            return order(
+              dayIndex,
+              overnight(dayIndex === 1 ? `${start} ${separator}${end}` : `${start} – ${end} ${MOON}`),
+              sameDay('8:30am – 9:00am'),
+            );
+          },
+        },
+        {
+          title: 'F. The same, wrapped to two lines',
+          caption:
+            'Option E over two lines. Fits the current 122px column and leaves the card its full width. Row height still has to grow.',
+          timeClass: 'day-month-stacked',
+          rows: dayIndex => {
+            const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
+            const end = dayIndex === 2 ? END.time : `${END.dayMonth} ${END.time}`;
+            return order(
+              dayIndex,
+              overnight(`${start} – ${MOON}<br />${end}`),
+              sameDay('8:30am – 9:00am'),
+            );
+          },
+        },
+        {
+          title: "G. Today's slice, clamped",
+          caption:
+            'Times clamped to today. Fits the current column and every row describes today. Shows boundary times the booking does not have.',
+          timeClass: '',
+          rows: dayIndex => {
+            const slice = ['10:00am - 11:59pm', '12:00am - 11:59pm', '12:00am - 11:30am'][dayIndex];
+            return order(dayIndex, overnight(`${slice} ${MOON}`), sameDay('8:30am - 9:00am'));
+          },
+        },
+      ];
+
+      const renderRow = (row, timeClass) => {
+        const { colour, icon } = STATUS[row.status];
+        return `
+          <div class="timeline-item">
+            <div class="timeline-separator">
+              <span class="timeline-dot">${icon(colour)}</span>
+              <span class="timeline-connector"></span>
+            </div>
+            <div class="timeline-content">
+              <div class="time-text ${timeClass}">${row.time}</div>
+              <div class="card-slot">
+                <div class="card" style="background-color: ${colour}1a">
+                  <div class="card-heading">${row.heading}</div>
+                  <div class="card-body">${row.body}</div>
+                </div>
+              </div>
+            </div>
+          </div>`;
+      };
+
+      const renderPane = (option, dayIndex) => `
+        <div class="pane-with-label">
+          <div class="day-label">${DAYS[dayIndex].label}</div>
+          <div class="container${option.wide ? ' wide' : ''}">
+            <div class="title-container">
+              <h4 class="heading4">Today's bookings</h4>
+              <span class="action-link">View all…</span>
+            </div>
+            <div class="timeline">
+              ${option
+                .rows(dayIndex)
+                .map(row => renderRow(row, option.timeClass))
+                .join('')}
+            </div>
+            <div class="footer"></div>
+          </div>
+        </div>`;
+
+      document.getElementById('options').innerHTML = OPTIONS.map(
+        option => `
+          <section class="option">
+            <h2 class="option-title">${option.title}</h2>
+            <p class="option-caption">${option.caption}</p>
+            <div class="panes">
+              ${DAYS.map((_, dayIndex) => renderPane(option, dayIndex)).join('')}
+            </div>
+          </section>`,
+      ).join('');
+    </script>
+  </body>
+</html>

--- a/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
+++ b/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
@@ -3,7 +3,7 @@
 <html lang="en-AU">
   <head>
     <meta charset="utf-8" />
-    <title>Today's bookings overnight time options</title>
+    <title>Today's bookings overnight times</title>
     <style>
       @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
 
@@ -15,8 +15,6 @@
         --outline: #dedede;
         --white: #ffffff;
         --background: #f3f5f7;
-        --purple: #4101c9;
-        --green: #19934e;
       }
 
       * {
@@ -54,24 +52,24 @@
         line-height: 15px;
       }
 
-      .option {
+      .section {
         margin-bottom: 44px;
       }
 
-      .option-title {
+      .section-title {
         font-weight: 500;
         font-size: 18px;
         line-height: 24px;
         margin: 0 0 4px;
       }
 
-      .option-caption {
+      .section-caption {
         max-width: 780px;
         margin: 0 0 16px;
         color: var(--dark-text);
       }
 
-      .option-caption code {
+      .section-caption code {
         font-size: 13px;
         color: var(--darkest-text);
       }
@@ -88,7 +86,7 @@
         gap: 6px;
       }
 
-      .day-label {
+      .pane-label {
         font-size: 11px;
         line-height: 15px;
         color: var(--mid-text);
@@ -105,11 +103,6 @@
         background-color: var(--white);
         display: flex;
         flex-direction: column;
-      }
-
-      .container.wide {
-        min-width: 530px;
-        width: 530px;
       }
 
       .title-container {
@@ -188,60 +181,52 @@
         flex-shrink: 0;
         width: 122px;
         text-transform: lowercase;
-        display: flex;
-        align-items: center;
-        gap: 4px;
       }
 
-      /* B: the range is wider than the column and the column has no clipping
-         rule, so in the real DOM it spills over the card. Clipped here so the
-         comparison stays readable. */
-      .time-text.clipped {
-        display: block;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
-      /* C: sized to content so it cannot overlap the card */
-      .time-text.fit {
-        width: max-content;
-        white-space: nowrap;
-      }
-
-      /* D */
-      .time-text.shortest {
-        width: 136px;
-        display: block;
-      }
-
-      /* E: day-month dates are words, so the column's lowercasing is scoped
-         back to the times */
-      .time-text.day-month {
-        width: 200px;
-        text-transform: none;
-        display: block;
-      }
-
-      /* F and F2: sized to its content with 122px as a floor, so the cards still
-         line up on the common case but no locale can be clipped */
-      .time-text.day-month-stacked {
-        width: max-content;
-        min-width: 122px;
-        text-transform: none;
-        display: block;
-      }
-
-      /* Current behaviour under a wider locale: fixed 122px, no clipping rule,
-         so the range runs over the card */
+      /* Today's fixed column has no clipping rule, so a wider locale runs over
+         the card */
       .time-text.overflowing {
-        display: block;
         white-space: nowrap;
-        overflow: visible;
       }
 
-      .nowrap {
-        white-space: nowrap;
+      /* Content-sized per row: nothing clips, but each row picks its own width
+         and the cards no longer line up */
+      .time-text.ragged {
+        width: max-content;
+        text-transform: none;
+      }
+
+      /* One grid for the whole list, so the time track is as wide as the widest
+         row and every card starts at the same place. minmax keeps today's 122px
+         as the floor. */
+      .timeline.aligned {
+        display: grid;
+        grid-template-columns: auto minmax(122px, auto) 1fr;
+        column-gap: 5px;
+      }
+
+      .timeline.aligned .timeline-item {
+        display: grid;
+        grid-template-columns: subgrid;
+        grid-column: 1 / -1;
+      }
+
+      .timeline.aligned .timeline-content {
+        display: grid;
+        grid-template-columns: subgrid;
+        grid-column: 2 / -1;
+        padding: 0;
+        gap: 0;
+      }
+
+      .timeline.aligned .time-text {
+        width: auto;
+        text-transform: none;
+        align-self: center;
+      }
+
+      .timeline.aligned .card-slot {
+        align-self: center;
       }
 
       .card-slot {
@@ -285,32 +270,33 @@
         display: inline-flex;
         vertical-align: -2px;
       }
+
+      .nowrap {
+        white-space: nowrap;
+      }
     </style>
   </head>
   <body>
-    <h1>Today's bookings overnight time options</h1>
+    <h1>Today's bookings overnight times</h1>
     <p class="intro">
-      One booking runs 12 Aug 10:00am to 14 Aug 11:30am. Each option is shown on all three days of
-      the stay, alongside a same-day booking so the effect on the common case is visible. Rows are
-      ordered by start time, which is why the overnight booking sorts to the top on the middle and
-      last days.
+      One booking runs 12 Aug 10:00am to 14 Aug 11:30am. The row shows the two times with the date
+      on whichever end is not today, an overnight icon closing the second line, and the list laid
+      out as a single grid so every card starts at the same place. Each set is shown on all three
+      days of the stay, alongside a same-day booking.
     </p>
     <p class="intro-note">
-      Widths quoted are en-AU; the reported deployment renders MM/DD/YYYY. Date and time formatting
-      follows a deployment setting that falls back to each user's browser locale, so the same range
-      runs up to 25% wider elsewhere. The last two sections carry that through. The time column is
-      122px today, and the pane budgets 60px of height per row.
+      Dates and times come from Intl, so they follow the date/time locale setting and fall back to
+      each user's browser locale. Interface copy comes from the translation layer and is left in
+      English here: only the parts Intl controls vary between the locale panes below.
     </p>
 
-    <div id="options"></div>
+    <div id="sections"></div>
 
     <script>
-      const moon = (size = 15) =>
+      const moon = (size = 13) =>
         `<span class="moon" aria-label="Overnight booking"><svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="currentColor"><path d="M10 2c-1.82 0-3.53.5-5 1.35C7.99 5.08 10 8.3 10 12s-2.01 6.92-5 8.65C6.47 21.5 8.18 22 10 22c5.52 0 10-4.48 10-10S15.52 2 10 2z"/></svg></span>`;
 
       const MOON = moon();
-      // Sized to the status indicator in this pane
-      const SMALL_MOON = moon(13);
 
       const STATUS = {
         arrived: {
@@ -325,14 +311,71 @@
         },
       };
 
-      const DAYS = [
-        { label: 'Wed 12 Aug · first day', short: '12/08/2026', shortest: '12/08/26' },
-        { label: 'Thu 13 Aug · middle day', short: '13/08/2026', shortest: '13/08/26' },
-        { label: 'Fri 14 Aug · last day', short: '14/08/2026', shortest: '14/08/26' },
+      const DAY_LABELS = [
+        'Wed 12 Aug · first day',
+        'Thu 13 Aug · middle day',
+        'Fri 14 Aug · last day',
       ];
 
-      const START = { short: '12/08/2026', shortest: '12/08/26', dayMonth: '12 Aug', time: '10:00am' };
-      const END = { short: '14/08/2026', shortest: '14/08/26', dayMonth: '14 Aug', time: '11:30am' };
+      // Produced by Intl with the format options the app passes: timeStyle short
+      // with hour12 forced on, and month short / day numeric for the date.
+      const LOCALES = {
+        'en-AU': {
+          startDate: '12 Aug',
+          startTime: '10:00am',
+          endDate: '14 Aug',
+          endTime: '11:30am',
+          sameDay: '8:30am – 9:00am',
+          today: '10:00am - 11:30am',
+          todaySameDay: '8:30am - 9:00am',
+        },
+        'es-ES': {
+          startDate: '12 ago',
+          startTime: '10:00a. m.',
+          endDate: '14 ago',
+          endTime: '11:30a. m.',
+          sameDay: '8:30a. m. – 9:00a. m.',
+          today: '10:00a. m. - 11:30a. m.',
+          todaySameDay: '8:30a. m. - 9:00a. m.',
+        },
+        'pt-BR': {
+          startDate: '12 de ago.',
+          startTime: '10:00am',
+          endDate: '14 de ago.',
+          endTime: '11:30am',
+          sameDay: '8:30am – 9:00am',
+        },
+        'ja-JP': {
+          startDate: '8月12日',
+          startTime: '午前10:00',
+          endDate: '8月14日',
+          endTime: '午前11:30',
+          sameDay: '午前8:30 – 午前9:00',
+          today: '午前10:00 - 午前11:30',
+          todaySameDay: '午前8:30 - 午前9:00',
+        },
+        'hu-HU': {
+          startDate: 'aug. 12.',
+          startTime: 'de.10:00',
+          endDate: 'aug. 14.',
+          endTime: 'de.11:30',
+          sameDay: 'de.8:30 – de.9:00',
+        },
+        'ur-PK': {
+          startDate: '12 اگست',
+          startTime: '10:00am',
+          endDate: '14 اگست',
+          endTime: '11:30am',
+          sameDay: '8:30am – 9:00am',
+        },
+        'ur-IN': {
+          startDate: '۱۲ اگست',
+          startTime: '۱۰:۰۰am',
+          endDate: '۱۴ اگست',
+          endTime: '۱۱:۳۰am',
+          sameDay: '۸:۳۰am – ۹:۰۰am',
+        },
+      };
 
       const overnight = time => ({
         time,
@@ -353,166 +396,32 @@
       const order = (dayIndex, overnightRow, sameDayRow) =>
         dayIndex === 0 ? [sameDayRow, overnightRow] : [overnightRow, sameDayRow];
 
-      const OPTIONS = [
-        {
-          title: 'Current behaviour',
-          caption: 'Two bare times of day. Reads as a 90-minute booking on every day of the stay.',
-          timeClass: '',
-          rows: dayIndex =>
-            order(dayIndex, overnight('10:00am - 11:30am'), sameDay('8:30am - 9:00am')),
-        },
-        {
-          title: 'A. Start time and overnight icon',
-          caption:
-            'Matches the location bookings calendar tiles, and there is nothing new to build. No end time anywhere on the dashboard, and the last day leads with a time that is not today.',
-          timeClass: '',
-          rows: dayIndex =>
-            order(dayIndex, overnight(`10:00am ${MOON}`), sameDay('8:30am - 9:00am')),
-        },
-        {
-          title: 'B. DateTimeRangeDisplay as it stands',
-          caption:
-            'The direct swap, no layout change. The range needs about 280px against a 122px column, so it does not fit. The component always renders the start date, so same-day rows pick one up too.',
-          timeClass: 'clipped',
-          rows: dayIndex =>
-            order(
-              dayIndex,
-              overnight(`${START.short} ${START.time} – ${END.short} ${END.time}`),
-              sameDay(`${DAYS[dayIndex].short} 8:30am – 9:00am`),
-            ),
-        },
-        {
-          title: 'C. DateTimeRangeDisplay as it stands, column widened',
-          caption:
-            'Same swap, with the time column sized to content and the pane grown to 530px to keep the card readable. Truthful on every day. The pane is 45% wider, and same-day rows carry a date they do not need.',
-          timeClass: 'fit',
-          wide: true,
-          rows: dayIndex =>
-            order(
-              dayIndex,
-              overnight(`${START.short} ${START.time} – ${END.short} ${END.time}`),
-              sameDay(`${DAYS[dayIndex].short} 8:30am – 9:00am`),
-            ),
-        },
-        {
-          title: 'D. Squeezed with shortest dates over two lines',
-          caption:
-            'Passes <code>dateFormat="shortest"</code> and wraps. Both dates are visible so the icon is redundant. Needs 136px and two lines, so the pane\'s per-row height budget has to grow. Same-day rows still carry a date.',
-          timeClass: 'shortest',
-          rows: dayIndex =>
-            order(
-              dayIndex,
-              overnight(`${START.shortest} ${START.time} –<br />${END.shortest} ${END.time}`),
-              sameDay(`${DAYS[dayIndex].shortest} 8:30am –<br />9:00am`),
-            ),
-        },
-        {
-          title: "E. Squeezed by dropping today's date",
-          caption:
-            'New behaviour in the shared component: suppress a date that falls on today, and render the rest as day-month. Same-day rows are untouched. Only the middle day, where neither end is today, needs two lines. At 200px the card truncates the location.',
-          timeClass: 'day-month',
-          rows: dayIndex => {
-            const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
-            const end = dayIndex === 2 ? END.time : `${END.dayMonth} ${END.time}`;
-            const separator = dayIndex === 1 ? `– ${MOON}<br />` : `– `;
-            return order(
-              dayIndex,
-              overnight(dayIndex === 1 ? `${start} ${separator}${end}` : `${start} – ${end} ${MOON}`),
-              sameDay('8:30am – 9:00am'),
-            );
-          },
-        },
-        {
-          title: 'F. The same, wrapped to two lines',
-          caption:
-            'Option E over two lines, with the icon pinned to the end of the second line so it can never be pushed onto a line of its own. The column is sized to its content with 122px as a floor, so it holds in any locale. Row height still has to grow.',
-          timeClass: 'day-month-stacked',
-          rows: dayIndex => {
-            const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
-            const end = dayIndex === 2 ? END.time : `${END.dayMonth} ${END.time}`;
-            return order(
-              dayIndex,
-              overnight(`${start} –<br /><span class="nowrap">${end} ${SMALL_MOON}</span>`),
-              sameDay('8:30am – 9:00am'),
-            );
-          },
-        },
-        {
-          title: 'F2. The same, with the icon in place of the dash',
-          caption:
-            'The icon does the work of the range dash: one glyph shorter, and it reads as running through the night. No explicit separator, so the two times rely on the icon and the line order.',
-          timeClass: 'day-month-stacked',
-          rows: dayIndex => {
-            const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
-            const end = dayIndex === 2 ? END.time : `${END.dayMonth} ${END.time}`;
-            return order(
-              dayIndex,
-              overnight(`<span class="nowrap">${start} ${SMALL_MOON}</span><br />${end}`),
-              sameDay('8:30am – 9:00am'),
-            );
-          },
-        },
-        {
-          title: "G. Today's slice, clamped",
-          caption:
-            'Times clamped to today. Fits the current column and every row describes today. Shows boundary times the booking does not have.',
-          timeClass: '',
-          rows: dayIndex => {
-            const slice = ['10:00am - 11:59pm', '12:00am - 11:59pm', '12:00am - 11:30am'][dayIndex];
-            return order(dayIndex, overnight(`${slice} ${MOON}`), sameDay('8:30am - 9:00am'));
-          },
-        },
-      ];
+      /**
+       * The date is dropped from whichever end falls on today. `isolate` wraps
+       * each formatted part so it cannot merge into a neighbouring bidi run.
+       */
+      const timeCell = (locale, dayIndex, isolate = false) => {
+        const { startDate, startTime, endDate, endTime } = LOCALES[locale];
+        const part = text => (isolate ? `<bdi>${text}</bdi>` : text);
+        const start =
+          dayIndex === 0 ? part(startTime) : `${part(startDate)} ${part(startTime)}`;
+        const end = dayIndex === 2 ? part(endTime) : `${part(endDate)} ${part(endTime)}`;
+        return `${start} –<br /><span class="nowrap">${end} ${MOON}</span>`;
+      };
 
-      // Middle day of the stay, where neither end is today, so both dates show.
-      // Times and dates come from Intl in each locale, with the same format
-      // options the app passes (hour12 is forced on, so 24-hour locales still
-      // carry a localised am/pm marker).
-      const LOCALES = [
-        { label: 'en-AU', start: '12 Aug 10:00am', end: '14 Aug 11:30am' },
-        { label: 'es-ES', start: '12 ago 10:00a. m.', end: '14 ago 11:30a. m.' },
-        { label: 'pt-BR', start: '12 de ago. 10:00am', end: '14 de ago. 11:30am' },
-        { label: 'ja-JP', start: '8月12日 午前10:00', end: '8月14日 午前11:30' },
-        { label: 'hu-HU', start: 'aug. 12. de.10:00', end: 'aug. 14. de.11:30' },
-      ];
+      const proposedRows = (locale, dayIndex, isolate = false) =>
+        order(
+          dayIndex,
+          overnight(timeCell(locale, dayIndex, isolate)),
+          sameDay(LOCALES[locale].sameDay),
+        );
 
-      const LOCALE_SECTIONS = [
-        {
-          title: 'Option F across locales',
-          caption:
-            'The middle day in five locales, with the column sized to its content. Nothing clips, and the card gives up width only where the locale needs it.',
-          panes: LOCALES.map(locale => ({
-            label: locale.label,
-            timeClass: 'day-month-stacked',
-            rows: [
-              overnight(
-                `${locale.start} –<br /><span class="nowrap">${locale.end} ${SMALL_MOON}</span>`,
-              ),
-              sameDay('8:30am – 9:00am'),
-            ],
-          })),
-        },
-        {
-          title: 'Why a pixel budget cannot hold',
-          caption:
-            'Current behaviour, unchanged, in two wider locales. The range already needs 148px in es-ES and 139px in ja-JP against a 122px column, and the column has no clipping rule, so it runs over the card today. Any fixed width is a guess at a locale.',
-          panes: [
-            {
-              label: 'es-ES · 148px in a 122px column',
-              timeClass: 'overflowing',
-              rows: [
-                overnight('10:00a. m. - 11:30a. m.'),
-                sameDay('8:30a. m. - 9:00a. m.'),
-              ],
-            },
-            {
-              label: 'ja-JP · 139px in a 122px column',
-              timeClass: 'overflowing',
-              rows: [overnight('午前10:00 - 午前11:30'), sameDay('午前8:30 - 午前9:00')],
-            },
-          ],
-        },
-      ];
+      const currentRows = (locale, dayIndex) =>
+        order(
+          dayIndex,
+          overnight(LOCALES[locale].today),
+          sameDay(LOCALES[locale].todaySameDay),
+        );
 
       const renderRow = (row, timeClass) => {
         const { colour, icon } = STATUS[row.status];
@@ -523,7 +432,7 @@
               <span class="timeline-connector"></span>
             </div>
             <div class="timeline-content">
-              <div class="time-text ${timeClass}">${row.time}</div>
+              <div class="time-text ${timeClass ?? ''}">${row.time}</div>
               <div class="card-slot">
                 <div class="card" style="background-color: ${colour}1a">
                   <div class="card-heading">${row.heading}</div>
@@ -534,62 +443,119 @@
           </div>`;
       };
 
-      const renderPane = (option, dayIndex) => `
+      const renderPane = ({ label, rows, timeClass, aligned = true, dir }) => `
         <div class="pane-with-label">
-          <div class="day-label">${DAYS[dayIndex].label}</div>
-          <div class="container${option.wide ? ' wide' : ''}">
+          <div class="pane-label">${label}</div>
+          <div class="container"${dir ? ` dir="${dir}"` : ''}>
             <div class="title-container">
               <h4 class="heading4">Today's bookings</h4>
               <span class="action-link">View all…</span>
             </div>
-            <div class="timeline">
-              ${option
-                .rows(dayIndex)
-                .map(row => renderRow(row, option.timeClass))
-                .join('')}
+            <div class="timeline${aligned ? ' aligned' : ''}">
+              ${rows.map(row => renderRow(row, timeClass)).join('')}
             </div>
             <div class="footer"></div>
           </div>
         </div>`;
 
-      const renderLabelledPane = pane => `
-        <div class="pane-with-label">
-          <div class="day-label">${pane.label}</div>
-          <div class="container">
-            <div class="title-container">
-              <h4 class="heading4">Today's bookings</h4>
-              <span class="action-link">View all…</span>
-            </div>
-            <div class="timeline">
-              ${pane.rows.map(row => renderRow(row, pane.timeClass)).join('')}
-            </div>
-            <div class="footer"></div>
-          </div>
-        </div>`;
+      const SECTIONS = [
+        {
+          title: 'The bug today',
+          caption:
+            'Two bare times of day in a fixed 122px column. It reads as a 90-minute booking on every day of the stay, and in a wider locale the range runs over the card whether the booking is overnight or not.',
+          panes: [
+            ...DAY_LABELS.map((label, dayIndex) => ({
+              label,
+              rows: currentRows('en-AU', dayIndex),
+              aligned: false,
+            })),
+            {
+              label: 'es-ES · 148px of text in a 122px column',
+              rows: currentRows('es-ES', 1),
+              timeClass: 'overflowing',
+              aligned: false,
+            },
+            {
+              label: 'ja-JP · 139px of text in a 122px column',
+              rows: currentRows('ja-JP', 1),
+              timeClass: 'overflowing',
+              aligned: false,
+            },
+          ],
+        },
+        {
+          title: 'The fix',
+          caption:
+            'The date appears on whichever end is not today, so a same-day row keeps the times it has now. The icon closes the second line, inside a nowrap span so it can never be pushed onto a line of its own.',
+          panes: DAY_LABELS.map((label, dayIndex) => ({
+            label,
+            rows: proposedRows('en-AU', dayIndex),
+          })),
+        },
+        {
+          title: 'Keeping the cards aligned',
+          caption:
+            'Sizing each row to its own content stops the clipping but leaves the card edges ragged. Making the list one grid, with each row a <code>subgrid</code> of it, gives the time column a single track as wide as the widest row, so the cards line up again and the whole list resizes together. <code>minmax(122px, auto)</code> keeps today\'s width as the floor. Subgrid is Chrome 117 and up, comfortably inside the supported range.',
+          panes: [
+            {
+              label: 'pt-BR · content-sized per row · ragged',
+              rows: proposedRows('pt-BR', 1),
+              timeClass: 'ragged',
+              aligned: false,
+            },
+            {
+              label: 'pt-BR · one grid, rows as subgrid · aligned',
+              rows: proposedRows('pt-BR', 1),
+            },
+            {
+              label: 'en-AU · aligned, for reference',
+              rows: proposedRows('en-AU', 1),
+            },
+          ],
+        },
+        {
+          title: 'Across locales',
+          caption:
+            'The middle day, where neither end is today and both dates show, in five locales. The time track takes what it needs and the card gives up width only where the locale asks for it.',
+          panes: ['en-AU', 'es-ES', 'pt-BR', 'ja-JP', 'hu-HU'].map(locale => ({
+            label: locale,
+            rows: proposedRows(locale, 1),
+          })),
+        },
+        {
+          title: 'Urdu, and a bidi defect it exposes',
+          caption:
+            'ur-PK localises the month name and keeps Western digits and a Latin am/pm marker; ur-IN uses Extended Arabic-Indic digits throughout. In the first two panes the row is broken, not merely unmirrored: an Arabic-script month turns the digits that follow it into an Arabic number, so the time joins the month\'s right-to-left run and renders to its left, stranding the am/pm marker on the far side. "14 اگست 11:30am" comes out as "14 11:30 اگستam". That is the whole date column today, in every locale written right to left, overnight or not.',
+          panes: [
+            { label: 'ur-PK · middle day, as it renders today', rows: proposedRows('ur-PK', 1) },
+            { label: 'ur-IN · middle day, as it renders today', rows: proposedRows('ur-IN', 1) },
+            {
+              label: 'ur-PK · each part isolated in a bdi',
+              rows: proposedRows('ur-PK', 1, true),
+            },
+            {
+              label: 'ur-PK · isolated, and dir="rtl" on the pane',
+              rows: proposedRows('ur-PK', 1, true),
+              dir: 'rtl',
+            },
+          ],
+        },
+        {
+          title: 'Fixing the direction',
+          caption:
+            'Wrapping each formatted part in a <code>bdi</code> keeps the runs apart, so the date and time stay in the right order even in a left-to-right pane: that is the third pane above, and it is cheap enough to do wherever a date is rendered. Setting the pane\'s direction from the locale is the fuller answer, and the setting already carries what is needed: <code>new Intl.Locale(locale).getTextInfo().direction</code>. The fourth pane above is both together, and it is the only one that reads correctly to an Urdu speaker: the grid mirrors, the dot and connector move to the right, and the dash and icon land at the visual end of their lines.',
+          panes: [],
+        },
+      ];
 
-      const section = (title, caption, panes) => `
-        <section class="option">
-          <h2 class="option-title">${title}</h2>
-          <p class="option-caption">${caption}</p>
-          <div class="panes">${panes}</div>
-        </section>`;
-
-      document.getElementById('options').innerHTML = [
-        ...OPTIONS.map(option =>
-          section(
-            option.title,
-            option.caption,
-            DAYS.map((_, dayIndex) => renderPane(option, dayIndex)).join(''),
-          ),
-        ),
-        ...LOCALE_SECTIONS.map(localeSection =>
-          section(
-            localeSection.title,
-            localeSection.caption,
-            localeSection.panes.map(renderLabelledPane).join(''),
-          ),
-        ),
-      ].join('');
+      document.getElementById('sections').innerHTML = SECTIONS.map(
+        ({ title, caption, panes }) => `
+          <section class="section">
+            <h2 class="section-title">${title}</h2>
+            <p class="section-caption">${caption}</p>
+            <div class="panes">${panes.map(renderPane).join('')}</div>
+          </section>`,
+      ).join('');
     </script>
   </body>
 </html>

--- a/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
+++ b/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
@@ -94,12 +94,17 @@
 
       /* Faithful to TodayBookingsPane */
 
+      /* Boxes are sized in rem so the pane grows with the reader's font-size
+         preference rather than staying put while the text inside it grows.
+         Anything that must line up with text uses a text-relative unit, and
+         every inset is logical so the RTL pane mirrors correctly. */
+
       .container {
-        min-width: 366px;
-        width: 366px;
+        min-inline-size: 22.875rem; /* 366px */
+        inline-size: 22.875rem;
         border: 1px solid var(--outline);
         border-radius: 3px;
-        padding-top: 15px;
+        padding-block-start: 0.9375rem; /* 15px */
         background-color: var(--white);
         display: flex;
         flex-direction: column;
@@ -109,9 +114,10 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        border-bottom: 1px solid var(--outline);
-        padding-bottom: 6px;
-        margin: 0 20px 11px;
+        border-block-end: 1px solid var(--outline);
+        padding-block-end: 6px;
+        margin-inline: 1.25rem; /* 20px */
+        margin-block-end: 11px;
       }
 
       .heading4 {
@@ -128,15 +134,15 @@
       }
 
       .timeline {
-        padding: 0 20px 0 12px;
-        margin: 0 0 -16px;
+        padding-inline: 0.75rem 1.25rem; /* start 12px, end 20px */
+        margin-block-end: -1rem;
         display: flex;
         flex-direction: column;
       }
 
       .timeline-item {
         display: flex;
-        min-height: 60px;
+        min-block-size: 3.75rem; /* 60px of vertical rhythm */
       }
 
       .timeline-separator {
@@ -158,7 +164,7 @@
 
       .timeline-connector {
         flex-grow: 1;
-        width: 1px;
+        inline-size: 1px;
         background-color: var(--outline);
       }
 
@@ -171,11 +177,13 @@
         display: flex;
         align-items: center;
         gap: 5px;
-        padding: 0 0 0 6px;
+        padding-inline-start: 6px;
         flex: 1;
-        min-width: 0;
+        min-inline-size: 0;
       }
 
+      /* Deliberately still 122px: the panes using this class depict the column
+         exactly as it is today, including its overflow. */
       .time-text {
         flex-grow: 0;
         flex-shrink: 0;
@@ -199,9 +207,12 @@
       /* One grid for the whole list, so the time track is as wide as the widest
          row and every card starts at the same place. minmax keeps today's 122px
          as the floor. */
+      /* The floor is in ch, so it tracks the font rather than pinning a pixel
+         count: 15ch is about the 122px the column has today. `auto` above it
+         means the track only ever grows to what the widest row needs. */
       .timeline.aligned {
         display: grid;
-        grid-template-columns: auto minmax(122px, auto) 1fr;
+        grid-template-columns: auto minmax(15ch, auto) 1fr;
         column-gap: 5px;
       }
 
@@ -231,13 +242,16 @@
 
       .card-slot {
         flex: 1;
-        min-width: 0;
+        min-inline-size: 0;
       }
 
+      /* 3lh is the 54px it has today, but as "three lines of text", so the card
+         grows instead of clipping if the text wraps or the reader's font grows */
       .card {
-        height: 54px;
+        min-block-size: 3lh;
         border-radius: 3px;
-        padding: 8px 16px;
+        padding-block: 8px;
+        padding-inline: 1rem;
       }
 
       .card-heading {
@@ -257,18 +271,26 @@
       }
 
       .footer {
-        margin: 4px 20px 0;
+        margin-inline: 1.25rem;
+        margin-block-start: 4px;
         flex-grow: 1;
-        min-height: 20px;
-        border-top: 1px solid var(--outline);
+        min-block-size: 1.25rem;
+        border-block-start: 1px solid var(--outline);
         background-color: var(--white);
       }
 
+      /* 1em, so the icon tracks the text beside it instead of being a number
+         chosen against one font size */
       .moon {
         flex: 0 0 auto;
         color: var(--primary);
         display: inline-flex;
         vertical-align: -2px;
+      }
+
+      .moon svg {
+        inline-size: 1em;
+        block-size: 1em;
       }
 
       .nowrap {
@@ -495,7 +517,7 @@
         {
           title: 'Keeping the cards aligned',
           caption:
-            'Sizing each row to its own content stops the clipping but leaves the card edges ragged. Making the list one grid, with each row a <code>subgrid</code> of it, gives the time column a single track as wide as the widest row, so the cards line up again and the whole list resizes together. <code>minmax(122px, auto)</code> keeps today\'s width as the floor. Subgrid is Chrome 117 and up, comfortably inside the supported range.',
+            'Sizing each row to its own content stops the clipping but leaves the card edges ragged. Making the list one grid, with each row a <code>subgrid</code> of it, gives the time column a single track as wide as the widest row, so the cards line up again and the whole list resizes together. <code>minmax(15ch, auto)</code> holds today\'s width as a floor without pinning it to a pixel count. Subgrid is Chrome 117 and up, well inside the Chrome 149 floor this app targets.',
           panes: [
             {
               label: 'pt-BR · content-sized per row · ragged',

--- a/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
+++ b/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
@@ -424,10 +424,12 @@
        */
       const timeCell = (locale, dayIndex, isolate = false) => {
         const { startDate, startTime, endDate, endTime } = LOCALES[locale];
-        const part = text => (isolate ? `<bdi>${text}</bdi>` : text);
-        const start =
-          dayIndex === 0 ? part(startTime) : `${part(startDate)} ${part(startTime)}`;
-        const end = dayIndex === 2 ? part(endTime) : `${part(endDate)} ${part(endTime)}`;
+        // The isolate goes around a whole end, date and time together. Isolating the
+        // date and the time separately keeps each intact but forces them into
+        // left-to-right order against each other, which is wrong for the locale.
+        const isolated = text => (isolate ? `<bdi>${text}</bdi>` : text);
+        const start = isolated(dayIndex === 0 ? startTime : `${startDate} ${startTime}`);
+        const end = isolated(dayIndex === 2 ? endTime : `${endDate} ${endTime}`);
         return `${start} –<br /><span class="nowrap">${end} ${MOON}</span>`;
       };
 
@@ -552,7 +554,7 @@
             { label: 'ur-PK · middle day, as it renders today', rows: proposedRows('ur-PK', 1) },
             { label: 'ur-IN · middle day, as it renders today', rows: proposedRows('ur-IN', 1) },
             {
-              label: 'ur-PK · each part isolated in a bdi',
+              label: 'ur-PK · each end isolated in a bdi',
               rows: proposedRows('ur-PK', 1, true),
             },
             {
@@ -565,7 +567,7 @@
         {
           title: 'Fixing the direction',
           caption:
-            'Wrapping each formatted part in a <code>bdi</code> keeps the runs apart, so the date and time stay in the right order even in a left-to-right pane: that is the third pane above, and it is cheap enough to do wherever a date is rendered. Setting the pane\'s direction from the locale is the fuller answer, and the setting already carries what is needed: <code>new Intl.Locale(locale).getTextInfo().direction</code>. The fourth pane above is both together, and it is the only one that reads correctly to an Urdu speaker: the grid mirrors, the dot and connector move to the right, and the dash and icon land at the visual end of their lines.',
+            'Wrapping each end of the range in a <code>bdi</code>, date and time together, keeps it from merging with what sits beside it: that is the third pane above, and it is cheap enough to do wherever a date is rendered. Measured left to right, that end renders in exactly the order a native right-to-left container gives it. Isolating the date and the time separately instead would keep each intact but order them left to right against each other. Setting the pane\'s direction from the locale is the fuller answer, and the setting already carries what is needed: <code>new Intl.Locale(locale).getTextInfo().direction</code>. The fourth pane above is both together, and it is the only one that reads correctly to an Urdu speaker: the grid mirrors, the dot and connector move to the right, and the dash and icon land at the visual end of their lines.',
           panes: [],
         },
       ];

--- a/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
+++ b/.workhorse/design/mockups/l3/todays-bookings-overnight-time-options.html
@@ -223,11 +223,15 @@
         display: block;
       }
 
-      /* F */
+      /* F and F2: 130px so the icon can never be pushed onto a line of its own */
       .time-text.day-month-stacked {
-        width: 122px;
+        width: 130px;
         text-transform: none;
         display: block;
+      }
+
+      .nowrap {
+        white-space: nowrap;
       }
 
       .card-slot {
@@ -289,7 +293,12 @@
     <div id="options"></div>
 
     <script>
-      const MOON = `<span class="moon" aria-label="Overnight booking"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M10 2c-1.82 0-3.53.5-5 1.35C7.99 5.08 10 8.3 10 12s-2.01 6.92-5 8.65C6.47 21.5 8.18 22 10 22c5.52 0 10-4.48 10-10S15.52 2 10 2z"/></svg></span>`;
+      const moon = (size = 15) =>
+        `<span class="moon" aria-label="Overnight booking"><svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="currentColor"><path d="M10 2c-1.82 0-3.53.5-5 1.35C7.99 5.08 10 8.3 10 12s-2.01 6.92-5 8.65C6.47 21.5 8.18 22 10 22c5.52 0 10-4.48 10-10S15.52 2 10 2z"/></svg></span>`;
+
+      const MOON = moon();
+      // Sized to the status indicator in this pane
+      const SMALL_MOON = moon(13);
 
       const STATUS = {
         arrived: {
@@ -404,14 +413,29 @@
         {
           title: 'F. The same, wrapped to two lines',
           caption:
-            'Option E over two lines. Fits the current 122px column and leaves the card its full width. Row height still has to grow.',
+            'Option E over two lines, with the icon pinned to the end of the second line so it can never be pushed onto a line of its own. Needs 130px rather than 122px, and the card keeps almost all of its width. Row height still has to grow.',
           timeClass: 'day-month-stacked',
           rows: dayIndex => {
             const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
             const end = dayIndex === 2 ? END.time : `${END.dayMonth} ${END.time}`;
             return order(
               dayIndex,
-              overnight(`${start} – ${MOON}<br />${end}`),
+              overnight(`${start} –<br /><span class="nowrap">${end} ${SMALL_MOON}</span>`),
+              sameDay('8:30am – 9:00am'),
+            );
+          },
+        },
+        {
+          title: 'F2. The same, with the icon in place of the dash',
+          caption:
+            'The icon does the work of the range dash. Two lines and 130px again, one glyph shorter, and it reads as running through the night. No explicit separator, so the two times rely on the icon and the line order.',
+          timeClass: 'day-month-stacked',
+          rows: dayIndex => {
+            const start = dayIndex === 0 ? START.time : `${START.dayMonth} ${START.time}`;
+            const end = dayIndex === 2 ? END.time : `${END.dayMonth} ${END.time}`;
+            return order(
+              dayIndex,
+              overnight(`<span class="nowrap">${start} ${SMALL_MOON}</span><br />${end}`),
               sameDay('8:30am – 9:00am'),
             );
           },

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -71,12 +71,12 @@ than the clipping was.
 So the list becomes one grid and each row a `subgrid` of it:
 
 ```
-grid-template-columns: auto minmax(122px, auto) 1fr;   /* separator | time | card */
+grid-template-columns: auto minmax(15ch, max-content) 1fr;   /* separator | time | card */
 ```
 
 The time track is then as wide as the widest row and no wider, every card starts at
 the same place, and the whole list resizes together when a locale needs more room.
-`minmax` keeps today's 122px as the floor so nothing moves in the common case.
+`minmax` keeps today's width as the floor, in `ch`, so nothing moves in the common case.
 Subgrid is Chrome 117 and up; the web bundle targets the last three Chrome majors
 and the default browser policy is Chromium-family, so it is comfortably in range.
 This means overriding MUI's flex layout on `Timeline`, `TimelineItem` and
@@ -114,7 +114,7 @@ rather than a redesign. Measured at the pane's 14px / 18px: `1ch` is 8px, `1em` 
 
 | Was | Becomes | Why |
 | --- | --- | --- |
-| `width: 122px` on the time column | `minmax(15ch, auto)` grid track | A digit count, not a pixel count. Tracks the font, and `auto` handles anything wider |
+| `width: 122px` on the time column | `minmax(15ch, max-content)` grid track | A digit count, not a pixel count. Tracks the font, and the max term handles anything wider |
 | `height: 54px` on the card | `min-block-size: 3lh` | Exactly today's height, expressed as lines of text, so it grows instead of clipping |
 | `min-height: 60px` on the row | `min-block-size: 3.75rem` | Vertical rhythm, not a text measure, so `rem` rather than `lh` |
 | `min-width: 366px` on the pane | `22.875rem` | Grows with the reader's font-size preference instead of holding still while the text grows |
@@ -135,6 +135,38 @@ codebase already uses them heavily (94 `padding-inline`, 60 `block-size`, 61
 Not worth reaching for: container query units (subgrid already sizes from content,
 so a container query buys nothing), `clamp()` (the single `minmax` is the whole
 constraint), `%`, viewport units, and `ex` / `cap` / `ic`.
+
+### What implementation changed about the plan
+
+Two of the mockup's conclusions did not survive contact with a real layout engine,
+found by measuring the shipped CSS in Chrome rather than reasoning about it:
+
+- **The icon cannot be held on a line by adjacency.** An icon is an atomic inline,
+  and the line-breaking rules allow a break either side of it whether or not there
+  is whitespace in the markup. Relying on "no whitespace between the range and the
+  icon" put the icon on a third line of its own, exactly the defect the mockup was
+  corrected for. The row now renders each end of the range as its own `nowrap`
+  block line, with the icon inside the second one, so neither line can be broken
+  and the icon has nowhere else to go.
+- **`min-content` on the track was wrong.** With the ends as explicit lines the
+  track is `minmax(15ch, max-content)`, which resolves to the wider of the two
+  lines. Measured: the track takes 130px for the two-line row, holds the 15ch floor
+  for a same-day row, and the cards line up at the same x either way.
+
+A booking wholly within the day keeps its single line, so the common case renders
+exactly as it does today.
+
+The date-suppression decision is shared as a `useDateRangeSpan` hook rather than
+being duplicated: `DateTimeRangeDisplay` uses it for its inline shape, and the pane
+uses it to compose its two-line shape. The hook also carries the display-timezone
+comparison and the `bdi` isolation reaches every existing caller.
+
+**Pre-existing, left alone:** the list overflows its own box by 21px because the
+timeline separator is offset `top: 21px`, so `overflow-y: auto` shows a scrollbar.
+The same harness reproduces it with the original CSS, and the `+ 21px` in the
+`max-height` formula was compensating for it. The per-row allowance is now generous
+enough to cover a two-line row, so the change does not make it worse, but the
+formula still never actually caps a long list.
 
 ### Other constraints the mockup surfaced
 

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -34,6 +34,32 @@ Two secondary consequences of the same root cause:
 - Rows are ordered by `startTime`, so a booking that began days ago sorts above
   today's bookings rather than at its position in today's timeline.
 
+## Display options
+
+Mocked up in "Today's bookings overnight time options", all seven rendered on the
+first, middle and last day of the stay, each alongside a same-day booking.
+
+| Option | Time column | Cost |
+| --- | --- | --- |
+| A. Start time and overnight icon | 122px | No end time at all; last day leads with a time that isn't today |
+| B. `DateTimeRangeDisplay` as-is | needs ~280px | Doesn't fit; dates on same-day rows |
+| C. `DateTimeRangeDisplay`, column widened | ~280px, pane 530px | Pane 45% wider; dates on same-day rows |
+| D. `dateFormat="shortest"`, two lines | 136px | Two lines on every row; dates on same-day rows |
+| E. Drop dates falling on today, day-month for the rest | 200px | Card truncates the location |
+| F. As E, wrapped to two lines | 122px | Two lines on overnight rows only |
+| G. Clamp to today's boundaries | 122px | Shows boundary times the booking doesn't have |
+
+Constraints the mockup surfaced:
+
+- `DateTimeRangeDisplay` always renders the start date, so options B, C and D
+  date-qualify every same-day row too. Suppressing a date that falls on today
+  (E, F) is a change to the shared component, and would want to apply wherever
+  the range is shown against a known day.
+- `StyledTimeline` budgets `60px` per row in its `max-height`, so any two-line
+  option needs that budget raised or the list starts scrolling.
+- The time column is `text-transform: lowercase`, so a day-month date renders
+  "12 aug" until the lowercasing is scoped to the times.
+
 ## Notes
 
 - Multi-day detection elsewhere (`DateTimeRangeDisplay`, `AppointmentTile`,

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -239,6 +239,10 @@ follow-up work worth its own card: it is a real correctness fix on each surface.
 - The time column was `text-transform: lowercase`, which would render a day-month
   date as "12 aug". It is dropped: `formatTime` already lowercases the am/pm marker,
   so the rule was redundant as well as harmful.
+- Whether a range has an end depends on `end` itself, not on whether it converted:
+  the old code threw on a malformed value, and deriving it from the converted value
+  made the end disappear silently. Now it renders through the formatter, which
+  supplies a visible placeholder.
 - Each end of the range is an explicit nowrap line. An icon is an atomic inline, so
   a break is allowed either side of it; left in an inline run it lands on a line of
   its own.

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -39,18 +39,41 @@ Two secondary consequences of the same root cause:
 Mocked up in "Today's bookings overnight time options", all seven rendered on the
 first, middle and last day of the stay, each alongside a same-day booking.
 
-| Option | Time column | Cost |
+| Option | Shape | Cost |
 | --- | --- | --- |
-| A. Start time and overnight icon | 122px | No end time at all; last day leads with a time that isn't today |
-| B. `DateTimeRangeDisplay` as-is | needs ~280px | Doesn't fit; dates on same-day rows |
-| C. `DateTimeRangeDisplay`, column widened | ~280px, pane 530px | Pane 45% wider; dates on same-day rows |
-| D. `dateFormat="shortest"`, two lines | 136px | Two lines on every row; dates on same-day rows |
-| E. Drop dates falling on today, day-month for the rest | 200px | Card truncates the location |
-| F. As E, wrapped to two lines, icon ending line two | 130px | Two lines on overnight rows only |
-| F2. As F, icon in place of the range dash | 130px | No explicit separator between the two times |
-| G. Clamp to today's boundaries | 122px | Shows boundary times the booking doesn't have |
+| A. Start time and overnight icon | one line, one time | No end time at all; last day leads with a time that isn't today |
+| B. `DateTimeRangeDisplay` as-is | one line, both dates | Roughly twice the column it has; dates on same-day rows |
+| C. `DateTimeRangeDisplay`, column widened | one line, both dates | Pane grows by about half; dates on same-day rows |
+| D. `dateFormat="shortest"`, two lines | two lines, both dates | Two lines on every row; dates on same-day rows |
+| E. Drop dates falling on today, day-month for the rest | one line | Card truncates the location |
+| F. As E, wrapped to two lines, icon ending line two | two lines | Two lines on overnight rows only |
+| F2. As F, icon in place of the range dash | two lines | No explicit separator between the two times |
+| G. Clamp to today's boundaries | one line | Shows boundary times the booking doesn't have |
 
-Constraints the mockup surfaced:
+### The time column cannot carry a fixed width
+
+Dates and times are `Intl`-formatted against the `dateTimeLocale` global setting,
+which accepts any BCP-47 locale and falls back to each user's browser locale when
+unset. Only the separators are hardcoded. So the width of a range is not a
+property of the design, it's a property of whoever is looking at it.
+
+Measured at 14px, the same range that is 125px in en-AU is 148px in es-ES
+("10:00a. m. - 11:30a. m.") and 139px in ja-JP ("午前10:00 - 午前11:30"). Note that
+`formatTime` forces `hour12: true`, so 24-hour locales still carry a localised
+am/pm marker rather than getting shorter.
+
+The column is 122px with no clipping rule, which means **the current pane already
+overflows into the card in those locales**, overnight or not. That is a separate
+defect from this card's, in the same six lines of code, and any option chosen here
+should fix it rather than re-budget it.
+
+The robust treatment is to stop budgeting: size the time column to its content
+(`width: max-content`) with the present 122px as a `min-width` floor. Cards stay
+aligned on the common case, the column grows only where a locale needs it, and the
+card absorbs the difference through the ellipsis it already has. Options F and F2
+are mocked up this way, including a five-locale spread.
+
+Other constraints the mockup surfaced:
 
 - `DateTimeRangeDisplay` always renders the start date, so options B, C and D
   date-qualify every same-day row too. Suppressing a date that falls on today
@@ -60,9 +83,11 @@ Constraints the mockup surfaced:
   option needs that budget raised or the list starts scrolling.
 - The time column is `text-transform: lowercase`, so a day-month date renders
   "12 aug" until the lowercasing is scoped to the times.
-- The overnight icon has to be in a nowrap span with the text it sits beside, or
-  it wraps onto a third line of its own. At the pane's icon scale (13px, matching
-  the status indicator) the column needs 130px.
+- The overnight icon has to sit in a nowrap span with the text beside it, or it
+  wraps onto a line of its own.
+- Right-to-left locales get Arabic-Indic digits and mirrored order from `Intl`,
+  which the pane's fixed left-to-right row does not account for. Out of scope
+  here, but a fixed-width column would compound it.
 
 ## Notes
 

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -46,7 +46,8 @@ first, middle and last day of the stay, each alongside a same-day booking.
 | C. `DateTimeRangeDisplay`, column widened | ~280px, pane 530px | Pane 45% wider; dates on same-day rows |
 | D. `dateFormat="shortest"`, two lines | 136px | Two lines on every row; dates on same-day rows |
 | E. Drop dates falling on today, day-month for the rest | 200px | Card truncates the location |
-| F. As E, wrapped to two lines | 122px | Two lines on overnight rows only |
+| F. As E, wrapped to two lines, icon ending line two | 130px | Two lines on overnight rows only |
+| F2. As F, icon in place of the range dash | 130px | No explicit separator between the two times |
 | G. Clamp to today's boundaries | 122px | Shows boundary times the booking doesn't have |
 
 Constraints the mockup surfaced:
@@ -59,6 +60,9 @@ Constraints the mockup surfaced:
   option needs that budget raised or the list starts scrolling.
 - The time column is `text-transform: lowercase`, so a day-month date renders
   "12 aug" until the lowercasing is scoped to the times.
+- The overnight icon has to be in a nowrap span with the text it sits beside, or
+  it wraps onto a third line of its own. At the pane's icon scale (13px, matching
+  the status indicator) the column needs 130px.
 
 ## Notes
 

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -92,9 +92,13 @@ stands, in every right-to-left locale, overnight or not.
 
 Two things fix it, and the mockup shows both:
 
-- Wrap each formatted part in a `bdi` so the runs cannot merge. Keeps the order
-  correct even in a left-to-right pane, and is cheap enough to apply wherever a
-  date is rendered.
+- Wrap each end of the range in a `bdi`, date and time together, so it cannot merge
+  with what sits beside it. Keeps the order correct even in a left-to-right pane,
+  and is cheap enough to apply wherever a date is rendered. Measured left to right,
+  an isolated end renders in exactly the order a native right-to-left container
+  gives it. Isolating the date and the time *separately* keeps each intact but
+  orders them left to right against each other, which is wrong for the locale, so
+  the isolate goes around the whole end.
 - Set the pane's direction from the locale. The setting already carries what is
   needed: `new Intl.Locale(locale).getTextInfo().direction` returns `rtl` for
   ur-PK, ur-IN, ar-EG and he-IL, `ltr` for en-AU and ja-JP. Note that Chrome
@@ -167,6 +171,28 @@ The same harness reproduces it with the original CSS, and the `+ 21px` in the
 `max-height` formula was compensating for it. The per-row allowance is now generous
 enough to cover a two-line row, so the change does not make it worse, but the
 formula still never actually caps a long list.
+
+### Test levels
+
+The overlap query is what puts a multi-day booking in each day's list, and it was
+untested: the existing endpoint tests only cover appointments with no `endTime`,
+which is the other branch of `buildTimeQuery`. That gap is now covered in
+`packages/facility-server/__tests__/apiv1/Appointments.test.js`, asserting the
+booking comes back on the day it starts, a day it merely covers, and the day it
+ends, and not on the day either side.
+
+Review asked for this as an E2E spec. It sits at the endpoint level instead: the
+claim is about what the API returns for a set of day bounds, which is API contract,
+and the rendering above it is already unit tested. The repo's own guidance puts API
+behaviour in integration tests and reserves E2E for business-critical multi-step UI
+flows. The end-to-end case stays on the test-cases list, unticked, as the one that
+would exercise the whole path in a browser; it needs a dashboard page object, since
+`packages/e2e-tests/pages/DashboardPage.ts` is an empty stub.
+
+Neither the E2E nor the endpoint test could be run here. E2E has no `.env` and no
+running stack, and the facility-server harness fails at database connection setup
+in this worktree for every test, including ones this card does not touch. The web
+unit tests and lint do run, and pass.
 
 ### Other constraints the mockup surfaced
 

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -104,6 +104,38 @@ Both together is the only combination that reads correctly to an Urdu speaker: t
 grid mirrors, the dot and connector move to the right, and the dash and icon land
 at the visual end of their lines.
 
+### Units
+
+The pane is written almost entirely in `px`, which is what made every earlier
+sizing answer a guess. Each magic number has a unit that states what it actually
+means, and today's values map onto them cleanly, so this is a rewrite in place
+rather than a redesign. Measured at the pane's 14px / 18px: `1ch` is 8px, `1em` is
+14px, `1rem` is 16px, `1lh` is 18px.
+
+| Was | Becomes | Why |
+| --- | --- | --- |
+| `width: 122px` on the time column | `minmax(15ch, auto)` grid track | A digit count, not a pixel count. Tracks the font, and `auto` handles anything wider |
+| `height: 54px` on the card | `min-block-size: 3lh` | Exactly today's height, expressed as lines of text, so it grows instead of clipping |
+| `min-height: 60px` on the row | `min-block-size: 3.75rem` | Vertical rhythm, not a text measure, so `rem` rather than `lh` |
+| `min-width: 366px` on the pane | `22.875rem` | Grows with the reader's font-size preference instead of holding still while the text grows |
+| `15px` / `20px` / `12px` insets | `rem` | Same reason |
+| Overnight icon at 13px | `1em` | Removes the question of which pixel size pairs with 14px text |
+
+`rem` is already the idiom here (629 uses across `web` and `ui-components`), and
+there is a `block-size: 3lh` precedent in `RecentlyViewedPatientsList`. `ch` and
+`lh` are both far inside the Chrome 149 floor this app targets.
+
+**Logical properties matter more than the units.** The pane uses
+`padding-left: 12px`, `padding-right: 20px` and `padding-left: 6px`. Under
+`dir="rtl"` those stay on the physical left and right, so the mirrored pane gets
+its insets on the wrong sides. `padding-inline` and friends fix it, and the
+codebase already uses them heavily (94 `padding-inline`, 60 `block-size`, 61
+`inline-size`). The mockup was converted and the RTL pane visibly corrected.
+
+Not worth reaching for: container query units (subgrid already sizes from content,
+so a container query buys nothing), `clamp()` (the single `minmax` is the whole
+constraint), `%`, viewport units, and `ex` / `cap` / `ic`.
+
 ### Other constraints the mockup surfaced
 
 - Suppressing a date that falls on today is a change to `DateTimeRangeDisplay`, and

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -1,0 +1,46 @@
+# Today's bookings displays incorrect times for overnight stays
+
+## Diagnosis
+
+The dashboard bookings pane renders the range as two bare times of day, with no
+awareness that the booking may span more than one day:
+
+`packages/web/app/views/dashboard/components/TodayBookingsPane.jsx:185`
+
+```jsx
+{formatTime(startTime)} - {formatTime(endTime)}
+```
+
+For a booking of 12 Aug 10:00am → 14 Aug 11:30am this renders "10:00am -
+11:30am" on every day of the stay, which reads as a 90-minute same-day booking.
+
+The pane is one of the few appointment surfaces that hand-rolls its time range.
+Everywhere else uses `DateTimeRangeDisplay`
+(`packages/ui-components/src/components/DateDisplay/DateDisplay.jsx:311`), which
+already drops the date qualifier only when start and end fall on the same day,
+or uses `AppointmentTile`, which renders the start time alone plus the overnight
+moon icon. Neither the moon icon nor any date appears in the pane.
+
+The booking legitimately appears on each day of the stay: the appointments list
+endpoint filters by overlap, not by start date
+(`buildTimeQuery`, `packages/facility-server/app/routes/apiv1/appointments.js:108`),
+and the pane queries today's facility-timezone day boundaries. So the middle and
+last days of the stay are expected rows; only their rendering is wrong.
+
+Two secondary consequences of the same root cause:
+
+- The pane's tooltip carries only location and patient, and the card has no
+  click-through, so there is no way to see the real dates from the dashboard.
+- Rows are ordered by `startTime`, so a booking that began days ago sorts above
+  today's bookings rather than at its position in today's timeline.
+
+## Notes
+
+- Multi-day detection elsewhere (`DateTimeRangeDisplay`, `AppointmentTile`,
+  `PastBookingsModal`) compares the stored primary-timezone strings rather than
+  the facility-timezone values, so it can be off by a day boundary where a
+  facility timezone differs from the primary timezone. Out of scope for this
+  card, but the fix here should compare facility-timezone values.
+- `TodayBookingsPane` destructures `getDayBoundaries()` directly while
+  `TodayAppointmentsPane` guards with `boundaries?.start`; the helper is typed as
+  nullable.

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -129,6 +129,16 @@ rather than a redesign. Measured at the pane's 14px / 18px: `1ch` is 8px, `1em` 
 there is a `block-size: 3lh` precedent in `RecentlyViewedPatientsList`. `ch` and
 `lh` are both far inside the Chrome 149 floor this app targets.
 
+**Only the rows were converted in the end.** Review pushed back on rewriting the
+pane's chrome (`Container`, `TitleContainer`, `Footer`) in the same change: `rem`
+tracks the root font where `px` did not, so converting the pane's own box changes
+rendered sizes for no bug-fix payoff, and the file ended up half-converted anyway
+(`NoDataContainer`, `column-gap: 5px`, `top: 21px` and others stayed physical).
+That is fair, so the chrome is back to `px` and physical insets. What stayed is what
+the fix needs: the `ch` floor on the grid track, `3lh` on the card so a two-line row
+grows instead of clipping, and `1em` on the icon. The table above is the reference
+for doing the pane-wide conversion as its own change.
+
 **Logical properties matter more than the units.** The pane uses
 `padding-left: 12px`, `padding-right: 20px` and `padding-left: 6px`. Under
 `dir="rtl"` those stay on the physical left and right, so the mirrored pane gets
@@ -165,12 +175,16 @@ being duplicated: `DateTimeRangeDisplay` uses it for its inline shape, and the p
 uses it to compose its two-line shape. The hook also carries the display-timezone
 comparison and the `bdi` isolation reaches every existing caller.
 
-**Pre-existing, left alone:** the list overflows its own box by 21px because the
-timeline separator is offset `top: 21px`, so `overflow-y: auto` shows a scrollbar.
-The same harness reproduces it with the original CSS, and the `+ 21px` in the
-`max-height` formula was compensating for it. The per-row allowance is now generous
-enough to cover a two-line row, so the change does not make it worse, but the
-formula still never actually caps a long list.
+**The row-count `max-height` is gone.** It read
+`calc(60px * length + 21px)`, which scales with the number of rows and so could
+never cap anything: it was dead except when a row exceeded 60px, where it clipped.
+Re-tuning the per-row allowance for the two-line row would have kept a rule with no
+effect while making it look load-bearing, so it is deleted instead. `overflow-y:
+auto` stays, because the list still overflows its own box by 21px: the timeline
+separator is offset `top: 21px`, which the `+ 21px` in the old formula was
+compensating for. That overflow predates this card and the same harness reproduces
+it with the original CSS. Choosing a real cap (how many rows before the list
+scrolls) is a product decision, not one to invent here.
 
 ### Test levels
 
@@ -194,24 +208,45 @@ running stack, and the facility-server harness fails at database connection setu
 in this worktree for every test, including ones this card does not touch. The web
 unit tests and lint do run, and pass.
 
+### Follow-up: four definitions of "overnight"
+
+`useDateRangeSpan` is the display-timezone answer to "does this range span days",
+but three existing surfaces still hand-roll it, each differently and each against
+the stored primary-timezone values, so each is wrong where a facility timezone
+differs from the primary one:
+
+- `AppointmentTile.jsx:121` — `!isSameDay(startTime, endTime)`
+- `LocationBookingsTable.jsx:257` — `startDate !== endDate`
+- `PastBookingsModal.jsx:125` — `!isSameDay(parseISO(...))`
+
+Each also styles its own `Brightness2Icon`. Review asked either to migrate them or
+to say why not. They stay as they are here, deliberately: the same review round
+asked for this card's unrelated scope to come *down*, and moving three more
+surfaces onto the hook changes when each shows its overnight marker, on screens
+this card does not otherwise touch and cannot verify visually. Migrating the three
+detections to `spansMultipleDays`, and promoting one shared `OvernightIcon`, is
+follow-up work worth its own card: it is a real correctness fix on each surface.
+
 ### Other constraints the mockup surfaced
 
-- Suppressing a date that falls on today is a change to `DateTimeRangeDisplay`, and
-  would want to apply wherever a range is shown against a known day.
-- `StyledTimeline` budgets `60px` per row in its `max-height`, so the two-line row
-  needs that budget raised or the list starts scrolling.
-- The time column is `text-transform: lowercase`, so a day-month date renders
-  "12 aug" until the lowercasing is scoped to the times.
-- The overnight icon has to sit in a nowrap span with the text beside it, or it
-  wraps onto a line of its own.
+- Suppressing a date that falls on a known day lives in `useDateRangeSpan`, not on
+  `DateTimeRangeDisplay`. It was briefly an `onDate` prop on the component too, but
+  no callsite passed it: the pane composes the hook to build its own two-line shape,
+  and the other six callers want the plain inline range. Review called that
+  generalisation ahead of evidence, which it was, so the prop is gone. The inline
+  component and the pane share `RangeEndDisplay` for the rendering half, so the bidi
+  isolation and the date/time pairing exist once.
+- The time column was `text-transform: lowercase`, which would render a day-month
+  date as "12 aug". It is dropped: `formatTime` already lowercases the am/pm marker,
+  so the rule was redundant as well as harmful.
+- Each end of the range is an explicit nowrap line. An icon is an atomic inline, so
+  a break is allowed either side of it; left in an inline run it lands on a line of
+  its own.
 
 ## Notes
 
-- Multi-day detection elsewhere (`DateTimeRangeDisplay`, `AppointmentTile`,
-  `PastBookingsModal`) compares the stored primary-timezone strings rather than
-  the facility-timezone values, so it can be off by a day boundary where a
-  facility timezone differs from the primary timezone. Out of scope for this
-  card, but the fix here should compare facility-timezone values.
+- `DateTimeRangeDisplay` now compares facility-timezone days; the surfaces that
+  still compare stored values are listed under the follow-up above.
 - `TodayBookingsPane` destructures `getDayBoundaries()` directly while
   `TodayAppointmentsPane` guards with `boundaries?.start`; the helper is typed as
   nullable.

--- a/.workhorse/plans/l3/plan.md
+++ b/.workhorse/plans/l3/plan.md
@@ -34,60 +34,86 @@ Two secondary consequences of the same root cause:
 - Rows are ordered by `startTime`, so a booking that began days ago sorts above
   today's bookings rather than at its position in today's timeline.
 
-## Display options
+## The fix
 
-Mocked up in "Today's bookings overnight time options", all seven rendered on the
-first, middle and last day of the stay, each alongside a same-day booking.
+Locked in. Mocked up in "Today's bookings overnight times", rendered on the first,
+middle and last day of the stay, each alongside a same-day booking.
 
-| Option | Shape | Cost |
-| --- | --- | --- |
-| A. Start time and overnight icon | one line, one time | No end time at all; last day leads with a time that isn't today |
-| B. `DateTimeRangeDisplay` as-is | one line, both dates | Roughly twice the column it has; dates on same-day rows |
-| C. `DateTimeRangeDisplay`, column widened | one line, both dates | Pane grows by about half; dates on same-day rows |
-| D. `dateFormat="shortest"`, two lines | two lines, both dates | Two lines on every row; dates on same-day rows |
-| E. Drop dates falling on today, day-month for the rest | one line | Card truncates the location |
-| F. As E, wrapped to two lines, icon ending line two | two lines | Two lines on overnight rows only |
-| F2. As F, icon in place of the range dash | two lines | No explicit separator between the two times |
-| G. Clamp to today's boundaries | one line | Shows boundary times the booking doesn't have |
+- The date appears on whichever end of the range does not fall on today, formatted
+  day-month. A booking wholly within today keeps the times it shows now, so the
+  common case is untouched.
+- The range wraps to two lines, with the overnight icon closing the second line.
+- The list is laid out as one grid so every card starts at the same place.
 
-### The time column cannot carry a fixed width
+Alternatives considered and rejected: start time alone with the icon (no end time
+anywhere); `DateTimeRangeDisplay` unchanged, with or without a wider column (needs
+roughly twice the column it has, and date-qualifies every same-day row, because the
+component always renders the start date); `dateFormat="shortest"` over two lines
+(two lines on every row); the same fix on one line (truncates the location on the
+card); clamping the times to today's boundaries (shows boundary times the booking
+does not have).
+
+### No fixed width, and no per-row width either
 
 Dates and times are `Intl`-formatted against the `dateTimeLocale` global setting,
 which accepts any BCP-47 locale and falls back to each user's browser locale when
-unset. Only the separators are hardcoded. So the width of a range is not a
-property of the design, it's a property of whoever is looking at it.
+unset. Only the separators are hardcoded. So the width of a range is not a property
+of the design, it's a property of whoever is looking at it. Measured at 14px, the
+same range that is 125px in en-AU is 148px in es-ES ("10:00a. m. - 11:30a. m.") and
+139px in ja-JP ("午前10:00 - 午前11:30"). `formatTime` forces `hour12: true`, so
+24-hour locales carry a localised am/pm marker rather than getting shorter.
 
-Measured at 14px, the same range that is 125px in en-AU is 148px in es-ES
-("10:00a. m. - 11:30a. m.") and 139px in ja-JP ("午前10:00 - 午前11:30"). Note that
-`formatTime` forces `hour12: true`, so 24-hour locales still carry a localised
-am/pm marker rather than getting shorter.
+The column is 122px with no clipping rule, so **the current pane already overflows
+into the card in those locales**, overnight or not. Sizing each row to its own
+content fixes the clipping but leaves the card edges ragged, which is worse to read
+than the clipping was.
 
-The column is 122px with no clipping rule, which means **the current pane already
-overflows into the card in those locales**, overnight or not. That is a separate
-defect from this card's, in the same six lines of code, and any option chosen here
-should fix it rather than re-budget it.
+So the list becomes one grid and each row a `subgrid` of it:
 
-The robust treatment is to stop budgeting: size the time column to its content
-(`width: max-content`) with the present 122px as a `min-width` floor. Cards stay
-aligned on the common case, the column grows only where a locale needs it, and the
-card absorbs the difference through the ellipsis it already has. Options F and F2
-are mocked up this way, including a five-locale spread.
+```
+grid-template-columns: auto minmax(122px, auto) 1fr;   /* separator | time | card */
+```
 
-Other constraints the mockup surfaced:
+The time track is then as wide as the widest row and no wider, every card starts at
+the same place, and the whole list resizes together when a locale needs more room.
+`minmax` keeps today's 122px as the floor so nothing moves in the common case.
+Subgrid is Chrome 117 and up; the web bundle targets the last three Chrome majors
+and the default browser policy is Chromium-family, so it is comfortably in range.
+This means overriding MUI's flex layout on `Timeline`, `TimelineItem` and
+`TimelineContent`.
 
-- `DateTimeRangeDisplay` always renders the start date, so options B, C and D
-  date-qualify every same-day row too. Suppressing a date that falls on today
-  (E, F) is a change to the shared component, and would want to apply wherever
-  the range is shown against a known day.
-- `StyledTimeline` budgets `60px` per row in its `max-height`, so any two-line
-  option needs that budget raised or the list starts scrolling.
+### Right-to-left is broken today, in a way worth fixing here
+
+An Arabic-script month name turns the digits that follow it into an Arabic number
+under the bidi algorithm, so the time joins the month's right-to-left run and
+renders to its left, stranding the am/pm marker on the far side. In Urdu,
+"14 اگست 11:30am" comes out as "14 11:30 اگستam". This is the date column as it
+stands, in every right-to-left locale, overnight or not.
+
+Two things fix it, and the mockup shows both:
+
+- Wrap each formatted part in a `bdi` so the runs cannot merge. Keeps the order
+  correct even in a left-to-right pane, and is cheap enough to apply wherever a
+  date is rendered.
+- Set the pane's direction from the locale. The setting already carries what is
+  needed: `new Intl.Locale(locale).getTextInfo().direction` returns `rtl` for
+  ur-PK, ur-IN, ar-EG and he-IL, `ltr` for en-AU and ja-JP. Note that Chrome
+  exposes `getTextInfo()`, not the older `textInfo` getter.
+
+Both together is the only combination that reads correctly to an Urdu speaker: the
+grid mirrors, the dot and connector move to the right, and the dash and icon land
+at the visual end of their lines.
+
+### Other constraints the mockup surfaced
+
+- Suppressing a date that falls on today is a change to `DateTimeRangeDisplay`, and
+  would want to apply wherever a range is shown against a known day.
+- `StyledTimeline` budgets `60px` per row in its `max-height`, so the two-line row
+  needs that budget raised or the list starts scrolling.
 - The time column is `text-transform: lowercase`, so a day-month date renders
   "12 aug" until the lowercasing is scoped to the times.
 - The overnight icon has to sit in a nowrap span with the text beside it, or it
   wraps onto a line of its own.
-- Right-to-left locales get Arabic-Indic digits and mirrored order from `Intl`,
-  which the pane's fixed left-to-right row does not account for. Out of scope
-  here, but a fixed-width column would compound it.
 
 ## Notes
 

--- a/.workhorse/test-cases/l3/overview.md
+++ b/.workhorse/test-cases/l3/overview.md
@@ -6,15 +6,22 @@ clinician it is assigned to.
 
 Ticked cases are covered by the unit tests in
 `packages/web/__tests__/views/dashboard/TodayBookingsPane.test.jsx` and
-`packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx`, or by
+`packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx`, the endpoint
+test in `packages/facility-server/__tests__/apiv1/Appointments.test.js`, or by
 measuring the pane's CSS in a browser. The unticked ones need the running app.
+
+The facility-server suite could not be run locally: its test database harness
+fails at connection setup in this worktree, for every test including untouched
+ones, so CI is the first execution of the endpoint test.
 
 ## The reported bug
 
 - [x] On the first day of the stay, the row shows the start time and the end time carrying its date, not two bare times (verifies spec: SCHEDULING)
 - [x] On a middle day, the row carries a date on both ends (verifies spec: SCHEDULING)
 - [x] On the last day, the row shows the start time carrying its date and the end time alone (verifies spec: SCHEDULING)
-- [ ] The booking appears on all three days of the stay (verifies spec: SCHEDULING)
+- [x] The booking appears on all three days of the stay (verifies spec: SCHEDULING)
+- [x] The appointments endpoint returns a booking spanning days on the day it starts, a day it neither starts nor ends on, and the day it ends, and not on the day either side (verifies spec: SCHEDULING)
+- [x] It returns both of the booking's times, so the pane can tell which day each falls on
 - [x] An overnight indicator appears on the row on each of those days (verifies spec: SCHEDULING)
 
 ## Bookings wholly within today
@@ -56,5 +63,6 @@ worsen it, but the case stays open until the offset or the overflow is addressed
 ## Regression
 
 - [ ] The other surfaces using the shared date range display are unchanged: appointment detail, location bookings table, past bookings, and the two cancel modals
+- [ ] End to end: a clinician opens the dashboard and sees a multi-day booking with the right dates on a middle day. Covered at the endpoint and unit levels instead; this stays open as the one case that exercises the whole path in a browser
 - [ ] Booking status colour, status indicator, and the tooltip on a truncated location or patient name all behave as before
 - [ ] "View all…" still opens location bookings filtered to the clinician

--- a/.workhorse/test-cases/l3/overview.md
+++ b/.workhorse/test-cases/l3/overview.md
@@ -44,6 +44,7 @@ ones, so CI is the first execution of the endpoint test.
 - [x] With the locale set to ur-PK, the day-month and the time beside it read in the intended order, with the am/pm marker attached to its own time (verifies spec: SCHEDULING)
 - [ ] With no locale set, formatting follows the browser locale and the row still fits
 - [x] A day-month date is not lowercased to "12 aug"
+- [ ] The overnight indicator's label is translated, and read out by a screen reader on the row
 
 ## Layout
 
@@ -57,8 +58,9 @@ ones, so CI is the first execution of the endpoint test.
 The scrollbar case is not met, and did not start with this card: the timeline
 separator is offset 21px, so the list overflows its own box and `overflow-y: auto`
 shows a scrollbar. The same harness reproduces it with the pre-change CSS. The
-per-row height allowance now covers a two-line row, so this change does not
-worsen it, but the case stays open until the offset or the overflow is addressed.
+row-count `max-height` that used to sit alongside it has been removed as dead, so
+nothing here clips, but the case stays open until the offset or the overflow is
+addressed.
 
 ## Regression
 

--- a/.workhorse/test-cases/l3/overview.md
+++ b/.workhorse/test-cases/l3/overview.md
@@ -1,0 +1,60 @@
+# Today's bookings displays incorrect times for overnight stays
+
+The booking used throughout: a location booking from 12 Aug 10:00am to 14 Aug
+11:30am, viewed on the facility dashboard's "Today's bookings" list as the
+clinician it is assigned to.
+
+Ticked cases are covered by the unit tests in
+`packages/web/__tests__/views/dashboard/TodayBookingsPane.test.jsx` and
+`packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx`, or by
+measuring the pane's CSS in a browser. The unticked ones need the running app.
+
+## The reported bug
+
+- [x] On the first day of the stay, the row shows the start time and the end time carrying its date, not two bare times (verifies spec: SCHEDULING)
+- [x] On a middle day, the row carries a date on both ends (verifies spec: SCHEDULING)
+- [x] On the last day, the row shows the start time carrying its date and the end time alone (verifies spec: SCHEDULING)
+- [ ] The booking appears on all three days of the stay (verifies spec: SCHEDULING)
+- [x] An overnight indicator appears on the row on each of those days (verifies spec: SCHEDULING)
+
+## Bookings wholly within today
+
+- [x] A booking that starts and ends today shows two times and no date at all (verifies spec: SCHEDULING)
+- [x] No overnight indicator appears on it (verifies spec: SCHEDULING)
+- [x] Its row is a single line, unchanged from before this card
+- [x] A booking with no end time shows a single time and no indicator
+
+## Timezone
+
+- [x] A booking that sits within one day in the primary timezone but crosses midnight in the facility timezone is treated as overnight (verifies spec: SCHEDULING)
+- [x] A booking that crosses midnight in the primary timezone but sits within one day in the facility timezone is not treated as overnight (verifies spec: SCHEDULING)
+- [x] Which end's date is suppressed is decided against today in the facility timezone
+
+## Locale and direction
+
+- [ ] With the date/time locale set to es-ES, the range is fully visible and does not run over the booking card
+- [ ] With the locale set to ja-JP, likewise
+- [x] With the locale set to ur-PK, the day-month and the time beside it read in the intended order, with the am/pm marker attached to its own time (verifies spec: SCHEDULING)
+- [ ] With no locale set, formatting follows the browser locale and the row still fits
+- [x] A day-month date is not lowercased to "12 aug"
+
+## Layout
+
+- [x] Every booking card in the list starts at the same horizontal position, whatever mix of one-line and two-line rows the list holds
+- [x] The time column widens only as far as the widest row needs, and no further
+- [x] A two-line row does not clip, and the card grows to hold it rather than cutting text off
+- [x] The overnight indicator sits on the second line with the end time, never on a line of its own
+- [ ] The list does not gain a scrollbar at two or three bookings because of the taller rows
+- [ ] The pane still fits its dashboard column with the tasks pane shown and hidden
+
+The scrollbar case is not met, and did not start with this card: the timeline
+separator is offset 21px, so the list overflows its own box and `overflow-y: auto`
+shows a scrollbar. The same harness reproduces it with the pre-change CSS. The
+per-row height allowance now covers a two-line row, so this change does not
+worsen it, but the case stays open until the offset or the overflow is addressed.
+
+## Regression
+
+- [ ] The other surfaces using the shared date range display are unchanged: appointment detail, location bookings table, past bookings, and the two cancel modals
+- [ ] Booking status colour, status indicator, and the tooltip on a truncated location or patient name all behave as before
+- [ ] "View all…" still opens location bookings filtered to the clinician

--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -280,6 +280,61 @@ describe('Appointments', () => {
         email,
       });
 
+    // A booking that spans days has to come back on every day it covers, not just
+    // the day it starts: that is what puts it in each day's dashboard list. The
+    // bounds below are the day boundaries the dashboard sends.
+    describe('listing a booking that spans days', () => {
+      const START_TIME = '2026-08-12 10:00:00';
+      const END_TIME = '2026-08-14 11:30:00';
+      let bookingId;
+
+      beforeAll(async () => {
+        const result = await makeBooking(START_TIME, END_TIME);
+        expect(result).toHaveSucceeded();
+        bookingId = result.body.id;
+      });
+
+      afterAll(async () => {
+        await models.Appointment.destroy({ where: { id: bookingId } });
+      });
+
+      const idsListedOn = async date => {
+        const after = encodeURIComponent(`${date} 00:00:00`);
+        const before = encodeURIComponent(`${date} 23:59:59`);
+        const result = await userApp.get(
+          `/api/appointments?all=true&locationId=&after=${after}&before=${before}&patientId=${patientId}&facilityId=${facilityId}`,
+        );
+        expect(result).toHaveSucceeded();
+        return result.body.data.map(({ id }) => id);
+      };
+
+      it.each([
+        ['the day it starts', '2026-08-12'],
+        ['a day it neither starts nor ends on', '2026-08-13'],
+        ['the day it ends', '2026-08-14'],
+      ])('returns the booking on %s', async (_, date) => {
+        expect(await idsListedOn(date)).toContain(bookingId);
+      });
+
+      it.each([
+        ['the day before it starts', '2026-08-11'],
+        ['the day after it ends', '2026-08-15'],
+      ])('does not return the booking on %s', async (_, date) => {
+        expect(await idsListedOn(date)).not.toContain(bookingId);
+      });
+
+      it('returns it with both of its times, so the reader can tell which day each falls on', async () => {
+        const after = encodeURIComponent('2026-08-13 00:00:00');
+        const before = encodeURIComponent('2026-08-13 23:59:59');
+        const result = await userApp.get(
+          `/api/appointments?all=true&locationId=&after=${after}&before=${before}&patientId=${patientId}&facilityId=${facilityId}`,
+        );
+        expect(result).toHaveSucceeded();
+        const booking = result.body.data.find(({ id }) => id === bookingId);
+        expect(booking).toMatchObject({ startTime: START_TIME, endTime: END_TIME });
+      });
+    });
+
     describe('booked time conflict checking', () => {
       beforeEach(async () => {
         await makeBooking('2024-10-02 12:00:00', '2024-10-02 12:30:00');

--- a/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
+++ b/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { isSameDay } from 'date-fns';
 import { Box, Typography } from '@material-ui/core';
 import styled from 'styled-components';
-import { parseDate, isISO9075DateString } from '@tamanu/utils/dateTime';
+import { isISO9075DateString, trimToDate } from '@tamanu/utils/dateTime';
 
 import { TAMANU_COLORS } from '../../constants';
 import { ThemedTooltip } from '../Tooltip';
@@ -291,12 +290,44 @@ export const TimeRangeDisplay = ({ range: { start, end } }) => (
 );
 
 /**
+ * Works out which ends of a range need a date, for callers laying a range out
+ * themselves rather than taking {@link DateTimeRangeDisplay}'s inline shape.
+ *
+ * Days are compared as they are displayed, not as they are stored: a range can sit
+ * within one day in the primary timezone and straddle midnight in the facility's,
+ * or the reverse.
+ *
+ * @param {string|Date} start
+ * @param {string|Date} end
+ * @param {string} onDate - A `yyyy-MM-dd` date in the display timezone that the
+ *   range is being shown against, if any. An end falling on it needs no date.
+ */
+export const useDateRangeSpan = ({ start, end, onDate = null }) => {
+  const { toFacilityDateTime } = useDateTime();
+
+  const startDay = trimToDate(toFacilityDateTime(start));
+  const endDay = end ? trimToDate(toFacilityDateTime(end)) : null;
+  const spansMultipleDays = Boolean(endDay) && startDay !== endDay;
+
+  return {
+    spansMultipleDays,
+    hasEnd: Boolean(endDay),
+    showStartDate: !onDate || startDay !== onDate,
+    showEndDate: spansMultipleDays && (!onDate || endDay !== onDate),
+  };
+};
+
+/**
  * DateTimeRangeDisplay - Shows a date/time range, intelligently handling multi-day spans
  * @param {string|Date} start - The start date/time
  * @param {string|Date} end - The end date/time (optional)
  * @param {string} weekdayFormat - "short" | "long" | "narrow" | null (default, no weekday)
  * @param {string} dateFormat - Date format (default "short")
  * @param {string} timeFormat - Time format (default "default")
+ * @param {string} onDate - A `yyyy-MM-dd` date in the display timezone. An end of the
+ *   range falling on it is shown as a time alone, because the reader already knows
+ *   the day. Use where the range is presented against a known day, such as a list
+ *   of today's bookings.
  *
  * @example
  * // Same day → "Fri 15/03/2024 9:30am – 10:00am"
@@ -307,30 +338,44 @@ export const TimeRangeDisplay = ({ range: { start, end } }) => (
  *
  * // No end → "Fri 15/03/2024 9:30am"
  * <DateTimeRangeDisplay start="2024-03-15 09:30:00" weekdayFormat="short" />
+ *
+ * // Multi-day, read on the last day → "15/03/2024 9:30am – 10:00am"
+ * <DateTimeRangeDisplay start="2024-03-15 09:30:00" end="2024-03-16 10:00:00" onDate="2024-03-16" />
  */
 export const DateTimeRangeDisplay = React.memo(
-  ({ start, end, weekdayFormat = null, dateFormat = 'short', timeFormat = 'default' }) => {
-    const startDate = parseDate(start);
-    const endDate = end ? parseDate(end) : null;
-    const spansMultipleDays = endDate && !isSameDay(startDate, endDate);
+  ({
+    start,
+    end,
+    weekdayFormat = null,
+    dateFormat = 'short',
+    timeFormat = 'default',
+    onDate = null,
+  }) => {
+    const { hasEnd, showStartDate, showEndDate } = useDateRangeSpan({ start, end, onDate });
 
     return (
       <span>
-        <DateDisplay
-          date={start}
-          format={dateFormat}
-          weekdayFormat={weekdayFormat}
-          timeFormat={timeFormat}
-          noTooltip
-        />
-        {endDate && (
+        {/* Each end is isolated so a right-to-left month name cannot absorb the
+            digits beside it and reorder the date against the time */}
+        <bdi>
+          <DateDisplay
+            date={start}
+            format={showStartDate ? dateFormat : null}
+            weekdayFormat={showStartDate ? weekdayFormat : null}
+            timeFormat={timeFormat}
+            noTooltip
+          />
+        </bdi>
+        {hasEnd && (
           <>
             &nbsp;&ndash;{' '}
-            {spansMultipleDays ? (
-              <DateDisplay date={end} format={dateFormat} timeFormat={timeFormat} noTooltip />
-            ) : (
-              <TimeDisplay date={end} format={timeFormat} noTooltip />
-            )}
+            <bdi>
+              {showEndDate ? (
+                <DateDisplay date={end} format={dateFormat} timeFormat={timeFormat} noTooltip />
+              ) : (
+                <TimeDisplay date={end} format={timeFormat} noTooltip />
+              )}
+            </bdi>
           </>
         )}
       </span>

--- a/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
+++ b/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
@@ -355,8 +355,13 @@ export const DateTimeRangeDisplay = React.memo(
 
     return (
       <span>
-        {/* Each end is isolated so a right-to-left month name cannot absorb the
-            digits beside it and reorder the date against the time */}
+        {/* Each end is isolated as a whole, date and time together, so a
+            right-to-left month name cannot absorb the digits beside it and strand
+            the am/pm marker. `bdi` resolves its base direction from the first
+            strong character, so an Urdu end becomes one right-to-left run and
+            renders exactly as a native RTL container would. Do not isolate the
+            date and time separately: that keeps them intact but forces them into
+            left-to-right order against each other, which is wrong for the locale. */}
         <bdi>
           <DateDisplay
             date={start}

--- a/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
+++ b/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
@@ -318,16 +318,49 @@ export const useDateRangeSpan = ({ start, end, onDate = null }) => {
 };
 
 /**
+ * RangeEndDisplay - One end of a date/time range
+ *
+ * Renders the instant as a date with its time, or as a time alone when `dateFormat`
+ * is null because the reader already knows the day.
+ *
+ * The end is isolated as a whole, date and time together, so a right-to-left month
+ * name cannot absorb the digits beside it and strand the am/pm marker. `bdi`
+ * resolves its base direction from the first strong character, so an Urdu end
+ * becomes one right-to-left run and renders exactly as a native RTL container
+ * would. Do not isolate the date and the time separately: that keeps them intact
+ * but forces them into left-to-right order against each other, which is wrong for
+ * the locale.
+ *
+ * @param {string|Date} date - The date/time value
+ * @param {string} dateFormat - Any {@link DateDisplay} format, or null for the time alone
+ * @param {string} timeFormat - Time format (default "default")
+ * @param {string} weekdayFormat - "short" | "long" | "narrow" | null (default, no weekday)
+ */
+export const RangeEndDisplay = React.memo(
+  ({ date, dateFormat = null, timeFormat = 'default', weekdayFormat = null }) => (
+    <bdi>
+      {dateFormat ? (
+        <DateDisplay
+          date={date}
+          format={dateFormat}
+          weekdayFormat={weekdayFormat}
+          timeFormat={timeFormat}
+          noTooltip
+        />
+      ) : (
+        <TimeDisplay date={date} format={timeFormat} noTooltip />
+      )}
+    </bdi>
+  ),
+);
+
+/**
  * DateTimeRangeDisplay - Shows a date/time range, intelligently handling multi-day spans
  * @param {string|Date} start - The start date/time
  * @param {string|Date} end - The end date/time (optional)
  * @param {string} weekdayFormat - "short" | "long" | "narrow" | null (default, no weekday)
  * @param {string} dateFormat - Date format (default "short")
  * @param {string} timeFormat - Time format (default "default")
- * @param {string} onDate - A `yyyy-MM-dd` date in the display timezone. An end of the
- *   range falling on it is shown as a time alone, because the reader already knows
- *   the day. Use where the range is presented against a known day, such as a list
- *   of today's bookings.
  *
  * @example
  * // Same day → "Fri 15/03/2024 9:30am – 10:00am"
@@ -338,49 +371,27 @@ export const useDateRangeSpan = ({ start, end, onDate = null }) => {
  *
  * // No end → "Fri 15/03/2024 9:30am"
  * <DateTimeRangeDisplay start="2024-03-15 09:30:00" weekdayFormat="short" />
- *
- * // Multi-day, read on the last day → "15/03/2024 9:30am – 10:00am"
- * <DateTimeRangeDisplay start="2024-03-15 09:30:00" end="2024-03-16 10:00:00" onDate="2024-03-16" />
  */
 export const DateTimeRangeDisplay = React.memo(
-  ({
-    start,
-    end,
-    weekdayFormat = null,
-    dateFormat = 'short',
-    timeFormat = 'default',
-    onDate = null,
-  }) => {
-    const { hasEnd, showStartDate, showEndDate } = useDateRangeSpan({ start, end, onDate });
+  ({ start, end, weekdayFormat = null, dateFormat = 'short', timeFormat = 'default' }) => {
+    const { hasEnd, spansMultipleDays } = useDateRangeSpan({ start, end });
 
     return (
       <span>
-        {/* Each end is isolated as a whole, date and time together, so a
-            right-to-left month name cannot absorb the digits beside it and strand
-            the am/pm marker. `bdi` resolves its base direction from the first
-            strong character, so an Urdu end becomes one right-to-left run and
-            renders exactly as a native RTL container would. Do not isolate the
-            date and time separately: that keeps them intact but forces them into
-            left-to-right order against each other, which is wrong for the locale. */}
-        <bdi>
-          <DateDisplay
-            date={start}
-            format={showStartDate ? dateFormat : null}
-            weekdayFormat={showStartDate ? weekdayFormat : null}
-            timeFormat={timeFormat}
-            noTooltip
-          />
-        </bdi>
+        <RangeEndDisplay
+          date={start}
+          dateFormat={dateFormat}
+          weekdayFormat={weekdayFormat}
+          timeFormat={timeFormat}
+        />
         {hasEnd && (
           <>
             &nbsp;&ndash;{' '}
-            <bdi>
-              {showEndDate ? (
-                <DateDisplay date={end} format={dateFormat} timeFormat={timeFormat} noTooltip />
-              ) : (
-                <TimeDisplay date={end} format={timeFormat} noTooltip />
-              )}
-            </bdi>
+            <RangeEndDisplay
+              date={end}
+              dateFormat={spansMultipleDays ? dateFormat : null}
+              timeFormat={timeFormat}
+            />
           </>
         )}
       </span>

--- a/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
+++ b/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
@@ -311,7 +311,10 @@ export const useDateRangeSpan = ({ start, end, onDate = null }) => {
 
   return {
     spansMultipleDays,
-    hasEnd: Boolean(endDay),
+    // Whether the range has an end is a property of `end`, not of whether it could
+    // be converted: a value that fails to convert renders as the formatter's
+    // placeholder, which is visible, rather than the end silently disappearing.
+    hasEnd: Boolean(end),
     showStartDate: !onDate || startDay !== onDate,
     showEndDate: spansMultipleDays && (!onDate || endDay !== onDate),
   };

--- a/packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx
+++ b/packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+  AuthContext,
+  DateTimeProvider,
+  DateTimeRangeDisplay,
+  SettingsContext,
+} from '@tamanu/ui-components';
+
+const PRIMARY_TIME_ZONE = 'Pacific/Auckland';
+
+const renderRange = ({ settings = {}, ...props }) =>
+  render(
+    <AuthContext.Provider value={{ primaryTimeZone: PRIMARY_TIME_ZONE }}>
+      <SettingsContext.Provider value={{ getSetting: key => settings[key] }}>
+        <DateTimeProvider>
+          <div data-testid="range">
+            <DateTimeRangeDisplay {...props} />
+          </div>
+        </DateTimeProvider>
+      </SettingsContext.Provider>
+    </AuthContext.Provider>,
+  );
+
+// The separator is a non-breaking space before the dash; normalise it so the
+// expectations below read as the text a person sees.
+const rangeText = () => screen.getByTestId('range').textContent.replace(/\u00a0/g, ' ');
+
+describe('DateTimeRangeDisplay', () => {
+  const settings = { dateTimeLocale: 'en-AU' };
+
+  describe('without onDate', () => {
+    it('shows one date for a range within a single day', () => {
+      renderRange({
+        settings,
+        start: '2026-08-12 10:00:00',
+        end: '2026-08-12 11:30:00',
+      });
+      expect(rangeText()).toBe('12/08/2026 10:00am – 11:30am');
+    });
+
+    it('shows both dates for a range spanning days', () => {
+      renderRange({
+        settings,
+        start: '2026-08-12 10:00:00',
+        end: '2026-08-14 11:30:00',
+      });
+      expect(rangeText()).toBe('12/08/2026 10:00am – 14/08/2026 11:30am');
+    });
+
+    it('shows the start alone when there is no end', () => {
+      renderRange({ settings, start: '2026-08-12 10:00:00' });
+      expect(rangeText()).toBe('12/08/2026 10:00am');
+    });
+  });
+
+  describe('with onDate', () => {
+    const start = '2026-08-12 10:00:00';
+    const end = '2026-08-14 11:30:00';
+
+    it('drops both dates when the range sits within the given day', () => {
+      renderRange({
+        settings,
+        start,
+        end: '2026-08-12 11:30:00',
+        onDate: '2026-08-12',
+        dateFormat: 'dayMonth',
+      });
+      expect(rangeText()).toBe('10:00am – 11:30am');
+    });
+
+    it('keeps only the end date on the first day of a span', () => {
+      renderRange({ settings, start, end, onDate: '2026-08-12', dateFormat: 'dayMonth' });
+      expect(rangeText()).toBe('10:00am – 14 Aug 11:30am');
+    });
+
+    it('keeps both dates on a day the range merely covers', () => {
+      renderRange({ settings, start, end, onDate: '2026-08-13', dateFormat: 'dayMonth' });
+      expect(rangeText()).toBe('12 Aug 10:00am – 14 Aug 11:30am');
+    });
+
+    it('keeps only the start date on the last day of a span', () => {
+      renderRange({ settings, start, end, onDate: '2026-08-14', dateFormat: 'dayMonth' });
+      expect(rangeText()).toBe('12 Aug 10:00am – 11:30am');
+    });
+  });
+
+  describe('multi-day detection uses the display timezone', () => {
+    // Values are stored in the primary timezone, Auckland (UTC+12 in August), and
+    // read in Honolulu (UTC-10), 22 hours behind. So a stored day and a displayed
+    // day are not the same day, in either direction.
+    const settingsInHonolulu = { dateTimeLocale: 'en-AU', facilityTimeZone: 'Pacific/Honolulu' };
+
+    it('treats a range as single-day when it stays within one day where it is read', () => {
+      renderRange({
+        settings: settingsInHonolulu,
+        // 12 Aug 11:30pm → 13 Aug 12:30am stored: two days in Auckland,
+        // but 1:30am → 2:30am on 12 Aug in Honolulu
+        start: '2026-08-12 23:30:00',
+        end: '2026-08-13 00:30:00',
+      });
+      expect(rangeText()).toBe('12/08/2026 1:30am – 2:30am');
+    });
+
+    it('treats a range as multi-day when it crosses midnight where it is read', () => {
+      renderRange({
+        settings: settingsInHonolulu,
+        // 12 Aug 8:00am → 11:00pm stored: one day in Auckland, but
+        // 11 Aug 10:00am → 12 Aug 1:00am in Honolulu
+        start: '2026-08-12 08:00:00',
+        end: '2026-08-12 23:00:00',
+      });
+      expect(rangeText()).toBe('11/08/2026 10:00am – 12/08/2026 1:00am');
+    });
+
+    it('decides onDate suppression against the display timezone too', () => {
+      renderRange({
+        settings: settingsInHonolulu,
+        start: '2026-08-12 23:30:00',
+        end: '2026-08-13 00:30:00',
+        onDate: '2026-08-12',
+      });
+      expect(rangeText()).toBe('1:30am – 2:30am');
+    });
+  });
+
+  describe('bidi isolation', () => {
+    it('wraps each end so a right-to-left month cannot absorb the time beside it', () => {
+      const { container } = renderRange({
+        settings: { dateTimeLocale: 'ur-PK' },
+        start: '2026-08-12 10:00:00',
+        end: '2026-08-14 11:30:00',
+        dateFormat: 'dayMonth',
+      });
+      const isolated = container.querySelectorAll('bdi');
+      expect(isolated).toHaveLength(2);
+      expect(isolated[0].textContent).toBe('12 اگست 10:00am');
+      expect(isolated[1].textContent).toBe('14 اگست 11:30am');
+    });
+  });
+});

--- a/packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx
+++ b/packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx
@@ -84,6 +84,13 @@ describe('DateTimeRangeDisplay', () => {
     });
   });
 
+  it('still shows an end that cannot be converted, as a placeholder', () => {
+    renderRange({ settings, start: '2026-08-12 10:00:00', end: 'not-a-datetime' });
+    // The end is present, so it is rendered; the formatter supplies the placeholder
+    expect(rangeText()).toContain('–');
+    expect(rangeText()).not.toBe('12/08/2026 10:00am');
+  });
+
   describe('bidi isolation', () => {
     // Visual order cannot be asserted here: jsdom does no layout, so it applies no
     // bidi reordering. What is pinned instead is the structure that produces the

--- a/packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx
+++ b/packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx
@@ -126,17 +126,43 @@ describe('DateTimeRangeDisplay', () => {
   });
 
   describe('bidi isolation', () => {
-    it('wraps each end so a right-to-left month cannot absorb the time beside it', () => {
+    // Visual order cannot be asserted here: jsdom does no layout, so it applies no
+    // bidi reordering. What is pinned instead is the structure that produces the
+    // right order, measured in a browser: one isolate per end, holding the date and
+    // the time together. Isolating them separately keeps the time intact but forces
+    // the date and time into left-to-right order against each other, which is wrong
+    // for a right-to-left locale.
+    it('isolates each end as a whole, date and time together', () => {
       const { container } = renderRange({
         settings: { dateTimeLocale: 'ur-PK' },
         start: '2026-08-12 10:00:00',
         end: '2026-08-14 11:30:00',
         dateFormat: 'dayMonth',
       });
+
       const isolated = container.querySelectorAll('bdi');
       expect(isolated).toHaveLength(2);
       expect(isolated[0].textContent).toBe('12 اگست 10:00am');
       expect(isolated[1].textContent).toBe('14 اگست 11:30am');
+      // No nested isolate splitting a date from its time
+      for (const end of isolated) {
+        expect(end.querySelectorAll('bdi')).toHaveLength(0);
+      }
+    });
+
+    it('isolates a time-only end too, so it cannot join a neighbouring run', () => {
+      const { container } = renderRange({
+        settings: { dateTimeLocale: 'ur-PK' },
+        start: '2026-08-12 10:00:00',
+        end: '2026-08-14 11:30:00',
+        onDate: '2026-08-14',
+        dateFormat: 'dayMonth',
+      });
+
+      const isolated = container.querySelectorAll('bdi');
+      expect(isolated).toHaveLength(2);
+      expect(isolated[0].textContent).toBe('12 اگست 10:00am');
+      expect(isolated[1].textContent).toBe('11:30am');
     });
   });
 });

--- a/packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx
+++ b/packages/web/__tests__/components/DateTimeRangeDisplay.test.jsx
@@ -30,7 +30,7 @@ const rangeText = () => screen.getByTestId('range').textContent.replace(/\u00a0/
 describe('DateTimeRangeDisplay', () => {
   const settings = { dateTimeLocale: 'en-AU' };
 
-  describe('without onDate', () => {
+  describe('inline range', () => {
     it('shows one date for a range within a single day', () => {
       renderRange({
         settings,
@@ -52,37 +52,6 @@ describe('DateTimeRangeDisplay', () => {
     it('shows the start alone when there is no end', () => {
       renderRange({ settings, start: '2026-08-12 10:00:00' });
       expect(rangeText()).toBe('12/08/2026 10:00am');
-    });
-  });
-
-  describe('with onDate', () => {
-    const start = '2026-08-12 10:00:00';
-    const end = '2026-08-14 11:30:00';
-
-    it('drops both dates when the range sits within the given day', () => {
-      renderRange({
-        settings,
-        start,
-        end: '2026-08-12 11:30:00',
-        onDate: '2026-08-12',
-        dateFormat: 'dayMonth',
-      });
-      expect(rangeText()).toBe('10:00am – 11:30am');
-    });
-
-    it('keeps only the end date on the first day of a span', () => {
-      renderRange({ settings, start, end, onDate: '2026-08-12', dateFormat: 'dayMonth' });
-      expect(rangeText()).toBe('10:00am – 14 Aug 11:30am');
-    });
-
-    it('keeps both dates on a day the range merely covers', () => {
-      renderRange({ settings, start, end, onDate: '2026-08-13', dateFormat: 'dayMonth' });
-      expect(rangeText()).toBe('12 Aug 10:00am – 14 Aug 11:30am');
-    });
-
-    it('keeps only the start date on the last day of a span', () => {
-      renderRange({ settings, start, end, onDate: '2026-08-14', dateFormat: 'dayMonth' });
-      expect(rangeText()).toBe('12 Aug 10:00am – 11:30am');
     });
   });
 
@@ -112,16 +81,6 @@ describe('DateTimeRangeDisplay', () => {
         end: '2026-08-12 23:00:00',
       });
       expect(rangeText()).toBe('11/08/2026 10:00am – 12/08/2026 1:00am');
-    });
-
-    it('decides onDate suppression against the display timezone too', () => {
-      renderRange({
-        settings: settingsInHonolulu,
-        start: '2026-08-12 23:30:00',
-        end: '2026-08-13 00:30:00',
-        onDate: '2026-08-12',
-      });
-      expect(rangeText()).toBe('1:30am – 2:30am');
     });
   });
 
@@ -153,9 +112,9 @@ describe('DateTimeRangeDisplay', () => {
     it('isolates a time-only end too, so it cannot join a neighbouring run', () => {
       const { container } = renderRange({
         settings: { dateTimeLocale: 'ur-PK' },
+        // Within one day, so the end is a time alone
         start: '2026-08-12 10:00:00',
-        end: '2026-08-14 11:30:00',
-        onDate: '2026-08-14',
+        end: '2026-08-12 11:30:00',
         dateFormat: 'dayMonth',
       });
 

--- a/packages/web/__tests__/views/dashboard/TodayBookingsPane.test.jsx
+++ b/packages/web/__tests__/views/dashboard/TodayBookingsPane.test.jsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { APPOINTMENT_STATUSES } from '@tamanu/constants';
+import { AuthContext, DateTimeProvider, SettingsContext } from '@tamanu/ui-components';
+
+import { renderElementWithTranslatedText } from '../../helpers/render';
+
+// The booking from the reported bug: 12 Aug 10:00am through to 14 Aug 11:30am.
+const OVERNIGHT_BOOKING = {
+  id: 'booking-overnight',
+  startTime: '2026-08-12 10:00:00',
+  endTime: '2026-08-14 11:30:00',
+  status: APPOINTMENT_STATUSES.ARRIVED,
+  patient: { firstName: 'Barton', lastName: 'Aufderhar' },
+  location: { name: 'Outpatient', locationGroup: { name: 'Outpatient' } },
+};
+
+const SAME_DAY_BOOKING = {
+  id: 'booking-same-day',
+  startTime: '2026-08-12 08:30:00',
+  endTime: '2026-08-12 09:00:00',
+  status: APPOINTMENT_STATUSES.SEEN,
+  patient: { firstName: 'Marisol', lastName: 'Frami' },
+  location: { name: 'Bed 2', locationGroup: { name: 'Ward 1' } },
+};
+
+const { bookings } = vi.hoisted(() => ({ bookings: { value: [] } }));
+
+vi.mock('../../../app/contexts/Auth', () => ({
+  useAuth: () => ({ currentUser: { id: 'user-1' }, facilityId: 'facility-1' }),
+}));
+
+vi.mock('../../../app/api/queries/useAutoUpdatingQuery', () => ({
+  useAutoUpdatingQuery: () => ({ data: { data: bookings.value } }),
+}));
+
+vi.mock('../../../app/api/mutations', () => ({
+  useUserPreferencesMutation: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('react-router', async importOriginal => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+import { TodayBookingsPane } from '../../../app/views/dashboard/components/TodayBookingsPane';
+
+const PRIMARY_TIME_ZONE = 'Pacific/Auckland';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+/**
+ * Drives "today" through the real clock rather than a stubbed `useDateTime`, so the
+ * date the pane compares against is the one the provider actually derives. 6:00 UTC
+ * is mid-evening in Auckland, well inside the intended day.
+ */
+const renderPane = ({ onDate, withBookings }) => {
+  vi.setSystemTime(new Date(`${onDate}T06:00:00Z`));
+  bookings.value = withBookings;
+  return renderElementWithTranslatedText(
+    <AuthContext.Provider value={{ primaryTimeZone: PRIMARY_TIME_ZONE }}>
+      <SettingsContext.Provider value={{ getSetting: key => ({ dateTimeLocale: 'en-AU' })[key] }}>
+        <DateTimeProvider>
+          <TodayBookingsPane />
+        </DateTimeProvider>
+      </SettingsContext.Provider>
+    </AuthContext.Provider>,
+  );
+};
+
+/** A row's lines, with the non-breaking space before the dash normalised. */
+const rowLines = () =>
+  [...document.querySelectorAll('[data-testid^="rangeline-"]')].map(line =>
+    line.textContent.replace(/\u00a0/g, ' '),
+  );
+
+describe('TodayBookingsPane overnight bookings', () => {
+  it('carries the end date on the first day, and leaves a same-day row alone', () => {
+    // Rows arrive sorted by start time, so on 12 Aug the 8:30am booking comes first
+    renderPane({ onDate: '2026-08-12', withBookings: [SAME_DAY_BOOKING, OVERNIGHT_BOOKING] });
+    expect(rowLines()).toEqual([
+      '8:30am – 9:00am', // one line, exactly as it renders today
+      '10:00am –',
+      '14 Aug 11:30am',
+    ]);
+  });
+
+  it('carries both dates on a day the stay merely covers', () => {
+    renderPane({ onDate: '2026-08-13', withBookings: [OVERNIGHT_BOOKING] });
+    expect(rowLines()).toEqual(['12 Aug 10:00am –', '14 Aug 11:30am']);
+  });
+
+  it('carries the start date on the last day of the stay', () => {
+    renderPane({ onDate: '2026-08-14', withBookings: [OVERNIGHT_BOOKING] });
+    expect(rowLines()).toEqual(['12 Aug 10:00am –', '11:30am']);
+  });
+
+  it('never shows the two times as though they were the same day', () => {
+    for (const onDate of ['2026-08-12', '2026-08-13', '2026-08-14']) {
+      const { unmount } = renderPane({ onDate, withBookings: [OVERNIGHT_BOOKING] });
+      expect(rowLines().join(' ')).not.toBe('10:00am – 11:30am');
+      unmount();
+    }
+  });
+
+  it('marks a booking spanning days with the overnight indicator', () => {
+    renderPane({ onDate: '2026-08-13', withBookings: [OVERNIGHT_BOOKING] });
+    expect(screen.getByTestId('overnighticon-p8ka')).toBeTruthy();
+  });
+
+  it('leaves a booking wholly within today unmarked, and on one line', () => {
+    renderPane({ onDate: '2026-08-12', withBookings: [SAME_DAY_BOOKING] });
+    expect(screen.queryByTestId('overnighticon-p8ka')).toBeNull();
+    expect(rowLines()).toEqual(['8:30am – 9:00am']);
+  });
+
+  it('shows a booking with no end time as a single time', () => {
+    renderPane({
+      onDate: '2026-08-12',
+      withBookings: [{ ...SAME_DAY_BOOKING, endTime: null }],
+    });
+    expect(rowLines()).toEqual(['8:30am']);
+    expect(screen.queryByTestId('overnighticon-p8ka')).toBeNull();
+  });
+});

--- a/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
+++ b/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
@@ -7,10 +7,17 @@ import TimelineSeparator from '@material-ui/lab/TimelineSeparator';
 import TimelineConnector from '@material-ui/lab/TimelineConnector';
 import TimelineContent from '@material-ui/lab/TimelineContent';
 import TimelineDot from '@material-ui/lab/TimelineDot';
+import Brightness2Icon from '@mui/icons-material/Brightness2';
 import { USER_PREFERENCES_KEYS, WS_EVENTS } from '@tamanu/constants';
 import { useNavigate } from 'react-router';
 import { Box } from '@material-ui/core';
-import { TranslatedText, useDateTime } from '@tamanu/ui-components';
+import {
+  DateDisplay,
+  TimeDisplay,
+  TranslatedText,
+  useDateRangeSpan,
+  useDateTime,
+} from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
 
 import { Heading4 } from '../../../components';
@@ -27,11 +34,11 @@ import { LOCATION_BOOKINGS_EMPTY_FILTER_STATE } from '../../../contexts/Location
 
 const Container = styled.div`
   ${({ showTasks }) => showTasks && 'flex-grow: 1; width: 100%;'}
-  min-width: 366px;
-  min-height: 41%;
+  min-inline-size: 22.875rem;
+  min-block-size: 41%;
   border: 1px solid ${Colors.outline};
   border-radius: 3px;
-  padding-top: 15px;
+  padding-block-start: 0.9375rem;
   background-color: ${Colors.white};
   display: flex;
   flex-direction: column;
@@ -41,9 +48,10 @@ const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid ${Colors.outline};
-  padding-bottom: 6px;
-  margin: 0 20px 11px;
+  border-block-end: 1px solid ${Colors.outline};
+  padding-block-end: 6px;
+  margin-inline: 1.25rem;
+  margin-block-end: 11px;
 `;
 
 const ActionLink = styled.span`
@@ -52,33 +60,43 @@ const ActionLink = styled.span`
   font-size: 14px;
 `;
 
+/**
+ * One grid for the whole list, with each row a subgrid of it, so the time column is
+ * a single track as wide as the widest row needs and every card starts at the same
+ * place. The track's floor is in `ch` rather than pixels because the times and dates
+ * are locale-formatted and their width belongs to the reader, not to the design.
+ */
 const StyledTimeline = styled(Timeline)`
-  padding-top: 0;
-  padding-right: 20px;
-  padding-left: 12px;
+  display: grid;
+  grid-template-columns: auto minmax(15ch, max-content) 1fr;
+  column-gap: 5px;
+  padding-block: 0;
+  padding-inline: 0.75rem 1.25rem;
   margin: 0;
-  margin-bottom: -16px;
+  margin-block-end: -1rem;
   overflow-y: auto;
-  ${({ length }) => `max-height: calc(60px * ${length} + 21px);`}
+  ${({ length }) => `max-block-size: calc(${length} * (3.75rem + 1lh) + 21px);`}
 `;
 
 const StyledTimelineContent = styled(TimelineContent)`
-  font-size: 14px;
-  display: flex;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 2 / -1;
   align-items: center;
-  gap: 5px;
+  font-size: 14px;
   padding: 0;
-  padding-left: 6px;
-  width: 0;
 `;
 
 const StyledTimelineConnector = styled(TimelineConnector)`
   background-color: ${Colors.outline};
-  width: 1px;
+  inline-size: 1px;
 `;
 
 const StyledTimelineItem = styled(TimelineItem)`
-  min-height: 60px;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  min-block-size: 3.75rem;
   &:before {
     content: none;
   }
@@ -101,13 +119,12 @@ const StyledTimelineSeparator = styled(TimelineSeparator)`
   top: 21px;
 `;
 
+/* Sized in lines of text, so it grows rather than clipping when a row wraps */
 const Card = styled.div`
-  background-color: ${Colors.outline};
-  height: 54px;
+  min-block-size: 3lh;
   border-radius: 3px;
-  padding: 8px 16px;
-  flex-grow: 0;
-  flex-shrink: 0;
+  padding-block: 8px;
+  padding-inline: 1rem;
   background-color: ${({ $color }) => `${$color}1a`};
 `;
 
@@ -124,17 +141,34 @@ const CardBody = styled(CardHeading)`
 `;
 
 const TimeText = styled.div`
-  flex-grow: 0;
-  flex-shrink: 0;
-  width: 122px;
-  text-transform: lowercase;
+  padding-inline-start: 6px;
+`;
+
+/**
+ * Each end of the range is its own line rather than one inline run that wraps. An
+ * icon is an atomic inline, so line breaks are allowed either side of it: left to
+ * wrap on its own it lands on a line of its own, and the width the grid track needs
+ * becomes hard to predict. As explicit lines, each one is unbreakable and the track
+ * is simply as wide as the wider of the two.
+ */
+const RangeLine = styled.div`
+  white-space: nowrap;
+`;
+
+const OvernightIcon = styled(Brightness2Icon)`
+  /* Tracks the text beside it rather than pinning a pixel size against 14px type */
+  font-size: 1em;
+  color: ${Colors.primary};
+  vertical-align: -0.1em;
+  margin-inline-start: 0.3em;
 `;
 
 const Footer = styled.div`
-  margin: 4px 20px 0;
+  margin-inline: 1.25rem;
+  margin-block-start: 4px;
   flex-grow: 1;
-  min-height: 20px;
-  border-top: 1px solid ${Colors.outline};
+  min-block-size: 1.25rem;
+  border-block-start: 1px solid ${Colors.outline};
   position: sticky;
   background-color: ${Colors.white};
 `;
@@ -158,10 +192,35 @@ const Link = styled.div`
   cursor: pointer;
 `;
 
-const BookingsTimelineItem = ({ appointment }) => {
-  const { formatTime } = useDateTime();
+/**
+ * One end of a booking's time range, isolated so a right-to-left month name cannot
+ * absorb the digits beside it and reorder the date against the time.
+ */
+const RangeEnd = ({ date, withDate, testIdSuffix }) => (
+  <bdi>
+    {withDate ? (
+      <DateDisplay
+        date={date}
+        format="dayMonth"
+        timeFormat="default"
+        noTooltip
+        data-testid={`datedisplay-${testIdSuffix}-w2kf`}
+      />
+    ) : (
+      <TimeDisplay date={date} noTooltip data-testid={`timedisplay-${testIdSuffix}-qz61`} />
+    )}
+  </bdi>
+);
+
+const BookingsTimelineItem = ({ appointment, today }) => {
   const { startTime, endTime, location, patient, status } = appointment;
   const { locationGroup } = location;
+
+  const { spansMultipleDays, hasEnd, showStartDate, showEndDate } = useDateRangeSpan({
+    start: startTime,
+    end: endTime,
+    onDate: today,
+  });
 
   const [headingRef, isHeadingOverflowing] = useOverflow();
   const [bodyRef, isBodyOverflowing] = useOverflow();
@@ -181,10 +240,38 @@ const BookingsTimelineItem = ({ appointment }) => {
         <StyledTimelineConnector data-testid="styledtimelineconnector-qmh4" />
       </StyledTimelineSeparator>
       <StyledTimelineContent data-testid="styledtimelinecontent-ptdu">
+        {/* A booking within the day keeps its single line. One that spans days takes
+            two, so neither line has to be broken to fit the column. */}
         <TimeText data-testid="timetext-4k7e">
-          {formatTime(startTime)} - {formatTime(endTime)}
+          {spansMultipleDays ? (
+            <>
+              <RangeLine data-testid="rangeline-start-8ptz">
+                <RangeEnd date={startTime} withDate={showStartDate} testIdSuffix="start" />
+                &nbsp;&ndash;
+              </RangeLine>
+              <RangeLine data-testid="rangeline-end-4vqx">
+                <RangeEnd date={endTime} withDate={showEndDate} testIdSuffix="end" />
+                <OvernightIcon
+                  aria-label="Overnight booking"
+                  aria-hidden={undefined}
+                  data-testid="overnighticon-p8ka"
+                />
+              </RangeLine>
+            </>
+          ) : (
+            <RangeLine data-testid="rangeline-start-8ptz">
+              <RangeEnd date={startTime} withDate={showStartDate} testIdSuffix="start" />
+              {hasEnd && (
+                <>
+                  &nbsp;&ndash; <RangeEnd date={endTime} withDate={false} testIdSuffix="end" />
+                </>
+              )}
+            </RangeLine>
+          )}
         </TimeText>
-        <Box width={0} flex={1} data-testid="box-i72x">
+        {/* min-width rather than width: in a grid track it is what lets the card
+            shrink below its content so the headings can ellipsise */}
+        <Box minWidth={0} data-testid="box-i72x">
           <ConditionalTooltip
             visible={showTooltip}
             title={
@@ -291,6 +378,7 @@ export const TodayBookingsPane = ({ showTasks }) => {
               <BookingsTimelineItem
                 key={appointment.id}
                 appointment={appointment}
+                today={todayFacility}
                 data-testid={`bookingstimelineitem-kl6a-${index}`}
               />
             ))}

--- a/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
+++ b/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
@@ -12,8 +12,7 @@ import { USER_PREFERENCES_KEYS, WS_EVENTS } from '@tamanu/constants';
 import { useNavigate } from 'react-router';
 import { Box } from '@material-ui/core';
 import {
-  DateDisplay,
-  TimeDisplay,
+  RangeEndDisplay,
   TranslatedText,
   useDateRangeSpan,
   useDateTime,
@@ -29,16 +28,17 @@ import useOverflow from '../../../hooks/useOverflow';
 import { ConditionalTooltip } from '../../../components/Tooltip';
 import { useAutoUpdatingQuery } from '../../../api/queries/useAutoUpdatingQuery';
 import { useAuth } from '../../../contexts/Auth';
+import { useTranslation } from '../../../contexts/Translation';
 import { useUserPreferencesMutation } from '../../../api/mutations';
 import { LOCATION_BOOKINGS_EMPTY_FILTER_STATE } from '../../../contexts/LocationBookings';
 
 const Container = styled.div`
   ${({ showTasks }) => showTasks && 'flex-grow: 1; width: 100%;'}
-  min-inline-size: 22.875rem;
-  min-block-size: 41%;
+  min-width: 366px;
+  min-height: 41%;
   border: 1px solid ${Colors.outline};
   border-radius: 3px;
-  padding-block-start: 0.9375rem;
+  padding-top: 15px;
   background-color: ${Colors.white};
   display: flex;
   flex-direction: column;
@@ -48,10 +48,9 @@ const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-block-end: 1px solid ${Colors.outline};
-  padding-block-end: 6px;
-  margin-inline: 1.25rem;
-  margin-block-end: 11px;
+  border-bottom: 1px solid ${Colors.outline};
+  padding-bottom: 6px;
+  margin: 0 20px 11px;
 `;
 
 const ActionLink = styled.span`
@@ -70,12 +69,12 @@ const StyledTimeline = styled(Timeline)`
   display: grid;
   grid-template-columns: auto minmax(15ch, max-content) 1fr;
   column-gap: 5px;
-  padding-block: 0;
-  padding-inline: 0.75rem 1.25rem;
+  padding-top: 0;
+  padding-right: 20px;
+  padding-left: 12px;
   margin: 0;
-  margin-block-end: -1rem;
+  margin-bottom: -16px;
   overflow-y: auto;
-  ${({ length }) => `max-block-size: calc(${length} * (3.75rem + 1lh) + 21px);`}
 `;
 
 const StyledTimelineContent = styled(TimelineContent)`
@@ -89,14 +88,14 @@ const StyledTimelineContent = styled(TimelineContent)`
 
 const StyledTimelineConnector = styled(TimelineConnector)`
   background-color: ${Colors.outline};
-  inline-size: 1px;
+  width: 1px;
 `;
 
 const StyledTimelineItem = styled(TimelineItem)`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1 / -1;
-  min-block-size: 3.75rem;
+  min-height: 60px;
   &:before {
     content: none;
   }
@@ -141,7 +140,7 @@ const CardBody = styled(CardHeading)`
 `;
 
 const TimeText = styled.div`
-  padding-inline-start: 6px;
+  padding-left: 6px;
 `;
 
 /**
@@ -160,15 +159,14 @@ const OvernightIcon = styled(Brightness2Icon)`
   font-size: 1em;
   color: ${Colors.primary};
   vertical-align: -0.1em;
-  margin-inline-start: 0.3em;
+  margin-left: 0.3em;
 `;
 
 const Footer = styled.div`
-  margin-inline: 1.25rem;
-  margin-block-start: 4px;
+  margin: 4px 20px 0;
   flex-grow: 1;
-  min-block-size: 1.25rem;
-  border-block-start: 1px solid ${Colors.outline};
+  min-height: 20px;
+  border-top: 1px solid ${Colors.outline};
   position: sticky;
   background-color: ${Colors.white};
 `;
@@ -192,27 +190,8 @@ const Link = styled.div`
   cursor: pointer;
 `;
 
-/**
- * One end of a booking's time range, isolated so a right-to-left month name cannot
- * absorb the digits beside it and reorder the date against the time.
- */
-const RangeEnd = ({ date, withDate, testIdSuffix }) => (
-  <bdi>
-    {withDate ? (
-      <DateDisplay
-        date={date}
-        format="dayMonth"
-        timeFormat="default"
-        noTooltip
-        data-testid={`datedisplay-${testIdSuffix}-w2kf`}
-      />
-    ) : (
-      <TimeDisplay date={date} noTooltip data-testid={`timedisplay-${testIdSuffix}-qz61`} />
-    )}
-  </bdi>
-);
-
 const BookingsTimelineItem = ({ appointment, today }) => {
+  const { getTranslation } = useTranslation();
   const { startTime, endTime, location, patient, status } = appointment;
   const { locationGroup } = location;
 
@@ -242,30 +221,27 @@ const BookingsTimelineItem = ({ appointment, today }) => {
       <StyledTimelineContent data-testid="styledtimelinecontent-ptdu">
         {/* A booking within the day keeps its single line. One that spans days takes
             two, so neither line has to be broken to fit the column. */}
+        {/* A booking within the day keeps its single line. One that spans days puts
+            its end on a second line, so neither line has to be broken to fit. */}
         <TimeText data-testid="timetext-4k7e">
-          {spansMultipleDays ? (
-            <>
-              <RangeLine data-testid="rangeline-start-8ptz">
-                <RangeEnd date={startTime} withDate={showStartDate} testIdSuffix="start" />
-                &nbsp;&ndash;
-              </RangeLine>
-              <RangeLine data-testid="rangeline-end-4vqx">
-                <RangeEnd date={endTime} withDate={showEndDate} testIdSuffix="end" />
-                <OvernightIcon
-                  aria-label="Overnight booking"
-                  aria-hidden={undefined}
-                  data-testid="overnighticon-p8ka"
-                />
-              </RangeLine>
-            </>
-          ) : (
-            <RangeLine data-testid="rangeline-start-8ptz">
-              <RangeEnd date={startTime} withDate={showStartDate} testIdSuffix="start" />
-              {hasEnd && (
-                <>
-                  &nbsp;&ndash; <RangeEnd date={endTime} withDate={false} testIdSuffix="end" />
-                </>
-              )}
+          <RangeLine data-testid="rangeline-start-8ptz">
+            <RangeEndDisplay date={startTime} dateFormat={showStartDate ? 'dayMonth' : null} />
+            {hasEnd && <>&nbsp;&ndash;</>}
+            {hasEnd && !spansMultipleDays && (
+              <>
+                {' '}
+                <RangeEndDisplay date={endTime} />
+              </>
+            )}
+          </RangeLine>
+          {spansMultipleDays && (
+            <RangeLine data-testid="rangeline-end-4vqx">
+              <RangeEndDisplay date={endTime} dateFormat={showEndDate ? 'dayMonth' : null} />
+              <OvernightIcon
+                aria-label={getTranslation('scheduling.bookingType.overnight', 'Overnight')}
+                aria-hidden={undefined}
+                data-testid="overnighticon-p8ka"
+              />
             </RangeLine>
           )}
         </TimeText>

--- a/specs/scheduling/overview.md
+++ b/specs/scheduling/overview.md
@@ -5,3 +5,14 @@ id: SCHEDULING
 # Scheduling
 
 Appointments and location/resource bookings.
+
+## Bookings that span more than one day
+
+A location booking may run from one calendar day into another, an **overnight booking**. Whether a booking spans more than one day is judged by the calendar days its start and end fall on in the display timezone, so a booking is overnight exactly when the person reading it would see it cross midnight.
+
+- [ ] A booking that spans more than one day belongs to each of the days it covers, from the day it starts to the day it ends, and appears in every one of those days' bookings.
+- [ ] Wherever a booking is listed against a particular day, each end of its time range carries the date that end falls on, except an end falling on the day being listed, which shows its time alone.
+- [ ] A booking listed against a day it neither starts nor ends on therefore carries a date on both ends, and a booking that starts and ends within the day being listed carries none.
+- [ ] A date shown alongside a time in a booking's range is a day and a month.
+- [ ] A booking spanning more than one day is marked with an overnight indicator wherever it is listed, including in lists compact enough to show only its times.
+- [ ] A date and the time beside it read in the order they were composed, including in a locale written right to left, where neither is reordered against the other.


### PR DESCRIPTION
### Changes

🤖 The dashboard's "Today's bookings" list rendered a booking's range as two bare times of day, so an overnight booking read as a short same-day booking on every day of the stay: a booking from 12 Aug 10:00am to 14 Aug 11:30am showed "10:00am - 11:30am" on all three days. Each end of the range now carries the date it falls on, except an end falling on the day being listed, and a booking spanning days is marked with the overnight icon. A booking wholly within today renders exactly as before.

Two fixes landed in `DateTimeRangeDisplay` along the way. Multi-day detection now compares the days as they are displayed rather than as they are stored, so it is correct where a facility timezone differs from the primary one. And each end is wrapped in a `bdi`, which fixes a bidi defect affecting every right-to-left locale, overnight or not: an Arabic-script month name pulls the digits after it into its own run, so "14 اگست 11:30am" rendered as "14 11:30 اگستam". The date-suppression decision is shared as a `useDateRangeSpan` hook so the pane's two-line layout and the component's inline layout cannot drift apart.

The pane's time column was a fixed 122px with no clipping rule, which already overflowed into the booking card in wider locales (the same range is 125px in en-AU, 148px in es-ES, 139px in ja-JP). The list is now one grid with each row a subgrid, so the time column is a single track as wide as the widest row needs, and every card starts at the same place whatever mix of one-line and two-line rows the list holds. Sizes that were pixel values are now in the unit that says what they mean.

One caveat for the reviewer: the layout was verified by measuring the pane's CSS in a browser against a copy of its DOM, not on the running dashboard. The part most worth a glance on screen is whether the styled-components overrides win over MUI's `Timeline` classes, since they sit at equal specificity.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
