### PR TITLE
fix: no-issue: fetch all medication preset labels, not just the first 25 (hotfix 2.60)

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -471,6 +471,35 @@ describe('Suggestions', () => {
         'W17',
       ]);
     });
+
+    it('should return every preset label when noLimit is set, bypassing the default page size', async () => {
+      await models.ReferenceData.destroy({
+        where: { type: REFERENCE_TYPES.MEDICATION_PRESET_LABEL },
+        force: true,
+      });
+
+      const presetCount = 30;
+      for (let index = 0; index < presetCount; index++) {
+        const code = String(index).padStart(3, '0');
+        await models.ReferenceData.create({
+          id: `medicationPresetLabel-${code}`,
+          type: REFERENCE_TYPES.MEDICATION_PRESET_LABEL,
+          code,
+          name: `Preset ${code}`,
+          visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        });
+      }
+
+      const cappedResult = await userApp.get('/api/suggestions/medicationPresetLabel');
+      expect(cappedResult).toHaveSucceeded();
+      expect(cappedResult.body.length).toEqual(25);
+
+      const uncappedResult = await userApp
+        .get('/api/suggestions/medicationPresetLabel')
+        .query({ noLimit: true });
+      expect(uncappedResult).toHaveSucceeded();
+      expect(uncappedResult.body.length).toEqual(presetCount);
+    });
   });
 
   describe('General functionality (via diagnoses)', () => {

--- a/packages/web/__tests__/utils/medications.test.jsx
+++ b/packages/web/__tests__/utils/medications.test.jsx
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import { buildInstructionText, buildLabelText } from '../../app/utils/medications';
+import {
+  buildInstructionText,
+  buildLabelText,
+  resolvePresetLabelText,
+} from '../../app/utils/medications';
 
 // Mirror the real translation helpers closely enough for formatting assertions:
 // getTranslation falls back to the provided English, getEnumTranslation resolves
@@ -75,5 +79,21 @@ describe('buildLabelText', () => {
     expect(buildInstructionText(basePrescription, getTranslation, getEnumTranslation)).toBe(
       '1 tab Two times daily, Oral, back pain. This is the medication note.',
     );
+  });
+});
+
+describe('resolvePresetLabelText', () => {
+  it('returns the fallback text when no preset is selected', () => {
+    expect(resolvePresetLabelText(null, 'Preset name', 'Default label')).toBe('Default label');
+    expect(resolvePresetLabelText(undefined, 'Preset name', 'Default label')).toBe('Default label');
+  });
+
+  it('resolves to the selected preset name', () => {
+    expect(resolvePresetLabelText('preset-1', 'Preset name', 'Default label')).toBe('Preset name');
+  });
+
+  it('falls back to the fallback text when the preset name is missing', () => {
+    expect(resolvePresetLabelText('preset-1', undefined, 'Default label')).toBe('Default label');
+    expect(resolvePresetLabelText('preset-1', null, 'Default label')).toBe('Default label');
   });
 });

