### PR TITLE
chore: TAM-7037: correct the cache tier claims in specs and test cases

### DIFF
--- a/.workhorse/test-cases/b2/overview.md
+++ b/.workhorse/test-cases/b2/overview.md
@@ -216,8 +216,10 @@ consumer guarantee and a serving guarantee at once.
 
 ### Tiers and read-through
 
-- [x] Locally originated content is admitted at the outbox tier, and content already held as cache stays cache when the same bytes are admitted as outbox (verifies spec: CACHE)
+- [x] Locally originated content is admitted at the outbox tier, and content already held as cache returns to the outbox when the same bytes are admitted locally (verifies spec: CACHE)
 - [x] An acknowledged blob is demoted to cache and its push-eligibility marker cleared (verifies spec: CACHE)
+- [x] Content stranded by an attachment write that failed is demoted to evictable cache rather than deleted, so the space is reclaimable and the bytes survive; a blob a record still references is left in the outbox, and one admitted inside the safety window is left alone (verifies spec: CACHE, RECL)
+- [x] Re-admitting content already held refreshes its recency, so a stranded blob whose new reference has not yet committed is not swept (verifies spec: CACHE, RECL)
 - [x] A read of content held locally serves the stored bytes and refreshes stale recency, while one inside the coalescing window leaves recency unchanged (verifies spec: CACHE)
 - [x] A read of content the server has dropped fetches it from central, admits it as cache, and serves it, so the cache is genuinely disposable (verifies spec: CACHE)
 - [x] A read of content held neither locally nor reachable reports not-found rather than hanging (verifies spec: CACHE)
@@ -226,7 +228,7 @@ consumer guarantee and a serving guarantee at once.
 
 - [x] Once over budget, the least-recently-used cache blobs go first and the more recent ones survive (verifies spec: CACHE)
 - [x] A lone cache blob larger than the entire budget is not evicted merely to satisfy the budget (verifies spec: CACHE)
-- [x] Outbox blobs are left untouched while cache blobs around them are evicted, so content not yet durable on central is never reclaimed (verifies spec: CACHE, RECL)
+- [x] Outbox blobs are left untouched while cache blobs around them are evicted, so content awaiting its push is never reclaimed (verifies spec: CACHE, RECL)
 - [x] A blob with a read in progress survives the pass and is evicted only once that read has completed and closed (verifies spec: CACHE)
 - [x] Free-disk-floor pressure evicts even the sole most-recently-used blob, which budget enforcement would have protected (verifies spec: CACHE, CAP)
 - [x] A changed budget applies on the next enforcement pass, with no restart (verifies spec: CACHE)
@@ -248,6 +250,15 @@ consumer guarantee and a serving guarantee at once.
 - [x] The same bytes captured twice resolve to one stored blob and keep the tier already recorded (verifies spec: MOB, CACHE)
 - [x] A capture is refused with an error naming the device's storage when free space is already below the device's reserve, and cache is evicted before that refusal (verifies spec: MOB, CAP)
 
+### Photo answers
+
+- [x] A photo the answer already holds is shown when the question is returned to, and is offered for removal rather than reading as no photo at all (verifies spec: MOB, ATCH)
+- [x] A photo the device does not hold is fetched by hash and shown (verifies spec: MOB, XFER)
+- [x] Content still awaiting upload from the capturing device, content that cannot be fetched with no connectivity, and a record that has not reached this device each report their own state rather than one generic error (verifies spec: MOB, XFER)
+- [x] A read still in flight when connectivity is reported completes rather than being cancelled, and a photo that could not be fetched is retried once connectivity returns (verifies spec: MOB, XFER)
+- [x] A read landing after the photo was removed or replaced is discarded rather than restoring what it replaced (verifies spec: MOB)
+- [x] Removing a photo demotes its blob to reclaimable cache, unless another attachment still references the same hash (verifies spec: MOB, CACHE)
+
 ### Reads, tiers and reconciliation
 
 - [x] Content the device holds is read from the store without touching the transfer channel (verifies spec: MOB)
