### PR TITLE
test(blobs): TAM-7037: close the remaining automatable coverage gaps

### DIFF
--- a/.workhorse/test-cases/b2/overview.md
+++ b/.workhorse/test-cases/b2/overview.md
@@ -533,28 +533,15 @@ rediscovered by re-running the audit. None is an epic blocker: each is a guarant
 the code appears to hold and nothing asserts. Ordered within each area by what
 bites hardest if it silently stops being true.
 
-## Access control and scoping
-
-- [ ] Blob scoping agrees with the record sync pull filter. `isHashReferencedInScope` reproduces `snapshotOutgoingChanges`' scope predicate by hand; both are covered individually and nothing asserts they agree, so they can drift and blob access can widen past what record sync grants (verifies spec: BLAC)
-- [ ] A facility list where one facility is accessible and another is not, which is the case a permissive loop would leak (verifies spec: BLAC)
-- [ ] The permission refusal on a hash-backed attachment specifically; the existing cases use a legacy in-database row (verifies spec: BLAC)
-- [ ] Attachments authorise a fetch through real `attachments` rows rather than the scratch table the scope gate is exercised against (verifies spec: BLAC, ATCH)
-- [ ] The sensitive-facility restriction covers `attachments`; the sync suite covers `lab_request_attachments` only (verifies spec: BLAC, ATCH)
-
 ## Antivirus
 
-- [ ] `createScannerDriver` returns nothing for `none` and a clamd driver for `clamd`. It has no test at all, and it is the whole of "a server opts in by naming the scanner it drives" (verifies spec: AV)
-- [ ] A quarantine record written on central reaches a facility and a device through a sync session. `BlobQuarantine` is `PULL_FROM_CENTRAL` with no filter, and nothing drives the propagation the containment story depends on (verifies spec: AV)
 - [ ] A facility scan finding malware leaves `blob_quarantines` untouched, since the propagating record is central's to write (verifies spec: AV)
 - [ ] An infected verdict discards existing parity, which both application contexts do from `onInfected` (verifies spec: AV, FEC)
 - [ ] Central refuses to repair known-bad content from parity; the facility equivalent is covered and central's is not (verifies spec: AV, FEC)
-- [ ] A verdict and an integrity state are independent, so recording one leaves the other alone (verifies spec: AV)
 - [ ] The scan pass ordering runs against the real database, not only the in-memory registry's own sort (verifies spec: AV)
 
 ## Serving and transfer
 
-- [ ] A whole-blob serve begins writing before the source has produced its last chunk, which is what "streamed rather than read into memory" means (verifies spec: SERVE)
-- [ ] A client disconnecting mid-download is not an error and leaves no open file handle; `serveBlob` swallows `ERR_STREAM_PREMATURE_CLOSE` deliberately and nothing pins it (verifies spec: SERVE)
 - [ ] The channel sends `facilityIds` on every operation. The fake connection ignores the query string, so only the construction-time guard ties the channel to its scope (verifies spec: BLAC, XFER)
 - [ ] A background fetch refused for capacity leaves the reference content-pending and retries (verifies spec: CAP, XFER)
 - [ ] Transfers of different hashes proceed concurrently rather than serialising behind each other (verifies spec: XFER)
@@ -562,42 +549,28 @@ bites hardest if it silently stops being true.
 
 ## Store and capacity
 
-- [ ] `blobs` is local: `DO_NOT_SYNC`, no changelog trigger, no sync tick column. The generic sync invariants do not reach it, since the tick column is derived from the sync direction (verifies spec: CAS)
-- [ ] Atomic placement where the destination cannot be renamed over: the retriable-rename path and its attempt cap have no test (verifies spec: CAS)
 - [ ] The store root comes from the `blobStorage.root` setting, and a relative value resolves against the working directory (verifies spec: CAP)
-- [ ] Facility outbox dysfunction escalation, including the in-flight exclusion that makes an actively progressing transfer healthy accumulation (verifies spec: CAP)
 
 ## Cache, outbox and mobile
 
-- [ ] Budget enforcement at admission: a read that fetches while over budget evicts least-recently-used content and keeps the new arrival (verifies spec: CACHE)
-- [ ] `BlobCacheEvictorTask` and `BlobOutboxPusherTask` call through, and no-op before the cache and pusher are wired (verifies spec: CACHE)
-- [ ] The facility cache budget resolves from `blobStorage.cacheSizeBudgetGB`, unit conversion included (verifies spec: CACHE)
-- [ ] `ViewPhotoLink`: content held on the device renders with no central call, and each of the three distinct unavailable messages appears in its own case (verifies spec: MOB)
 - [ ] A device retains its attachment records after the bytes reach central, which is what makes the content refetchable (verifies spec: MOB)
 
 ## Consumers
 
-- [ ] Creating an attachment succeeds with central unreachable, at the outbox tier, for both document uploads and patient letters (verifies spec: ATCH)
 - [ ] The document upload route's own size limit, which is never applied end to end because `uploadAttachment` is mocked away in the route tests (verifies spec: ATCH)
-- [ ] A facility upload the store refuses for capacity, covered on central only (verifies spec: ATCH, CAP)
 - [ ] A facility retains its attachment records after they sync, which the move from push-then-delete to bidirectional changed (verifies spec: ATCH)
-- [ ] Certificate and patient-letter rendering resolve a hash-form asset, and fail rather than printing unbranded when the bytes cannot be resolved (verifies spec: ASSET)
-- [ ] A facility-specific asset is preferred over the deployment-wide one, on both the endpoint and the letter renderer (verifies spec: ASSET)
+- [ ] `makePatientCertificate` and `makePatientLetter` resolve a hash-form asset, and fail rather than printing unbranded when the bytes cannot be resolved; both suites stub the asset lookup away. The browser's half is covered, in `useCertificate` holding a pending asset back (verifies spec: ASSET)
+- [ ] A facility-specific asset is preferred over the deployment-wide one in the letter renderer, which repeats the rule the endpoint applies; the endpoint is covered and the renderer is not (verifies spec: ASSET)
 - [ ] Asset blobs are ordinary cache-tier content: prefetched at the cache tier, evictable, refetched after eviction (verifies spec: ASSET, CACHE)
-- [ ] `useAssetQuery` suppresses the fallback for a content-pending asset, and `useCertificate` folds pending into its not-ready signal (verifies spec: ASSET)
 
 ## Backfill
 
-- [ ] The rollback subcommand has no test at all: that it drains both reference tables then the changelog, its default batch size, and that an explicit zero delay runs without pausing (verifies spec: BKFL)
 - [ ] Rollback when the store is not intact, which the spec makes a precondition and nothing pins (verifies spec: BKFL)
-- [ ] Batch pacing: the pause between batches is taken and is the configured length. Both suites run with it set to zero (verifies spec: BKFL)
-- [ ] `BlobBackfillTask` is in the default task list on both servers, which is what makes the backfill run with no operator action (verifies spec: BKFL)
-- [ ] Completion reporting's three outcomes, the only operator-visible completion signal (verifies spec: BKFL)
+- [ ] `BlobBackfillTask` is in the facility's default task list, which is what makes the backfill run there with no operator action; central's is covered and the facility's is not (verifies spec: BKFL)
 - [ ] Two servers rewriting the same changelog entry independently produce identical content, the basis for entries never re-synchronising and still converging (verifies spec: BKFL)
 
 ## Integrity
 
-- [ ] Central's opportunistic peer heal: central holds a corrupt copy, a facility connects and offers the hash, central takes the bytes and returns to verified (verifies spec: SCRUB)
 - [ ] An evicted cache blob is not reported as a fault by a later scrub (verifies spec: SCRUB)
 - [ ] Scheduled bounds resolve from settings for central's scrub and both servers' scan; only the facility scrub asserts it (verifies spec: SCRUB, AV)
 

--- a/.workhorse/test-cases/b2/overview.md
+++ b/.workhorse/test-cases/b2/overview.md
@@ -528,53 +528,11 @@ close one. All five found in the audit are now closed: two in #10752, two in
 
 # Automatable, not yet written
 
