### PR TITLE
fix(charts): no-issue: don't record blank chart measures as answers

### DIFF
--- a/packages/database/src/models/SurveyResponse.ts
+++ b/packages/database/src/models/SurveyResponse.ts
@@ -446,8 +446,10 @@ export class SurveyResponse extends Model {
         throw new Error(`no data element for question: ${dataElementId}`);
       }
       const body = await SurveyResponse.getBodyForAnswer(dataElement.type, value, models);
-      // Don't create null answers
-      if (body === null) {
+      // Don't create empty answers. A blank measure is not a recorded value, so persisting it as
+      // an empty-bodied row would surface its creation in chart history as a spurious "Entry
+      // deleted" line (chart history is derived from the answer audit changelog).
+      if (body === null || body === '') {
         continue;
       }
 
@@ -456,7 +458,7 @@ export class SurveyResponse extends Model {
         body,
         responseId: record.id,
       });
-      if (!isVitalSurvey || body === '') continue;
+      if (!isVitalSurvey) continue;
       // Generate initial vital log
       await models.VitalLog.create({
         date: record.endTime || getCurrentDateTimeString(),

--- a/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
+++ b/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
@@ -208,6 +208,31 @@ describe('EncounterCharting', () => {
       expect(saved).toHaveProperty('body', '1234');
     });
 
+    it('should not create an answer record for a measure left blank', async () => {
+      const submissionDate = getCurrentDateTimeString();
+      const result = await app.post('/api/surveyResponse').send({
+        surveyId: 'simple-chart-survey-0',
+        patientId: chartsPatient.id,
+        startTime: submissionDate,
+        endTime: submissionDate,
+        answers: {
+          [CHARTING_DATA_ELEMENT_IDS.dateRecorded]: submissionDate,
+          'pde-ChartQuestionOneA': 1234,
+          // Left blank in the form, submitted as an empty string
+          'pde-ChartQuestionTwoA': '',
+        },
+        facilityId,
+      });
+      expect(result).toHaveSucceeded();
+
+      // The blank measure must not be persisted as an empty-bodied answer, otherwise its creation
+      // shows up in the cell's history as a spurious "Entry deleted" line.
+      const blankAnswer = await models.SurveyResponseAnswer.findOne({
+        where: { dataElementId: 'pde-ChartQuestionTwoA' },
+      });
+      expect(blankAnswer).toBeNull();
+    });
+
     it('should get simple chart readings for an encounter', async () => {
       const surveyId = 'simple-chart-survey-0';
       const submissionDate = getCurrentDateTimeString();


### PR DESCRIPTION
### Changes

Fixes chart history incorrectly showing "Entry deleted" for number/free-text measures that were never filled in. Blank measures (submitted as empty strings) were still being persisted as survey response answer rows with an empty body, and since chart history is derived from the answer audit changelog, creating that empty-bodied row was rendered as a deletion event.

`SurveyResponse` now skips creating an answer record when the body is `null` **or** an empty string, so a blank measure leaves no record and no spurious history entry. Vital log creation logic was adjusted accordingly, since it previously relied on `body === ''` to skip creating a vital log for blank vital survey answers — that check is no longer needed since blank answers are never created at all.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Artillery load test <!-- #deployopt %synthetic -->
- [ ] Seed from closest snapshot <!-- #deployopt %seed-snapshot -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Build all images (amd64 + Windows; default is arm64 only) <!-- #deployopt %allimages -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->
- [ ] **Run DAST scan** <!-- #dast -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->