### PR TITLE
fix(reports): no-issue: exclude soft-deleted survey responses from generic survey export

### DIFF
--- a/packages/facility-server/__tests__/apiv1/reports/generic-survey-export-line-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/generic-survey-export-line-list.test.js
@@ -210,6 +210,92 @@ describe('Generic survey export line list report', () => {
     });
   });
 
+  describe('Soft-deleted survey responses', () => {
+    it('excludes soft-deleted survey responses from the report', async () => {
+      const {
+        Facility,
+        Location,
+        Department,
+        Patient,
+        User,
+        Encounter,
+        Program,
+        Survey,
+        SurveyResponse,
+        ProgramDataElement,
+        SurveyScreenComponent,
+        SurveyResponseAnswer,
+      } = models;
+
+      const facility = await Facility.create(fake(Facility));
+      const location = await Location.create({
+        ...fake(Location),
+        facilityId: facility.id,
+      });
+      const department = await Department.create({
+        ...fake(Department),
+        facilityId: facility.id,
+      });
+      const examiner = await User.create(fake(User));
+      const program = await Program.create(fake(Program));
+      const deletionSurvey = await Survey.create({
+        ...fake(Survey),
+        programId: program.id,
+      });
+      const dataElement = await ProgramDataElement.create(fake(ProgramDataElement));
+      await SurveyScreenComponent.create({
+        ...fake(SurveyScreenComponent),
+        dataElementId: dataElement.id,
+        surveyId: deletionSurvey.id,
+      });
+
+      const createResponseForPatient = async () => {
+        const patient = await Patient.create(fake(Patient));
+        const encounter = await Encounter.create({
+          ...fake(Encounter),
+          patientId: patient.id,
+          departmentId: department.id,
+          locationId: location.id,
+          examinerId: examiner.id,
+        });
+        const response = await SurveyResponse.create({
+          ...fake(SurveyResponse),
+          surveyId: deletionSurvey.id,
+          encounterId: encounter.id,
+          endTime: getCurrentDateTimeString(),
+        });
+        await SurveyResponseAnswer.create({
+          ...fake(SurveyResponseAnswer),
+          dataElementId: dataElement.id,
+          responseId: response.id,
+          body: 'some answer',
+        });
+        return response;
+      };
+
+      const keptResponse = await createResponseForPatient();
+      const deletedResponse = await createResponseForPatient();
+      await deletedResponse.destroy();
+
+      const permissions = [
+        ['run', 'ReportDefinition', GENERIC_SURVEY_EXPORT_REPORT_ID],
+        ['read', 'Survey', deletionSurvey.id],
+      ];
+      app = await baseApp.asNewRole(permissions);
+      const result = await app.post(`/api/reports/${reportVersionId}`).send({
+        parameters: { surveyId: deletionSurvey.id },
+      });
+
+      expect(result).toHaveSucceeded();
+      const [, ...rows] = result.body;
+      expect(rows).toHaveLength(1);
+
+      const patientIdColumnIndex = result.body[0].indexOf('Patient ID');
+      const keptPatient = await keptResponse.getEncounter().then(e => e.getPatient());
+      expect(rows[0][patientIdColumnIndex]).toBe(keptPatient.displayId);
+    });
+  });
+
   describe('Signature answers', () => {
     let signatureSurvey;
 

--- a/packages/shared/src/reports/generic-survey-export-line-list.js
+++ b/packages/shared/src/reports/generic-survey-export-line-list.js
@@ -25,20 +25,21 @@ const SIGNATURE_EXPORT = /** @type {const} */ ({
   UNSIGNED: 'Unsigned',
 });
 
-// Uncomment deleted_at checks once Tan-1421 is complete, see https://linear.app/bes/issue/TAN-1456/update-existing-sql-reports-to-support-deleted-at
 const query = `
 with
 	answers_and_results as (
 		select
 			response_id,
 			data_element_id,
-			body
+			body,
+			deleted_at
 		from survey_response_answers sra
 		union all
 		select
 			id,
 			'Result',
-			result_text
+			result_text,
+			deleted_at
 		from survey_responses sr
 	),
 	responses_with_answers as (
@@ -49,7 +50,7 @@ with
 			) "answers"
 		from answers_and_results aar
 		where body <> '' -- Doesn't really matter, just could save some memory
-		--and aar.deleted_at is null
+		and aar.deleted_at is null
 		and data_element_id is not null
 		group by response_id
 	)
@@ -72,11 +73,11 @@ left join reference_data vil on vil.id = p.village_id
 join surveys s on s.id = sr.survey_id
 where p.id != '${TEST_PATIENT_ID}'
 AND sr.survey_id  = :survey_id
+and sr.deleted_at is null
 and CASE WHEN :village_id IS NOT NULL THEN p.village_id = :village_id ELSE true end
 and CASE WHEN :from_date IS NOT NULL THEN sr.end_time::date >= :from_date::date ELSE true END
 and CASE WHEN :to_date IS NOT NULL THEN sr.end_time::date <= :to_date::date ELSE true END
 order by sr.end_time desc
---and sr.deleted_at is null
 `;
 
 /**


### PR DESCRIPTION
### Changes

The raw SQL for the Generic Survey Export - Line List report (packages/shared/src/reports/generic-survey-export-line-list.js) had its deleted_at filters commented out back in 2022, pending a ticket that has since been completed — both survey_responses and survey_response_answers are Sequelize-paranoid with a real deleted_at column today, so soft-deleted survey responses and their answers were leaking into exports. This re-enables the filters, fixing two latent bugs in the dead code along the way (a column that was never selected in the CTE, and a WHERE clause misplaced after ORDER BY), and adds a regression test.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