--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -194,7 +194,7 @@ export const DispenseMedicationWorkflowModal = memo(
     const { facilityId, currentUser } = useAuth();
     const { getTranslation, getEnumTranslation, getReferenceDataTranslation } = useTranslation();
     const practitionerSuggester = useSuggester('practitioner');
-    const { presetLabelSuggester, presetLabelsList, hasPresetLabels } = usePresetLabelsQuery({
+    const { presetLabelSuggester, hasPresetLabels } = usePresetLabelsQuery({
       enabled: open,
       facilityId,
     });
@@ -342,14 +342,14 @@ export const DispenseMedicationWorkflowModal = memo(
       });
     };
 
-    const handlePresetLabelChange = (rowIndex, { target: { value: presetId } }) => {
+    const handlePresetLabelChange = (rowIndex, { target: { value: presetId, presetName } }) => {
       setItems(prev => {
         const next = [...prev];
         const current = next[rowIndex];
         if (!current) return prev;
 
         const fallback = buildLabelText(current.prescription, getTranslation, getEnumTranslation);
-        const nextLabelText = resolvePresetLabelText(presetId, presetLabelsList, fallback);
+        const nextLabelText = resolvePresetLabelText(presetId, presetName, fallback);
 
         next[rowIndex] = {
           ...current,

--- a/packages/web/app/components/Medication/EditMedicationDispenseModal.jsx
+++ b/packages/web/app/components/Medication/EditMedicationDispenseModal.jsx
@@ -92,7 +92,7 @@ export const EditMedicationDispenseModal = memo(
     const { facilityId } = useAuth();
     const { getTranslation, getEnumTranslation, getReferenceDataTranslation } = useTranslation();
     const practitionerSuggester = useSuggester('practitioner');
-    const { presetLabelSuggester, presetLabelsList, hasPresetLabels } = usePresetLabelsQuery({
+    const { presetLabelSuggester, hasPresetLabels } = usePresetLabelsQuery({
       enabled: open,
       facilityId,
     });
@@ -170,8 +170,8 @@ export const EditMedicationDispenseModal = memo(
     };
 
     // Functional setters so a quick preset-then-type doesn't lose the typing.
-    const handlePresetLabelChange = ({ target: { value: presetId } }) => {
-      const nextLabelText = resolvePresetLabelText(presetId, presetLabelsList, defaultLabelText);
+    const handlePresetLabelChange = ({ target: { value: presetId, presetName } }) => {
+      const nextLabelText = resolvePresetLabelText(presetId, presetName, defaultLabelText);
       setItem(prev => ({
         ...prev,
         medicationPresetLabelId: presetId || null,

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -31,8 +31,13 @@ import { useSuggester } from '../api';
 import { STOCK_STATUS_COLORS } from '../constants';
 import { singularize } from './utils';
 
-// `name` is carried through so the change handler can populate Label text from it.
-export const presetLabelFormatter = ({ id, code, name }) => ({ value: id, label: code, name });
+// `presetName` (not `name`) is carried through so it survives AutocompleteInput's
+// change event — which overwrites a `name` key with its own form-field name prop.
+export const presetLabelFormatter = ({ id, code, name }) => ({
+  value: id,
+  label: code,
+  presetName: name,
+});
 export const PRESET_LABEL_SUGGESTER_OPTIONS = { formatter: presetLabelFormatter };
 
 const StyledInstructionsTextInput = styled(TextInput)`
@@ -118,19 +123,14 @@ export const usePresetLabelsQuery = ({ enabled, facilityId }) => {
   });
   return {
     presetLabelSuggester,
-    presetLabelsList,
     hasPresetLabels: (presetLabelsList?.length ?? 0) > 0,
   };
 };
 
-// Picking a preset replaces Label text with its translated name; clearing reverts
-// to the prescription-derived default. Pure — both modals' handlers reduce to one
-// call.
-export const resolvePresetLabelText = (presetId, presetLabelsList, fallbackText) => {
-  if (!presetId) return fallbackText ?? '';
-  const preset = presetLabelsList?.find(p => p.value === presetId);
-  return preset?.name ?? fallbackText ?? '';
-};
+// Picking a preset replaces Label text with its translated name (read straight off
+// the change event); clearing reverts to the prescription-derived default.
+export const resolvePresetLabelText = (presetId, presetName, fallbackText) =>
+  presetId ? presetName ?? fallbackText ?? '' : fallbackText ?? '';
 
 // Only drop the leading capital from ordinary capitalised words (e.g. 'Tablet' ->
 // 'tablet', 'Oral' -> 'oral', 'Two times daily' -> 'two times daily'). Acronym and


### PR DESCRIPTION
### Changes

Hotfix cherry-pick of `14b67b2714` (merged to `main` in #10777) onto `release/2.60`.

Selecting a "Preset label" outside the first page of results (25, ordered by
code) in the Dispense medication workflow silently left the Label field on
its auto-generated default instead of the preset's wording — reported on FSM
Demo (v2.61.1) with preset "SCABY", but present since the preset-label
feature shipped in 2.60 (TAM-6801).

Root cause: the change handlers resolved the selected preset's text against
a separately fetched/cached list that was capped at the suggester's default
page size (25). The fix reads the preset's name directly off
`AutocompleteInput`'s change event instead (renaming the suggester
formatter's `name` field to `presetName` so it isn't overwritten by the
input's own `name` prop), removing the capped lookup entirely.

`packages/web/__tests__/utils/medications.test.jsx` was adapted for this
branch: it doesn't yet have the `isDispenseModifiedByPharmacy` /
`getDispensedMedication` tests/functions from later branches, so only the
new `resolvePresetLabelText` describe block and import were added.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
