### PR TITLE
tweak(settings): no-issue: link the Claude model list from AI settings

### DIFF
--- a/packages/settings/src/schema/central.ts
+++ b/packages/settings/src/schema/central.ts
@@ -49,6 +49,8 @@ export const centralSettings = {
     ai: {
       name: 'AI',
       description: 'Settings for AI-powered features',
+      infoBanner:
+        'Model IDs for the model settings below are listed at https://platform.claude.com/docs/en/about-claude/models/overview',
       properties: {
         enabled: {
           name: 'Enabled',

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -148,6 +148,33 @@ const MatchedDescription = styled(BodyText)`
   max-inline-size: 60ch;
 `;
 
+const BannerLink = styled.a`
+  color: inherit;
+  text-decoration: underline;
+`;
+
+// banner text comes from the settings schema, which is a React-free package, so
+// a URL arrives as plain text and only becomes a link here
+const linkifyUrls = text => {
+  if (typeof text !== 'string') return text;
+  const matcher = /https?:\/\/[^\s]+/g;
+  const parts = [];
+  let last = 0;
+  let match;
+  while ((match = matcher.exec(text))) {
+    parts.push(text.slice(last, match.index));
+    parts.push(
+      <BannerLink key={match.index} href={match[0]} target="_blank" rel="noreferrer">
+        {match[0]}
+      </BannerLink>,
+    );
+    last = match.index + match[0].length;
+  }
+  if (last === 0) return text;
+  parts.push(text.slice(last));
+  return parts;
+};
+
 // substring (not word-start) so it explains rows from either matching tier
 const highlightMatches = (text, query) => {
   const needle = query?.trim();
@@ -333,7 +360,7 @@ export const Category = ({
       />
       {schema.infoBanner && (
         <InfoBannerAlert severity="info" $indent={depth} data-testid="infobanneralert-fw01">
-          {schema.infoBanner}
+          {linkifyUrls(schema.infoBanner)}
         </InfoBannerAlert>
       )}
       {sortedProperties.map(([key, propertySchema]) => {


### PR DESCRIPTION
### Changes

<img width="1440" height="900" alt="ai-settings-banner" src="https://github.com/user-attachments/assets/c1201e4d-757e-434b-a877-99da5ffae59d" />

The two Anthropic model settings gave no pointer to what a valid model ID looks like, so an admin had to guess or ask.

- Adds an info banner on the AI settings category linking the Claude models overview.
- Banner URLs now render as real links. `infoBanner` is a plain string because `@tamanu/settings` has no React dependency, so the anchor is built at render time in `Category.jsx` rather than by putting JSX in the schema.
- Left the two model field tooltips alone: `ThemedTooltip` is not interactive, so a link in a tooltip would close before it could be clicked. The banner sits directly above both fields.

One gap worth knowing: the banner renders on the category page, not in search results, so an admin who finds the field by searching will not see it.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->