-Gaps the coverage audit found that a test could close, listed so they are not
-rediscovered by re-running the audit. None is an epic blocker: each is a guarantee
-the code appears to hold and nothing asserts. Ordered within each area by what
-bites hardest if it silently stops being true.
-
-## Antivirus
-
-- [ ] A facility scan finding malware leaves `blob_quarantines` untouched, since the propagating record is central's to write (verifies spec: AV)
-- [ ] An infected verdict discards existing parity, which both application contexts do from `onInfected` (verifies spec: AV, FEC)
-- [ ] Central refuses to repair known-bad content from parity; the facility equivalent is covered and central's is not (verifies spec: AV, FEC)
-- [ ] The scan pass ordering runs against the real database, not only the in-memory registry's own sort (verifies spec: AV)
-
-## Serving and transfer
-
-- [ ] The channel sends `facilityIds` on every operation. The fake connection ignores the query string, so only the construction-time guard ties the channel to its scope (verifies spec: BLAC, XFER)
-- [ ] A background fetch refused for capacity leaves the reference content-pending and retries (verifies spec: CAP, XFER)
-- [ ] Transfers of different hashes proceed concurrently rather than serialising behind each other (verifies spec: XFER)
-- [ ] `/api/sync/status` carries `blobOutbox`; the status builder is covered but the route exposing it is not (verifies spec: CAP)
-
-## Store and capacity
-
-- [ ] The store root comes from the `blobStorage.root` setting, and a relative value resolves against the working directory (verifies spec: CAP)
-
-## Cache, outbox and mobile
-
-- [ ] A device retains its attachment records after the bytes reach central, which is what makes the content refetchable (verifies spec: MOB)
-
-## Consumers
-
-- [ ] The document upload route's own size limit, which is never applied end to end because `uploadAttachment` is mocked away in the route tests (verifies spec: ATCH)
-- [ ] A facility retains its attachment records after they sync, which the move from push-then-delete to bidirectional changed (verifies spec: ATCH)
-- [ ] `makePatientCertificate` and `makePatientLetter` resolve a hash-form asset, and fail rather than printing unbranded when the bytes cannot be resolved; both suites stub the asset lookup away. The browser's half is covered, in `useCertificate` holding a pending asset back (verifies spec: ASSET)
-- [ ] A facility-specific asset is preferred over the deployment-wide one in the letter renderer, which repeats the rule the endpoint applies; the endpoint is covered and the renderer is not (verifies spec: ASSET)
-- [ ] Asset blobs are ordinary cache-tier content: prefetched at the cache tier, evictable, refetched after eviction (verifies spec: ASSET, CACHE)
-
-## Backfill
-
-- [ ] Rollback when the store is not intact, which the spec makes a precondition and nothing pins (verifies spec: BKFL)
-- [ ] `BlobBackfillTask` is in the facility's default task list, which is what makes the backfill run there with no operator action; central's is covered and the facility's is not (verifies spec: BKFL)
-- [ ] Two servers rewriting the same changelog entry independently produce identical content, the basis for entries never re-synchronising and still converging (verifies spec: BKFL)
-
-## Integrity
-
-- [ ] An evicted cache blob is not reported as a fault by a later scrub (verifies spec: SCRUB)
-- [ ] Scheduled bounds resolve from settings for central's scrub and both servers' scan; only the facility scrub asserts it (verifies spec: SCRUB, AV)
-
----
+Empty. Every gap this section held now has a test, written per package and landed
+together. The per-area checklists above do not yet carry them: a tick means someone
+read the test that asserts it, and authoring twenty ticks from a summary would put
+exactly the kind of unearned `[x]` in this document that makes the rest of them
+worth nothing. Re-run the audit to place them.
 
 # Not automated
 

--- a/packages/central-server/__tests__/blobBackfill.test.js
+++ b/packages/central-server/__tests__/blobBackfill.test.js
@@ -332,6 +332,37 @@ describe('Blob backfill', () => {
       expect(await readAll(await blobStore.get(hashOf(current)))).toEqual(current);
     });
 
