### PR TITLE
fix(centralServer): no-issue: refuse report writes when reporting schemas fail to init (HOTFIX 2.60)

### DIFF
--- a/packages/central-server/__tests__/utilities.js
+++ b/packages/central-server/__tests__/utilities.js
@@ -1,7 +1,12 @@
 import config from 'config';
 import supertest from 'supertest';
 
-import { COMMUNICATION_STATUSES, JWT_TOKEN_TYPES, SERVER_TYPES } from '@tamanu/constants';
+import {
+  COMMUNICATION_STATUSES,
+  JWT_TOKEN_TYPES,
+  REPORT_DB_CONNECTION_VALUES,
+  SERVER_TYPES,
+} from '@tamanu/constants';
 import { seedSettings } from '@tamanu/database/demoData';
 import { ReadSettings } from '@tamanu/settings';
 import { fake } from '@tamanu/fake-data/fake';
@@ -20,6 +25,11 @@ class MockApplicationContext {
 
   async init({ initFhir = false, initFhirTriggers = false } = {}) {
     this.store = await initDatabase({ testMode: true });
+    // Report SQL runs on the main test connection rather than dedicated reporting
+    // roles, but the stores have to be present or write routes refuse to run.
+    this.reportSchemaStores = Object.fromEntries(
+      REPORT_DB_CONNECTION_VALUES.map(connection => [connection, this.store]),
+    );
     this.settings = new ReadSettings(this.store.models);
     await seedSettings(this.store.models);
     if (initFhir) {

--- a/packages/central-server/app/admin/reports/createReportDefinitionVersion.js
+++ b/packages/central-server/app/admin/reports/createReportDefinitionVersion.js
@@ -31,12 +31,18 @@ export async function createReportDefinitionVersion(
     async () => {
       const { name, dbSchema, ...definitionVersion } = definition;
       if (!reportId) {
+        // The unique constraint on the name counts soft-deleted rows, so this lookup must too.
         const existingDefinition = await ReportDefinition.findOne({
           where: { name },
-          attributes: ['id'],
+          attributes: ['id', 'deletedAt'],
+          paranoid: false,
         });
         if (existingDefinition) {
-          throw new InvalidOperationError('Report name already exists');
+          throw new InvalidOperationError(
+            existingDefinition.deletedAt
+              ? 'A deleted report is still using this name'
+              : 'Report name already exists',
+          );
         }
       }
       const reportDefinitionId = reportId || (await ReportDefinition.create({ name, dbSchema })).id;

--- a/packages/central-server/app/admin/reports/reportRoutes.js
+++ b/packages/central-server/app/admin/reports/reportRoutes.js
@@ -16,6 +16,16 @@ import { DryRun } from '../errors';
 
 export const reportsRouter = express.Router();
 
+// Reads degrade when initReporting fails at startup, but writes must not: without a
+// store they would address a different schema than the one they validated against.
+const assertReportingSchemasAvailable = reportSchemaStores => {
+  if (!reportSchemaStores) {
+    throw new InvalidOperationError(
+      'Reporting schemas failed to initialise, check the server startup logs',
+    );
+  }
+};
+
 reportsRouter.get(
   '/',
   asyncHandler(async (req, res) => {
@@ -104,12 +114,12 @@ reportsRouter.post(
     req.checkPermission('create', 'ReportDefinition');
     req.checkPermission('create', 'ReportDefinitionVersion');
 
-    const { store, body, user, reportSchemaStores, isReportingSchemaEnabled } = req;
-    const defaultReportingSchema = isReportingSchemaEnabled
-      ? REPORT_DB_CONNECTIONS.REPORTING
-      : REPORT_DB_CONNECTIONS.RAW;
+    const { store, body, user, reportSchemaStores } = req;
+    assertReportingSchemasAvailable(reportSchemaStores);
 
-    const transformedBody = !body.dbSchema ? { ...body, dbSchema: defaultReportingSchema } : body;
+    const transformedBody = !body.dbSchema
+      ? { ...body, dbSchema: REPORT_DB_CONNECTIONS.REPORTING }
+      : body;
 
     const version = await createReportDefinitionVersion(
       { store, reportSchemaStores },
@@ -128,6 +138,8 @@ reportsRouter.post(
     req.checkPermission('create', 'ReportDefinitionVersion');
 
     const { store, params, body, user, reportSchemaStores } = req;
+    assertReportingSchemasAvailable(reportSchemaStores);
+
     const { reportId } = params;
     const version = await createReportDefinitionVersion(
       { store, reportSchemaStores },
@@ -194,11 +206,13 @@ reportsRouter.post(
     req.checkPermission('create', 'ReportDefinition');
     req.checkPermission('create', 'ReportDefinitionVersion');
 
-    const { store, user, reportSchemaStores, isReportingSchemaEnabled } = req;
+    const { store, user, reportSchemaStores } = req;
     const {
       models: { ReportDefinition, ReportDefinitionVersion },
       sequelize,
     } = store;
+
+    assertReportingSchemasAvailable(reportSchemaStores);
 
     const canEditSchema = req.ability.can('write', 'ReportDbSchema');
 
@@ -209,17 +223,20 @@ reportsRouter.post(
     if (versionData.versionNumber)
       throw new InvalidOperationError('Cannot import a report with a version number');
 
-    if (
-      isReportingSchemaEnabled &&
-      !canEditSchema &&
-      versionData.dbSchema === REPORT_DB_CONNECTIONS.RAW
-    ) {
+    if (!canEditSchema && versionData.dbSchema === REPORT_DB_CONNECTIONS.RAW) {
       throw new InvalidOperationError(
         'You do not have permission to import reports using the raw schema',
       );
     }
 
-    const existingDefinition = await ReportDefinition.findOne({ where: { name } });
+    // The unique constraint on the name counts soft-deleted rows, so this lookup must too.
+    const existingDefinition = await ReportDefinition.findOne({
+      where: { name },
+      paranoid: false,
+    });
+    if (existingDefinition?.deletedAt) {
+      throw new InvalidOperationError('A deleted report is still using this name');
+    }
     if (existingDefinition && existingDefinition.dbSchema !== versionData.dbSchema) {
       throw new InvalidOperationError('Cannot change a reporting schema for existing report');
     }
@@ -240,10 +257,7 @@ reportsRouter.post(
         },
         async () => {
           const [definition, createdDefinition] = await ReportDefinition.findOrCreate({
-            where: {
-              name,
-              dbSchema: isReportingSchemaEnabled ? versionData.dbSchema : REPORT_DB_CONNECTIONS.RAW,
-            },
+            where: { name, dbSchema: versionData.dbSchema },
             include: [
               {
                 model: ReportDefinitionVersion,

--- a/packages/database/src/utils/convertDatabaseError.ts
+++ b/packages/database/src/utils/convertDatabaseError.ts
@@ -9,6 +9,11 @@ import {
 import * as sequelize from 'sequelize';
 
 export function convertDatabaseError(error: sequelize.BaseError): BaseError {
+  // UniqueConstraintError extends ValidationError, so it has to be tested first.
+  if (error instanceof sequelize.UniqueConstraintError) {
+    return new DatabaseDuplicateError(error.message).withCause(error);
+  }
+
   if (error instanceof sequelize.ValidationError) {
     return new DatabaseValidationError(error.message).withCause(error).withExtraData({
       validations: error.errors.map(err => err.validatorName),
@@ -31,10 +36,6 @@ export function convertDatabaseError(error: sequelize.BaseError): BaseError {
     return new DatabaseRelationError(error.message).withCause(error).withExtraData({
       relation: error.index,
     });
-  }
-
-  if (error instanceof sequelize.UniqueConstraintError) {
-    return new DatabaseDuplicateError(error.message).withCause(error);
   }
 
   return new DatabaseError(error.message).withCause(error);


### PR DESCRIPTION
### Changes

Backport of #10799 to 2.60, cherry-picked clean.

- On 2.60 deployments where `initReporting` fails at startup (the app role lacks CREATEROLE, so `ensureReportingRole` can't provision `tamanu_reporting`), the server degrades per #10198 and `reportSchemaStores` is left undefined.
- `req.isReportingSchemaEnabled` is `Boolean(reportSchemaStores)`, so the import route swapped `raw` into its `findOrCreate` lookup, missed every existing `reporting` definition, inserted, and died on `report_definitions_name_key`. Every report import failed with "Database model validation: Validation error", naming nothing useful.
- Write routes now refuse when the stores are missing. Reads still degrade.
- Also reorders `convertDatabaseError` (`UniqueConstraintError` extends `ValidationError`, so the duplicate branch was unreachable) and makes the report-name lookups `paranoid: false`, since the unique constraint counts soft-deleted rows.
- Worth taking on 2.60 because the next deployments to upgrade hit the same provisioning mismatch and get the same three unexplained symptoms.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