@@ -259,6 +270,8 @@ consumer guarantee and a serving guarantee at once.
 - [x] A pre-blob-store attachment whose record has already been pushed is adopted as evictable cache with its hash set and its sync tick untouched (verifies spec: MOB)
 - [x] A pre-blob-store attachment whose file is gone loses its pointer and presents as awaiting content (verifies spec: MOB)
 - [x] One legacy row that cannot be adopted is left for a later start without stalling the rest of the pass (verifies spec: MOB)
+- [x] Cache-tier content returns to the outbox when the device captures the same bytes, so content the central server never received is pushed rather than left evictable (verifies spec: CACHE, MOB)
+- [x] Content stranded by a capture whose record never landed, then captured again, reaches the central server rather than staying reclaimable (verifies spec: CACHE, MOB)
 
 ---
 
@@ -559,8 +572,6 @@ bites hardest if it silently stops being true.
 - [ ] Budget enforcement at admission: a read that fetches while over budget evicts least-recently-used content and keeps the new arrival (verifies spec: CACHE)
 - [ ] `BlobCacheEvictorTask` and `BlobOutboxPusherTask` call through, and no-op before the cache and pusher are wired (verifies spec: CACHE)
 - [ ] The facility cache budget resolves from `blobStorage.cacheSizeBudgetGB`, unit conversion included (verifies spec: CACHE)
-- [ ] Outbox admission is coupled to the referencing record on a facility: an attachment write that fails after admission leaves no outbox row. Mobile has a reconciliation pass for this and the facility has neither it nor a test (verifies spec: CACHE)
-- [ ] `UploadPhoto`: capture admits to the outbox and records only the hash; an insufficient-storage refusal shows the device-storage message and leaves no attachment; removing a photo demotes its blob only when no other attachment references that hash (verifies spec: MOB, CACHE)
 - [ ] `ViewPhotoLink`: content held on the device renders with no central call, and each of the three distinct unavailable messages appears in its own case (verifies spec: MOB)
 - [ ] A device retains its attachment records after the bytes reach central, which is what makes the content refetchable (verifies spec: MOB)
 

--- a/specs/blob-storage/reclamation.md
+++ b/specs/blob-storage/reclamation.md
@@ -56,4 +56,7 @@ implements this has to answer both:
 - [ ] Facility and mobile servers hold blobs as a bounded cache and reclaim space
   by evicting cached blobs under a least-recently-used and size budget, never by
   orphan collection.
-- [ ] A blob that is not yet durable on the central server is never evicted.
+- [ ] A blob awaiting its push is never evicted: it stays in the outbox until the
+  central server acknowledges it. Content no record references is demoted out of
+  the outbox and reclaimed with the rest of the cache, whether or not the central
+  server ever received it.


### PR DESCRIPTION
### Changes

Returning re-admitted content to the outbox changed a rule that three documents still state the old way, which matters because QA reads these as the statement of intended behaviour.

`reclamation.md` claimed "a blob that is not yet durable on the central server is never evicted". That is no longer true and cannot be made true: stranded content is demoted precisely so its space can be reclaimed, and making eviction check durability would mean never reclaiming it. The criterion now says what actually holds. A blob awaiting its push is never evicted, because it stays in the outbox until central acknowledges it; content no record references is demoted out and reclaimed with the rest of the cache.

Two test-case entries asserted the reversed behaviour. One ticked "content already held as cache stays cache when the same bytes are admitted as outbox", which is exactly what changed. The other justified leaving outbox blobs alone with "content not yet durable on central is never reclaimed", the same claim as above.

The equivalent entry at the store level is left alone deliberately: `MobileBlobStore` and `BlobStore` still leave a live row's tier untouched on re-admission, and their tests still assert it. That primitive did not change; the tier policy above it did.

Two items move out of the automatable-but-unwritten list because they are now written: the facility's coupling of outbox admission to the referencing record, and the `UploadPhoto` capture, storage-refusal and shared-hash removal cases. Their covered equivalents are added, along with entries for the photo resolution, connectivity and stale-read cases and the mobile durability sequence. Every added entry is worded from a test that exists on this branch rather than from what the changes were meant to do.

`ViewPhotoLink` stays on the unwritten list; nothing here covers it.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
