### PR TITLE
fix(facility): TAM-7037: demote stranded outbox blobs only in the sweep

### DIFF
--- a/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
@@ -106,6 +106,12 @@ describe('PatientLetter', () => {
     }
 
     const hash = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+    await models.Blob.update(
+      { lastAccessedAt: new Date(Date.now() - 2 * 60 * 60 * 1000) },
+      { where: { hash }, silent: true },
+    );
+    await ctx.blobCache.demoteStrandedOutbox();
+
     expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
   });
 

--- a/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
+++ b/packages/facility-server/__tests__/blobCache/outboxAdmission.test.js
@@ -135,7 +135,7 @@ describe('outbox admission and the referencing record', () => {
     expect(await models.Blob.findOne({ where: { hash } })).toBeNull();
   });
 
-  it('leaves no outbox row when the attachment record write fails', async () => {
+  it('leaves no outbox row once the sweep reaches an attachment write that failed', async () => {
     // verifies spec: CACHE — a blob whose referencing record is never created is
     // not left in the outbox, where a facility can neither push it nor evict it
     const { hash } = await stageUpload();
@@ -145,6 +145,8 @@ describe('outbox admission and the referencing record', () => {
         patientId: 'patient-that-does-not-exist',
       }),
     ).rejects.toThrow();
+    await ageBlob(hash, BEYOND_SAFETY_WINDOW_MS);
+    await blobCache.demoteStrandedOutbox();
 
     expect(await models.Attachment.findOne({ where: { hash } })).toBeNull();
     expect(await outboxRowFor(hash)).toBeNull();
@@ -160,18 +162,21 @@ describe('outbox admission and the referencing record', () => {
         patientId: 'patient-that-does-not-exist',
       }),
     ).rejects.toThrow();
+    await ageBlob(hash, BEYOND_SAFETY_WINDOW_MS);
+    await blobCache.demoteStrandedOutbox();
 
     expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
     expect(await blobStore.has(hash)).toBe(true);
   });
 
