### PR TITLE
fix(web): no-issue: resolve translated label before lowercasing it

### DIFF
--- a/packages/web/__tests__/components/Field/SearchMultiSelectField.test.jsx
+++ b/packages/web/__tests__/components/Field/SearchMultiSelectField.test.jsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SettingsContext, TranslatedText } from '@tamanu/ui-components';
+
+import { renderElementWithTranslatedText } from '../../helpers';
+import { SearchMultiSelectInput } from '../../../app/components/Field/SearchMultiSelectField';
+
+const options = Array.from({ length: 12 }, (_, index) => ({
+  value: `option-${index}`,
+  label: `Option ${index}`,
+}));
+
+describe('SearchMultiSelectInput', () => {
+  it('accepts a translated label alongside the option search box', async () => {
+    renderElementWithTranslatedText(
+      <SettingsContext.Provider value={{ getSetting: () => false }}>
+        <SearchMultiSelectInput
+          name="searchFields"
+          value={[]}
+          onChange={() => {}}
+          options={options}
+          label={
+            <TranslatedText stringId="admin.settings.searchFields.label" fallback="Search fields" />
+          }
+        />
+      </SettingsContext.Provider>,
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByTestId('styledtextinput-ryvy-searchFields')).toBeDefined();
+  });
+});

--- a/packages/web/app/components/Field/SearchMultiSelectField.jsx
+++ b/packages/web/app/components/Field/SearchMultiSelectField.jsx
@@ -9,11 +9,13 @@ import Button from '@mui/material/Button';
 import InputAdornment from '@mui/material/InputAdornment';
 import Search from '@mui/icons-material/Search';
 
+import { extractTranslationFromComponent } from '@tamanu/ui-components';
 import { CheckboxIconChecked, CheckboxIconUnchecked } from '../Icons/CheckboxIcon';
 import { Colors } from '../../constants';
 import { TextButton } from '../Button';
 import { useSuggesterOptions } from '../../hooks';
 import { TranslatedText } from '../Translation';
+import { useTranslation } from '../../contexts/Translation';
 import { TextInput } from './TextField';
 
 const StyledTextInput = styled(TextInput)`
@@ -105,6 +107,7 @@ export const SearchMultiSelectInput = ({
   options = [],
   ...props
 }) => {
+  const { getTranslation } = useTranslation();
   const [anchorEl, setAnchorEl] = useState(null);
   const [searchValue, setSearchValue] = useState('');
 
@@ -125,6 +128,12 @@ export const SearchMultiSelectInput = ({
   };
 
   const shouldShowSearch = options?.length > 10;
+  const labelText = extractTranslationFromComponent(label, getTranslation);
+  const searchPlaceholder = labelText
+    ? getTranslation('general.action.searchField', 'Search :field', {
+        replacements: { field: labelText.toLowerCase() },
+      })
+    : getTranslation('general.action.search', 'Search');
 
   return (
     <>
@@ -153,7 +162,7 @@ export const SearchMultiSelectInput = ({
                   </Icon>
                 ),
               }}
-              placeholder={`Search ${label.toLowerCase()}`}
+              placeholder={searchPlaceholder}
               style={{ paddingInlineStart: 0 }}
               value={searchValue}
               onChange={(e) => setSearchValue(e.target.value)}


### PR DESCRIPTION
### Changes

- Admin settings crashed with `n.toLowerCase is not a function` whenever a `SearchMultiSelectInput` rendered with more than 10 options and a `TranslatedText` label. The search-box placeholder lowercased `label` directly, so a translation element threw during render. Hit on `/admin/settings?scope=global&q=in` (the query matches `patientSearch.additionalSearchFields`, which has 36 options), and equally from the Patient search category.
- Placeholder now resolves the label with `extractTranslationFromComponent`, the helper `SelectField` already uses: plain strings pass through, translation elements resolve. It is also a translated string now (`Search :field`) instead of an English literal glued to a label.
- Every other caller passes `label` as a string from `getTranslation`, so nothing else changes visually.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->