### PR TITLE
fix: no-issue: scrub secrets from the seed database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,8 @@ ENV NODE_CONFIG_DIR=/app/packages/central-server/config \
 ENTRYPOINT ["bash", "-euc"]
 # DB_* come from the connection Secret the pgsnap operator injects via envFrom.
 # ROUNDS sets the fake-data volume; override it to scale the snapshot's size.
+# The scrub runs last: migrate provisions secrets encrypted with this image's key file,
+# which the deploy restoring the snapshot doesn't have, so they must not ship in it.
 CMD ["\
 export CONFIG_SYNC_DB_HOST=\"$DB_HOST\" CONFIG_SYNC_DB_PORT=\"$DB_PORT\" \
        CONFIG_SYNC_DB_NAME=\"$DB_NAME\" CONFIG_SYNC_DB_USERNAME=\"$DB_USERNAME\" \
@@ -91,7 +93,8 @@ node --import tsx app migrate\n\
 node --import tsx ../scripts/src/fake.mts \
   --database \"$DB_NAME\" \
   --rounds \"$ROUNDS\" \
-  --from-tally ../fake-data/src/populateDb/parseTally/standard.json\
+  --from-tally ../fake-data/src/populateDb/parseTally/standard.json\n\
+node --import tsx ../scripts/src/scrubSeedSecrets.mts\
 "]
 
 

--- a/packages/database/__tests__/models/LocalSystemSecret.test.ts
+++ b/packages/database/__tests__/models/LocalSystemSecret.test.ts
@@ -41,6 +41,15 @@ describe('LocalSystemSecret', () => {
     expect(await models.LocalSystemSecret.get(FACT_DEVICE_KEY)).toBe('first');
   });
 
+  it('mints and stores a device key when none is held', async () => {
+    const deviceKey = await models.LocalSystemSecret.getDeviceKey();
+    expect(deviceKey.privateKeyPem()).toContain('BEGIN');
+    expect(isEncryptedSecret(await rawValue(FACT_DEVICE_KEY))).toBe(true);
+
+    const reread = await models.LocalSystemSecret.getDeviceKey();
+    expect(reread.privateKeyPem()).toBe(deviceKey.privateKeyPem());
+  });
+
   it('self-heals a legacy plaintext value on read', async () => {
     // Simulate a row moved from local_system_facts before encryption was
     // mandatory by writing plaintext straight to the column.

--- a/packages/scripts/src/scrubSeedSecrets.mts
+++ b/packages/scripts/src/scrubSeedSecrets.mts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+// Clears the secrets migrate provisioned, so the snapshot taken from a seed build ships
+// none of them: they are encrypted with that build's key file, which never leaves it, and
+// a deploy restoring the snapshot provisions its own under its own key file.
+
+import config from 'config';
+import type { Sequelize } from '@tamanu/database';
+import { initDatabase } from '@tamanu/database/services/database';
+import { resolveDbConfig } from '@tamanu/database/services/connectionConfig';
+
+// Cleared secrets can't decrypt anything left behind, so refuse to ship a snapshot
+// whose facts or settings still hold encrypted values.
+const OTHER_ENCRYPTABLE_TABLES = ['local_system_facts', 'settings'];
+
+const queryKeys = async (sequelize: Sequelize, sql: string): Promise<string[]> => {
+  const [rows] = await sequelize.query(sql);
+  return (rows as { key: string }[]).map(({ key }) => key);
+};
+
+async function scrubSeedSecrets(sequelize: Sequelize): Promise<string[]> {
+  const encrypted: string[] = [];
+  for (const table of OTHER_ENCRYPTABLE_TABLES) {
+    const keys = await queryKeys(
+      sequelize,
+      `SELECT key FROM ${table} WHERE deleted_at IS NULL AND ltrim(value::text, '"') LIKE 'S1:%'`,
+    );
+    encrypted.push(...keys.map(key => `${table}.${key}`));
+  }
+  if (encrypted.length > 0) {
+    throw new Error(
+      `Encrypted values remain in the seeded database and only this build's key file can ` +
+        `read them: ${encrypted.join(', ')}`,
+    );
+  }
+
+  // Hard delete: the unique index on `key` ignores deleted_at, so a soft-deleted row
+  // would leave setIfAbsent a silent no-op and the secret would never be reprovisioned.
+  return queryKeys(sequelize, 'DELETE FROM local_system_secrets RETURNING key');
+}
+
+async function main() {
+  const { sequelize } = await initDatabase({
+    ...resolveDbConfig((config as any).db),
+    alwaysCreateConnection: false,
+  });
+
+  try {
+    const cleared = await scrubSeedSecrets(sequelize);
+    console.log('Cleared seed secrets:', cleared.join(', ') || 'none');
+  } finally {
+    await sequelize.close();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Changes

Every deploy seeded from a database snapshot fails, and has done since `local_system_secrets` landed in 2.62 (#10082). The snapshot carries secrets encrypted with the seed build's key file; the deploy restoring it has its own. `LocalSystemSecret.get` throws on an undecryptable value rather than returning null, and `initDeviceKey`'s check is `!(await LocalSystemSecret.get(FACT_DEVICE_KEY))`, so the existence probe itself explodes. Migrations apply fine, then the upgrade dies and every pod behind it crash-loops. The surfaced error is a grants failure about thirty minutes in, which points nowhere near the cause.

The seed now scrubs its secrets as its last step, so snapshots ship without them and each deploy mints its own.

The delete has to be hard, which is the one way this could have relocated the failure: `local_system_secrets` has a unique index on `key` that ignores `deleted_at`, and `setIfAbsent` inserts `ON CONFLICT (key) DO NOTHING`, so a soft-deleted row would make PSK provisioning a silent permanent no-op and the deploy would come up with no PSK and no error.

The scrub refuses to run if `local_system_facts` or `settings` still hold `S1:` ciphertext, and checks before deleting. Today the seed creates no encrypted settings, since all seven `secret: true` leaves resolve from config values that are empty in `default.json5` and the image runs with no `local.json5`. If that ever changes, the seed Job fails and no snapshot is taken, rather than a deploy failing later on a setting it cannot decrypt.

Clearing the other two secrets is safe. Nothing persisted is bound to the device key; its only consumer uses it as an mTLS client cert. The sync password is never present in a seed at all, being facility-only.

Two pre-existing issues of the same class are left alone: the seed records `centralConfigMigratedToSettings`, so a restored deploy never migrates its own config and the seed's settings rows win over its config file; and `fake()` leaves 50 users whose password derives from their `phone_number` column, so every snapshot-seeded deployment carries them.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