-  it('leaves an outbox blob alone when a failed upload deduplicated onto it', async () => {
-    // verifies spec: CACHE — content already referenced by a live record is not
-    // demoted out from under it by a later upload of the same bytes
+  it('keeps content pushable when another upload of the same file fails', async () => {
+    // verifies spec: CACHE — the upload that succeeds admits its content first
+    // and writes its record last, so the failing upload of the same bytes sees a
+    // blob nothing references yet. Its admission and record write are split to
+    // hold that ordering, which is what the two uploads race for.
     const patient = await models.Patient.create(fake(models.Patient));
     const content = Buffer.from(`uploaded document ${randomUUID()}`);
-    const { hash } = await stageUpload(content);
-    await uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, { patientId: patient.id });
+    const { hash, size } = await blobCache.putOutbox(Readable.from(content));
 
     await stageUpload(content);
     await expect(
@@ -180,25 +185,7 @@ describe('outbox admission and the referencing record', () => {
       }),
     ).rejects.toThrow();
 
-    expect(await outboxRowFor(hash)).not.toBeNull();
-  });
-
-  it('pushes the content to central when a failed upload is retried', async () => {
-    // verifies spec: CACHE — content demoted when its record write failed
-    // rejoins the outbox on the upload that does reference it, so the pusher
-    // still delivers the bytes central has never been offered
-    const patient = await models.Patient.create(fake(models.Patient));
-    const content = Buffer.from(`uploaded document ${randomUUID()}`);
-    const { hash } = await stageUpload(content);
-    await expect(
-      uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, {
-        patientId: 'patient-that-does-not-exist',
-      }),
-    ).rejects.toThrow();
-    expect(await outboxRowFor(hash)).toBeNull();
-
-    await stageUpload(content);
-    await uploadAttachment({ models, blobCache }, DOCUMENT_SIZE_LIMIT, { patientId: patient.id });
+    await models.Attachment.create({ type: 'application/pdf', hash, size, patientId: patient.id });
 
     const pushed = [];
     await new BlobOutboxPusher({

--- a/packages/facility-server/app/blobCache/FacilityBlobCache.js
+++ b/packages/facility-server/app/blobCache/FacilityBlobCache.js
@@ -90,50 +90,21 @@ export class FacilityBlobCache {
 
   // spec: CACHE
   /**
-   * Demote a blob whose referencing record failed to write, so it does not sit
-   * in the outbox where this server can neither push nor evict it. Best effort:
-   * the caller is already failing with its own error, and the periodic sweep
-   * covers whatever this misses.
-   */
-  async demoteIfStranded(hash) {
-    try {
-      return await this.#demoteStranded({ hash });
-    } catch (error) {
-      log.warn('FacilityBlobCache: could not demote a stranded outbox blob', {
-        hash,
-        error: error.message,
-      });
-      return [];
-    }
-  }
-
-  // spec: CACHE
-  /**
-   * Demote every outbox blob no live record references. Covers what a write
-   * path cannot: a crash between admission and the record write leaves no
-   * catch to run, and the blob would otherwise persist forever.
+   * Demote every outbox blob no live record references, which nothing else
+   * reclaims: a crash between admission and the record write leaves no catch to
+   * run, and the blob would otherwise persist forever.
+   *
+   * Demotes rather than deletes, and tests the reference in the same statement
+   * as the update: admission is content-addressed and idempotent, so these bytes
+   * may be the only copy backing a reference this pass cannot see.
    */
   async demoteStrandedOutbox() {
-    const demoted = await this.#demoteStranded({ minimumAgeMs: STRANDED_SAFETY_WINDOW_MS });
-    if (demoted.length > 0) {
-      log.info('FacilityBlobCache: demoted stranded outbox blobs', { hashes: demoted });
-    }
-    return demoted;
-  }
-
-  // Demotes rather than deletes, and tests the reference in the same statement
-  // as the update: admission is content-addressed and idempotent, so these bytes
-  // may be the only copy backing a reference this pass cannot see.
-  async #demoteStranded({ hash, minimumAgeMs = 0 }) {
     const [, demoted] = await this.#models.Blob.update(
       { tier: BLOB_TIERS.CACHE, eligibleSinceTick: null },
       {
         where: {
           tier: BLOB_TIERS.OUTBOX,
-          ...(hash ? { hash } : {}),
-          ...(minimumAgeMs
-            ? { lastAccessedAt: { [Op.lt]: new Date(Date.now() - minimumAgeMs) } }
-            : {}),
+          lastAccessedAt: { [Op.lt]: new Date(Date.now() - STRANDED_SAFETY_WINDOW_MS) },
           [Op.and]: [literal(UNREFERENCED_BLOB_CONDITION)],
         },
         returning: ['hash'],
@@ -143,7 +114,11 @@ export class FacilityBlobCache {
       // spec: FEC — a facility covers only its outbox with parity.
       await this.#blobStore.discardParity(blob.hash);
     }
-    return demoted.map(blob => blob.hash);
+    const hashes = demoted.map(blob => blob.hash);
+    if (hashes.length > 0) {
+      log.info('FacilityBlobCache: demoted stranded outbox blobs', { hashes });
+    }
+    return hashes;
   }
 
   // spec: CACHE

--- a/packages/facility-server/app/routeHandlers/createPatientLetter.js
+++ b/packages/facility-server/app/routeHandlers/createPatientLetter.js
@@ -47,19 +47,13 @@ export const createPatientLetter = (modelName, idField) =>
     );
     fs.unlink(filePath, () => null);
 
-    let attachmentId;
-    try {
-      ({ id: attachmentId } = await models.Attachment.create({
-        type: mimeType,
-        hash,
-        size: storedSize,
-        [idField]: params.id,
-        ...(modelName === 'Encounter' ? { patientId: specifiedObject.patientId } : {}),
-      }));
-    } catch (error) {
-      await req.blobCache.demoteIfStranded(hash);
-      throw error;
-    }
+    const { id: attachmentId } = await models.Attachment.create({
+      type: mimeType,
+      hash,
+      size: storedSize,
+      [idField]: params.id,
+      ...(modelName === 'Encounter' ? { patientId: specifiedObject.patientId } : {}),
+    });
 
     const documentMetadataObject = await models.DocumentMetadata.create({
       name,

--- a/packages/facility-server/app/utils/uploadAttachment.js
+++ b/packages/facility-server/app/utils/uploadAttachment.js
@@ -27,18 +27,12 @@ export const uploadAttachment = async (req, maxFileSize, scope = {}) => {
     const { hash, size: storedSize } = await blobCache.putOutbox(fs.createReadStream(file), {
       sizeHint: size,
     });
-    let attachment;
-    try {
-      attachment = await models.Attachment.create({
-        type,
-        hash,
-        size: storedSize,
-        ...scope,
-      });
-    } catch (error) {
-      await blobCache.demoteIfStranded(hash);
-      throw error;
-    }
+    const attachment = await models.Attachment.create({
+      type,
+      hash,
+      size: storedSize,
+      ...scope,
+    });
 
     return {
       attachmentId: attachment.id,


### PR DESCRIPTION
### Changes

Demoting a stranded blob from the write path ran with no age window, so a failing upload could mark bytes reclaimable at the moment a concurrent upload of the same content was about to commit its record. The loser is a patient attachment whose only copy becomes evictable and stops being pushed, so central never receives it. Bugbot flagged this as High on the previous PR and it was a known residual there.

The sweep cannot make that mistake, so it is now the only thing that demotes. `demoteIfStranded` and its calls in `uploadAttachment` and `createPatientLetter` are gone; the window, the reference predicate and the parity discard are unchanged.

What makes the sweep safe is recency, and it is worth checking rather than trusting. `BLOB_TIERS.OUTBOX` reaches `blobStore.put` in exactly one place, `FacilityBlobCache.putOutbox`, so all four admission paths (`uploadAttachment`, `createPatientLetter`, `admitAttachmentBlob` for survey photos and FHIR, and the blank-a-photo route) refresh recency when admission deduplicates. A fresh admission is covered by `last_accessed_at` defaulting to `now()`. Either way a row whose record write is still in flight sits inside the window, so the sweep's `last_accessed_at < now() - 1h` cannot match it.

The cost is that disk from a failed upload waits for the sweep instead of being reclaimed immediately.

Three tests moved to the sweep rather than being dropped. Two were removed as vacuous, and one of those is worth a reviewer's attention: a sequential retry cannot pin this behaviour, because the retry's own admission promotes the blob back to the outbox and the push succeeds whether or not the write path demoted. The replacement holds the ordering that does distinguish them, with the succeeding upload admitting first and committing its record last.

One case is left open, unchanged by this. `existed` reports whether the file was on disk, not whether a row existed, so a live row whose bytes are absent skips the promotion. Closing it is one line, dropping the `if (admitted.existed)` guard at the cost of a redundant update on every fresh admission.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