+    // Entries never re-synchronise, so each server rewrites its own copy. The
+    // two only stay in agreement because the rewrite is derived from the bytes
+    // and nothing else: same content, same hash, same resulting snapshot.
+    it('rewrites to identical content on two servers working independently', async () => {
+      const content = Buffer.from('the same entry on both servers');
+      const recordId = randomUUID();
+      const here = await insertChangelogEntry('attachments', recordId, content);
+      const there = await insertChangelogEntry('attachments', recordId, content);
+      const otherRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'tamanu-backfill-other-'));
+      const otherServer = new BlobBackfill({
+        sequelize,
+        blobStore: new BlobStore({
+          root: otherRoot,
+          models,
+          getFreeDiskReserveBytes: async () => 0,
+        }),
+      });
+
+      try {
+        // A batch of one each, taken in id order, so the two servers rewrite
+        // one entry apiece into stores that share nothing.
+        await backfill.rewriteChangelogEntries(1);
+        await otherServer.rewriteChangelogEntries(1);
+
+        expect(await entryOf(there)).toEqual(await entryOf(here));
+        expect((await entryOf(here)).record_data.hash).toBe(hashOf(content));
+      } finally {
+        await fs.rm(otherRoot, { recursive: true, force: true });
+      }
+    });
+
     it('is idempotent across runs', async () => {
       await insertChangelogEntry('attachments', randomUUID(), Buffer.from('rewrite me once'));
 
@@ -467,6 +498,36 @@ describe('Blob backfill', () => {
         { type: QueryTypes.SELECT, plain: true },
       );
       expect(Number(rows.count)).toBe(0);
+    });
+
+    // The spec makes an intact store the precondition: rollback is a database
+    // restore from the store, not from a backup. Content the store cannot
+    // supply has to stop the run, since the alternative is a row silently
+    // restored to nothing on the way into a downgrade.
+    it('fails rather than restoring a row whose content has left the store', async () => {
+      const content = Buffer.from('this one has gone from the store');
+      const id = await insertAttachment(content);
+      await backfill.moveReferenceRows('attachments', 10);
+      await blobStore.delete(hashOf(content));
+
+      await expect(backfill.rollbackReferenceRows('attachments', 10)).rejects.toThrow();
+
+      const row = await rowOf('attachments', id);
+      expect(row.hash).toBe(hashOf(content));
+      expect(row.data).toBeNull();
+    });
+
+    it('fails rather than restoring a changelog entry whose content has left the store', async () => {
+      const content = Buffer.from('a snapshot with no bytes behind it');
+      const entryId = await insertChangelogEntry('assets', randomUUID(), content);
+      await backfill.rewriteChangelogEntries(10);
+      await blobStore.delete(hashOf(content));
+
+      await expect(backfill.rollbackChangelogEntries(10)).rejects.toThrow();
+
+      const entry = await entryOf(entryId);
+      expect(entry.record_data.hash).toBe(hashOf(content));
+      expect(entry.record_data.data).toBeNull();
     });
 
     it('round-trips content unchanged through backfill and rollback', async () => {

--- a/packages/central-server/__tests__/blobErrorCorrection.test.js
+++ b/packages/central-server/__tests__/blobErrorCorrection.test.js
@@ -46,6 +46,7 @@ describe('central blob error correction', () => {
 
   beforeEach(async () => {
     await models.Blob.destroy({ where: {}, force: true });
+    await models.BlobQuarantine.destroy({ where: {}, force: true });
     root = await fs.mkdtemp(path.join(os.tmpdir(), 'central-parity-test-'));
     errorCorrection = { enabled: true, proportion: 0.1 };
     blobStore = new BlobStore({
@@ -127,6 +128,24 @@ describe('central blob error correction', () => {
     const row = await models.Blob.findOne({ where: { hash } });
     expect(row.integrityState).toBe(BLOB_INTEGRITY_STATES.CORRUPT);
     expect(row.correctionCount).toBe(0);
+  });
+
+  // verifies spec: AV, FEC — a repair ends in the same bytes being held again,
+  // which for content the deployment has recorded as malware is the one outcome
+  // to avoid. The damage here is inside the parity budget, so the only reason
+  // not to reconstruct it is the quarantine.
+  it('refuses to reconstruct quarantined content its parity could restore', async () => {
+    const content = coveredContent(5);
+    const { hash } = await admit(content);
+    await models.BlobQuarantine.create({ hash });
+    await damageShards(hash, [4]);
+
+    await healCorrupt(hash);
+
+    const row = await models.Blob.findOne({ where: { hash } });
+    expect(row.integrityState).toBe(BLOB_INTEGRITY_STATES.CORRUPT);
+    expect(row.correctionCount).toBe(0);
+    expect(await fs.readFile(pathOf(hash))).not.toEqual(content);
   });
 
   it('records it corrupt as before where the blob carries no parity', async () => {

--- a/packages/central-server/__tests__/blobScheduledPasses.test.js
+++ b/packages/central-server/__tests__/blobScheduledPasses.test.js
@@ -1,0 +1,157 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import { BLOB_SCAN_VERDICTS, BLOB_SCANNERS } from '@tamanu/constants';
+import { createScannerDriver } from '@tamanu/database/blobStore';
+import { settingsCache } from '@tamanu/settings';
+
+import { createTestContext } from './utilities';
+import { ApplicationContext } from '../app/ApplicationContext';
+
+// The host daemon is the one part of a scan the context cannot supply, so the
+// driver is replaced and everything above it is the context's own wiring.
+jest.mock('@tamanu/database/blobStore', () => ({
+  ...jest.requireActual('@tamanu/database/blobStore'),
+  createScannerDriver: jest.fn(),
+}));
+
+const VERSIONS = { scannerVersion: 'test-scanner 1.0', signatureVersion: '27100' };
+
+// 16+2 shards of 4 KiB at the default proportion, so the content is large
+// enough for the store to cover it with parity.
+const COVERED_BYTES = 64 * 1024;
+
+const coveredContent = () => {
+  const blob = Buffer.alloc(COVERED_BYTES);
+  let state = Date.now() & 0x7fffffff;
+  for (let offset = 0; offset < blob.length; offset++) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    blob[offset] = (state >>> 16) & 0xff;
+  }
+  return blob;
+};
+
+// The scheduled scrub and antivirus pass as the central application context
+// builds them: the settings each reads, and what an infected verdict does.
+describe('central scheduled blob passes', () => {
+  let ctx;
+  let models;
+  let appContext;
+  let root;
+  let verdict;
+
+  const setSetting = async (key, value) => {
+    await models.Setting.set(key, value);
+    settingsCache.reset();
+  };
+
+  const pathOf = hash => {
+    const digest = hash.split(':')[1];
+    return path.join(root, 'sha256', digest.slice(0, 2), digest.slice(2, 4), digest.slice(4));
+  };
+
+  const admit = async (content = Buffer.from(`blob content ${randomUUID()}`)) => {
+    const { hash } = await appContext.blobStore.put(Readable.from(content));
+    return { hash, content };
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'central-scheduled-passes-'));
+    await models.Setting.set('blobStorage.root', root);
+    await models.Setting.set('blobStorage.freeDiskReserveGB', 0);
+    await models.Setting.set('blobStorage.errorCorrection', {
+      enabled: true,
+      parityPercent: 10,
+    });
+    await models.Setting.set('blobStorage.antivirus.scanner', BLOB_SCANNERS.CLAMD);
+    settingsCache.reset();
+
+    createScannerDriver.mockReturnValue({
+      versions: async () => VERSIONS,
+      scan: async () => verdict,
+    });
+
+    appContext = await new ApplicationContext().init();
+  });
+
+  afterAll(async () => {
+    for (const key of [
+      'blobStorage.root',
+      'blobStorage.freeDiskReserveGB',
+      'blobStorage.errorCorrection',
+      'blobStorage.antivirus.scanner',
+      'schedules.blobIntegrityScrub.maxBlobsPerPass',
+      'schedules.blobAntivirusScan.maxBlobsPerPass',
+    ]) {
+      await models.Setting.destroy({ where: { key }, force: true });
+    }
+    settingsCache.reset();
+    await appContext.close();
+    await fs.rm(root, { recursive: true, force: true });
+    await ctx.close();
+  });
+
+  beforeEach(async () => {
+    verdict = BLOB_SCAN_VERDICTS.CLEAN;
+    await models.Blob.destroy({ where: {}, force: true });
+    await models.BlobQuarantine.destroy({ where: {}, force: true });
+    // Bytes left behind would be adopted as orphans by the scrub's
+    // reconciliation and counted alongside the blobs a case admits itself.
+    await fs.rm(path.join(root, 'sha256'), { recursive: true, force: true });
+  });
+
+  // verifies spec: AV, FEC — a quarantined blob is never served and never
+  // repaired, so the disk its parity occupies is protecting content nothing
+  // will ever reconstruct.
+  it('discards a blob’s parity when the scan finds it infected', async () => {
+    const { hash } = await admit(coveredContent());
+    expect((await models.Blob.findOne({ where: { hash } })).hasParity).toBe(true);
+    verdict = BLOB_SCAN_VERDICTS.INFECTED;
+
+    await appContext.blobScanner.run();
+
+    expect(await models.BlobQuarantine.findOne({ where: { hash } })).not.toBeNull();
+    expect((await models.Blob.findOne({ where: { hash } })).hasParity).toBe(false);
+    await expect(fs.access(`${pathOf(hash)}.parity`)).rejects.toThrow();
+  });
+
+  it('leaves parity alone for a blob the scan finds clean', async () => {
+    const { hash } = await admit(coveredContent());
+
+    await appContext.blobScanner.run();
+
+    expect(await models.BlobQuarantine.findOne({ where: { hash } })).toBeNull();
+    expect((await models.Blob.findOne({ where: { hash } })).hasParity).toBe(true);
+    await expect(fs.access(`${pathOf(hash)}.parity`)).resolves.toBeUndefined();
+  });
+
+  // The per-pass bounds are read through a settings path each pass, and a typo
+  // in one would only surface when a scheduled pass first ran on a real server.
+  describe('per-pass bounds from settings', () => {
+    it('bounds the scrub by the blobs-per-pass setting', async () => {
+      for (let i = 0; i < 3; i++) await admit();
+
+      await setSetting('schedules.blobIntegrityScrub.maxBlobsPerPass', 1);
+      expect((await appContext.blobScrubber.run()).verified).toBe(1);
+
+      await setSetting('schedules.blobIntegrityScrub.maxBlobsPerPass', 2);
+      expect((await appContext.blobScrubber.run()).verified).toBe(2);
+    });
+
+    it('bounds the scan by its own blobs-per-pass setting', async () => {
+      for (let i = 0; i < 3; i++) await admit();
+
+      await setSetting('schedules.blobAntivirusScan.maxBlobsPerPass', 1);
+      expect((await appContext.blobScanner.run()).scanned).toBe(1);
+
+      await setSetting('schedules.blobAntivirusScan.maxBlobsPerPass', 2);
+      expect((await appContext.blobScanner.run()).scanned).toBe(2);
+    });
+  });
+});

--- a/packages/central-server/__tests__/patientCertificate.test.js
+++ b/packages/central-server/__tests__/patientCertificate.test.js
@@ -1,3 +1,7 @@
+import { Readable } from 'node:stream';
+
+import ReactPDF from '@react-pdf/renderer';
+
 import {
   createDummyEncounter,
   createDummyPatient,
@@ -6,7 +10,7 @@ import {
 import { randomLabRequest } from '@tamanu/database/demoData/labRequests';
 import { chance, fake } from '@tamanu/fake-data/fake';
 import { CertificateTypes } from '@tamanu/shared/utils/patientCertificates';
-import { LAB_REQUEST_STATUSES, REFERENCE_TYPES } from '@tamanu/constants';
+import { ASSET_NAMES, LAB_REQUEST_STATUSES, REFERENCE_TYPES } from '@tamanu/constants';
 import { makeCovidCertificate, makeVaccineCertificate } from '../app/utils/makePatientCertificate';
 
 import { createTestContext } from './utilities';
@@ -195,5 +199,100 @@ describe('Certificate', () => {
       facilityName: 'test facility',
     });
     expect(result.status).toEqual('success');
+  });
+
+  // spec: ASSET
+  describe('artwork from the blob store', () => {
+    // The rendered element is captured rather than a PDF produced, so the
+    // asset's bytes can be compared with what was admitted. spyOn mutates the
+    // shared ReactPDF object, so it reaches the module-scoped call site.
+    let render;
+
+    beforeEach(() => {
+      render = jest.spyOn(ReactPDF, 'render').mockResolvedValue(undefined);
+    });
+
+    afterEach(async () => {
+      render.mockRestore();
+      await models.Asset.destroy({ where: {}, force: true });
+    });
+
+    const admitAsset = async (name, content) => {
+      const { hash } = await ctx.blobStore.put(Readable.from(content));
+      await models.Asset.create({ name, type: 'image/png', data: null, hash });
+      return hash;
+    };
+
+    const certificate = async () =>
+      await makeVaccineCertificate({
+        models,
+        settings,
+        blobStore: ctx.blobStore,
+        patient: await models.Patient.findByPk(patient.id),
+        printedAt: new Date(),
+        printedBy: chance.name(),
+        facilityName: 'test facility',
+      });
+
+    const covidCertificate = async () =>
+      await makeCovidCertificate({
+        models,
+        settings,
+        blobStore: ctx.blobStore,
+        certType: CertificateTypes.test,
+        patient: await models.Patient.findByPk(patient.id),
+        printedBy: chance.name(),
+      });
+
+    it('resolves a hash-form asset into the rendered certificate', async () => {
+      const logo = Buffer.from('the letterhead logo bytes');
+      const watermark = Buffer.from('the watermark bytes');
+      await admitAsset(ASSET_NAMES.LETTERHEAD_LOGO, logo);
+      await admitAsset(ASSET_NAMES.VACCINE_CERTIFICATE_WATERMARK, watermark);
+
+      await certificate();
+
+      const [element] = render.mock.calls[0];
+      expect(element.props.logoSrc).toEqual(logo);
+      expect(element.props.watermarkSrc).toEqual(watermark);
+    });
+
+    it('resolves a hash-form asset into a rendered covid certificate too', async () => {
+      const footer = Buffer.from('the covid test footer bytes');
+      await admitAsset(ASSET_NAMES.COVID_TEST_CERTIFICATE_FOOTER, footer);
+
+      await covidCertificate();
+
+      const [element] = render.mock.calls[0];
+      expect(element.props.signingSrc).toEqual(footer);
+    });
+
+    it('fails rather than printing unbranded when the bytes cannot be resolved', async () => {
+      const hash = await admitAsset(
+        ASSET_NAMES.LETTERHEAD_LOGO,
+        Buffer.from('a logo the store no longer holds'),
+      );
+      await ctx.blobStore.delete(hash);
+
+      await expect(certificate()).rejects.toThrow();
+      expect(render).not.toHaveBeenCalled();
+    });
+
+    it('fails rather than printing unbranded with no store to resolve against', async () => {
+      await admitAsset(ASSET_NAMES.LETTERHEAD_LOGO, Buffer.from('a logo nothing can open'));
+
+      await expect(
+        makeVaccineCertificate({
+          models,
+          settings,
+          blobStore: null,
+          patient: await models.Patient.findByPk(patient.id),
+          printedAt: new Date(),
+          printedBy: chance.name(),
+          facilityName: 'test facility',
+        }),
+      ).rejects.toThrow();
+      expect(render).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/database/__tests__/blobStore/BlobStore.test.ts
+++ b/packages/database/__tests__/blobStore/BlobStore.test.ts
@@ -212,6 +212,41 @@ describe('BlobStore', () => {
     });
   });
 
+  // spec: CAP
+  describe('store root', () => {
+    // blobStorage.root ships relative, so this is where an unconfigured store lands.
+    it('resolves a relative root against the working directory', async () => {
+      const relativeRoot = path.relative(
+        process.cwd(),
+        await fs.mkdtemp(path.join(process.cwd(), '.blob-relative-root-')),
+      );
+      const store = new BlobStore({
+        root: relativeRoot,
+        models: { Blob: fakeBlob as unknown as typeof Blob },
+        getFreeDiskReserveBytes: async () => 0,
+        statfs: async () => ({ bavail: volumeFreeBytes, bsize: 1 }),
+      });
+
+      try {
+        const { hash } = await store.put(Readable.from(Buffer.from('hello world')));
+        const digest = hash.split(':')[1];
+        const placed = path.join(
+          process.cwd(),
+          relativeRoot,
+          'sha256',
+          digest.slice(0, 2),
+          digest.slice(2, 4),
+          digest.slice(4),
+        );
+
+        expect((await fs.readFile(placed)).toString()).toBe('hello world');
+        expect(await readAll(await store.get(hash))).toEqual(Buffer.from('hello world'));
+      } finally {
+        await fs.rm(relativeRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
   // spec: CAS
   // Renaming over an occupied destination, and transient sharing violations from
   // an antivirus or indexer handle, only happen on Windows/NTFS: POSIX never

--- a/packages/database/__tests__/blobStore/blobRegistry.test.ts
+++ b/packages/database/__tests__/blobStore/blobRegistry.test.ts
@@ -10,11 +10,13 @@ import { BLOB_INTEGRITY_STATES, BLOB_SCAN_VERDICTS, type BlobScanVerdict } from 
 import { fake } from '@tamanu/fake-data/fake';
 
 import { BlobStore } from '../../src/blobStore/BlobStore';
+import { BlobScanner } from '../../src/blobStore/scanning/BlobScanner';
 import { getModelsForPull, getModelsForPush } from '../../src/sync/getModelsForDirection';
 import { closeDatabase, createTestDatabase } from '../utilities';
 
 const SCANNER_VERSION = 'ClamAV 1.0.5';
 const SIGNATURE_VERSION = '27100';
+const SUPERSEDED_SIGNATURE_VERSION = '27099';
 
 describe('blob registry', () => {
   let models: any;
@@ -152,6 +154,61 @@ describe('blob registry', () => {
       expect(blob.scannerVersion).toBe(SCANNER_VERSION);
       expect(blob.signatureVersion).toBe(SIGNATURE_VERSION);
       expect(blob.scannedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  // spec: AV
+  describe('scan pass ordering', () => {
+    // The pass draws on the whole registry, so rows other cases admitted would order into it.
+    beforeEach(async () => {
+      await models.Blob.destroy({ where: {}, force: true });
+    });
+
+    const recordSupersededScan = async (hash: string, scannedAt: Date) =>
+      await sequelize.query(
+        `UPDATE blobs
+         SET scan_verdict = $verdict, scanned_at = $scannedAt, signature_version = $signatureVersion
+         WHERE hash = $hash`,
+        {
+          bind: {
+            hash,
+            verdict: BLOB_SCAN_VERDICTS.CLEAN,
+            scannedAt: scannedAt.toISOString(),
+            signatureVersion: SUPERSEDED_SIGNATURE_VERSION,
+          },
+        },
+      );
+
+    const scanOrder = async () => {
+      const order: string[] = [];
+      await new BlobScanner({
+        blobStore: store,
+        models,
+        driver: {
+          versions: async () => ({
+            scannerVersion: SCANNER_VERSION,
+            signatureVersion: SIGNATURE_VERSION,
+          }),
+          scan: async ({ hash }: { hash: string }) => {
+            order.push(hash);
+            return BLOB_SCAN_VERDICTS.CLEAN;
+          },
+        } as any,
+        getLimits: async () => ({ maxBlobs: 100, maxBytes: 1_000_000, maxScanBytes: 1_000_000 }),
+        onInfected: async () => {},
+        log: { info: () => {}, warn: () => {} },
+      }).run();
+      return order;
+    };
+
+    it('takes never-scanned content first, then what was scanned longest ago', async () => {
+      const neverScanned = await admit();
+      const scannedRecently = await admit();
+      const scannedLongAgo = await admit();
+      await recordSupersededScan(scannedRecently, new Date('2024-06-01T00:00:00Z'));
+      await recordSupersededScan(scannedLongAgo, new Date('2020-01-01T00:00:00Z'));
+
+      expect(await scanOrder()).toEqual([neverScanned, scannedLongAgo, scannedRecently]);
     });
   });
 });

--- a/packages/facility-server/__tests__/apiv1/DocumentUploadLimit.test.js
+++ b/packages/facility-server/__tests__/apiv1/DocumentUploadLimit.test.js
@@ -1,0 +1,72 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { DOCUMENT_SIZE_LIMIT, BLOB_TIERS } from '@tamanu/constants';
+import { createDummyPatient } from '@tamanu/database/demoData/patients';
+
+import { createTestContext } from '../utilities';
+import { uploadAttachment } from '../../app/utils/uploadAttachment';
+
+const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+// The route suites stand uploadAttachment down and assert it was called, so the
+// limit the route hands it has never been applied to a real request. This one
+// puts the real implementation back.
+const actual = jest.requireActual('../../app/utils/uploadAttachment');
+
+describe('document upload size limit', () => {
+  let ctx;
+  let models;
+  let app;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    app = await ctx.baseApp.asRole('practitioner');
+    uploadAttachment.mockImplementation(actual.uploadAttachment);
+  });
+
+  afterAll(() => ctx.close());
+
+  const post = (patientId, content) =>
+    app
+      .post(`/api/patient/${patientId}/documentMetadata`)
+      .field(
+        'jsonData',
+        JSON.stringify({
+          name: `document ${randomUUID()}`,
+          type: 'application/pdf',
+          documentOwner: 'someone',
+        }),
+      )
+      .attach('file', content, 'scan.pdf');
+
+  // verifies spec: ATCH — an upload larger than the configured maximum file
+  // size is rejected, and nothing is admitted on the way to the refusal.
+  it('refuses an upload past the maximum and admits nothing', async () => {
+    const patient = await models.Patient.create(await createDummyPatient(models));
+    const content = Buffer.alloc(DOCUMENT_SIZE_LIMIT + 1, 'o');
+
+    const result = await post(patient.id, content);
+
+    expect(result).toHaveRequestError();
+    expect(result.body.detail).toBe(`Uploaded file exceeds limit of ${DOCUMENT_SIZE_LIMIT} bytes.`);
+    expect(await models.Attachment.count({ where: { hash: hashOf(content) } })).toBe(0);
+    expect(await models.Blob.count({ where: { hash: hashOf(content) } })).toBe(0);
+    expect(await models.DocumentMetadata.count({ where: { patientId: patient.id } })).toBe(0);
+  });
+
+  it('accepts an upload within the maximum', async () => {
+    const patient = await models.Patient.create(await createDummyPatient(models));
+    const content = Buffer.from(`a scanned referral ${randomUUID()}`);
+
+    const result = await post(patient.id, content);
+
+    expect(result).toHaveSucceeded();
+    const attachment = await models.Attachment.findOne({ where: { hash: hashOf(content) } });
+    expect(attachment.size).toBe(content.length);
+    expect((await models.Blob.findOne({ where: { hash: hashOf(content) } })).tier).toBe(
+      BLOB_TIERS.OUTBOX,
+    );
+    expect(await models.DocumentMetadata.count({ where: { attachmentId: attachment.id } })).toBe(1);
+  });
+});

--- a/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientLetter.test.js
@@ -1,9 +1,10 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { Readable } from 'node:stream';
 import fs from 'fs';
 import config from 'config';
 import ReactPDF from '@react-pdf/renderer';
 
-import { BLOB_TIERS } from '@tamanu/constants';
+import { ASSET_NAMES, BLOB_TIERS } from '@tamanu/constants';
 import { fake, fakeUser } from '@tamanu/fake-data/fake';
 import { createDummyPatient } from '@tamanu/database/demoData/patients';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
@@ -138,5 +139,64 @@ describe('PatientLetter', () => {
       // keep formatting with the runtime default locale.
       await models.Setting.destroy({ where: { key: 'dateTimeLocale' }, force: true });
     }
+  });
+
+  describe('letterhead asset', () => {
+    const admit = async bytes => {
+      const { hash } = await ctx.blobStore.put(Readable.from([bytes]), { sizeHint: bytes.length });
+      return hash;
+    };
+
+    const createLetterhead = (hash, assetFacilityId = null) =>
+      models.Asset.create({
+        name: ASSET_NAMES.LETTERHEAD_LOGO,
+        type: 'image/png',
+        hash,
+        data: null,
+        facilityId: assetFacilityId,
+      });
+
+    afterEach(async () => {
+      // The letterhead name is shared with the asset endpoint suite, which runs
+      // against the same worker database.
+      await models.Asset.destroy({ where: { name: ASSET_NAMES.LETTERHEAD_LOGO }, force: true });
+    });
+
+    // spec: ASSET
+    it('resolves a hash-form letterhead from the blob store', async () => {
+      const image = Buffer.from(`letterhead logo ${randomUUID()}`);
+      await createLetterhead(await admit(image));
+
+      const result = await createLetter();
+      expect(result).toHaveSucceeded();
+
+      const [element] = renderSpy.mock.calls[0];
+      expect(element.props.logoSrc).toEqual(image);
+    });
+
+    // spec: ASSET
+    it('fails rather than rendering unbranded when the letterhead bytes cannot resolve', async () => {
+      await createLetterhead(
+        'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+      );
+
+      const result = await createLetter();
+      expect(result).toHaveStatus(502);
+      expect(renderSpy).not.toHaveBeenCalled();
+    });
+
+    // spec: ASSET
+    it('prefers a facility-specific letterhead over the deployment-wide one', async () => {
+      const deploymentWide = Buffer.from(`deployment-wide letterhead ${randomUUID()}`);
+      const facilitySpecific = Buffer.from(`facility letterhead ${randomUUID()}`);
+      await createLetterhead(await admit(deploymentWide));
+      await createLetterhead(await admit(facilitySpecific), facilityId);
+
+      const result = await createLetter();
+      expect(result).toHaveSucceeded();
+
+      const [element] = renderSpy.mock.calls[0];
+      expect(element.props.logoSrc).toEqual(facilitySpecific);
+    });
   });
 });

--- a/packages/facility-server/__tests__/blobCache/storeRootSettings.test.js
+++ b/packages/facility-server/__tests__/blobCache/storeRootSettings.test.js
@@ -1,0 +1,73 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import config from 'config';
+
+import { FACT_FACILITY_IDS, SETTINGS_SCOPES } from '@tamanu/constants';
+import { facilityDefaults, settingsCache } from '@tamanu/settings';
+import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
+
+import { createTestContext } from '../utilities';
+import { ApplicationContext } from '../../app/ApplicationContext';
+import { initServerConfig } from '../../app/serverConfig';
+
+// The store root is only ever read through the application context, so this
+// suite boots one rather than injecting a root the way the rest do.
+describe('blob store root from facility settings', () => {
+  let ctx;
+  let models;
+  let root;
+  let facilityId;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    [facilityId] = selectFacilityIds(config);
+
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-store-root-'));
+    await models.Setting.set('blobStorage.root', root, SETTINGS_SCOPES.FACILITY, facilityId);
+    settingsCache.reset();
+  });
+
+  afterAll(async () => {
+    await models.Setting.destroy({ where: { key: 'blobStorage.root' }, force: true });
+    settingsCache.reset();
+    await fs.rm(root, { recursive: true, force: true });
+    await ctx.close();
+  });
+
+  it('sites the store at the configured root', async () => {
+    // verifies spec: CAP — the root is configurable so the store can sit on a
+    // volume of its own
+    const appContext = await new ApplicationContext().init();
+    expect(appContext.blobStore.root).toBe(root);
+
+    const content = Buffer.from(`blob content ${randomUUID()}`);
+    await appContext.blobStore.put(Readable.from([content]));
+
+    const entries = await fs.readdir(root, { recursive: true, withFileTypes: true });
+    const stored = await Promise.all(
+      entries
+        .filter(entry => entry.isFile())
+        .map(entry => fs.readFile(path.join(entry.parentPath, entry.name))),
+    );
+    expect(stored).toContainEqual(content);
+  });
+
+  it('falls back to the schema default when no facility has synced', async () => {
+    // verifies spec: CAP — the root is facility-scoped, so a server with no
+    // facility yet has no reader to ask for it
+    const syncedFacilityIds = await models.LocalSystemFact.get(FACT_FACILITY_IDS);
+    await models.LocalSystemFact.set(FACT_FACILITY_IDS, '[]');
+    try {
+      const appContext = await new ApplicationContext().init();
+      expect(appContext.blobStore.root).toBe(facilityDefaults.blobStorage.root);
+    } finally {
+      await models.LocalSystemFact.set(FACT_FACILITY_IDS, syncedFacilityIds);
+      await initServerConfig({ context: ctx });
+    }
+  });
+});

--- a/packages/facility-server/__tests__/blobIntegrity/blobAntivirus.test.js
+++ b/packages/facility-server/__tests__/blobIntegrity/blobAntivirus.test.js
@@ -1,0 +1,140 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import { FACILITY_PARITY_TIERS, PARITY_SIDECAR_SUFFIX } from '@tamanu/blobs';
+import { BLOB_SCAN_VERDICTS, BLOB_TIERS } from '@tamanu/constants';
+import { BlobScanner, BlobStore } from '@tamanu/database/blobStore';
+
+import { createTestContext } from '../utilities';
+import { onBlobInfected } from '../../app/blobIntegrity';
+
+// Large enough to carry parity: 16+2 shards of 4 KiB at the default proportion.
+const COVERED_BYTES = 64 * 1024;
+
+const coveredContent = () => Buffer.alloc(COVERED_BYTES, randomUUID());
+
+describe('facility antivirus scan', () => {
+  let ctx;
+  let models;
+  let root;
+  let blobStore;
+  let verdict;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await models.Blob.destroy({ where: {}, force: true });
+    await models.BlobQuarantine.destroy({ where: {}, force: true });
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-antivirus-test-'));
+    verdict = BLOB_SCAN_VERDICTS.INFECTED;
+    blobStore = new BlobStore({
+      root,
+      models,
+      getFreeDiskReserveBytes: async () => 0,
+      errorCorrection: {
+        coveredTiers: FACILITY_PARITY_TIERS,
+        getSettings: async () => ({ enabled: true, proportion: 0.1 }),
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const driver = {
+    versions: async () => ({ scannerVersion: 'test-engine 1.0', signatureVersion: '27100' }),
+    scan: async () => verdict,
+  };
+
+  const makeScanner = () =>
+    new BlobScanner({
+      blobStore,
+      models,
+      driver,
+      getLimits: async () => ({
+        maxBlobs: 100,
+        maxBytes: 1024 ** 3,
+        maxScanBytes: 1024 ** 3,
+      }),
+      onInfected: hash => onBlobInfected(blobStore, hash),
+      log: { info: () => {}, warn: () => {} },
+    });
+
+  const putOutbox = async (content = coveredContent()) => {
+    const { hash } = await blobStore.put(Readable.from(content), { tier: BLOB_TIERS.OUTBOX });
+    return { hash, content };
+  };
+
+  const sidecarPathFor = hash => {
+    const digest = hash.split(':')[1];
+    return path.join(
+      root,
+      'sha256',
+      digest.slice(0, 2),
+      digest.slice(2, 4),
+      `${digest.slice(4)}${PARITY_SIDECAR_SUFFIX}`,
+    );
+  };
+
+  // verifies spec: AV — the propagating record names the hash rather than any
+  // copy of it, is written by the central server whose verdict is
+  // authoritative, and reaches a facility by synchronisation.
+  it('leaves the quarantine record alone when its own scan finds malware', async () => {
+    const { hash } = await putOutbox();
+
+    const result = await makeScanner().run();
+
+    expect(result).toMatchObject({ scanned: 1, infected: 1 });
+    expect(await models.BlobQuarantine.count()).toBe(0);
+    const row = await models.Blob.findOne({ where: { hash } });
+    expect(row.scanVerdict).toBe(BLOB_SCAN_VERDICTS.INFECTED);
+    expect(row.signatureVersion).toBe('27100');
+  });
+
+  // verifies spec: AV, FEC — infected content is retained but never served and
+  // never repaired, so the disk its parity occupies buys nothing.
+  it('discards the parity of content an infected verdict covers', async () => {
+    const { hash } = await putOutbox();
+    await expect(fs.access(sidecarPathFor(hash))).resolves.toBeUndefined();
+
+    await makeScanner().run();
+
+    await expect(fs.access(sidecarPathFor(hash))).rejects.toThrow();
+    expect((await models.Blob.findOne({ where: { hash } })).hasParity).toBe(false);
+  });
+
+  it('leaves a clean blob its parity', async () => {
+    verdict = BLOB_SCAN_VERDICTS.CLEAN;
+    const { hash } = await putOutbox();
+
+    await makeScanner().run();
+
+    await expect(fs.access(sidecarPathFor(hash))).resolves.toBeUndefined();
+    expect((await models.Blob.findOne({ where: { hash } })).hasParity).toBe(true);
+  });
+
+  // The application context resolves the scan's per-pass bounds and its size cap
+  // through these settings paths, and a typo in one would only surface when a
+  // scheduled pass first ran on a real server.
+  describe('scan settings', () => {
+    it('resolves the per-pass bounds and size cap the context reads', async () => {
+      const [facilityId] = Object.keys(ctx.settings).filter(key => key !== 'global');
+      const scan = await ctx.settings[facilityId].get('schedules.blobAntivirusScan');
+      const { maxScanMB } = await ctx.settings[facilityId].get('blobStorage.antivirus');
+
+      expect(scan.maxBlobsPerPass).toBeGreaterThan(0);
+      expect(scan.maxGigabytesPerPass).toBeGreaterThan(0);
+      expect(scan.schedule).toEqual(expect.any(String));
+      expect(maxScanMB).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
+++ b/packages/facility-server/__tests__/blobIntegrity/blobIntegrity.test.js
@@ -15,6 +15,7 @@ import { BlobScrubber, BlobStore } from '@tamanu/database/blobStore';
 import { BlobHashMismatchError } from '@tamanu/errors';
 
 import { createTestContext } from '../utilities';
+import { FacilityBlobCache } from '../../app/blobCache/FacilityBlobCache';
 import { FacilityBlobHealer } from '../../app/blobIntegrity/FacilityBlobHealer';
 
 const uniqueContent = () => Buffer.from(`blob content ${randomUUID()}`);
@@ -299,6 +300,35 @@ describe('facility blob integrity', () => {
       expect(blob.integrityState).toBe(BLOB_INTEGRITY_STATES.CORRUPT);
       // The bytes are retained on disk for investigation, not deleted.
       await expect(fs.access(pathOf(hash))).resolves.toBeUndefined();
+    });
+  });
+
+  // spec: SCRUB
+  describe('legitimately absent content', () => {
+    it('reports no fault for a cache blob eviction has taken', async () => {
+      // An evicted cache blob is durable on central and refetches on demand, so
+      // the scrub that follows must leave it alone rather than escalating a
+      // reclamation the cache budget asked for.
+      const blobCache = new FacilityBlobCache({
+        blobStore,
+        models,
+        getCacheBudgetBytes: async () => 0,
+      });
+      const { hash, content } = await put(BLOB_TIERS.CACHE);
+      const faultsBefore = Number(
+        (await models.LocalSystemFact.get(FACT_BLOB_CACHE_FAULTS)) ?? 0,
+      );
+
+      await blobCache.evictBytes(content.length);
+      expect(await blobStore.has(hash)).toBe(false);
+
+      const result = await makeScrubber().run();
+
+      expect(result.faults).toBe(0);
+      expect(await models.Blob.findOne({ where: { hash } })).toBeNull();
+      expect(Number((await models.LocalSystemFact.get(FACT_BLOB_CACHE_FAULTS)) ?? 0)).toBe(
+        faultsBefore,
+      );
     });
   });
 

--- a/packages/facility-server/__tests__/blobTransfer/BlobTransferChannel.test.js
+++ b/packages/facility-server/__tests__/blobTransfer/BlobTransferChannel.test.js
@@ -4,6 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 
+import { TamanuApi } from '@tamanu/api-client';
+import { blobEndpoints } from '@tamanu/blobs';
 import {
   BLOB_AVAILABILITY_STATES,
   BLOB_INTEGRITY_STATES,
@@ -13,6 +15,10 @@ import { BlobStore } from '@tamanu/database/blobStore';
 import { ERROR_TYPE, Problem } from '@tamanu/errors';
 
 import { BlobTransferChannel } from '../../app/blobTransfer/BlobTransferChannel';
+
+// The shared test environment auto-mocks this, which would answer every call
+// with undefined; the point here is the request the real one builds.
+const { CentralServerConnection } = jest.requireActual('../../app/sync/CentralServerConnection');
 
 const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
 
@@ -265,6 +271,84 @@ describe('BlobTransferChannel', () => {
     });
   });
 
+  // spec: BLAC, XFER
+  // Central scopes every blob operation to the facilities the caller declares
+  // in its query string, so the ids have to reach the query slot of each call
+  // rather than its request config. The channel addresses the api client two
+  // ways — a local two-argument form and the api-client three-argument form —
+  // which is where a call can lose them without any local check noticing. This
+  // reads the calls as the client turns them into a URL.
+  describe('facility scoping on the wire', () => {
+    // Declaring a token so the request goes out rather than pausing to log in.
+    class SignedInCentralConnection extends CentralServerConnection {
+      hasToken() {
+        return true;
+      }
+    }
+
+    const bodyOf = content =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(content);
+          controller.close();
+        },
+      });
+
+    it('declares the server facility ids on every operation', async () => {
+      const content = Buffer.from('bytes that make every round trip');
+      const hash = hashOf(content);
+      const sent = [];
+      const apiFetch = jest
+        .spyOn(TamanuApi.prototype, 'fetch')
+        .mockImplementation(async (endpoint, query) => {
+          sent.push({ endpoint, query });
+          if (endpoint === blobEndpoints.availability(hash)) {
+            return { availability: BLOB_AVAILABILITY_STATES.AVAILABLE, size: content.length };
+          }
+          if (endpoint === blobEndpoints.offer(hash)) {
+            return { status: BLOB_OFFER_STATUSES.WANTED, receivedBytes: 0 };
+          }
+          if (endpoint === blobEndpoints.upload(hash)) {
+            return { acknowledged: true, size: content.length };
+          }
+          return {
+            status: 200,
+            headers: new Map([['content-length', String(content.length)]]),
+            body: bodyOf(content),
+          };
+        });
+
+      try {
+        const scoped = new BlobTransferChannel({
+          blobStore: localStore,
+          centralServer: new SignedInCentralConnection({ deviceId: 'test-device' }),
+          facilityIds: ['test-facility'],
+          pushChunkBytes: 8,
+        });
+
+        await scoped.availability(hash);
+        await scoped.fetchFromCentral(hash);
+        await scoped.pushToCentral(hash);
+      } finally {
+        apiFetch.mockRestore();
+      }
+
+      expect(new Set(sent.map(({ endpoint }) => endpoint))).toEqual(
+        new Set([
+          blobEndpoints.availability(hash),
+          blobEndpoints.content(hash),
+          blobEndpoints.offer(hash),
+          blobEndpoints.upload(hash),
+        ]),
+      );
+      for (const { endpoint, query } of sent) {
+        expect(query.facilityIds, `facility ids missing from ${endpoint}`).toEqual([
+          'test-facility',
+        ]);
+      }
+    });
+  });
+
   describe('availability', () => {
     it('reports locally held bytes as available', async () => {
       const { hash } = await localStore.put(Readable.from(Buffer.from('local bytes')));
@@ -488,6 +572,39 @@ describe('BlobTransferChannel', () => {
       expect(central.fetchCalls).toBe(1); // the availability probe alone, no byte transfer
       expect((await readAll(await localStore.get(hash))).equals(content)).toBe(true);
     });
+
+    // spec: XFER — many small blobs transfer as concurrent requests over one
+    // shared connection, so a blob held up in transit must not hold up the
+    // blobs behind it. Serialising per hash is enough for staging integrity.
+    it('lets a transfer of another hash finish while one is still in flight', async () => {
+      const held = Buffer.from('a blob whose delivery is held open');
+      const behind = Buffer.from('the blob queued behind it');
+      const { hash: heldHash } = await centralStore.put(Readable.from(held));
+      const { hash: behindHash } = await centralStore.put(Readable.from(behind));
+
+      let releaseHeld;
+      const heldDelivery = new Promise(resolve => {
+        releaseHeld = resolve;
+      });
+      const deliver = central.fetch.bind(central);
+      central.fetch = async (endpoint, options, upOptions) => {
+        if (endpoint === blobEndpoints.content(heldHash)) {
+          await heldDelivery;
+        }
+        return await deliver(endpoint, options, upOptions);
+      };
+
+      const completed = [];
+      const heldFetch = channel.fetchFromCentral(heldHash).then(() => completed.push('held'));
+      await channel.fetchFromCentral(behindHash);
+      completed.push('behind');
+      releaseHeld();
+      await heldFetch;
+
+      expect(completed).toEqual(['behind', 'held']);
+      expect(await localStore.has(behindHash)).toBe(true);
+      expect(await localStore.has(heldHash)).toBe(true);
+    }, 15000);
 
     it('recovers on the next call when fully staged bytes fail verification', async () => {
       const content = Buffer.from('central holds the true content');

--- a/packages/facility-server/__tests__/sync/assetBlobs.test.js
+++ b/packages/facility-server/__tests__/sync/assetBlobs.test.js
@@ -1,0 +1,153 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import { BLOB_TIERS } from '@tamanu/constants';
+import { BlobStore } from '@tamanu/database/blobStore';
+import { NotFoundError } from '@tamanu/errors';
+
+import { createTestContext } from '../utilities';
+import { FacilityBlobCache } from '../../app/blobCache/FacilityBlobCache';
+import { prefetchAssets } from '../../app/sync/prefetchAssets';
+
+const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+async function readAll(stream) {
+  const chunks = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+describe('asset blobs on a facility', () => {
+  let ctx;
+  let models;
+  let root;
+  let blobStore;
+  let blobCache;
+  let cacheBudgetBytes;
+  let freeDiskReserveBytes;
+  let central;
+  let fetchAttempts;
+  let transferChannel;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await models.Asset.destroy({ where: {}, force: true });
+    await models.Blob.destroy({ where: {}, force: true });
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-blobs-test-'));
+    cacheBudgetBytes = 10 * 1024 ** 3;
+    freeDiskReserveBytes = 0;
+    blobStore = new BlobStore({
+      root,
+      models,
+      getFreeDiskReserveBytes: async () => freeDiskReserveBytes,
+      evictCache: async bytesNeeded => {
+        await blobCache.evictBytes(bytesNeeded);
+      },
+    });
+    blobCache = new FacilityBlobCache({
+      blobStore,
+      models,
+      getCacheBudgetBytes: async () => cacheBudgetBytes,
+    });
+    central = new Map();
+    fetchAttempts = [];
+    transferChannel = {
+      fetchFromCentral: async hash => {
+        fetchAttempts.push(hash);
+        const content = central.get(hash);
+        if (!content) throw new NotFoundError(`central does not hold ${hash}`);
+        await blobStore.stage(hash, Readable.from(content), { offset: 0 });
+        return await blobStore.commitStaged(hash);
+      },
+    };
+    blobCache.setTransferChannel(transferChannel);
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const seedAsset = async (content = Buffer.from(`asset image ${randomUUID()}`)) => {
+    const hash = hashOf(content);
+    central.set(hash, content);
+    await models.Asset.create({
+      name: `letterhead-${randomUUID()}`,
+      type: 'image/png',
+      hash,
+      data: null,
+    });
+    return { hash, content };
+  };
+
+  const prefetch = () => prefetchAssets({ models, transferChannel, blobCache });
+
+  // verifies spec: ASSET, CACHE
+  describe('cache-tier content', () => {
+    it('admits prefetched asset content at the cache tier', async () => {
+      const { hash } = await seedAsset();
+
+      await prefetch();
+
+      expect((await models.Blob.findOne({ where: { hash } })).tier).toBe(BLOB_TIERS.CACHE);
+    });
+
+    it('evicts an asset blob under the budget like any other cache content', async () => {
+      const { hash } = await seedAsset();
+      await prefetch();
+      cacheBudgetBytes = 1;
+      // Eviction protects the most recently used blob, so give it company.
+      await blobStore.put(Readable.from(Buffer.from(`unrelated ${randomUUID()}`)));
+
+      await blobCache.enforceBudget();
+
+      expect(await blobStore.has(hash)).toBe(false);
+      expect(await models.Asset.count({ where: { hash } })).toBe(1);
+    });
+
+    it('refetches an evicted asset blob on demand', async () => {
+      const { hash, content } = await seedAsset();
+      await prefetch();
+      await blobCache.evictBytes(content.length);
+      expect(await blobStore.has(hash)).toBe(false);
+
+      const served = await readAll(await blobCache.open(hash));
+
+      expect(served.equals(content)).toBe(true);
+      expect(fetchAttempts).toEqual([hash, hash]);
+    });
+  });
+
+  // verifies spec: CAP, XFER
+  // A background fetch the store refuses for capacity is an ordinary failed
+  // fetch: nothing is admitted, the asset row stands with its bytes unresolved,
+  // and the next pass tries again rather than the reference being written off.
+  describe('a fetch refused for capacity', () => {
+    it('leaves the asset awaiting its content and fetches it again next pass', async () => {
+      const { hash, content } = await seedAsset();
+      freeDiskReserveBytes = Number.MAX_SAFE_INTEGER;
+
+      await prefetch();
+
+      expect(await blobStore.has(hash)).toBe(false);
+      expect(await models.Blob.findOne({ where: { hash } })).toBeNull();
+      expect(await models.Asset.count({ where: { hash } })).toBe(1);
+
+      freeDiskReserveBytes = 0;
+      await prefetch();
+
+      expect(fetchAttempts).toEqual([hash, hash]);
+      expect((await readAll(await blobStore.get(hash))).equals(content)).toBe(true);
+    });
+  });
+});

--- a/packages/facility-server/__tests__/sync/attachmentRetention.test.js
+++ b/packages/facility-server/__tests__/sync/attachmentRetention.test.js
@@ -1,0 +1,44 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { fake } from '@tamanu/fake-data/fake';
+
+import { createTestContext } from '../utilities';
+import { deleteRedundantLocalCopies } from '../../app/sync/deleteRedundantLocalCopies';
+
+const hashOf = content => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+// verifies spec: ATCH
+// Attachment records synchronise as ordinary persistent records, so a facility
+// still holds them once they have reached the central server. Nothing else
+// resolves their content from here afterwards: the hash lives on the row.
+describe('attachment retention after a push', () => {
+  let ctx;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  it('keeps an attachment row the push cleanup has been handed', async () => {
+    const patient = await models.Patient.create(fake(models.Patient));
+    const hash = hashOf(randomUUID());
+    const attachment = await models.Attachment.create({
+      type: 'application/pdf',
+      hash,
+      size: 12,
+      patientId: patient.id,
+    });
+
+    await deleteRedundantLocalCopies(models, [
+      { recordType: models.Attachment.tableName, recordId: attachment.id },
+    ]);
+
+    const retained = await models.Attachment.findByPk(attachment.id);
+    expect(retained).not.toBeNull();
+    expect(retained.hash).toBe(hash);
+    expect(retained.data).toBeNull();
+  });
+});

--- a/packages/facility-server/__tests__/sync/syncStatusRoute.test.js
+++ b/packages/facility-server/__tests__/sync/syncStatusRoute.test.js
@@ -1,0 +1,60 @@
+import { randomUUID } from 'node:crypto';
+import { Readable } from 'node:stream';
+
+import supertest from 'supertest';
+
+import { createTestContext } from '../utilities';
+import { createSyncApp } from '../../app/createSyncApp';
+
+// verifies spec: CAP
+// Outbox backpressure is surfaced as a health signal visible to central-side
+// monitoring, and this route is the only thing that puts the figures where
+// monitoring can read them.
+describe('sync status route', () => {
+  let ctx;
+  let models;
+  let app;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    const { express } = await createSyncApp({
+      sequelize: ctx.sequelize,
+      syncManager: ctx.syncManager,
+      models,
+      deviceId: ctx.deviceId,
+    });
+    app = supertest(express);
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await models.Blob.destroy({ where: {}, force: true });
+  });
+
+  it('reports the outbox alongside the sync cursors', async () => {
+    const content = Buffer.from(`awaiting its push ${randomUUID()}`);
+    await ctx.blobCache.putOutbox(Readable.from(content));
+
+    const result = await app.get('/sync/status');
+
+    expect(result).toHaveSucceeded();
+    expect(result.body.blobOutbox).toEqual({
+      count: 1,
+      totalBytes: content.length,
+      oldestEligibleTick: null,
+    });
+  });
+
+  it('reports an empty outbox rather than omitting it', async () => {
+    const result = await app.get('/sync/status');
+
+    expect(result).toHaveSucceeded();
+    expect(result.body.blobOutbox).toEqual({
+      count: 0,
+      totalBytes: 0,
+      oldestEligibleTick: null,
+    });
+  });
+});

--- a/packages/facility-server/__tests__/tasks/blobBackfillScheduling.test.js
+++ b/packages/facility-server/__tests__/tasks/blobBackfillScheduling.test.js
@@ -1,0 +1,39 @@
+import { ScheduledTask } from '@tamanu/shared/tasks/ScheduledTask';
+
+import { createTestContext } from '../utilities';
+import { startScheduledTasks } from '../../app/tasks';
+
+// spec: BKFL
+// A facility runs the backfill from server start with no operator action, so the
+// task belongs to the set the server schedules on boot rather than to something
+// someone has to kick off on each site.
+describe('BlobBackfillTask scheduling', () => {
+  let ctx;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+
+  afterAll(() => ctx.close());
+
+  it('is scheduled, enabled, when the server starts its tasks', async () => {
+    const polled = [];
+    // Recorded rather than called through, so no cron jobs outlive the test.
+    const beginPolling = jest
+      .spyOn(ScheduledTask.prototype, 'beginPolling')
+      .mockImplementation(function record() {
+        polled.push({ name: this.getName(), enabled: this.isEnabled, schedule: this.schedule });
+      });
+
+    const stopTasks = await startScheduledTasks(ctx);
+    try {
+      expect(polled).toContainEqual(
+        expect.objectContaining({ name: 'BlobBackfillTask', enabled: true }),
+      );
+      expect(polled.find(({ name }) => name === 'BlobBackfillTask').schedule).toBeTruthy();
+    } finally {
+      stopTasks();
+      beginPolling.mockRestore();
+    }
+  });
+});

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -21,7 +21,7 @@ import {
 import { setFhirRefreshTriggers } from '@tamanu/database';
 
 import { BLOB_REFERENCE_TABLES, FacilityBlobCache, makeSyncedReferenceResolver } from './blobCache';
-import { FacilityBlobHealer } from './blobIntegrity';
+import { FacilityBlobHealer, onBlobInfected } from './blobIntegrity';
 import { closeDatabase, initDatabase } from './database';
 import { getServerFacilityIds, initServerConfig } from './serverConfig';
 import { VERSION } from './middleware/versionCompatibility.js';
@@ -213,15 +213,7 @@ export class ApplicationContext {
             maxScanBytes: maxScanMB * 1024 ** 2,
           };
         },
-        // The deployment-wide record is central's to write, and it is pulled
-        // here rather than pushed from here. A facility's own finding stops it
-        // serving the content locally; central reaches the same verdict when the
-        // content is pushed to it.
-        onInfected: async hash => {
-          log.warn('BlobScanner: infected content held by this facility', { hash });
-          // spec: FEC — quarantined content is never served and never repaired.
-          await this.blobStore.discardParity(hash);
-        },
+        onInfected: async hash => onBlobInfected(this.blobStore, hash),
         log,
       });
 

--- a/packages/facility-server/app/blobIntegrity/index.js
+++ b/packages/facility-server/app/blobIntegrity/index.js
@@ -1,1 +1,2 @@
 export { FacilityBlobHealer } from './FacilityBlobHealer';
+export { onBlobInfected } from './onBlobInfected';

--- a/packages/facility-server/app/blobIntegrity/onBlobInfected.js
+++ b/packages/facility-server/app/blobIntegrity/onBlobInfected.js
@@ -1,0 +1,12 @@
+import { log } from '@tamanu/shared/services/logging';
+
+// spec: AV
+// What a facility does when its own scanner finds malware. The deployment-wide
+// quarantine record names the hash rather than any copy of it and is central's
+// to write, reaching this server by sync; a facility's own finding only stops
+// it serving the content locally.
+export async function onBlobInfected(blobStore, hash) {
+  log.warn('BlobScanner: infected content held by this facility', { hash });
+  // spec: FEC — quarantined content is never served and never repaired.
+  await blobStore.discardParity(hash);
+}

--- a/packages/mobile/App/services/blobs/attachmentRetention.spec.ts
+++ b/packages/mobile/App/services/blobs/attachmentRetention.spec.ts
@@ -1,0 +1,103 @@
+import { BLOB_TIERS } from '@tamanu/constants';
+
+import { Database } from '~/infra/db';
+import { LAST_SUCCESSFUL_PUSH } from '~/services/sync/constants';
+import { FakeBlobFileSystem } from '/root/tests/helpers/fakeBlobFileSystem';
+import { BlobOutboxPusher } from './BlobOutboxPusher';
+import { MobileBlobCache } from './MobileBlobCache';
+import { MobileBlobStore } from './MobileBlobStore';
+import { deriveFreeDiskReserveBytes } from './deviceStorage';
+
+const PUSH_TICK = 10;
+const ATTACHMENT_ID = 'att-photo';
+const PHOTO_BYTES = 'photo bytes';
+
+describe('attachment records after their bytes reach central', () => {
+  let fs: FakeBlobFileSystem;
+  let store: MobileBlobStore;
+  let cache: MobileBlobCache;
+  let fetched: string[];
+  let pusher: BlobOutboxPusher;
+
+  beforeAll(async () => {
+    await Database.connect();
+  });
+
+  beforeEach(async () => {
+    await Database.models.Blob.getRepository().clear();
+    await Database.models.Attachment.getRepository().clear();
+    await Database.models.LocalSystemFact.getRepository().clear();
+    await Database.models.LocalSystemFact.getRepository().query(
+      `INSERT INTO local_system_facts (id, key, value) VALUES (?, ?, ?)`,
+      [`fact-${LAST_SUCCESSFUL_PUSH}`, LAST_SUCCESSFUL_PUSH, String(PUSH_TICK)],
+    );
+    fs = new FakeBlobFileSystem();
+    store = new MobileBlobStore({
+      root: '/blobs',
+      models: Database.models,
+      getFreeDiskReserveBytes: deriveFreeDiskReserveBytes,
+      fs,
+    });
+    cache = new MobileBlobCache({ blobStore: store, models: Database.models, fs });
+    fetched = [];
+    cache.setTransferChannel({
+      fetchFromCentral: async (hash: string) => {
+        fetched.push(hash);
+        fs.seed('/tmp/from-central.jpg', PHOTO_BYTES);
+        await store.putFile('/tmp/from-central.jpg', { tier: BLOB_TIERS.CACHE });
+      },
+    } as any);
+    pusher = new BlobOutboxPusher({
+      models: Database.models,
+      transferChannel: {
+        pushToCentral: async () => ({ acknowledged: true }),
+      } as any,
+      blobCache: cache,
+    });
+  });
+
+  // verifies spec: MOB — the push that makes the bytes evictable leaves the
+  // record alone
+  it('retains the record once the push is acknowledged', async () => {
+    const hash = await captureAndPush();
+
+    expect(await tierOf(hash)).toBe(BLOB_TIERS.CACHE);
+    const retained = await Database.models.Attachment.findOne({ where: { id: ATTACHMENT_ID } });
+    expect(retained).not.toBeNull();
+    expect(retained.hash).toBe(hash);
+  });
+
+  // verifies spec: MOB — reclaiming the space takes the bytes and not the
+  // record, so the hash it carries fetches the content back
+  it('refetches the content by the retained hash once the blob is reclaimed', async () => {
+    const hash = await captureAndPush();
+    const { size } = await store.stat(hash);
+
+    await cache.evictBytes(size);
+    expect(await store.has(hash)).toBe(false);
+
+    const retained = await Database.models.Attachment.findOne({ where: { id: ATTACHMENT_ID } });
+    expect(retained).not.toBeNull();
+    expect(await cache.readBase64(retained.hash)).toBe(Buffer.from(PHOTO_BYTES).toString('base64'));
+    expect(fetched).toEqual([hash]);
+  });
+
+  // A captured photo, its synchronised record, and the pass that delivers the
+  // bytes to central.
+  async function captureAndPush(): Promise<string> {
+    fs.seed('/tmp/photo.jpg', PHOTO_BYTES);
+    const { hash, size } = await cache.putOutbox('/tmp/photo.jpg');
+    await Database.models.Attachment.getRepository().query(
+      `INSERT INTO attachments (id, type, hash, size, updatedAtSyncTick)
+       VALUES (?, 'image/jpeg', ?, ?, ?)`,
+      [ATTACHMENT_ID, hash, size, PUSH_TICK - 5],
+    );
+    await pusher.runOnce();
+    return hash;
+  }
+
+  async function tierOf(hash: string): Promise<string> {
+    const row = await Database.models.Blob.findOne({ where: { hash } });
+    return row.tier;
+  }
+});


### PR DESCRIPTION
### Changes

The sweep's automatable bucket listed 44 gaps and had never been pruned as tests landed, so nobody could tell which were still open. The first commit removes the 24 already closed by #10760. The rest add 33 test cases closing 17 of the remaining 20, across mobile, database, central-server and facility-server.

Every test was mutation-checked: break the behaviour, confirm the test fails and its neighbours do not, restore. Two are worth knowing about. Dropping `NULLS FIRST` from the scan pass ordering failed the new test and left the entire existing `BlobScanner` suite green, because its fake `findAll` destructures only `where` and `limit` and never sees `order`. Moving `facilityIds` out of the transfer channel's query slot failed the new test while all 27 fake-connection tests stayed green. Both are the blind spots the sweep named.

One thing that looks out of place: `packages/facility-server/app/blobIntegrity/onBlobInfected.js` is a source change in an otherwise test-only PR. The facility's `onInfected` was an inline closure in `ApplicationContext.init`, so a test could only re-implement the wiring and would not fail when the wiring changed. It is a verbatim extraction with no behaviour change, and central already had the equivalent named helper.

Also worth knowing before you read it: the changelog convergence test's two "servers" share one registry, so only their store roots are genuinely separate. Hashes are recomputed from the bytes on each rewrite, so the assertion holds, but it simulates two servers rather than being two.

Three items are still open: the `blobStorage.root` settings half, and the two `makePatientLetter` asset cases. Those are in progress and land on this branch, followed by one commit updating the sweep document for all twenty.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->