### PR TITLE
fix(web): X4: prevent duplicate document upload on double-click

### DIFF
--- a/packages/web/__tests__/forms/DocumentForm.test.jsx
+++ b/packages/web/__tests__/forms/DocumentForm.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+import { renderElementWithTranslatedText } from '../helpers';
+import { DocumentForm } from '../../app/forms/DocumentForm';
+
+const postWithFileUpload = vi.fn();
+
+vi.mock('../../app/api', () => ({
+  useApi: () => ({ postWithFileUpload }),
+  useSuggester: () => ({}),
+}));
+
+// The real inputs aren't needed for this test; the form is seeded valid via
+// editedObject, so render the field components as no-ops.
+vi.mock('@tamanu/ui-components', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    FileChooserField: () => null,
+    TextField: () => null,
+  };
+});
+
+vi.mock('../../app/components/Field', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    AutocompleteField: () => null,
+  };
+});
+
+describe('DocumentForm double submit', () => {
+  it('only uploads once when Add is clicked twice while the request is in flight', async () => {
+    // Never-resolving upload keeps the request in flight across both clicks.
+    postWithFileUpload.mockReturnValue(new Promise(() => {}));
+
+    // handleSubmit reads file.lastModified / file.type, so seed a File-like value.
+    const file = { lastModified: 0, type: 'application/pdf', toString: () => 'f.pdf' };
+
+    renderElementWithTranslatedText(
+      <DocumentForm
+        onStart={() => {}}
+        onSubmit={() => {}}
+        onError={() => {}}
+        onCancel={() => {}}
+        endpoint="test"
+        editedObject={{ file, name: 'My file' }}
+      />,
+    );
+
+    const addButton = screen.getByTestId('formsubmitcancelrow-me5l-confirmButton');
+
+    await act(async () => {
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+    });
+
+    await waitFor(() => expect(postWithFileUpload).toHaveBeenCalled());
+    expect(postWithFileUpload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/__tests__/forms/DocumentForm.test.jsx
+++ b/packages/web/__tests__/forms/DocumentForm.test.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, waitFor, act } from '@testing-library/react';
 
 import { renderElementWithTranslatedText } from '../helpers';
 import { DocumentForm } from '../../app/forms/DocumentForm';
+
+// Double-clicking Add used to create two identical documents (card X4): the shared
+// Form's duplicate-submit guard reads a stale `isSubmitting`, so two clicks landing
+// before the re-render commits both reached the upload.
 
 const postWithFileUpload = vi.fn();
 
@@ -12,8 +16,8 @@ vi.mock('../../app/api', () => ({
   useSuggester: () => ({}),
 }));
 
-// The real inputs aren't needed for this test; the form is seeded valid via
-// editedObject, so render the field components as no-ops.
+// The real inputs aren't needed here; the form is seeded valid via editedObject,
+// so render the field components as no-ops.
 vi.mock('@tamanu/ui-components', async importOriginal => {
   const actual = await importOriginal();
   return {
@@ -31,33 +35,68 @@ vi.mock('../../app/components/Field', async importOriginal => {
   };
 });
 
+// handleSubmit reads file.lastModified / file.type, so seed a File-like value.
+const file = { lastModified: 0, type: 'application/pdf', toString: () => 'f.pdf' };
+
+const renderDocumentForm = ({ onSubmit = () => {} } = {}) =>
+  renderElementWithTranslatedText(
+    <DocumentForm
+      onStart={() => {}}
+      onSubmit={onSubmit}
+      onError={() => {}}
+      onCancel={() => {}}
+      endpoint="test"
+      editedObject={{ file, name: 'My file' }}
+    />,
+  );
+
+// Query by type rather than test id: the disabled variant of the button renders its
+// own hardcoded test id, so a test-id lookup wouldn't find it once it's disabled.
+const getAddButton = container => container.querySelector('button[type="submit"]');
+
 describe('DocumentForm double submit', () => {
-  it('only uploads once when Add is clicked twice while the request is in flight', async () => {
-    // Never-resolving upload keeps the request in flight across both clicks.
+  beforeEach(() => {
+    postWithFileUpload.mockReset();
+    // A never-resolving upload keeps the request in flight across both clicks.
     postWithFileUpload.mockReturnValue(new Promise(() => {}));
+  });
 
-    // handleSubmit reads file.lastModified / file.type, so seed a File-like value.
-    const file = { lastModified: 0, type: 'application/pdf', toString: () => 'f.pdf' };
-
-    renderElementWithTranslatedText(
-      <DocumentForm
-        onStart={() => {}}
-        onSubmit={() => {}}
-        onError={() => {}}
-        onCancel={() => {}}
-        endpoint="test"
-        editedObject={{ file, name: 'My file' }}
-      />,
-    );
-
-    const addButton = screen.getByTestId('formsubmitcancelrow-me5l-confirmButton');
+  it('only uploads once when Add is clicked twice while the request is in flight', async () => {
+    const { container } = renderDocumentForm();
 
     await act(async () => {
-      fireEvent.click(addButton);
-      fireEvent.click(addButton);
+      fireEvent.click(getAddButton(container));
+      fireEvent.click(getAddButton(container));
     });
 
     await waitFor(() => expect(postWithFileUpload).toHaveBeenCalled());
+    expect(postWithFileUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the Add button disabled while the upload is still in flight', async () => {
+    const { container } = renderDocumentForm();
+
+    await act(async () => {
+      fireEvent.click(getAddButton(container));
+      fireEvent.click(getAddButton(container));
+    });
+
+    // The ignored second click must not clear the form's submitting state while the
+    // upload it deferred to is still running.
+    expect(getAddButton(container).disabled).toBe(true);
+  });
+
+  it('completes a single successful upload', async () => {
+    postWithFileUpload.mockResolvedValue({});
+    const onSubmit = vi.fn();
+
+    const { container } = renderDocumentForm({ onSubmit });
+
+    await act(async () => {
+      fireEvent.click(getAddButton(container));
+    });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(postWithFileUpload).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/app/forms/DocumentForm.jsx
+++ b/packages/web/app/forms/DocumentForm.jsx
@@ -172,7 +172,7 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
   const api = useApi();
   const { getTranslation } = useTranslation();
   const [error, setError] = useState(false);
-  const isUploading = useRef(false);
+  const inFlightUpload = useRef(null);
 
   const departmentSuggester = useSuggester('department', {
     baseQueryParameters: { filterByFacility: true },
@@ -180,22 +180,31 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
 
   const handleSubmit = useCallback(
     async ({ file, ...data }) => {
-      // Ignore repeat submissions (e.g. double-clicking Add) while an upload is
-      // in flight so the document is only created once.
-      if (isUploading.current) return;
-      isUploading.current = true;
+      // A repeat submission (e.g. double-clicking Add) waits on the upload already
+      // in flight rather than starting a second one. Waiting rather than returning
+      // keeps the form marked as submitting, so Add stays disabled until the
+      // upload settles.
+      if (inFlightUpload.current) {
+        await inFlightUpload.current;
+        return;
+      }
+
       onStart();
 
       // Read file metadata
       const birthtime = new Date(file.lastModified);
       const attachmentType = file.type;
 
+      const upload = api.postWithFileUpload(endpoint, file, {
+        ...data,
+        type: attachmentType,
+        documentCreatedAt: toDateTimeString(birthtime),
+      });
+      // Waiters only need to know when the upload settled; failures are handled here.
+      inFlightUpload.current = upload.catch(() => {});
+
       try {
-        await api.postWithFileUpload(endpoint, file, {
-          ...data,
-          type: attachmentType,
-          documentCreatedAt: toDateTimeString(birthtime),
-        });
+        await upload;
       } catch (e) {
         onError(e);
         // Assume that if submission fails is because of lack of storage
@@ -208,7 +217,7 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
         }
       } finally {
         // eslint-disable-next-line require-atomic-updates -- ref latch guarding against repeat submissions
-        isUploading.current = false;
+        inFlightUpload.current = null;
       }
 
       onSubmit();

--- a/packages/web/app/forms/DocumentForm.jsx
+++ b/packages/web/app/forms/DocumentForm.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import styled from 'styled-components';
 import * as yup from 'yup';
 import { Typography } from '@material-ui/core';
@@ -172,6 +172,7 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
   const api = useApi();
   const { getTranslation } = useTranslation();
   const [error, setError] = useState(false);
+  const isUploading = useRef(false);
 
   const departmentSuggester = useSuggester('department', {
     baseQueryParameters: { filterByFacility: true },
@@ -179,6 +180,10 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
 
   const handleSubmit = useCallback(
     async ({ file, ...data }) => {
+      // Ignore repeat submissions (e.g. double-clicking Add) while an upload is
+      // in flight so the document is only created once.
+      if (isUploading.current) return;
+      isUploading.current = true;
       onStart();
 
       // Read file metadata
@@ -201,6 +206,9 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
           setError(e.message);
           return;
         }
+      } finally {
+        // eslint-disable-next-line require-atomic-updates -- ref latch guarding against repeat submissions
+        isUploading.current = false;
       }
 
       onSubmit();


### PR DESCRIPTION
### Changes

Fixes a bug where clicking "Add" twice in quick succession on the document upload form created two identical document records. `DocumentForm`'s submit handler now guards against re-entrant submissions with a ref-based latch while an upload is in flight, so repeat clicks are ignored until the request completes. Added a test covering the double-click scenario.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->