### PR TITLE
test(blobs): TAM-7037: cover central's asset blob scope registration

### DIFF
--- a/packages/central-server/__tests__/sync/assetBlobScope.test.js
+++ b/packages/central-server/__tests__/sync/assetBlobScope.test.js
@@ -1,0 +1,88 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { fake } from '@tamanu/fake-data/fake';
+import { fakeUUID } from '@tamanu/utils/generateId';
+import { settingsCache } from '@tamanu/settings';
+
+import { ApplicationContext } from '../../app/ApplicationContext';
+import { CentralSyncManager } from '../../app/sync/CentralSyncManager';
+import { isHashReferencedInScope } from '../../app/blobReferences';
+import { createTestContext } from '../utilities';
+
+// spec: ASSET, BLAC
+// A facility fetches an asset's bytes by hash, and central authorises that fetch
+// against the referencing asset row. Assets only reach the reference layer
+// because the application context registers them there at boot; the module's
+// static list holds attachments alone. Nothing else exercises that registration,
+// so without this the whole asset arm can be removed and the suite stays green,
+// while every facility silently stops receiving letterhead and logo bytes.
+describe('Asset blob scope', () => {
+  let ctx;
+  let models;
+  let sequelize;
+  let appContext;
+  let root;
+  let facility;
+  let otherFacility;
+
+  const assetCarryingHash = async (name, overrides = {}) => {
+    const hash = `sha256:${fakeUUID().replace(/-/g, '')}`;
+    await models.Asset.create(
+      fake(models.Asset, { name, data: null, hash, facilityId: null, ...overrides }),
+    );
+    return hash;
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+    sequelize = ctx.store.sequelize;
+
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-blob-scope-'));
+    await models.Setting.set('blobStorage.root', root);
+    settingsCache.reset();
+
+    facility = await models.Facility.create(fake(models.Facility));
+    otherFacility = await models.Facility.create(fake(models.Facility));
+
+    appContext = await new ApplicationContext().init();
+  });
+
+  afterAll(async () => {
+    await models.Setting.destroy({ where: { key: 'blobStorage.root' }, force: true });
+    settingsCache.reset();
+    await appContext.close();
+    await fs.rm(root, { recursive: true, force: true });
+    await ctx.close();
+  });
+
+  const inScope = async (hash, facilityIds) =>
+    await isHashReferencedInScope(sequelize, { hash, facilityIds });
+
+  it('authorises a deployment-wide asset for any facility', async () => {
+    const hash = await assetCarryingHash('letterhead');
+    await new CentralSyncManager(ctx).updateLookupTable();
+
+    expect(await inScope(hash, [facility.id])).toBe(true);
+    expect(await inScope(hash, [otherFacility.id])).toBe(true);
+  });
+
+  // A facility-specific asset is preferred over the deployment-wide one by the
+  // renderer, which is a different question from who may fetch its bytes: assets
+  // sync to every facility, so every facility server is entitled to any of them.
+  it('authorises a facility-specific asset for a facility it does not belong to', async () => {
+    const hash = await assetCarryingHash('facility letterhead', { facilityId: facility.id });
+    await new CentralSyncManager(ctx).updateLookupTable();
+
+    expect(await inScope(hash, [facility.id])).toBe(true);
+    expect(await inScope(hash, [otherFacility.id])).toBe(true);
+  });
+
+  // Without this the two cases above would pass against a predicate that
+  // admitted everything, which is what an over-broad registration looks like.
+  it('refuses a hash no asset references', async () => {
+    expect(await inScope(`sha256:${fakeUUID().replace(/-/g, '')}`, [facility.id])).toBe(false);
+  });
+});


### PR DESCRIPTION
### Changes

Central authorises a facility's fetch of an asset's bytes against the referencing asset row. Assets only reach that reference layer because `ApplicationContext.init` registers them at boot: the module's static list in `app/blobReferences.js` holds `attachments` alone. Nothing exercised that registration, so it could be deleted and the suite stayed green.

Proven rather than assumed. I removed the `registerBlobReferenceSource({ recordType: 'assets' })` line and ran the whole central suite: 1,645 passed, and the only 2 failing suites were the pre-existing `Set.prototype.intersection` ones that fail on the clean tip too (local Node is v20, `.node-version` wants v26). Zero new failures.

What that would mean in production: every facility asset fetch refused at central, so letterheads and logos never arrive, and the first symptom is a document printing unbranded or failing at print time. That is TEST_16 in the manual QA flows, a field observation on an intermittent link, which is about the worst place to find out.

Three cases, using the real `ApplicationContext` rather than the test utilities' `MockApplicationContext`, which is why the gap existed. Removing the registration fails both positive cases and leaves the negative control passing.

One correction the spec settled: my first draft asserted a facility-specific asset is refused for another facility. It is not, and should not be. Assets sync to every facility, so every facility server may fetch any asset's bytes; the row's `facilityId` is a preference rule for the renderer, not an authorisation boundary. The test now pins that distinction.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->